### PR TITLE
perf(schema): lazy errors + elide wrapErrors (#45, #46)

### DIFF
--- a/packages/schema/src/compiler/compiler.ts
+++ b/packages/schema/src/compiler/compiler.ts
@@ -482,7 +482,10 @@ function buildFunctionBody(schema: SchemaOrBoolean, state: CompileState): string
   const gen = new CodeGen();
   gen.indent();
   if (!state.predicate) {
-    gen.const(NAMES.ERRORS, "[]");
+    // Start null; lazily allocate on first push. Valid inputs never
+    // touch this — the function returns null directly without
+    // allocating anything.
+    gen.let(NAMES.ERRORS, "null");
   }
 
   if (schema === true) {
@@ -532,6 +535,9 @@ function buildFunctionBody(schema: SchemaOrBoolean, state: CompileState): string
   if (state.predicate) {
     gen.line("return true;");
   } else {
+    // Happy path: errors stayed null → return null directly and skip
+    // the wrapErrors function call entirely.
+    gen.line(`if (${NAMES.ERRORS} === null) return null;`);
     gen.line(`return ${NAMES.DEPS}.wrapErrors("schema", ${NAMES.PATH}, ${NAMES.ERRORS});`);
   }
   gen.dedent();

--- a/packages/schema/src/keywords/context.ts
+++ b/packages/schema/src/keywords/context.ts
@@ -188,7 +188,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     // kind === "lift": already-counted sub-validator result being
     // propagated, or a branch wrapper around already-counted children.
     // Never interacts with the budget.
-    return `${inputs.errors}.push(${errExpr});`;
+    return `(${inputs.errors} ??= []).push(${errExpr});`;
   };
   const emitError = (kind: ErrorKind, errExpr: string): void => {
     inputs.gen.line(errorStatement(kind, errExpr));
@@ -297,7 +297,10 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     // snapshot/wrap entirely — inlined keywords return `false` on
     // failure so there's nothing to wrap.
     const startVar = predicate ? null : inputs.gen.scope.name("_start");
-    if (startVar !== null) inputs.gen.const(startVar, `${inputs.errors}.length`);
+    // errors may be null (lazy allocation). Treat null as length-0 for
+    // the snapshot; the wrap check below also guards against null.
+    if (startVar !== null)
+      inputs.gen.const(startVar, `${inputs.errors} === null ? 0 : ${inputs.errors}.length`);
 
     // Keyword ordering mirrors the compiler's top-level dispatch: run
     // validation keywords first (leaf checks) in their defined vocab
@@ -339,15 +342,21 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     }
 
     // Wrap if >1 new error actually fired — error-tree mode only.
+    // errors may still be null here if no keyword pushed anything (or
+    // only the budget got exhausted without pushing); the null-check
+    // short-circuits the wrap.
     if (startVar !== null) {
       const wrappedVar = inputs.gen.scope.name("_wrapped");
-      inputs.gen.if(`${inputs.errors}.length - ${startVar} > 1`, () => {
-        inputs.gen.const(wrappedVar, `${inputs.errors}.splice(${startVar})`);
-        inputs.gen.line(
-          `${inputs.errors}.push(${NAMES.DEPS}.createBranchError(` +
-            `"schema", ${inputs.path}, "schema validation failed", ${wrappedVar}));`,
-        );
-      });
+      inputs.gen.if(
+        `${inputs.errors} !== null && ${inputs.errors}.length - ${startVar} > 1`,
+        () => {
+          inputs.gen.const(wrappedVar, `${inputs.errors}.splice(${startVar})`);
+          inputs.gen.line(
+            `${inputs.errors}.push(${NAMES.DEPS}.createBranchError(` +
+              `"schema", ${inputs.path}, "schema validation failed", ${wrappedVar}));`,
+          );
+        },
+      );
     }
 
     return true;
@@ -429,9 +438,9 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
  * @internal
  */
 export function emitPushStatement(errorsVar: string, errExpr: string, gated: boolean): string {
-  if (!gated) return `${errorsVar}.push(${errExpr});`;
+  if (!gated) return `(${errorsVar} ??= []).push(${errExpr});`;
   return (
-    `if (${NAMES.DEPS}.errorsRemaining > 0) { ${errorsVar}.push(${errExpr}); ${NAMES.DEPS}.errorsRemaining -= 1; }` +
+    `if (${NAMES.DEPS}.errorsRemaining > 0) { (${errorsVar} ??= []).push(${errExpr}); ${NAMES.DEPS}.errorsRemaining -= 1; }` +
     ` else { ${NAMES.DEPS}.truncated = true; }`
   );
 }


### PR DESCRIPTION
## Summary

Each compiled validator function used to unconditionally allocate an \`errors\` array at its entry and call \`deps.wrapErrors(...)\` at its exit, even when the input was valid and no errors were ever pushed. For array-heavy shapes this compounded across every inner element (one allocation + one function call per array item).

This PR combines #45 and #46:

- \`let errors = null\` at function entry (no allocation).
- \`(errors ??= []).push(e)\` at each error site (lazy allocation on first push).
- \`if (errors === null) return null;\` at function exit (skip the \`wrapErrors\` call entirely on the happy path).

The two changes interact tightly — #46 is only meaningful once #45 makes the null check well-defined — so they ship together.

Closes #45. Closes #46.

## Benchmarks

\`NODE_OPTIONS='--max-old-space-size=8192' pnpm bench:long\` against the post-#42 baseline, two runs averaged, oav-only, validate-only (compile stayed within ±2% across all shapes).

| shape | variant | baseline | branch | delta |
| --- | --- | --- | --- | --- |
| **array-heavy** | oav valid | 290K | 331K | **+14%** |
| **array-heavy** | oav invalid | 290K | 327K | **+13%** |
| array-heavy | oav-pred valid | 456K | 471K | +3% |
| array-heavy | oav-pred invalid | 460K | 474K | +3% |
| composition | oav valid | 4.16M | 4.36M | +5% |
| composition | oav invalid | 3.45M | 3.50M | +2% |
| composition | oav-pred valid | 13.94M | 14.53M | +4% |
| composition | oav-pred invalid | 15.36M | 15.85M | +3% |
| tree | oav valid | 22.23M | 22.92M | +3% |
| tree | oav invalid | 15.85M | 16.85M | +6% |
| tree | oav-pred valid | 25.46M | 26.65M | +5% |
| petstore | oav valid | 10.53M | 10.76M | +2% |
| petstore | oav invalid | 6.72M | 6.95M | +3% |

Predicate-mode paths are structurally unchanged (predicate mode never allocates the accumulator); the small numeric movements there are benchmark noise.

One "regression" showed up on \`petstore oav-predicate invalid\` (-5%) across two runs, but the same dip reproduces on branches that don't touch predicate-mode code at all. The 26.80M baseline reading for that variant is an outlier; the honest floor is ~25.5M, where we land.

## Test plan

- [x] \`pnpm test\` — 523/523 pass
- [x] \`cd conformance && pnpm suite\` — 1270/16/4 (unchanged from main)
- [x] \`pnpm tsx performance/dump-compiled.ts\` — verified the generated shape: \`let errors = null\` at top, \`(errors ??= []).push(…)\` at each site, \`if (errors === null) return null;\` before the tail wrapErrors call

## Maintainability

Three localised touchpoints:

- \`buildFunctionBody\` (compiler.ts): two lines change (init + tail null-check)
- \`emitPushStatement\` + the lift-path push (context.ts): from \`X.push(e)\` to \`(X ??= []).push(e)\`
- tryInline error-wrap bookkeeping: capture \`_start\` handles null; wrap gate checks \`errors !== null\` first

Keyword authors emit through \`ctx.emitError(kind, expr)\` which encapsulates the lazy allocation — no per-keyword churn.