### PR TITLE
perf(schema): lazy path — skip push/pop on happy path (#39)

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -319,13 +319,23 @@ export function createLeafError(
   path: PathSegment[],
   message: string,
   params: Record<string, unknown> = {},
+  extraSegment?: PathSegment,
 ): ValidationError {
   // Children: a shared frozen empty array rather than a fresh `[]` on
   // every leaf. Saves one allocation per failure on hot invalid paths.
   // Leaves never accumulate children; the type is
   // `ValidationError[]` (mutable) for branch uses, but readers should
   // treat a leaf's array as read-only — which is the existing contract.
-  return { code, path: [...path], message, params, children: EMPTY_CHILDREN };
+  //
+  // The `extraSegment` tail parameter lets generated validators append
+  // one segment (a missing property name, an array index) without
+  // allocating an intermediate array at the call site: we pass the
+  // base `path` plus the extra segment and build the final path here
+  // in one allocation. Absent the extra segment, we snapshot `path`
+  // so mutation by the caller after the error is returned can't
+  // corrupt it.
+  const finalPath = extraSegment !== undefined ? [...path, extraSegment] : [...path];
+  return { code, path: finalPath, message, params, children: EMPTY_CHILDREN };
 }
 
 // Shared frozen empty array so leaf errors reuse one `children` value
@@ -366,9 +376,11 @@ export function createBranchError(
   message: string,
   children: ValidationError[],
   params: Record<string, unknown> = {},
+  extraSegment?: PathSegment,
 ): ValidationError {
-  // See note in {@link createError} on snapshotting.
-  return { code, path: [...path], message, params, children };
+  // See note in {@link createLeafError} on `extraSegment`.
+  const finalPath = extraSegment !== undefined ? [...path, extraSegment] : [...path];
+  return { code, path: finalPath, message, params, children };
 }
 
 /**

--- a/packages/schema/src/keywords/composition.ts
+++ b/packages/schema/src/keywords/composition.ts
@@ -421,13 +421,13 @@ export const dependenciesKeyword: KeywordDefinition = {
               for (const prop of entry) {
                 const propLit = quoteString(prop);
                 gi.if(`!Object.prototype.hasOwnProperty.call(${ctx.data}, ${propLit})`, () => {
-                  ctx.withPathSegment(propLit, () => {
+                  ctx.withPathSegment(propLit, (base, seg) => {
                     ctx.emitError(
                       "leaf",
                       `${NAMES.DEPS}.createLeafError(` +
-                        `${quoteString("dependencies")}, ${ctx.path}, ` +
+                        `${quoteString("dependencies")}, ${base}, ` +
                         `\`property "${prop}" is required when "${trigger}" is present\`, ` +
-                        `{ trigger: ${triggerLit}, missing: ${propLit} })`,
+                        `{ trigger: ${triggerLit}, missing: ${propLit} }, ${seg})`,
                     );
                   });
                 });
@@ -474,13 +474,13 @@ export const dependentRequiredKeyword: KeywordDefinition = {
             for (const prop of required) {
               const propLit = quoteString(prop);
               gi.if(`!Object.prototype.hasOwnProperty.call(${ctx.data}, ${propLit})`, () => {
-                ctx.withPathSegment(propLit, () => {
+                ctx.withPathSegment(propLit, (base, seg) => {
                   ctx.emitError(
                     "leaf",
                     `${NAMES.DEPS}.createLeafError(` +
-                      `${quoteString("dependentRequired")}, ${ctx.path}, ` +
+                      `${quoteString("dependentRequired")}, ${base}, ` +
                       `\`property "${prop}" is required when "${trigger}" is present\`, ` +
-                      `{ trigger: ${triggerLit}, missing: ${propLit} })`,
+                      `{ trigger: ${triggerLit}, missing: ${propLit} }, ${seg})`,
                   );
                 });
               });

--- a/packages/schema/src/keywords/context.ts
+++ b/packages/schema/src/keywords/context.ts
@@ -1,5 +1,5 @@
 import type { SchemaObject, SchemaOrBoolean } from "@oav/core";
-import { NAMES, type CodeGen } from "../codegen/index.js";
+import { NAMES, pathJoinExpr, rawExpr, type CodeGen } from "../codegen/index.js";
 import type {
   ErrorKind,
   KeywordCompileContext,
@@ -205,20 +205,18 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     if (stmt !== "") inputs.gen.line(stmt);
   };
 
-  // Push a path segment onto the shared mutable path array, run `body`,
-  // then pop. Runtime helpers (`createError`, `createLeafError`,
-  // `createBranchError`) snapshot `path` at error-creation time, so
-  // errors emitted inside `body` keep the correct path after the pop.
-  // Predicate mode never emits errors, so the push/pop pair becomes
-  // dead work — skip it entirely.
-  const withPathSegment = (segmentExpr: string, body: () => void): void => {
-    if (predicate) {
-      body();
-      return;
-    }
-    inputs.gen.line(`${inputs.path}.push(${segmentExpr});`);
-    body();
-    inputs.gen.line(`${inputs.path}.pop();`);
+  // No runtime mutation — on the happy path the segment is invisible.
+  // `body` receives the base path and the segment separately so error
+  // constructors can pass them as distinct arguments to
+  // `createLeafError` / `createBranchError` (the runtime allocates the
+  // extended path array once, inside the helper, on the error path).
+  // Predicate mode doesn't emit errors, so the values go unused in
+  // that mode — we pass them anyway for a stable API.
+  const withPathSegment = (
+    segmentExpr: string,
+    body: (basePath: string, segExpr: string) => void,
+  ): void => {
+    body(inputs.path, segmentExpr);
   };
 
   const inlineDepth = inputs.inlineDepth ?? 0;
@@ -238,7 +236,8 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
    *   wrap the new errors in a "schema" branch to match the tree
    *   shape of the would-be function's `wrapErrors` return value.
    */
-  const tryInline = (schema: SchemaObject, dataExpr: string): boolean => {
+  const tryInline = (schema: SchemaObject, dataExpr: string, pathOverride?: string): boolean => {
+    const path = pathOverride ?? inputs.path;
     if (inputs.byKeyword === undefined) return false;
     const allKeys = Object.keys(schema);
     const validationKeys: string[] = [];
@@ -265,7 +264,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
         schema: (schema as Record<string, unknown>)[k],
         parentSchema: schema,
         data: dataExpr,
-        path: inputs.path,
+        path,
         errors: inputs.errors,
         compileSubschema: inputs.compileSubschema,
         resolveRef: inputs.resolveRef,
@@ -326,7 +325,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
         schema: (schema as Record<string, unknown>)[kwName],
         parentSchema: schema,
         data: dataExpr,
-        path: inputs.path,
+        path,
         errors: inputs.errors,
         compileSubschema: inputs.compileSubschema,
         resolveRef: inputs.resolveRef,
@@ -353,7 +352,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
           inputs.gen.const(wrappedVar, `${inputs.errors}.splice(${startVar})`);
           inputs.gen.line(
             `${inputs.errors}.push(${NAMES.DEPS}.createBranchError(` +
-              `"schema", ${inputs.path}, "schema validation failed", ${wrappedVar}));`,
+              `"schema", ${path}, "schema validation failed", ${wrappedVar}));`,
           );
         },
       );
@@ -367,42 +366,51 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     dataExpr: string,
     options?: ValidateSubschemaOptions,
   ): void => {
-    const emitInner = (): void => {
-      if (schema === true) return;
-      if (schema === false) {
-        if (predicate) {
-          inputs.gen.line("return false;");
-          return;
-        }
-        const falseErr =
-          `${NAMES.DEPS}.createLeafError("false", ${inputs.path}, ` +
-          `"schema is false, nothing is valid")`;
-        emitError("leaf", falseErr);
-        return;
-      }
-      if (tryInline(schema, dataExpr)) return;
-      // Fall back: compile subschema to a named function and call it.
-      // In predicate mode the sub returns boolean and takes no path;
-      // any failure short-circuits the caller with `return false;`.
-      const fn = inputs.compileSubschema(schema);
-      if (predicate) {
-        inputs.gen.line(`if (!${fn}(${dataExpr})) return false;`);
-        return;
-      }
-      // Tree mode: call with the SHARED path. The sub-function's error
-      // emissions snapshot the path before committing it to
-      // ValidationError, so the shared-array reuse is safe.
-      const errVar = inputs.gen.scope.name("e");
-      inputs.gen.const(errVar, `${fn}(${dataExpr}, ${inputs.path})`);
-      inputs.gen.if(`${errVar} !== null`, () => {
-        emitError("lift", errVar);
-      });
-    };
     const segment = options?.segment;
-    if (segment === undefined) {
-      emitInner();
-    } else {
-      withPathSegment(segment, emitInner);
+    // Inline path uses a lazy extended-path expression — only evaluated
+    // when an error actually fires. Function-call fallback keeps the
+    // classic push/pop-then-call shape because the callee reads the
+    // (mutated) shared array directly, avoiding a per-call array
+    // allocation for the extended path.
+    if (schema === true) return;
+    if (schema === false) {
+      if (predicate) {
+        inputs.gen.line("return false;");
+        return;
+      }
+      // Use the runtime's `extraSegment` parameter so the extended
+      // path array is built once inside createLeafError rather than
+      // pre-materialized at the call site and then re-snapshotted.
+      const falseErr =
+        segment !== undefined
+          ? `${NAMES.DEPS}.createLeafError("false", ${inputs.path}, ` +
+            `"schema is false, nothing is valid", {}, ${segment})`
+          : `${NAMES.DEPS}.createLeafError("false", ${inputs.path}, ` +
+            `"schema is false, nothing is valid")`;
+      emitError("leaf", falseErr);
+      return;
+    }
+    const inlineExtPath =
+      segment !== undefined ? pathJoinExpr(inputs.path, [rawExpr(segment)]) : undefined;
+    if (tryInline(schema, dataExpr, inlineExtPath)) return;
+    // Function-call fallback — push/pop around the call so the callee
+    // sees the extended path via the shared array (no per-call
+    // allocation just to pass a path).
+    const fn = inputs.compileSubschema(schema);
+    if (predicate) {
+      inputs.gen.line(`if (!${fn}(${dataExpr})) return false;`);
+      return;
+    }
+    if (segment !== undefined) {
+      inputs.gen.line(`${inputs.path}.push(${segment});`);
+    }
+    const errVar = inputs.gen.scope.name("e");
+    inputs.gen.const(errVar, `${fn}(${dataExpr}, ${inputs.path})`);
+    inputs.gen.if(`${errVar} !== null`, () => {
+      emitError("lift", errVar);
+    });
+    if (segment !== undefined) {
+      inputs.gen.line(`${inputs.path}.pop();`);
     }
   };
 

--- a/packages/schema/src/keywords/discriminator.ts
+++ b/packages/schema/src/keywords/discriminator.ts
@@ -71,13 +71,13 @@ export const discriminatorKeyword: KeywordDefinition = {
               g.line("return false;");
               return;
             }
-            ctx.withPathSegment(propLit, () => {
+            ctx.withPathSegment(propLit, (base, seg) => {
               ctx.emitError(
                 "leaf",
                 `${NAMES.DEPS}.createLeafError(` +
-                  `${quoteString("discriminator")}, ${ctx.path}, ` +
+                  `${quoteString("discriminator")}, ${base}, ` +
                   `\`discriminator property "${propertyName}" must be a string\`, ` +
-                  `{ propertyName: ${propLit} })`,
+                  `{ propertyName: ${propLit} }, ${seg})`,
               );
             });
           },
@@ -108,14 +108,14 @@ export const discriminatorKeyword: KeywordDefinition = {
             gi.line(`switch (${discVal}) {`);
             gi.line(switchLines);
             gi.line(`      default: {`);
-            ctx.withPathSegment(propLit, () => {
+            ctx.withPathSegment(propLit, (base, seg) => {
               gi.line(
                 ctx.errorStatement(
                   "leaf",
                   `${NAMES.DEPS}.createLeafError(` +
-                    `${quoteString("discriminator")}, ${ctx.path}, ` +
+                    `${quoteString("discriminator")}, ${base}, ` +
                     `"discriminator value does not match any branch", ` +
-                    `{ propertyName: ${propLit}, value: ${discVal} })`,
+                    `{ propertyName: ${propLit}, value: ${discVal} }, ${seg})`,
                 ),
               );
             });

--- a/packages/schema/src/keywords/items.ts
+++ b/packages/schema/src/keywords/items.ts
@@ -53,12 +53,12 @@ export const itemsKeyword: KeywordDefinition = {
           g.line(`${ctx.evaluatedItemsVar}.add(${i});`);
         }
       } else if (subSchema === false) {
-        ctx.withPathSegment(i, () => {
+        ctx.withPathSegment(i, (base, seg) => {
           ctx.emitError(
             "leaf",
             `${NAMES.DEPS}.createLeafError(` +
-              `${quoteString("items")}, ${ctx.path}, ` +
-              `"no additional items allowed", {})`,
+              `${quoteString("items")}, ${base}, ` +
+              `"no additional items allowed", {}, ${seg})`,
           );
         });
       } else {
@@ -119,9 +119,12 @@ export const containsKeyword: KeywordDefinition = {
       g.const(matchedIdx, "[]");
       g.forRange(i, `${ctx.data}.length`, (gi) => {
         const errVar = gi.scope.name("e");
-        ctx.withPathSegment(i, () => {
-          gi.const(errVar, `${fn}(${ctx.data}[${i}], ${ctx.path})`);
-        });
+        // Function-call subschema: push/pop around the call so the
+        // callee sees the extended path via the shared array (avoids
+        // per-call allocation of `[...path, i]`).
+        gi.line(`${ctx.path}.push(${i});`);
+        gi.const(errVar, `${fn}(${ctx.data}[${i}], ${ctx.path})`);
+        gi.line(`${ctx.path}.pop();`);
         gi.if(`${errVar} === null`, (gii) => {
           gii.line(`${count} += 1;`);
           gii.line(`${matchedIdx}.push(${i});`);

--- a/packages/schema/src/keywords/object-validation.ts
+++ b/packages/schema/src/keywords/object-validation.ts
@@ -86,13 +86,13 @@ export const requiredKeyword: KeywordDefinition = {
       });
       g.if(`${missingVar}.length > 0`, (gi) => {
         gi.forOf("_m", missingVar, () => {
-          ctx.withPathSegment("_m", () => {
+          ctx.withPathSegment("_m", (base, seg) => {
             ctx.emitError(
               "leaf",
               `${NAMES.DEPS}.createLeafError(` +
-                `${quoteString("required")}, ${ctx.path}, ` +
+                `${quoteString("required")}, ${base}, ` +
                 `\`must have required property "\${_m}"\`, ` +
-                `{ missing: _m })`,
+                `{ missing: _m }, ${seg})`,
             );
           });
           ctx.emitBudgetBreak();

--- a/packages/schema/src/keywords/properties.ts
+++ b/packages/schema/src/keywords/properties.ts
@@ -116,13 +116,13 @@ export const additionalPropertiesKeyword: KeywordDefinition = {
           return;
         }
         if (subSchema === false) {
-          ctx.withPathSegment(key, () => {
+          ctx.withPathSegment(key, (base, seg) => {
             ctx.emitError(
               "leaf",
               `${NAMES.DEPS}.createLeafError(` +
-                `${quoteString("additionalProperties")}, ${ctx.path}, ` +
+                `${quoteString("additionalProperties")}, ${base}, ` +
                 `\`additional property "\${${key}}" is not allowed\`, ` +
-                `{ unexpected: ${key} })`,
+                `{ unexpected: ${key} }, ${seg})`,
             );
           });
           ctx.emitBudgetBreak();

--- a/packages/schema/src/keywords/types.ts
+++ b/packages/schema/src/keywords/types.ts
@@ -166,16 +166,20 @@ export interface KeywordCompileContext {
     options?: ValidateSubschemaOptions,
   ): void;
   /**
-   * Emit `path.push(segmentExpr); <body>; path.pop();` into the current
-   * code generator. Use when a keyword needs to emit errors whose path
-   * includes an extra segment (e.g. `required` reports a missing
-   * property at `[...path, missingKey]`).
+   * Run `body` in a scope where the current path logically has an
+   * extra segment appended. `body` receives two JS expression strings:
+   * `basePath` (equivalent to `ctx.path`) and `segExpr` (the extra
+   * segment). Pass them as the 4th and 5th arguments of
+   * `deps.createLeafError(code, basePath, message, params, segExpr)`
+   * — the runtime helper allocates the extended path array once,
+   * avoiding the double-copy that a pre-materialized `[...path, seg]`
+   * would trigger.
    *
-   * Every runtime error-creation helper snapshots `path` before
-   * committing it to the `ValidationError`, so errors emitted inside
-   * `body` retain the correct path even after the `pop`.
+   * Implementation: no runtime mutation on the happy path. The
+   * extended path is only materialized when an error actually fires
+   * (inside the error helper).
    */
-  withPathSegment(segmentExpr: string, body: () => void): void;
+  withPathSegment(segmentExpr: string, body: (basePath: string, segExpr: string) => void): void;
   /**
    * Emit a `const <name> = <expr>;` declaration at the top of the
    * generated module (outside every validator function). Returns the

--- a/packages/schema/src/keywords/unevaluated.ts
+++ b/packages/schema/src/keywords/unevaluated.ts
@@ -34,16 +34,16 @@ export const unevaluatedPropertiesKeyword: KeywordDefinition = {
           return;
         }
         if (sub === false) {
-          ctx.withPathSegment(key, () => {
+          ctx.withPathSegment(key, (base, seg) => {
             // Offending key name lives in params.unexpected; dropping
             // it from the message turns the emitted string into a
             // constant literal.
             ctx.emitError(
               "leaf",
               `${NAMES.DEPS}.createLeafError(` +
-                `${quoteString("unevaluatedProperties")}, ${ctx.path}, ` +
+                `${quoteString("unevaluatedProperties")}, ${base}, ` +
                 `"property is not evaluated by the schema", ` +
-                `{ unexpected: ${key} })`,
+                `{ unexpected: ${key} }, ${seg})`,
             );
           });
           ctx.emitBudgetBreak();
@@ -82,13 +82,13 @@ export const unevaluatedItemsKeyword: KeywordDefinition = {
           return;
         }
         if (sub === false) {
-          ctx.withPathSegment(i, () => {
+          ctx.withPathSegment(i, (base, seg) => {
             ctx.emitError(
               "leaf",
               `${NAMES.DEPS}.createLeafError(` +
-                `${quoteString("unevaluatedItems")}, ${ctx.path}, ` +
+                `${quoteString("unevaluatedItems")}, ${base}, ` +
                 `"item is not evaluated by the schema", ` +
-                `{ index: ${i} })`,
+                `{ index: ${i} }, ${seg})`,
             );
           });
           ctx.emitBudgetBreak();

--- a/packages/schema/test/path-leak-probe.test.ts
+++ b/packages/schema/test/path-leak-probe.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { compileSchema, jsonSchemaDialect } from "../src/index.js";
+
+type Err = { code: string; path: readonly (string | number)[]; children?: readonly Err[] };
+
+function walkLeaves(err: Err, acc: Err[] = []): Err[] {
+  if ((err.children ?? []).length === 0) acc.push(err);
+  for (const c of err.children ?? []) walkLeaves(c, acc);
+  return acc;
+}
+
+describe("error paths survive path-array reuse", () => {
+  // Regression probe for the lazy-path optimisation. Generated
+  // validators traverse a shared mutable path array (push/pop around
+  // function-call boundaries); errors constructed inside a callee
+  // must snapshot the path so the caller's subsequent pop doesn't
+  // silently rewrite the error's .path.
+  it("a type error inside items[0] stays at [0] after items[1] runs", () => {
+    const { validate } = compileSchema(
+      {
+        type: "array",
+        items: {
+          type: "object",
+          properties: { x: { type: "number" } },
+          required: ["x"],
+        },
+      },
+      { dialect: jsonSchemaDialect },
+    );
+    const r = validate(["not-an-object", { x: "bad" }]);
+    if (r.valid) throw new Error("unexpected valid");
+    const leaves = walkLeaves(r.error! as Err);
+    const typeErr = leaves.find((e) => e.code === "type" && e.path.length > 0);
+    expect(typeErr?.path).toEqual([0]);
+  });
+});


### PR DESCRIPTION
## Summary

Generated validators no longer mutate the shared \`path\` array at every property descent. On the happy path, nothing touches it at all; errors materialize the extended path only when they fire.

Closes #39. Part of #39's intent — the remaining regression on tryInline's inline-with-segment case is tracked as a follow-up (see below).

## What changed

1. \`ctx.withPathSegment(seg, body)\` no longer emits \`path.push\` / \`path.pop\`. The body callback now receives \`(basePath, segExpr)\` as separate expression strings. Leaf-error callers pass them as the 4th and 5th args of \`deps.createLeafError(code, basePath, message, params, segExpr)\` — the runtime helper allocates the final path once.
2. \`createLeafError\` / \`createBranchError\` gain an optional \`extraSegment\` parameter. Equivalent to the old internal \`[...path]\` snapshot plus one appended segment, without the call-site \`[...path, seg]\` allocation that would otherwise double-allocate.
3. \`validateSubschema\` handles segments without \`withPathSegment\`: it threads an extended-path expression into \`tryInline\` for the inline case, and emits \`path.push(seg); ...; path.pop()\` directly around the function-call fallback. The push/pop on the function-call path is preserved on purpose — the callee reads the shared array directly, and lazy semantics would cost a per-call array allocation.
4. The 10 keyword call sites of \`withPathSegment\` updated to the new 2-arg form:
   - \`required\`, \`additionalProperties\` (\`false\`), \`items\` (\`false\`), \`dependencies\`, \`dependentRequired\`, both \`discriminator\` branches, \`unevaluatedProperties\`, \`unevaluatedItems\`
5. \`items\`'s \`contains\` sub-function call switches from \`withPathSegment\` to an explicit \`push\` / call / \`pop\` pattern, since the callee reads the shared path.
6. New regression test \`test/path-leak-probe.test.ts\` catches the class of bug an earlier iteration introduced (skipping the defensive snapshot silently rewrote errors' \`.path\` after the caller popped).

## Benchmarks

\`pnpm bench:long\` vs post-#48 baseline, oav-only:

| shape | variant | baseline | branch | delta |
| --- | --- | --- | --- | --- |
| **array-heavy** | oav valid | 330K | 402K | **+22%** |
| **array-heavy** | oav invalid | 327K | 394K | **+20%** |
| **petstore** | oav valid | 10.25M | 11.08M | **+8%** |
| **petstore** | oav invalid | 6.81M | 7.38M | **+8%** |
| petstore | oav-pred valid | 11.62M | 12.41M | +7% |
| tree | oav valid | 22.77M | 23.91M | +5% |
| tree | oav invalid | 16.50M | 14.92M | **-10%** |
| composition | oav valid | 4.28M | 3.98M | -7% |
| composition | oav invalid | 3.47M | 3.25M | -6% |
| compile (every shape) | — | — | — | flat (±3%) |

array-heavy and petstore are the highest-value workloads (the shapes real APIs actually have). The regressions concentrate on error-heavy speculative paths (oneOf branches all failing; recursive type errors in tree) — a known remaining inefficiency.

## Follow-up: inline-with-segment double-allocation

The regressions on \`composition\` and \`tree oav invalid\` come from \`tryInline\` threading a pre-built \`[...path, seg]\` expression as \`ctx.path\` for inlined keywords. Those keywords call \`createLeafError(code, ctx.path, …)\` with the single-argument form, which still does an internal \`[...path]\` snapshot — so every leaf error inside an inlined segmented subschema pays one extra allocation.

Fix would refactor the keyword context to carry \`basePath\` and a pending-segment stack separately, so inlined keywords can use the \`extraSegment\` form. Non-trivial change, ~100 lines in \`context.ts\` plus touching every leaf keyword that builds an error expression. Deferred, tracking as a new issue.

## Test plan

- [x] \`pnpm test\` — 524/524 pass (new regression test added)
- [x] \`cd conformance && pnpm suite\` — 1270/16/4 (unchanged from main)
- [x] \`pnpm tsx performance/dump-compiled.ts\` — verified generated shape on petstore: no \`path.push\` / \`path.pop\` for property descents; each leaf error passes \`(path, … , seg)\`
- [x] \`pnpm bench:long\` — numbers above, consistent across two runs