### PR TITLE
perf(schema): elide pure-$ref wrapper functions (#40)

### DIFF
--- a/packages/schema/src/compiler/compiler.ts
+++ b/packages/schema/src/compiler/compiler.ts
@@ -408,9 +408,28 @@ function compileValidator(schema: SchemaOrBoolean, state: CompileState): string 
   const cached = state.compiledFor.get(schema);
   if (cached !== undefined) return cached;
 
+  // Reserve a name up front so cyclic `$ref`s that point back to this
+  // schema hit the cache below and emit a normal recursive call.
   const name = `validate_${state.nextFn}`;
   state.nextFn += 1;
   state.compiledFor.set(schema, name);
+
+  // Pure-`$ref` elision: a schema whose only non-annotation keyword is
+  // `$ref` compiles to a pass-through wrapper today (allocates a
+  // scratch errors array, calls the target, propagates the result).
+  // Nothing structural comes out of the wrapper — inlining it away
+  // saves one function call per descent on every composition branch /
+  // items call / properties subschema that uses `$ref`. When the ref
+  // resolves back to this schema (self-recursion), alias returns the
+  // placeholder name we just reserved, so we fall through and emit a
+  // real wrapper function.
+  if (isPureRefSchema(schema, state)) {
+    const targetName = resolvePureRefTarget(schema as SchemaObject, state);
+    if (targetName !== null && targetName !== name) {
+      state.compiledFor.set(schema, targetName);
+      return targetName;
+    }
+  }
 
   const body = buildFunctionBody(schema, state);
   // Predicate mode drops the `path` parameter: error expressions
@@ -422,6 +441,44 @@ function compileValidator(schema: SchemaOrBoolean, state: CompileState): string 
     : `${NAMES.DATA}, ${NAMES.PATH}, ${NAMES.OUT_EVAL_PROPS}, ${NAMES.OUT_EVAL_ITEMS}`;
   state.functionBodies.push(`function ${name}(${params}) {\n${body}\n}`);
   return name;
+}
+
+/**
+ * True when `schema` is an object schema whose only non-annotation
+ * keyword is `$ref` (plus possibly `$id`, `$schema`, `$comment`,
+ * `title`, `description`, `$defs`, anchors). Such schemas compile to
+ * a pass-through wrapper that's equivalent to calling the target
+ * validator directly.
+ *
+ * Boolean schemas are excluded (not object-valued); schemas with any
+ * other validation keyword (even a second applicator) are excluded —
+ * those need a full compile because the sibling keywords contribute
+ * to the result.
+ */
+function isPureRefSchema(schema: SchemaOrBoolean, state: CompileState): boolean {
+  if (typeof schema !== "object" || schema === null || Array.isArray(schema)) return false;
+  if (typeof (schema as Record<string, unknown>).$ref !== "string") return false;
+  for (const key of Object.keys(schema)) {
+    if (key === "$ref") continue;
+    const kw = state.byKeyword.get(key);
+    if (kw?.annotation === true) continue;
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Resolve a pure-`$ref` schema's target to a function name.
+ * Mirrors the resolution logic in {@link compileSchemaKeywords}'s
+ * `resolveRefToFunction` but reachable from {@link compileValidator}
+ * before the schema's keywords are walked.
+ */
+function resolvePureRefTarget(schema: SchemaObject, state: CompileState): string | null {
+  const ref = (schema as Record<string, unknown>).$ref;
+  if (typeof ref !== "string") return null;
+  const currentBaseUri = state.graph.schemaBaseUri.get(schema) ?? state.graph.baseUri;
+  const target = state.refResolver.resolve(ref, currentBaseUri);
+  return compileValidator(target, state);
 }
 
 /**


### PR DESCRIPTION
## Summary

A schema whose only non-annotation keyword is \`\$ref\` used to compile to its own wrapper function — one that did nothing but call the referenced validator and propagate the result. Composition branches (\`oneOf: [{ \$ref: "#/\$defs/Cat" }, …]\`) and recursive schemas (\`items: { \$ref: "#/\$defs/Node" }\`) were going through one extra function call per descent for no structural benefit.

\`compileValidator\` now detects pure-\`\$ref\` schemas up front and aliases the schema's cache entry directly to the target validator. Callers reach the real validator in one hop.

Self-referential pure-\`\$ref\` schemas (the ref resolves back to the same schema node) fall through to the existing emission path — no alias, real recursive call stays in place.

Closes #40.

## What changed

- \`compileValidator\` (in \`packages/schema/src/compiler/compiler.ts\`) gains a short-circuit branch: if the schema is pure-\`\$ref\` and the target resolves to a different schema, alias into \`state.compiledFor\` and return the target's name without emitting a wrapper function body.
- Two helper functions (\`isPureRefSchema\`, \`resolvePureRefTarget\`) added nearby. Both internal.

## Before / after (composition schema)

**Before**: 8 functions (\`validate_0\` through \`validate_7\`). Each oneOf branch \`{ \$ref: "#/\$defs/Cat" }\` compiled to \`validate_2\` which called \`validate_3\` (the Cat schema body). Same pattern for Dog / Fish.

**After**: 5 functions. The Cat/Dog/Fish bodies are called directly from the oneOf dispatcher.

Similar reduction for the tree schema (3 → 2 functions).

## Benchmarks

\`pnpm bench:long\` vs post-#49 baseline, two runs averaged:

| shape | variant | baseline | branch | delta |
| --- | --- | --- | --- | --- |
| **tree** | compile | 33K | 45K | **+38%** |
| **composition** | compile | 15K | 17K | **+15%** |
| **tree** | oav invalid | 14.39M | 15.81M | **+10%** |
| **composition** | oav invalid | 3.28M | 3.52M | **+7%** |
| **composition** | oav-pred invalid | 14.50M | 15.66M | **+8%** |
| composition | oav valid | 4.00M | 4.20M | +5% |
| petstore / array-heavy / tiny | — | — | — | flat (no \`\$ref\` use at root) |

Composition oav-pred valid dipped 2-4% across both runs, but the non-predicate variants of the same schema improved; likely a V8 IC reshuffle on a path that's already near ajv parity. Net clearly positive on every \`\$ref\`-using benchmark.

## Test plan

- [x] \`pnpm test\` — 524/524 pass
- [x] \`cd conformance && pnpm suite\` — 1270/16/4 (unchanged from main)
- [x] \`pnpm tsx performance/dump-compiled.ts\` — verified composition drops from 8 → 5 functions, tree from 3 → 2. The new \`validate\` bottom-of-module for the tree schema calls \`validate_1\` directly (the old \`validate_0\` wrapper is gone).

## Followups

- Second half of #40's scope (inline applicator bodies under a size budget) deferred. That's a separate compile-time analysis; #40's \`\$ref\`-wrapper elision is the bulk of the structural win on composition.
- #50 (inline-tryInline segment-plumbing refactor) still recommended to recover the small composition-oav-pred-valid dip and to close the last wins on error-heavy inlined paths.