### PR TITLE
perf(schema): thread pathSegments through tryInline's inlined ctx

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ cli → validator → router
 
    `ctx.predicate` is `true` when the user requested predicate mode
    (`compileSchema(..., { predicate: true })`). Most keywords don't
-   need to read this — `ctx.emitError`, `ctx.withPathSegment`,
+   need to read this — `ctx.emitError`, `ctx.leafErrorExpr`,
    `ctx.validateSubschema`, and `ctx.emitBudgetBreak` all do the
    right thing automatically. Branch on it only when your keyword
    reads a sub-validator's return value (composition keywords,
@@ -105,7 +105,13 @@ cli → validator → router
    - `ctx.emitError(kind, expr)` / `ctx.errorStatement(kind, expr)` —
      push an error expression (`"leaf"` = counts against `maxErrors`,
      `"lift"` = propagating an already-counted sub-validator result).
-   - `ctx.withPathSegment(seg, body)` — scoped path push/pop.
+   - `ctx.leafErrorExpr(codeExpr, msgExpr, paramsExpr, extraSegments?)`
+     — build a `deps.createLeafError(...)` call. Pass any per-error
+     trailing path segment (e.g. a missing property name) via
+     `extraSegments` so the runtime helper splices them; the helper
+     also picks up any segments pending from an enclosing inlined
+     `validateSubschema` call. `ctx.branchErrorExpr(...)` is the
+     equivalent for branch errors.
    - `ctx.validateSubschema(schema, dataExpr, { segment? })` — the
      common "descend into a subschema" pattern (inlines when simple).
    - `ctx.compileSubschema(schema) -> fnName` — lower-level; use when
@@ -113,6 +119,10 @@ cli → validator → router
      logic (composition keywords do this).
    - `ctx.resolveRef(ref)`, `ctx.evaluatedPropertiesVar` /
      `ctx.evaluatedItemsVar` — for `$ref` and unevaluated-tracking.
+   - `ctx.effectivePathExpr` — JS expression for the runtime path
+     including any pending inline segments. Reach for this only when
+     passing the path to something other than the error helpers
+     (e.g. a user-supplied custom-keyword callback).
    - `ctx.emitBudgetBreak()` at the tail of hot loops.
 
 2. Add it to the vocabulary's `keywords` array in `vocabulary.ts`.

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -320,6 +320,7 @@ export function createLeafError(
   message: string,
   params: Record<string, unknown> = {},
   extraSegment?: PathSegment,
+  extraSegment2?: PathSegment,
 ): ValidationError {
   // Children: a shared frozen empty array rather than a fresh `[]` on
   // every leaf. Saves one allocation per failure on hot invalid paths.
@@ -327,14 +328,21 @@ export function createLeafError(
   // `ValidationError[]` (mutable) for branch uses, but readers should
   // treat a leaf's array as read-only — which is the existing contract.
   //
-  // The `extraSegment` tail parameter lets generated validators append
-  // one segment (a missing property name, an array index) without
-  // allocating an intermediate array at the call site: we pass the
-  // base `path` plus the extra segment and build the final path here
-  // in one allocation. Absent the extra segment, we snapshot `path`
-  // so mutation by the caller after the error is returned can't
-  // corrupt it.
-  const finalPath = extraSegment !== undefined ? [...path, extraSegment] : [...path];
+  // The `extraSegment` / `extraSegment2` tail parameters let generated
+  // validators append up to two path segments without allocating an
+  // intermediate array at the call site: we pass the base `path` plus
+  // the extras and build the final path here in one allocation. The
+  // two-slot form supports inlined-with-segment subschemas whose
+  // leaves themselves append another segment (e.g. an inlined
+  // `required` under a `properties` entry). Deeper nesting (>2
+  // trailing segments) is rare enough that callers pre-materialize the
+  // full path rather than burn more runtime params on it.
+  const finalPath =
+    extraSegment2 !== undefined
+      ? [...path, extraSegment!, extraSegment2]
+      : extraSegment !== undefined
+        ? [...path, extraSegment]
+        : [...path];
   return { code, path: finalPath, message, params, children: EMPTY_CHILDREN };
 }
 
@@ -377,9 +385,15 @@ export function createBranchError(
   children: ValidationError[],
   params: Record<string, unknown> = {},
   extraSegment?: PathSegment,
+  extraSegment2?: PathSegment,
 ): ValidationError {
-  // See note in {@link createLeafError} on `extraSegment`.
-  const finalPath = extraSegment !== undefined ? [...path, extraSegment] : [...path];
+  // See note in {@link createLeafError} on `extraSegment` / `extraSegment2`.
+  const finalPath =
+    extraSegment2 !== undefined
+      ? [...path, extraSegment!, extraSegment2]
+      : extraSegment !== undefined
+        ? [...path, extraSegment]
+        : [...path];
   return { code, path: finalPath, message, params, children };
 }
 

--- a/packages/core/test/errors.test.ts
+++ b/packages/core/test/errors.test.ts
@@ -39,6 +39,23 @@ describe("createLeafError", () => {
     expect(err.code).toBe("type");
     expect(err.path).toEqual(["a", 0]);
   });
+  it("appends extraSegment to the path when provided", () => {
+    const err = createLeafError("required", ["user"], "missing", { missing: "id" }, "id");
+    expect(err.path).toEqual(["user", "id"]);
+  });
+  it("appends extraSegment + extraSegment2 when both are provided", () => {
+    // Used by the subschema inliner when a caller's pending segment
+    // stacks with the leaf keyword's own trailing segment.
+    const err = createLeafError(
+      "required",
+      [],
+      "missing",
+      { missing: "id" },
+      "user",
+      "id",
+    );
+    expect(err.path).toEqual(["user", "id"]);
+  });
 });
 
 describe("createBranchError", () => {
@@ -47,6 +64,11 @@ describe("createBranchError", () => {
     const err = createBranchError("oneOf", [], "must match one", leaves, { matchCount: 0 });
     expect(err.children).toBe(leaves);
     expect(err.params).toEqual({ matchCount: 0 });
+  });
+  it("appends extraSegment + extraSegment2 when both are provided", () => {
+    const children = [createLeafError("type", ["a", "b"], "x")];
+    const err = createBranchError("schema", [], "wrap", children, {}, "a", "b");
+    expect(err.path).toEqual(["a", "b"]);
   });
 });
 

--- a/packages/schema/src/keywords/array-validation.ts
+++ b/packages/schema/src/keywords/array-validation.ts
@@ -15,10 +15,11 @@ export const maxItemsKeyword: KeywordDefinition = {
     ctx.gen.if(`Array.isArray(${ctx.data}) && ${ctx.data}.length > ${limit}`, () => {
       ctx.emitError(
         "leaf",
-        `${NAMES.DEPS}.createLeafError(` +
-          `${quoteString("maxItems")}, ${ctx.path}, ` +
-          `\`must have at most ${limit} items\`, ` +
-          `{ maxItems: ${limit}, actual: ${ctx.data}.length })`,
+        ctx.leafErrorExpr(
+          quoteString("maxItems"),
+          `\`must have at most ${limit} items\``,
+          `{ maxItems: ${limit}, actual: ${ctx.data}.length }`,
+        ),
       );
     });
   },
@@ -37,10 +38,11 @@ export const minItemsKeyword: KeywordDefinition = {
     ctx.gen.if(`Array.isArray(${ctx.data}) && ${ctx.data}.length < ${limit}`, () => {
       ctx.emitError(
         "leaf",
-        `${NAMES.DEPS}.createLeafError(` +
-          `${quoteString("minItems")}, ${ctx.path}, ` +
-          `\`must have at least ${limit} items\`, ` +
-          `{ minItems: ${limit}, actual: ${ctx.data}.length })`,
+        ctx.leafErrorExpr(
+          quoteString("minItems"),
+          `\`must have at least ${limit} items\``,
+          `{ minItems: ${limit}, actual: ${ctx.data}.length }`,
+        ),
       );
     });
   },
@@ -80,10 +82,11 @@ export const uniqueItemsKeyword: KeywordDefinition = {
         // concatenation.
         ctx.emitError(
           "leaf",
-          `${NAMES.DEPS}.createLeafError(` +
-            `${quoteString("uniqueItems")}, ${ctx.path}, ` +
-            `"must have unique items", ` +
-            `{ duplicates: [${dup}.a, ${dup}.b] })`,
+          ctx.leafErrorExpr(
+            quoteString("uniqueItems"),
+            `"must have unique items"`,
+            `{ duplicates: [${dup}.a, ${dup}.b] }`,
+          ),
         );
       });
     });

--- a/packages/schema/src/keywords/composition.ts
+++ b/packages/schema/src/keywords/composition.ts
@@ -1,4 +1,4 @@
-import { NAMES, quoteString } from "../codegen/index.js";
+import { quoteString } from "../codegen/index.js";
 import type { SchemaOrBoolean } from "@oav/core";
 import type { KeywordCompileContext, KeywordDefinition } from "./types.js";
 import { APPLICATOR_VOCAB } from "./vocabulary-uris.js";
@@ -69,10 +69,12 @@ export const allOfKeyword: KeywordDefinition = {
     ctx.gen.if(`${errsVar}.length > 0`, () => {
       ctx.emitError(
         "lift",
-        `${NAMES.DEPS}.createBranchError(` +
-          `${quoteString("allOf")}, ${ctx.path}, ` +
-          `\`must satisfy all ${n} schemas (\${${errsVar}.length} failed)\`, ` +
-          `${errsVar}, { total: ${n}, failed: ${errsVar}.length })`,
+        ctx.branchErrorExpr(
+          quoteString("allOf"),
+          `\`must satisfy all ${n} schemas (\${${errsVar}.length} failed)\``,
+          errsVar,
+          `{ total: ${n}, failed: ${errsVar}.length }`,
+        ),
       );
     });
   },
@@ -145,10 +147,12 @@ export const anyOfKeyword: KeywordDefinition = {
     ctx.gen.if(`!${matched}`, () => {
       ctx.emitError(
         "lift",
-        `${NAMES.DEPS}.createBranchError(` +
-          `${quoteString("anyOf")}, ${ctx.path}, ` +
-          `\`must match at least one of ${n} schemas\`, ` +
-          `${errsVar}, { total: ${n} })`,
+        ctx.branchErrorExpr(
+          quoteString("anyOf"),
+          `\`must match at least one of ${n} schemas\``,
+          errsVar,
+          `{ total: ${n} }`,
+        ),
       );
     });
   },
@@ -240,10 +244,12 @@ export const oneOfKeyword: KeywordDefinition = {
     ctx.gen.if(`${matchCount} !== 1`, () => {
       ctx.emitError(
         "lift",
-        `${NAMES.DEPS}.createBranchError(` +
-          `${quoteString("oneOf")}, ${ctx.path}, ` +
-          `\`must match exactly one of ${n} schemas (matched \${${matchCount}})\`, ` +
-          `${errsVar}, { total: ${n}, matchCount: ${matchCount} })`,
+        ctx.branchErrorExpr(
+          quoteString("oneOf"),
+          `\`must match exactly one of ${n} schemas (matched \${${matchCount}})\``,
+          errsVar,
+          `{ total: ${n}, matchCount: ${matchCount} }`,
+        ),
       );
     });
   },
@@ -271,9 +277,7 @@ export const notKeyword: KeywordDefinition = {
     ctx.gen.if(`${errVar} === null`, () => {
       ctx.emitError(
         "leaf",
-        `${NAMES.DEPS}.createLeafError(` +
-          `${quoteString("not")}, ${ctx.path}, ` +
-          `"must NOT match the schema", {})`,
+        ctx.leafErrorExpr(quoteString("not"), `"must NOT match the schema"`, `{}`),
       );
     });
   },
@@ -421,15 +425,15 @@ export const dependenciesKeyword: KeywordDefinition = {
               for (const prop of entry) {
                 const propLit = quoteString(prop);
                 gi.if(`!Object.prototype.hasOwnProperty.call(${ctx.data}, ${propLit})`, () => {
-                  ctx.withPathSegment(propLit, (base, seg) => {
-                    ctx.emitError(
-                      "leaf",
-                      `${NAMES.DEPS}.createLeafError(` +
-                        `${quoteString("dependencies")}, ${base}, ` +
-                        `\`property "${prop}" is required when "${trigger}" is present\`, ` +
-                        `{ trigger: ${triggerLit}, missing: ${propLit} }, ${seg})`,
-                    );
-                  });
+                  ctx.emitError(
+                    "leaf",
+                    ctx.leafErrorExpr(
+                      quoteString("dependencies"),
+                      `\`property "${prop}" is required when "${trigger}" is present\``,
+                      `{ trigger: ${triggerLit}, missing: ${propLit} }`,
+                      [propLit],
+                    ),
+                  );
                 });
               }
             });
@@ -474,15 +478,15 @@ export const dependentRequiredKeyword: KeywordDefinition = {
             for (const prop of required) {
               const propLit = quoteString(prop);
               gi.if(`!Object.prototype.hasOwnProperty.call(${ctx.data}, ${propLit})`, () => {
-                ctx.withPathSegment(propLit, (base, seg) => {
-                  ctx.emitError(
-                    "leaf",
-                    `${NAMES.DEPS}.createLeafError(` +
-                      `${quoteString("dependentRequired")}, ${base}, ` +
-                      `\`property "${prop}" is required when "${trigger}" is present\`, ` +
-                      `{ trigger: ${triggerLit}, missing: ${propLit} }, ${seg})`,
-                  );
-                });
+                ctx.emitError(
+                  "leaf",
+                  ctx.leafErrorExpr(
+                    quoteString("dependentRequired"),
+                    `\`property "${prop}" is required when "${trigger}" is present\``,
+                    `{ trigger: ${triggerLit}, missing: ${propLit} }`,
+                    [propLit],
+                  ),
+                );
               });
             }
           });

--- a/packages/schema/src/keywords/context.ts
+++ b/packages/schema/src/keywords/context.ts
@@ -7,6 +7,8 @@ import type {
   ValidateSubschemaOptions,
 } from "./types.js";
 
+const EMPTY_PATH_SEGMENTS: readonly string[] = Object.freeze([]);
+
 /**
  * Inputs accepted by {@link createKeywordContext}. The compiler assembles
  * these from its own state — keyword authors never construct them directly.
@@ -20,6 +22,12 @@ export interface KeywordContextInputs {
   data: string;
   path: string;
   errors: string;
+  /**
+   * Extra path segments that the inliner has accumulated without
+   * materializing them into `path`. See
+   * {@link KeywordCompileContext.pathSegments}. Defaults to empty.
+   */
+  pathSegments?: readonly string[];
   compileSubschema: (schema: SchemaOrBoolean) => string;
   resolveRef: (ref: string) => string;
   evaluatedPropertiesVar?: string | null;
@@ -160,6 +168,14 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
   const evaluatedItemsVar = inputs.evaluatedItemsVar ?? null;
   const gated = inputs.gated ?? false;
   const predicate = inputs.predicate ?? false;
+  const pathSegments = inputs.pathSegments ?? EMPTY_PATH_SEGMENTS;
+  const effectivePathExpr =
+    pathSegments.length === 0
+      ? inputs.path
+      : pathJoinExpr(
+          inputs.path,
+          pathSegments.map((s) => rawExpr(s)),
+        );
   // Fall back to a local-scope const when no compiler-provided hoist sink
   // is threaded in (for tests or out-of-tree callers that build a
   // context directly). In that case the "hoisted" value just lives in
@@ -205,19 +221,59 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     if (stmt !== "") inputs.gen.line(stmt);
   };
 
-  // No runtime mutation — on the happy path the segment is invisible.
-  // `body` receives the base path and the segment separately so error
-  // constructors can pass them as distinct arguments to
-  // `createLeafError` / `createBranchError` (the runtime allocates the
-  // extended path array once, inside the helper, on the error path).
-  // Predicate mode doesn't emit errors, so the values go unused in
-  // that mode — we pass them anyway for a stable API.
-  const withPathSegment = (
-    segmentExpr: string,
-    body: (basePath: string, segExpr: string) => void,
-  ): void => {
-    body(inputs.path, segmentExpr);
+  // Assemble a `deps.createLeafError(...)` / `createBranchError(...)`
+  // call. Up to two trailing segments embed as explicit parameters,
+  // matching the runtime signature; three-plus fall back to eagerly
+  // materializing `[...path, ...segs]` at the call site (rare —
+  // pathologically nested inlined subschemas, capped by
+  // MAX_INLINE_DEPTH).
+  const assembleErrorExpr = (
+    fnName: string,
+    fixedArgs: (pathExpr: string) => string,
+    allSegs: readonly string[],
+  ): string => {
+    if (allSegs.length === 0) {
+      return `${NAMES.DEPS}.${fnName}(${fixedArgs(inputs.path)})`;
+    }
+    if (allSegs.length <= 2) {
+      return `${NAMES.DEPS}.${fnName}(${fixedArgs(inputs.path)}, ${allSegs.join(", ")})`;
+    }
+    const materialized = pathJoinExpr(
+      inputs.path,
+      allSegs.map((s) => rawExpr(s)),
+    );
+    return `${NAMES.DEPS}.${fnName}(${fixedArgs(materialized)})`;
   };
+  const concatSegs = (extras: readonly string[]): readonly string[] =>
+    extras.length === 0
+      ? pathSegments
+      : pathSegments.length === 0
+        ? extras
+        : [...pathSegments, ...extras];
+  const leafErrorExpr = (
+    codeExpr: string,
+    messageExpr: string,
+    paramsExpr: string,
+    extraSegments: readonly string[] = EMPTY_PATH_SEGMENTS,
+  ): string =>
+    assembleErrorExpr(
+      "createLeafError",
+      (pathExpr: string) => `${codeExpr}, ${pathExpr}, ${messageExpr}, ${paramsExpr}`,
+      concatSegs(extraSegments),
+    );
+  const branchErrorExpr = (
+    codeExpr: string,
+    messageExpr: string,
+    childrenExpr: string,
+    paramsExpr: string = "{}",
+    extraSegments: readonly string[] = EMPTY_PATH_SEGMENTS,
+  ): string =>
+    assembleErrorExpr(
+      "createBranchError",
+      (pathExpr: string) =>
+        `${codeExpr}, ${pathExpr}, ${messageExpr}, ${childrenExpr}, ${paramsExpr}`,
+      concatSegs(extraSegments),
+    );
 
   const inlineDepth = inputs.inlineDepth ?? 0;
 
@@ -236,8 +292,12 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
    *   wrap the new errors in a "schema" branch to match the tree
    *   shape of the would-be function's `wrapErrors` return value.
    */
-  const tryInline = (schema: SchemaObject, dataExpr: string, pathOverride?: string): boolean => {
-    const path = pathOverride ?? inputs.path;
+  const tryInline = (
+    schema: SchemaObject,
+    dataExpr: string,
+    innerPathSegments?: readonly string[],
+  ): boolean => {
+    const innerSegments = innerPathSegments ?? pathSegments;
     if (inputs.byKeyword === undefined) return false;
     const allKeys = Object.keys(schema);
     const validationKeys: string[] = [];
@@ -264,7 +324,8 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
         schema: (schema as Record<string, unknown>)[k],
         parentSchema: schema,
         data: dataExpr,
-        path,
+        path: inputs.path,
+        pathSegments: innerSegments,
         errors: inputs.errors,
         compileSubschema: inputs.compileSubschema,
         resolveRef: inputs.resolveRef,
@@ -325,7 +386,8 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
         schema: (schema as Record<string, unknown>)[kwName],
         parentSchema: schema,
         data: dataExpr,
-        path,
+        path: inputs.path,
+        pathSegments: innerSegments,
         errors: inputs.errors,
         compileSubschema: inputs.compileSubschema,
         resolveRef: inputs.resolveRef,
@@ -346,14 +408,24 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     // short-circuits the wrap.
     if (startVar !== null) {
       const wrappedVar = inputs.gen.scope.name("_wrapped");
+      // The wrap expression lives at the same extended path as its
+      // leaf children — use the inner-scope segments directly (not
+      // the outer ctx's `pathSegments`, which is what the public
+      // helpers would concat).
+      // Always include the empty `params` slot so the runtime
+      // helper correctly sees any trailing segments in the
+      // `extraSegment` / `extraSegment2` positions.
+      const wrapExpr = assembleErrorExpr(
+        "createBranchError",
+        (pathExpr: string) =>
+          `"schema", ${pathExpr}, "schema validation failed", ${wrappedVar}, {}`,
+        innerSegments,
+      );
       inputs.gen.if(
         `${inputs.errors} !== null && ${inputs.errors}.length - ${startVar} > 1`,
         () => {
           inputs.gen.const(wrappedVar, `${inputs.errors}.splice(${startVar})`);
-          inputs.gen.line(
-            `${inputs.errors}.push(${NAMES.DEPS}.createBranchError(` +
-              `"schema", ${path}, "schema validation failed", ${wrappedVar}));`,
-          );
+          inputs.gen.line(`${inputs.errors}.push(${wrapExpr});`);
         },
       );
     }
@@ -367,32 +439,36 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     options?: ValidateSubschemaOptions,
   ): void => {
     const segment = options?.segment;
-    // Inline path uses a lazy extended-path expression — only evaluated
-    // when an error actually fires. Function-call fallback keeps the
-    // classic push/pop-then-call shape because the callee reads the
-    // (mutated) shared array directly, avoiding a per-call array
-    // allocation for the extended path.
+    // Inline path threads `pathSegments` through the inner keyword
+    // contexts — leaves splice the segments as trailing
+    // createLeafError args, avoiding the pre-materialized
+    // `[...path, seg]` double-allocation. Function-call fallback
+    // keeps the classic push/pop-then-call shape because the callee
+    // reads the (mutated) shared array directly.
     if (schema === true) return;
     if (schema === false) {
       if (predicate) {
         inputs.gen.line("return false;");
         return;
       }
-      // Use the runtime's `extraSegment` parameter so the extended
-      // path array is built once inside createLeafError rather than
-      // pre-materialized at the call site and then re-snapshotted.
-      const falseErr =
-        segment !== undefined
-          ? `${NAMES.DEPS}.createLeafError("false", ${inputs.path}, ` +
-            `"schema is false, nothing is valid", {}, ${segment})`
-          : `${NAMES.DEPS}.createLeafError("false", ${inputs.path}, ` +
-            `"schema is false, nothing is valid")`;
+      // `leafErrorExpr` picks up the ctx's pending pathSegments plus
+      // the subschema's own segment (if any) automatically.
+      const falseErr = leafErrorExpr(
+        '"false"',
+        '"schema is false, nothing is valid"',
+        "{}",
+        segment !== undefined ? [segment] : EMPTY_PATH_SEGMENTS,
+      );
       emitError("leaf", falseErr);
       return;
     }
-    const inlineExtPath =
-      segment !== undefined ? pathJoinExpr(inputs.path, [rawExpr(segment)]) : undefined;
-    if (tryInline(schema, dataExpr, inlineExtPath)) return;
+    const innerSegments =
+      segment === undefined
+        ? pathSegments
+        : pathSegments.length === 0
+          ? [segment]
+          : [...pathSegments, segment];
+    if (tryInline(schema, dataExpr, innerSegments)) return;
     // Function-call fallback — push/pop around the call so the callee
     // sees the extended path via the shared array (no per-call
     // allocation just to pass a path).
@@ -420,6 +496,8 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     parentSchema: inputs.parentSchema,
     data: inputs.data,
     path: inputs.path,
+    pathSegments,
+    effectivePathExpr,
     errors: inputs.errors,
     compileSubschema: inputs.compileSubschema,
     resolveRef: inputs.resolveRef,
@@ -431,7 +509,8 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     emitError,
     budgetBreakStatement,
     emitBudgetBreak,
-    withPathSegment,
+    leafErrorExpr,
+    branchErrorExpr,
     validateSubschema,
     hoistConstant,
   };

--- a/packages/schema/src/keywords/custom.ts
+++ b/packages/schema/src/keywords/custom.ts
@@ -64,7 +64,7 @@ export function createCustomKeywordDefinition(keyword: string): KeywordDefinitio
       const schemaValueJson = JSON.stringify(ctx.schema);
       const resultVar = ctx.gen.scope.name("custom");
       ctx.gen.line(
-        `const ${resultVar} = ${NAMES.DEPS}.customKeywords.get(${keywordLit})(${ctx.data}, ${schemaValueJson}, ${ctx.path});`,
+        `const ${resultVar} = ${NAMES.DEPS}.customKeywords.get(${keywordLit})(${ctx.data}, ${schemaValueJson}, ${ctx.effectivePathExpr});`,
       );
       ctx.gen.if(`${resultVar} !== true`, () => {
         const messageVar = ctx.gen.scope.name("customMsg");
@@ -75,10 +75,7 @@ export function createCustomKeywordDefinition(keyword: string): KeywordDefinitio
         ctx.gen.line(
           `const ${paramsVar} = (${resultVar} && typeof ${resultVar} === "object" && ${resultVar}.params && typeof ${resultVar}.params === "object") ? ${resultVar}.params : {};`,
         );
-        ctx.emitError(
-          "leaf",
-          `${NAMES.DEPS}.createLeafError(${keywordLit}, ${ctx.path}, ${messageVar}, ${paramsVar})`,
-        );
+        ctx.emitError("leaf", ctx.leafErrorExpr(keywordLit, messageVar, paramsVar));
       });
     },
   };

--- a/packages/schema/src/keywords/discriminator.ts
+++ b/packages/schema/src/keywords/discriminator.ts
@@ -1,4 +1,4 @@
-import { NAMES, quoteString } from "../codegen/index.js";
+import { quoteString } from "../codegen/index.js";
 import type { KeywordCompileContext, KeywordDefinition } from "./types.js";
 import { APPLICATOR_VOCAB } from "./vocabulary-uris.js";
 
@@ -71,15 +71,15 @@ export const discriminatorKeyword: KeywordDefinition = {
               g.line("return false;");
               return;
             }
-            ctx.withPathSegment(propLit, (base, seg) => {
-              ctx.emitError(
-                "leaf",
-                `${NAMES.DEPS}.createLeafError(` +
-                  `${quoteString("discriminator")}, ${base}, ` +
-                  `\`discriminator property "${propertyName}" must be a string\`, ` +
-                  `{ propertyName: ${propLit} }, ${seg})`,
-              );
-            });
+            ctx.emitError(
+              "leaf",
+              ctx.leafErrorExpr(
+                quoteString("discriminator"),
+                `\`discriminator property "${propertyName}" must be a string\``,
+                `{ propertyName: ${propLit} }`,
+                [propLit],
+              ),
+            );
           },
           (gi) => {
             if (ctx.predicate) {
@@ -108,17 +108,17 @@ export const discriminatorKeyword: KeywordDefinition = {
             gi.line(`switch (${discVal}) {`);
             gi.line(switchLines);
             gi.line(`      default: {`);
-            ctx.withPathSegment(propLit, (base, seg) => {
-              gi.line(
-                ctx.errorStatement(
-                  "leaf",
-                  `${NAMES.DEPS}.createLeafError(` +
-                    `${quoteString("discriminator")}, ${base}, ` +
-                    `"discriminator value does not match any branch", ` +
-                    `{ propertyName: ${propLit}, value: ${discVal} }, ${seg})`,
+            gi.line(
+              ctx.errorStatement(
+                "leaf",
+                ctx.leafErrorExpr(
+                  quoteString("discriminator"),
+                  `"discriminator value does not match any branch"`,
+                  `{ propertyName: ${propLit}, value: ${discVal} }`,
+                  [propLit],
                 ),
-              );
-            });
+              ),
+            );
             gi.line(`      }`);
             gi.line(`    }`);
           },

--- a/packages/schema/src/keywords/equality.ts
+++ b/packages/schema/src/keywords/equality.ts
@@ -27,10 +27,11 @@ export const enumKeyword: KeywordDefinition = {
     ctx.gen.if(`!${matched}`, () => {
       ctx.emitError(
         "leaf",
-        `${NAMES.DEPS}.createLeafError(` +
-          `${quoteString("enum")}, ${ctx.path}, ` +
-          `"must be one of the allowed values", ` +
-          `{ allowed: ${valuesLit}, actual: ${ctx.data} })`,
+        ctx.leafErrorExpr(
+          quoteString("enum"),
+          `"must be one of the allowed values"`,
+          `{ allowed: ${valuesLit}, actual: ${ctx.data} }`,
+        ),
       );
     });
   },
@@ -51,10 +52,11 @@ export const constKeyword: KeywordDefinition = {
     ctx.gen.if(`!${NAMES.DEPS}.deepEqual(${ctx.data}, ${valueLit})`, () => {
       ctx.emitError(
         "leaf",
-        `${NAMES.DEPS}.createLeafError(` +
-          `${quoteString("const")}, ${ctx.path}, ` +
-          `"must equal the expected constant", ` +
-          `{ expected: ${valueLit}, actual: ${ctx.data} })`,
+        ctx.leafErrorExpr(
+          quoteString("const"),
+          `"must equal the expected constant"`,
+          `{ expected: ${valueLit}, actual: ${ctx.data} }`,
+        ),
       );
     });
   },

--- a/packages/schema/src/keywords/items.ts
+++ b/packages/schema/src/keywords/items.ts
@@ -1,4 +1,4 @@
-import { NAMES, quoteString } from "../codegen/index.js";
+import { quoteString } from "../codegen/index.js";
 import type { SchemaOrBoolean } from "@oav/core";
 import type { KeywordCompileContext, KeywordDefinition } from "./types.js";
 import { APPLICATOR_VOCAB } from "./vocabulary-uris.js";
@@ -53,14 +53,10 @@ export const itemsKeyword: KeywordDefinition = {
           g.line(`${ctx.evaluatedItemsVar}.add(${i});`);
         }
       } else if (subSchema === false) {
-        ctx.withPathSegment(i, (base, seg) => {
-          ctx.emitError(
-            "leaf",
-            `${NAMES.DEPS}.createLeafError(` +
-              `${quoteString("items")}, ${base}, ` +
-              `"no additional items allowed", {}, ${seg})`,
-          );
-        });
+        ctx.emitError(
+          "leaf",
+          ctx.leafErrorExpr(quoteString("items"), `"no additional items allowed"`, `{}`, [i]),
+        );
       } else {
         ctx.validateSubschema(subSchema, `${ctx.data}[${i}]`, { segment: i });
         if (ctx.evaluatedItemsVar !== null) {
@@ -139,10 +135,11 @@ export const containsKeyword: KeywordDefinition = {
           // message turns the emitted string into a constant literal.
           ctx.emitError(
             "leaf",
-            `${NAMES.DEPS}.createLeafError(` +
-              `${quoteString("contains")}, ${ctx.path}, ` +
-              `\`must contain at least ${min} matching item(s)\`, ` +
-              `{ minContains: ${min}, actual: ${count} })`,
+            ctx.leafErrorExpr(
+              quoteString("contains"),
+              `\`must contain at least ${min} matching item(s)\``,
+              `{ minContains: ${min}, actual: ${count} }`,
+            ),
           );
         });
       }
@@ -150,10 +147,11 @@ export const containsKeyword: KeywordDefinition = {
         g.if(`${count} > ${max}`, () => {
           ctx.emitError(
             "leaf",
-            `${NAMES.DEPS}.createLeafError(` +
-              `${quoteString("maxContains")}, ${ctx.path}, ` +
-              `\`must contain at most ${max} matching item(s)\`, ` +
-              `{ maxContains: ${max}, actual: ${count} })`,
+            ctx.leafErrorExpr(
+              quoteString("maxContains"),
+              `\`must contain at most ${max} matching item(s)\``,
+              `{ maxContains: ${max}, actual: ${count} }`,
+            ),
           );
         });
       }

--- a/packages/schema/src/keywords/number.ts
+++ b/packages/schema/src/keywords/number.ts
@@ -1,4 +1,4 @@
-import { NAMES, quoteString } from "../codegen/index.js";
+import { quoteString } from "../codegen/index.js";
 import type { KeywordCompileContext, KeywordDefinition } from "./types.js";
 import { CORE_VALIDATION_VOCAB } from "./vocabulary-uris.js";
 
@@ -12,11 +12,7 @@ function emitNumericError(
   message: string,
   paramsObj: string,
 ): void {
-  ctx.emitError(
-    "leaf",
-    `${NAMES.DEPS}.createLeafError(` +
-      `${quoteString(code)}, ${ctx.path}, ${message}, ${paramsObj})`,
-  );
+  ctx.emitError("leaf", ctx.leafErrorExpr(quoteString(code), message, paramsObj));
 }
 
 /**
@@ -52,10 +48,11 @@ export const multipleOfKeyword: KeywordDefinition = {
       ctx.gen.if(`Math.abs(${q} - Math.round(${q})) > ${tol}`, () => {
         ctx.emitError(
           "leaf",
-          `${NAMES.DEPS}.createLeafError(` +
-            `${quoteString("multipleOf")}, ${ctx.path}, ` +
-            `\`must be a multiple of ${divisor}\`, ` +
-            `{ multipleOf: ${divisor}, actual: ${ctx.data} })`,
+          ctx.leafErrorExpr(
+            quoteString("multipleOf"),
+            `\`must be a multiple of ${divisor}\``,
+            `{ multipleOf: ${divisor}, actual: ${ctx.data} }`,
+          ),
         );
       });
     });

--- a/packages/schema/src/keywords/oas30.ts
+++ b/packages/schema/src/keywords/oas30.ts
@@ -53,10 +53,11 @@ export const oas30TypeKeyword: KeywordDefinition = {
       const actualExpr = `${NAMES.DEPS}.typeOf(${ctx.data})`;
       ctx.emitError(
         "leaf",
-        `${NAMES.DEPS}.createLeafError(` +
-          `${quoteString("type")}, ${ctx.path}, ` +
-          `"must be " + ${JSON.stringify(nullable ? `${declared} or null` : declared)}, ` +
-          `{ expected: ${expectedLit}, actual: ${actualExpr} })`,
+        ctx.leafErrorExpr(
+          quoteString("type"),
+          `"must be " + ${JSON.stringify(nullable ? `${declared} or null` : declared)}`,
+          `{ expected: ${expectedLit}, actual: ${actualExpr} }`,
+        ),
       );
     });
   },
@@ -97,10 +98,11 @@ export const oas30MaximumKeyword: KeywordDefinition = {
       () => {
         ctx.emitError(
           "leaf",
-          `${NAMES.DEPS}.createLeafError(` +
-            `${quoteString("maximum")}, ${ctx.path}, ` +
-            `\`must be ${exclusive ? "<" : "<="} ${limit}\`, ` +
-            `{ maximum: ${limit}, exclusive: ${exclusive}, actual: ${ctx.data} })`,
+          ctx.leafErrorExpr(
+            quoteString("maximum"),
+            `\`must be ${exclusive ? "<" : "<="} ${limit}\``,
+            `{ maximum: ${limit}, exclusive: ${exclusive}, actual: ${ctx.data} }`,
+          ),
         );
       },
     );
@@ -125,10 +127,11 @@ export const oas30MinimumKeyword: KeywordDefinition = {
       () => {
         ctx.emitError(
           "leaf",
-          `${NAMES.DEPS}.createLeafError(` +
-            `${quoteString("minimum")}, ${ctx.path}, ` +
-            `\`must be ${exclusive ? ">" : ">="} ${limit}\`, ` +
-            `{ minimum: ${limit}, exclusive: ${exclusive}, actual: ${ctx.data} })`,
+          ctx.leafErrorExpr(
+            quoteString("minimum"),
+            `\`must be ${exclusive ? ">" : ">="} ${limit}\``,
+            `{ minimum: ${limit}, exclusive: ${exclusive}, actual: ${ctx.data} }`,
+          ),
         );
       },
     );

--- a/packages/schema/src/keywords/object-validation.ts
+++ b/packages/schema/src/keywords/object-validation.ts
@@ -1,4 +1,4 @@
-import { NAMES, quoteString } from "../codegen/index.js";
+import { quoteString } from "../codegen/index.js";
 import type { KeywordCompileContext, KeywordDefinition } from "./types.js";
 import { CORE_VALIDATION_VOCAB } from "./vocabulary-uris.js";
 
@@ -26,10 +26,11 @@ export const maxPropertiesKeyword: KeywordDefinition = {
       g.if(`${count} > ${limit}`, () => {
         ctx.emitError(
           "leaf",
-          `${NAMES.DEPS}.createLeafError(` +
-            `${quoteString("maxProperties")}, ${ctx.path}, ` +
-            `\`must have at most ${limit} properties\`, ` +
-            `{ maxProperties: ${limit}, actual: ${count} })`,
+          ctx.leafErrorExpr(
+            quoteString("maxProperties"),
+            `\`must have at most ${limit} properties\``,
+            `{ maxProperties: ${limit}, actual: ${count} }`,
+          ),
         );
       });
     });
@@ -52,10 +53,11 @@ export const minPropertiesKeyword: KeywordDefinition = {
       g.if(`${count} < ${limit}`, () => {
         ctx.emitError(
           "leaf",
-          `${NAMES.DEPS}.createLeafError(` +
-            `${quoteString("minProperties")}, ${ctx.path}, ` +
-            `\`must have at least ${limit} properties\`, ` +
-            `{ minProperties: ${limit}, actual: ${count} })`,
+          ctx.leafErrorExpr(
+            quoteString("minProperties"),
+            `\`must have at least ${limit} properties\``,
+            `{ minProperties: ${limit}, actual: ${count} }`,
+          ),
         );
       });
     });
@@ -86,15 +88,15 @@ export const requiredKeyword: KeywordDefinition = {
       });
       g.if(`${missingVar}.length > 0`, (gi) => {
         gi.forOf("_m", missingVar, () => {
-          ctx.withPathSegment("_m", (base, seg) => {
-            ctx.emitError(
-              "leaf",
-              `${NAMES.DEPS}.createLeafError(` +
-                `${quoteString("required")}, ${base}, ` +
-                `\`must have required property "\${_m}"\`, ` +
-                `{ missing: _m }, ${seg})`,
-            );
-          });
+          ctx.emitError(
+            "leaf",
+            ctx.leafErrorExpr(
+              quoteString("required"),
+              `\`must have required property "\${_m}"\``,
+              `{ missing: _m }`,
+              ["_m"],
+            ),
+          );
           ctx.emitBudgetBreak();
         });
       });

--- a/packages/schema/src/keywords/properties.ts
+++ b/packages/schema/src/keywords/properties.ts
@@ -116,15 +116,15 @@ export const additionalPropertiesKeyword: KeywordDefinition = {
           return;
         }
         if (subSchema === false) {
-          ctx.withPathSegment(key, (base, seg) => {
-            ctx.emitError(
-              "leaf",
-              `${NAMES.DEPS}.createLeafError(` +
-                `${quoteString("additionalProperties")}, ${base}, ` +
-                `\`additional property "\${${key}}" is not allowed\`, ` +
-                `{ unexpected: ${key} }, ${seg})`,
-            );
-          });
+          ctx.emitError(
+            "leaf",
+            ctx.leafErrorExpr(
+              quoteString("additionalProperties"),
+              `\`additional property "\${${key}}" is not allowed\``,
+              `{ unexpected: ${key} }`,
+              [key],
+            ),
+          );
           ctx.emitBudgetBreak();
           return;
         }

--- a/packages/schema/src/keywords/string.ts
+++ b/packages/schema/src/keywords/string.ts
@@ -17,10 +17,11 @@ export const maxLengthKeyword: KeywordDefinition = {
     ctx.gen.if(`typeof ${ctx.data} === "string" && ${lenExpr} > ${limit}`, () => {
       ctx.emitError(
         "leaf",
-        `${NAMES.DEPS}.createLeafError(` +
-          `${quoteString("maxLength")}, ${ctx.path}, ` +
-          `\`must have at most ${limit} characters\`, ` +
-          `{ maxLength: ${limit}, actual: ${lenExpr} })`,
+        ctx.leafErrorExpr(
+          quoteString("maxLength"),
+          `\`must have at most ${limit} characters\``,
+          `{ maxLength: ${limit}, actual: ${lenExpr} }`,
+        ),
       );
     });
   },
@@ -41,10 +42,11 @@ export const minLengthKeyword: KeywordDefinition = {
     ctx.gen.if(`typeof ${ctx.data} === "string" && ${lenExpr} < ${limit}`, () => {
       ctx.emitError(
         "leaf",
-        `${NAMES.DEPS}.createLeafError(` +
-          `${quoteString("minLength")}, ${ctx.path}, ` +
-          `\`must have at least ${limit} characters\`, ` +
-          `{ minLength: ${limit}, actual: ${lenExpr} })`,
+        ctx.leafErrorExpr(
+          quoteString("minLength"),
+          `\`must have at least ${limit} characters\``,
+          `{ minLength: ${limit}, actual: ${lenExpr} }`,
+        ),
       );
     });
   },
@@ -67,10 +69,11 @@ export const patternKeyword: KeywordDefinition = {
     ctx.gen.if(`typeof ${ctx.data} === "string" && !${patternVar}.test(${ctx.data})`, () => {
       ctx.emitError(
         "leaf",
-        `${NAMES.DEPS}.createLeafError(` +
-          `${quoteString("pattern")}, ${ctx.path}, ` +
-          `\`must match pattern ${escapeMessage(source)}\`, ` +
-          `{ pattern: ${patternLit}, actual: ${ctx.data} })`,
+        ctx.leafErrorExpr(
+          quoteString("pattern"),
+          `\`must match pattern ${escapeMessage(source)}\``,
+          `{ pattern: ${patternLit}, actual: ${ctx.data} }`,
+        ),
       );
     });
   },
@@ -113,10 +116,11 @@ export const formatAssertionKeyword: KeywordDefinition = {
       () => {
         ctx.emitError(
           "leaf",
-          `${NAMES.DEPS}.createLeafError(` +
-            `${quoteString("format")}, ${ctx.path}, ` +
-            `\`must match format ${escapeMessage(formatName)}\`, ` +
-            `{ format: ${formatLit}, actual: ${ctx.data} })`,
+          ctx.leafErrorExpr(
+            quoteString("format"),
+            `\`must match format ${escapeMessage(formatName)}\``,
+            `{ format: ${formatLit}, actual: ${ctx.data} }`,
+          ),
         );
       },
     );

--- a/packages/schema/src/keywords/type.ts
+++ b/packages/schema/src/keywords/type.ts
@@ -20,10 +20,11 @@ export const typeKeyword: KeywordDefinition = {
       const actualExpr = `${NAMES.DEPS}.typeOf(${ctx.data})`;
       ctx.emitError(
         "leaf",
-        `${NAMES.DEPS}.createLeafError(` +
-          `${quoteString("type")}, ${ctx.path}, ` +
-          `"must be " + ${JSON.stringify(formatTypeList(expected))}, ` +
-          `{ expected: ${expectedLit}, actual: ${actualExpr} })`,
+        ctx.leafErrorExpr(
+          quoteString("type"),
+          `"must be " + ${JSON.stringify(formatTypeList(expected))}`,
+          `{ expected: ${expectedLit}, actual: ${actualExpr} }`,
+        ),
       );
     });
   },

--- a/packages/schema/src/keywords/types.ts
+++ b/packages/schema/src/keywords/types.ts
@@ -91,7 +91,7 @@ export interface KeywordCompileContext {
    * `true` when predicate mode is active — the compiled validator
    * returns `boolean` and constructs no error tree. Most keywords
    * don't need to read this directly: `emitError`,
-   * `errorStatement`, `withPathSegment`, and `validateSubschema` all
+   * `errorStatement`, `leafErrorExpr`, and `validateSubschema` all
    * do the right thing automatically. Composition-style keywords
    * that inspect a sub-validator's return value for their own
    * control flow (`allOf`, `anyOf`, `oneOf`, `not`, `if/then/else`,
@@ -166,20 +166,67 @@ export interface KeywordCompileContext {
     options?: ValidateSubschemaOptions,
   ): void;
   /**
-   * Run `body` in a scope where the current path logically has an
-   * extra segment appended. `body` receives two JS expression strings:
-   * `basePath` (equivalent to `ctx.path`) and `segExpr` (the extra
-   * segment). Pass them as the 4th and 5th arguments of
-   * `deps.createLeafError(code, basePath, message, params, segExpr)`
-   * — the runtime helper allocates the extended path array once,
-   * avoiding the double-copy that a pre-materialized `[...path, seg]`
-   * would trigger.
+   * Pending path segments to splice as trailing args into
+   * `createLeafError` / `createBranchError`. Populated by the
+   * subschema inliner when it flattens a segmented
+   * `validateSubschema` call into the enclosing function body —
+   * instead of pre-materializing `[...path, seg]` for the inner
+   * keyword contexts (which the runtime then re-snapshots, doubling
+   * allocation), we leave `path` unchanged and let leaf keywords
+   * splice segments as extra args.
    *
-   * Implementation: no runtime mutation on the happy path. The
-   * extended path is only materialized when an error actually fires
-   * (inside the error helper).
+   * Most keywords don't need to read this directly: prefer
+   * {@link KeywordCompileContext.leafErrorExpr} /
+   * {@link KeywordCompileContext.branchErrorExpr}, which both
+   * already consume it.
    */
-  withPathSegment(segmentExpr: string, body: (basePath: string, segExpr: string) => void): void;
+  readonly pathSegments: readonly string[];
+  /**
+   * JS expression producing the effective path at runtime —
+   * equivalent to `ctx.path` when `pathSegments` is empty, and to
+   * `[...path, seg1, seg2, …]` otherwise. Prefer the error helpers
+   * for error construction; reach for this only when a keyword
+   * needs to pass the runtime path to something other than
+   * `createLeafError` / `createBranchError` (e.g. a user-supplied
+   * custom-keyword callback).
+   */
+  readonly effectivePathExpr: string;
+  /**
+   * Assemble a `deps.createLeafError(...)` call expression, splicing
+   * any pending {@link KeywordCompileContext.pathSegments} plus the
+   * caller's own `extraSegments` as trailing args. Up to two total
+   * extras embed as explicit parameters (matching the runtime
+   * signature); three or more fall back to eagerly materializing the
+   * extended path at the call site (rare — pathologically nested
+   * inlined subschemas).
+   *
+   * @param codeExpr - Pre-quoted JS expression for the error code
+   *   (e.g. `quoteString("type")`).
+   * @param messageExpr - JS expression for the message (literal or
+   *   template string).
+   * @param paramsExpr - JS expression for the `params` object, or
+   *   `"{}"`.
+   * @param extraSegments - Additional segments this keyword wants to
+   *   append (e.g. a missing property name). Appended after any
+   *   already-pending `pathSegments`.
+   */
+  leafErrorExpr(
+    codeExpr: string,
+    messageExpr: string,
+    paramsExpr: string,
+    extraSegments?: readonly string[],
+  ): string;
+  /**
+   * Assemble a `deps.createBranchError(...)` call expression. Same
+   * trailing-segment rules as {@link KeywordCompileContext.leafErrorExpr}.
+   */
+  branchErrorExpr(
+    codeExpr: string,
+    messageExpr: string,
+    childrenExpr: string,
+    paramsExpr?: string,
+    extraSegments?: readonly string[],
+  ): string;
   /**
    * Emit a `const <name> = <expr>;` declaration at the top of the
    * generated module (outside every validator function). Returns the

--- a/packages/schema/src/keywords/unevaluated.ts
+++ b/packages/schema/src/keywords/unevaluated.ts
@@ -1,4 +1,4 @@
-import { NAMES, quoteString } from "../codegen/index.js";
+import { quoteString } from "../codegen/index.js";
 import type { SchemaOrBoolean } from "@oav/core";
 import type { KeywordCompileContext, KeywordDefinition } from "./types.js";
 import { UNEVALUATED_VOCAB } from "./vocabulary-uris.js";
@@ -34,18 +34,18 @@ export const unevaluatedPropertiesKeyword: KeywordDefinition = {
           return;
         }
         if (sub === false) {
-          ctx.withPathSegment(key, (base, seg) => {
-            // Offending key name lives in params.unexpected; dropping
-            // it from the message turns the emitted string into a
-            // constant literal.
-            ctx.emitError(
-              "leaf",
-              `${NAMES.DEPS}.createLeafError(` +
-                `${quoteString("unevaluatedProperties")}, ${base}, ` +
-                `"property is not evaluated by the schema", ` +
-                `{ unexpected: ${key} }, ${seg})`,
-            );
-          });
+          // Offending key name lives in params.unexpected; dropping
+          // it from the message turns the emitted string into a
+          // constant literal.
+          ctx.emitError(
+            "leaf",
+            ctx.leafErrorExpr(
+              quoteString("unevaluatedProperties"),
+              `"property is not evaluated by the schema"`,
+              `{ unexpected: ${key} }`,
+              [key],
+            ),
+          );
           ctx.emitBudgetBreak();
           return;
         }
@@ -82,15 +82,15 @@ export const unevaluatedItemsKeyword: KeywordDefinition = {
           return;
         }
         if (sub === false) {
-          ctx.withPathSegment(i, (base, seg) => {
-            ctx.emitError(
-              "leaf",
-              `${NAMES.DEPS}.createLeafError(` +
-                `${quoteString("unevaluatedItems")}, ${base}, ` +
-                `"item is not evaluated by the schema", ` +
-                `{ index: ${i} }, ${seg})`,
-            );
-          });
+          ctx.emitError(
+            "leaf",
+            ctx.leafErrorExpr(
+              quoteString("unevaluatedItems"),
+              `"item is not evaluated by the schema"`,
+              `{ index: ${i} }`,
+              [i],
+            ),
+          );
           ctx.emitBudgetBreak();
           return;
         }

--- a/packages/schema/test/path-leak-probe.test.ts
+++ b/packages/schema/test/path-leak-probe.test.ts
@@ -33,4 +33,75 @@ describe("error paths survive path-array reuse", () => {
     const typeErr = leaves.find((e) => e.code === "type" && e.path.length > 0);
     expect(typeErr?.path).toEqual([0]);
   });
+
+  // Regression probe for the inline-pathSegments optimisation (#50).
+  // A single-keyword leaf inlined with a pending segment must place
+  // the segment in its error's .path — the inliner no longer
+  // pre-materializes `[...path, seg]` for the inner ctx, so a leaf
+  // that forgets to splice its pending segment would drop it.
+  it("inlined const under properties reports path ['kind']", () => {
+    const { validate } = compileSchema(
+      {
+        type: "object",
+        properties: { kind: { const: "Cat" } },
+      },
+      { dialect: jsonSchemaDialect },
+    );
+    const r = validate({ kind: "Dog" });
+    if (r.valid) throw new Error("unexpected valid");
+    const leaves = walkLeaves(r.error! as Err);
+    const constErr = leaves.find((e) => e.code === "const");
+    expect(constErr?.path).toEqual(["kind"]);
+  });
+
+  // Regression probe for the multi-keyword inline wrap. When an
+  // inlined subschema has 2+ keywords that both fail, the wrap
+  // branch error should live at the extended path too — not at the
+  // caller's unextended path.
+  it("inlined multi-keyword wrap reports path ['fins']", () => {
+    const { validate } = compileSchema(
+      {
+        type: "object",
+        properties: { fins: { type: "integer", minimum: 0 } },
+      },
+      { dialect: jsonSchemaDialect },
+    );
+    const r = validate({ fins: -1.5 });
+    if (r.valid) throw new Error("unexpected valid");
+    // Two inlined leaves (type + minimum) wrapped in a "schema"
+    // branch — `wrapErrors` unwraps single-child, so the root error
+    // IS that "schema" branch.
+    const root = r.error! as Err;
+    expect(root.code).toBe("schema");
+    expect(root.path).toEqual(["fins"]);
+    const leaves = walkLeaves(root);
+    for (const leaf of leaves) {
+      expect(leaf.path).toEqual(["fins"]);
+    }
+  });
+
+  // Regression probe: inlined `required` under a segmented
+  // validateSubschema call must splice BOTH the caller's pending
+  // segment and its own missing-property segment (2 trailing
+  // segments). Exercises the extraSegment2 codepath in the runtime
+  // helper.
+  it("inlined required reports path [<key>, <missing>]", () => {
+    const { validate } = compileSchema(
+      {
+        type: "object",
+        properties: {
+          user: {
+            type: "object",
+            required: ["id"],
+          },
+        },
+      },
+      { dialect: jsonSchemaDialect },
+    );
+    const r = validate({ user: {} });
+    if (r.valid) throw new Error("unexpected valid");
+    const leaves = walkLeaves(r.error! as Err);
+    const requiredErr = leaves.find((e) => e.code === "required");
+    expect(requiredErr?.path).toEqual(["user", "id"]);
+  });
 });


### PR DESCRIPTION
## Summary

Closes #50. Removes the double path-array allocation for errors inside inlined-with-segment subschemas.

- `tryInline` now threads a compile-time `pathSegments` stack through inner keyword contexts instead of pre-materialising `[...path, seg]`. Leaves splice the pending segments as trailing `createLeafError` / `createBranchError` args.
- New `ctx.leafErrorExpr(code, msg, params, extraSegments?)` and `ctx.branchErrorExpr(...)` helpers assemble the call expression with the segments spliced in. Replaces the old `withPathSegment(seg, cb)` callback pattern — every keyword site collapsed to a direct helper call.
- `createLeafError` / `createBranchError` now accept a second optional `extraSegment2` parameter, sized to the real upper bound (outer inline segment + inner leaf segment). Three-plus trailing segments fall back to eager path concat at the call site — bounded by `MAX_INLINE_DEPTH=6`, unreachable in practice.

Inspected the dumped `performance/compiled-dump/*.oav.js` — every generated validator is now free of `[...path, ...]` eager spreads.

## Benchmark deltas (`pnpm bench:long`, Node v25.9.0, --time=1500)

| schema | metric | baseline | branch | delta |
|---|---|---|---|---|
| tiny | validate valid | 36.36M | 42.88M | +17.9% |
| tiny | validate invalid | 25.00M | 30.59M | +22.4% |
| petstore | validate valid | 10.79M | 11.71M | +8.5% |
| petstore | validate invalid | 7.14M | 7.57M | +6.0% |
| tree | validate valid | 24.06M | 24.08M | +0.1% |
| tree | validate invalid | 16.47M | 19.54M | **+18.6%** |
| composition | validate valid | 4.12M | 4.58M | **+11.2%** |
| composition | validate invalid | 3.50M | 3.89M | **+11.1%** |
| array-heavy | validate valid | 396.1K | 399.1K | +0.8% |
| array-heavy | validate invalid | 387.1K | 394.4K | +1.9% |

Tree invalid (+18.6%) recovers the regression flagged in #39; composition valid/invalid (+11%) recovers the #49 regression and then some. Tiny's large swings are mostly system-state noise (ajv baseline 36M → branch 50M for the same code). array-heavy stays flat as expected — its hot path has no inline-with-segment errors.

## Test plan

- [x] `pnpm test` (529/529 pass; added 3 new probes to `path-leak-probe.test.ts` + 2 `createLeafError` / `createBranchError` two-segment unit tests)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `cd conformance && pnpm suite` (1270/1290 — unchanged from baseline)
- [x] `cd conformance && pnpm openapi` (32/32 pass)