### PR TITLE
chore(ci): prefix dependabot PR titles with chore(deps)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore
+      prefix-development: chore
+      include: scope
     groups:
       types:
         patterns:
@@ -19,6 +23,9 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope
     groups:
       actions:
         patterns:


### PR DESCRIPTION
## Summary

Adds `commit-message` config so dependabot generates titles like `chore(deps): bump X from A to B` (or `chore(deps-dev)` for dev deps). Without the prefix the semantic-PR-title action fails every dependabot PR.

## Test plan

- [x] Config matches [dependabot's commit-message docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#commit-message--).
- [ ] Next dependabot run produces correctly-prefixed titles (verify after merge).