### PR TITLE
chore(tsconfig): explicitly list "node" in types

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "lib": ["ES2022"],
+    "types": ["node"],
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": false,


### PR DESCRIPTION
## Summary

Makes `@types/node` inclusion explicit in the base tsconfig.

Previously we relied on TypeScript's default behavior of auto-including every `@types/*` package in `node_modules`. That default is intact through 5.x but TypeScript 6.0 tightened it — `@types/node` no longer loads unless a project opts in via `types`. Making the dependency explicit keeps the base tsconfig working across the boundary without surprise.

Discovered while spiking the TypeScript 6 upgrade on #5. That upgrade itself is blocked on [tsup#1390](https://github.com/egoist/tsup/pull/1390) (tsup's DTS build step injects a deprecated `baseUrl`), but the explicit `types` field is a genuine improvement worth landing on its own.

## Test plan

- [x] `pnpm typecheck` (clean on TS 5.9.3)
- [x] `pnpm test` (530/530 pass)