### PR TITLE
docs(claude): replace prefixPath with startPath reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Both have their own `package.json` + `pnpm-workspace.yaml` (with empty
   parameter deserialization (style + explode), and returns a
   `ValidationError` tree. Subtrees returned from sub-validators are
   prefixed with the HTTP location (`body`, `query`, `header`, ...) via
-  `prefixPath`.
+  the `startPath` argument to `validate(data, startPath)`.
 - **`@oav/cli`** — thin commander wrapper. No business logic beyond arg
   parsing, I/O, and exit codes.
 


### PR DESCRIPTION
## Summary
- CLAUDE.md:54 named a `prefixPath` symbol that doesn't exist in the repo.
- Sub-validator subtrees are actually prefixed via the `startPath` argument to `validate(data, startPath)` (see `packages/schema/src/compiler/compiler.ts:682`).
- Updated the wording so the design doc matches the real API.

## Test plan
- [x] `pnpm test` (530/530 pass)
- [x] `pnpm lint`
- [x] `pnpm typecheck`

Closes #66