### PR TITLE
fix(validator): use singular "header" path on response side

### DIFF
--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -26,9 +26,9 @@ const responseErr = validator.validateResponse(
 
 Both methods return `null` on success or a `ValidationError` tree on
 failure. Errors are rooted at the HTTP frame (`["body", …]`,
-`["query", name, …]`, `["headers", name, …]` on the response side,
-etc.) so downstream code can group by location. The top-level node's
-`code` (`"request"` vs `"response"`) distinguishes the leg.
+`["query", name, …]`, `["header", name, …]`, etc.) so downstream code
+can group by location. The top-level node's `code` (`"request"` vs
+`"response"`) distinguishes the leg.
 
 `validator.detectedVersion` reflects the `openapi` string that was
 detected on construction (or `undefined` if the field was missing or

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -548,7 +548,7 @@ export function createValidator(
               children.push(
                 createLeafError(
                   "header-param",
-                  ["headers", name],
+                  ["header", name],
                   `missing required header "${name}"`,
                   {
                     name,
@@ -571,7 +571,7 @@ export function createValidator(
               style: hdr.style,
               explode: hdr.explode,
             });
-            const r = validator.validate(value, ["headers", name]);
+            const r = validator.validate(value, ["header", name]);
             if (!r.valid && r.error !== undefined) {
               children.push(r.error);
             }

--- a/packages/validator/test/response.test.ts
+++ b/packages/validator/test/response.test.ts
@@ -47,6 +47,40 @@ describe("validateResponse", () => {
     expect(leafCodes(err)).toContain("status");
   });
 
+  it('response header errors are rooted at ["header", name] (singular, matching request side)', () => {
+    const spec: OpenAPIDocument = {
+      openapi: "3.1.0",
+      info: { title: "t", version: "1" },
+      paths: {
+        "/items": {
+          get: {
+            responses: {
+              "200": {
+                description: "ok",
+                headers: {
+                  "X-Count": { required: true, schema: { type: "integer", minimum: 0 } },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const sv = createValidator(spec);
+
+    const missing = sv.validateResponse(
+      { method: "GET", path: "/items" },
+      { status: 200, headers: {} },
+    );
+    expect(leafAt(missing, "header.X-Count")).toBeDefined();
+
+    const invalid = sv.validateResponse(
+      { method: "GET", path: "/items" },
+      { status: 200, headers: { "x-count": "-1" } },
+    );
+    expect(leafAt(invalid, "header.X-Count")).toBeDefined();
+  });
+
   it("writeOnly properties are rejected in response bodies", () => {
     const spec: OpenAPIDocument = {
       openapi: "3.1.0",


### PR DESCRIPTION
## Summary
- All HTTP frames use singular path segments on the request side (`body`, `query`, `path`, `cookie`, `header`).
- The response-side header handling in `packages/validator/src/validator.ts` emitted `["headers", name]` for both the missing-required branch (`:551`) and the invalid-value branch (`:574`).
- Consumers that match by path prefix (`err.path[0] === "header"`) handled the request side but silently missed the response side.
- Updated both sites to `["header", name]`, updated the package README accordingly, and added a regression test covering both branches.

## Test plan
- [x] `pnpm test` (531/531 pass)
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] New test `response header errors are rooted at ["header", name]` fails before the fix, passes after.

Closes #65