### PR TITLE
perf(schema): flag oas30 modifier keywords as annotations

### DIFF
--- a/packages/schema/src/keywords/oas30.ts
+++ b/packages/schema/src/keywords/oas30.ts
@@ -74,6 +74,7 @@ export const oas30TypeKeyword: KeywordDefinition = {
 export const oas30NullableKeyword: KeywordDefinition = {
   keyword: "nullable",
   vocabulary: OAS30_VOCAB,
+  annotation: true,
   compile(): void {
     // intentionally empty — consumed by oas30TypeKeyword
   },
@@ -147,6 +148,7 @@ export const oas30MinimumKeyword: KeywordDefinition = {
 export const oas30ExclusiveMaximumKeyword: KeywordDefinition = {
   keyword: "exclusiveMaximum",
   vocabulary: OAS30_VOCAB,
+  annotation: true,
   compile(): void {
     // intentionally empty
   },
@@ -161,6 +163,7 @@ export const oas30ExclusiveMaximumKeyword: KeywordDefinition = {
 export const oas30ExclusiveMinimumKeyword: KeywordDefinition = {
   keyword: "exclusiveMinimum",
   vocabulary: OAS30_VOCAB,
+  annotation: true,
   compile(): void {
     // intentionally empty
   },


### PR DESCRIPTION
## Summary
- `oas30NullableKeyword`, `oas30ExclusiveMaximumKeyword`, and `oas30ExclusiveMinimumKeyword` all have empty `compile` bodies — their effect is read by sibling `type` / `maximum` / `minimum` keywords. They exist purely so the dispatcher does not flag them as unknown.
- Without `annotation: true`, the subschema inliner (`packages/schema/src/keywords/context.ts:310` and `packages/schema/src/compiler/compiler.ts:464`) counts them as real validation keywords, which can flip a common OAS 3.0 subschema like `{ nullable: true, type: "string", minLength: 2 }` from the inline path to the function-call path.
- Same pattern the 2020-12 meta-data keywords follow (`title`, `description`, `readOnly`, `writeOnly`, …).

CLAUDE.md explicitly warns: *"set them correctly or performance optimisations silently mis-fire."*

## Test plan
- [x] `pnpm test` (530/530 pass — no correctness regression)
- [x] `pnpm lint`
- [x] `pnpm typecheck`

No behaviour change — silent performance improvement on OAS 3.0 specs.

Closes #63