### PR TITLE
feat(validator): inject warn sink for onUnknownVersion: 'warn'

### DIFF
--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -220,13 +220,21 @@ export interface ValidatorOptions {
    * or not one of the supported versions (3.0, 3.1, 3.2).
    *
    * - `"fallback31"` (default) — silently use the 3.1 dialect.
-   * - `"warn"` — write a message to `stderr` and use the 3.1 dialect.
+   * - `"warn"` — emit a warning via {@link ValidatorOptions.warn} (defaults
+   *   to `process.stderr.write`) and use the 3.1 dialect.
    * - `"throw"` — throw an `Error`.
    *
    * Regardless of the choice, `OavValidator.detectedVersion` is set to
    * `undefined` so callers can introspect after the fact.
    */
   onUnknownVersion?: "fallback31" | "warn" | "throw";
+  /**
+   * Sink for the warning emitted by `onUnknownVersion: "warn"`. Defaults
+   * to `(m) => process.stderr.write(m)`. Inject an alternative when
+   * embedding the validator in workers / edge runtimes / test harnesses
+   * where `process.stderr` isn't the right destination.
+   */
+  warn?: (message: string) => void;
 }
 
 interface OperationCache {
@@ -296,7 +304,8 @@ export function createValidator(
         );
       }
       if (policy === "warn") {
-        process.stderr.write(
+        const warn = options.warn ?? ((m: string) => void process.stderr.write(m));
+        warn(
           "createValidator: spec has a missing or unsupported `openapi` field; falling back to the 3.1 dialect\n",
         );
       }

--- a/packages/validator/test/versioning.test.ts
+++ b/packages/validator/test/versioning.test.ts
@@ -385,18 +385,12 @@ describe("unknown version", () => {
     );
   });
 
-  it("warns on stderr when onUnknownVersion is 'warn'", () => {
+  it("routes the warning through options.warn when onUnknownVersion is 'warn'", () => {
     const chunks: string[] = [];
-    const original = process.stderr.write.bind(process.stderr);
-    process.stderr.write = ((chunk: unknown) => {
-      chunks.push(String(chunk));
-      return true;
-    }) as typeof process.stderr.write;
-    try {
-      createValidator(bareSpec(), { onUnknownVersion: "warn" });
-    } finally {
-      process.stderr.write = original;
-    }
+    createValidator(bareSpec(), {
+      onUnknownVersion: "warn",
+      warn: (msg) => chunks.push(msg),
+    });
     expect(chunks.join("")).toMatch(/falling back to the 3.1 dialect/);
   });
 });


### PR DESCRIPTION
## Summary
- `createValidator` wrote its `onUnknownVersion: "warn"` message directly to `process.stderr.write`, with no injection seam.
- That blocks consumers embedding the validator in workers / edge runtimes / shims that replace `process.stderr`, and forced the validator's own test to monkey-patch `process.stderr.write` — the only Node global mutation in the validator test suite.
- Added `ValidatorOptions.warn?: (message: string) => void`, defaulting to `(m) => process.stderr.write(m)`.
- Switched `versioning.test.ts` from monkey-patching `process.stderr.write` to injecting a capture function via the new option.

## Test plan
- [x] `pnpm test` (530/530 pass)
- [x] `pnpm lint`
- [x] `pnpm typecheck`

Closes #61