### PR TITLE
refactor(core): move output-format dispatch to @oav/core

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,15 +143,20 @@ cli → validator → router
 3. Add it to the `builtInFormats` record.
 4. Test with RFC-sourced valid + invalid examples.
 
-## How to add a new CLI output format
+## How to add a new output format
+
+Output format dispatch lives in `@oav/core` (not the CLI) so library
+consumers can render by format name too. Programmatic callers can also
+pass a renderer function directly — `formatError(err, (e) => ...)` —
+without forking the switch.
 
 1. Add the name to `KNOWN_OUTPUT_FORMATS` in
-   `packages/cli/src/format-output.ts` — the `OutputFormat` type and
-   the Commander `--format` validator are both derived from it.
+   `packages/core/src/format-output.ts` — the `OutputFormat` type and
+   the CLI's Commander `--format` validator are both derived from it.
 2. Add the rendering function to `packages/core/src/format.ts` (or emit
    straight from the leaves).
-3. Add a branch to `formatError()`.
-4. Add a test in `packages/cli/test/format-output.test.ts`.
+3. Add a branch to `formatError()` in `packages/core/src/format-output.ts`.
+4. Add a test in `packages/core/test/format-output.test.ts`.
 
 ## Error-collection modes
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
+import { KNOWN_OUTPUT_FORMATS, isOutputFormat, type OutputFormat } from "@oav/core";
 import { type CommandIo, resolveCommand, validateCommand, type ValidateMode } from "./commands.js";
-import { KNOWN_OUTPUT_FORMATS, isOutputFormat, type OutputFormat } from "./format-output.js";
 
 /**
  * Options accepted by {@link buildProgram}.

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile } from "node:fs/promises";
-import type { JsonValue, ValidationError } from "@oav/core";
+import { formatError, type JsonValue, type OutputFormat, type ValidationError } from "@oav/core";
 import {
   composeReaders,
   createFileReader,
@@ -9,7 +9,6 @@ import {
 } from "@oav/spec";
 import { createValidator } from "@oav/validator";
 import { parseHttpFile } from "./http-parser.js";
-import { formatError, type OutputFormat } from "./format-output.js";
 
 /**
  * Input shared by all CLI commands.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,5 +6,4 @@ export {
   type CommandResult,
   type ValidateMode,
 } from "./commands.js";
-export { formatError, type OutputFormat } from "./format-output.js";
 export { parseHttpFile } from "./http-parser.js";

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -1,7 +1,7 @@
-import { createMemoryReader, type DocumentReader } from "@oav/spec";
 import { describe, expect, it } from "vitest";
 import { buildProgram } from "../src/cli.js";
 import type { CommandIo } from "../src/commands.js";
+import { memoryIo } from "./fixtures.js";
 
 /**
  * Argv-level coverage of the Commander program. Previously the CLI
@@ -9,32 +9,6 @@ import type { CommandIo } from "../src/commands.js";
  * so argv wiring (deriveMode, --format validation, exit code 3 for
  * usage errors) had no in-process regression guard.
  */
-
-function memoryIo(
-  entries: Array<[string, unknown]>,
-  textFiles: Array<[string, string]> = [],
-): {
-  io: CommandIo;
-  writes: Array<[string, string]>;
-} {
-  const reader: DocumentReader = createMemoryReader(new Map(entries));
-  const textMap = new Map(textFiles);
-  const writes: Array<[string, string]> = [];
-  return {
-    io: {
-      reader,
-      async readText(path: string) {
-        const hit = textMap.get(path);
-        if (hit === undefined) throw new Error(`missing text file: ${path}`);
-        return hit;
-      },
-      async writeText(path: string, content: string) {
-        writes.push([path, content]);
-      },
-    },
-    writes,
-  };
-}
 
 interface Captured {
   stdout: string;

--- a/packages/cli/test/commands.test.ts
+++ b/packages/cli/test/commands.test.ts
@@ -1,35 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { createMemoryReader, type DocumentReader } from "@oav/spec";
-import {
-  resolveCommand,
-  validateCommand,
-  type CommandIo,
-  type CommandOptions,
-} from "../src/commands.js";
-
-function memoryIo(
-  entries: Array<[string, unknown]>,
-  textFiles: Array<[string, string]> = [],
-): { io: CommandIo; writes: Array<[string, string]>; textMap: Map<string, string> } {
-  const reader: DocumentReader = createMemoryReader(new Map(entries));
-  const textMap = new Map(textFiles);
-  const writes: Array<[string, string]> = [];
-  return {
-    io: {
-      reader,
-      async readText(path: string) {
-        const hit = textMap.get(path);
-        if (hit === undefined) throw new Error(`missing text file: ${path}`);
-        return hit;
-      },
-      async writeText(path: string, content: string) {
-        writes.push([path, content]);
-      },
-    },
-    writes,
-    textMap,
-  };
-}
+import { resolveCommand, validateCommand, type CommandOptions } from "../src/commands.js";
+import { memoryIo } from "./fixtures.js";
 
 const textOpts: CommandOptions = { format: "text", quiet: false };
 

--- a/packages/cli/test/fixtures.ts
+++ b/packages/cli/test/fixtures.ts
@@ -1,0 +1,39 @@
+import { createMemoryReader, type DocumentReader } from "@oav/spec";
+import type { CommandIo } from "../src/commands.js";
+
+/**
+ * Shared helpers for the CLI test suite. The two callers
+ * (`cli.test.ts` argv coverage, `commands.test.ts` in-process coverage)
+ * both need a `CommandIo` wired to in-memory documents, text files, and
+ * a write sink — factored out here so the helpers can't drift.
+ */
+
+export interface MemoryIo {
+  io: CommandIo;
+  writes: Array<[string, string]>;
+  textMap: Map<string, string>;
+}
+
+export function memoryIo(
+  entries: Array<[string, unknown]>,
+  textFiles: Array<[string, string]> = [],
+): MemoryIo {
+  const reader: DocumentReader = createMemoryReader(new Map(entries));
+  const textMap = new Map(textFiles);
+  const writes: Array<[string, string]> = [];
+  return {
+    io: {
+      reader,
+      async readText(path: string) {
+        const hit = textMap.get(path);
+        if (hit === undefined) throw new Error(`missing text file: ${path}`);
+        return hit;
+      },
+      async writeText(path: string, content: string) {
+        writes.push([path, content]);
+      },
+    },
+    writes,
+    textMap,
+  };
+}

--- a/packages/core/src/format-output.ts
+++ b/packages/core/src/format-output.ts
@@ -1,4 +1,5 @@
-import { formatFlat, formatGithub, formatJson, formatText, type ValidationError } from "@oav/core";
+import { formatFlat, formatGithub, formatJson, formatText } from "./format.js";
+import type { ValidationError } from "./errors.js";
 
 /**
  * Single source of truth for the CLI's `--format` flag. The
@@ -11,7 +12,7 @@ import { formatFlat, formatGithub, formatJson, formatText, type ValidationError 
 export const KNOWN_OUTPUT_FORMATS = ["text", "json", "flat", "github"] as const;
 
 /**
- * Supported output formats for the CLI.
+ * Supported built-in output formats.
  *
  * @public
  */
@@ -28,17 +29,35 @@ export function isOutputFormat(value: string): value is OutputFormat {
 }
 
 /**
+ * A programmatic renderer: any function that turns a
+ * {@link ValidationError} tree into a string.
+ *
+ * @public
+ */
+export type ErrorRenderer = (err: ValidationError) => string;
+
+/**
  * Format a {@link ValidationError} tree as a string in the requested style.
  *
+ * `renderer` may be one of the built-in format names
+ * ({@link OutputFormat}) or a caller-supplied function, which lets
+ * library consumers plug in SARIF / RFC 7807 / JUnit renderers without
+ * forking the dispatch switch.
+ *
  * @param err - The error tree.
- * @param format - One of `"text" | "json" | "flat" | "github"`.
- * @param depth - Optional max depth (applies to `text` format).
+ * @param renderer - A built-in format name or a custom render function.
+ * @param depth - Optional max depth (applies to `"text"` format only).
  * @returns The rendered string.
  *
  * @public
  */
-export function formatError(err: ValidationError, format: OutputFormat, depth?: number): string {
-  switch (format) {
+export function formatError(
+  err: ValidationError,
+  renderer: OutputFormat | ErrorRenderer,
+  depth?: number,
+): string {
+  if (typeof renderer === "function") return renderer(err);
+  switch (renderer) {
     case "json":
       return JSON.stringify(formatJson(err), null, 2);
     case "flat":

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,14 @@ export {
 } from "./format.js";
 
 export {
+  formatError,
+  isOutputFormat,
+  KNOWN_OUTPUT_FORMATS,
+  type ErrorRenderer,
+  type OutputFormat,
+} from "./format-output.js";
+
+export {
   collectIssues,
   toProblemDetails,
   type ProblemDetails,

--- a/packages/core/test/format-output.test.ts
+++ b/packages/core/test/format-output.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createBranchError, createLeafError } from "@oav/core";
-import { formatError } from "../src/format-output.js";
+import { createBranchError, createLeafError, formatError, isOutputFormat } from "../src/index.js";
 
 const sample = createBranchError("request", [], "request validation failed", [
   createLeafError("type", ["body", "age"], "must be number", { expected: "number" }),
@@ -29,5 +28,24 @@ describe("formatError", () => {
   it("respects depth truncation in text mode", () => {
     const out = formatError(sample, "text", 0);
     expect(out.split("\n").length).toBeLessThan(3);
+  });
+
+  it("accepts a custom renderer function", () => {
+    const out = formatError(sample, (err) => `custom:${err.code}:${err.children.length}`);
+    expect(out).toBe("custom:request:1");
+  });
+});
+
+describe("isOutputFormat", () => {
+  it("narrows valid names", () => {
+    expect(isOutputFormat("text")).toBe(true);
+    expect(isOutputFormat("json")).toBe(true);
+    expect(isOutputFormat("flat")).toBe(true);
+    expect(isOutputFormat("github")).toBe(true);
+  });
+
+  it("rejects unknown names", () => {
+    expect(isOutputFormat("xml")).toBe(false);
+    expect(isOutputFormat("")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
Every other oav extension point (custom keywords, formats, dialects, readers, overlays) is plugin-style. Output formats were the exception: `KNOWN_OUTPUT_FORMATS` was a frozen tuple and `formatError` a hard-coded switch, both in `@oav/cli`, so library consumers wanting a SARIF / RFC 7807 / JUnit renderer had to fork or re-implement the dispatch.

- Moved `formatError`, `OutputFormat`, `KNOWN_OUTPUT_FORMATS`, `isOutputFormat` into `@oav/core`.
- Added a programmatic overload: `formatError(err, renderer)` accepts either a built-in format name or a caller-supplied `(err) => string` function.
- CLI now imports directly from `@oav/core` (no shim package).
- Relocated the format-output test from `packages/cli/test/` to `packages/core/test/`; added coverage for the custom-renderer path and `isOutputFormat`.
- Extracted the duplicated `memoryIo()` test helper from `cli.test.ts` + `commands.test.ts` into `packages/cli/test/fixtures.ts`.
- Updated `CLAUDE.md`'s "How to add a new output format" section.

## Test plan
- [x] `pnpm test` (533/533 pass — three new test cases)
- [x] `pnpm lint`
- [x] `pnpm typecheck`

Closes #60