### PR TITLE
fix(core,validator): tighten BuiltInErrorParams narrowing; fix *-param drift

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -134,10 +134,30 @@ export interface BuiltInErrorParams {
   "query-param": { name: string; in: "query" };
   "header-param": { name: string; in: "header" };
   "cookie-param": { name: string; in: "cookie" };
-
-  /** Catch-all for custom / not-yet-documented codes. */
-  [code: string]: Record<string, unknown>;
 }
+
+/**
+ * Params shape for codes that aren't documented in
+ * {@link BuiltInErrorParams} — custom keywords, consumer-defined
+ * HTTP-layer wrappers, or anything reached via a string variable the
+ * compiler can't narrow.
+ *
+ * @public
+ */
+export type CustomErrorParams = Record<string, unknown>;
+
+/**
+ * The params shape for an arbitrary error `code`. Built-in codes narrow
+ * to the documented {@link BuiltInErrorParams} entry; any other code
+ * widens to {@link CustomErrorParams}. Lets downstream code narrow
+ * through a variable — `ErrorParams<typeof err.code>` — not just a
+ * string literal.
+ *
+ * @public
+ */
+export type ErrorParams<Code extends string> = Code extends keyof BuiltInErrorParams
+  ? BuiltInErrorParams[Code]
+  : CustomErrorParams;
 
 /**
  * Runtime-visible list of every named code documented in

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,8 @@ export {
   walkErrors,
   type BuiltInErrorParams,
   type CreateErrorParams,
+  type CustomErrorParams,
+  type ErrorParams,
   type ErrorParamsFor,
   type PathSegment,
   type ValidationError,

--- a/packages/core/test/errors.test.ts
+++ b/packages/core/test/errors.test.ts
@@ -6,6 +6,9 @@ import {
   createLeafError,
   joinPath,
   walkErrors,
+  type BuiltInErrorParams,
+  type CustomErrorParams,
+  type ErrorParams,
   type ErrorParamsFor,
   type ValidationError,
 } from "../src/errors.js";
@@ -125,6 +128,27 @@ describe("BuiltInErrorParams", () => {
     }>();
     expectTypeOf<ErrorParamsFor<"required">>().toEqualTypeOf<{ missing: string }>();
     expectTypeOf<ErrorParamsFor<"allOf">>().toEqualTypeOf<{ total: number; failed: number }>();
+  });
+
+  it("keyof BuiltInErrorParams is a finite union, not string", () => {
+    // Without an index signature the union collapses to the actual
+    // documented keys. A regression that re-adds `[code: string]: ...`
+    // would widen this to `string` and the assertion would fail at
+    // compile time.
+    type Keys = keyof BuiltInErrorParams;
+    expectTypeOf<"type">().toExtend<Keys>();
+    expectTypeOf<"required">().toExtend<Keys>();
+    expectTypeOf<"header-param">().toExtend<Keys>();
+    expectTypeOf<string>().not.toExtend<Keys>();
+    // The union can exclude an arbitrary made-up code.
+    expectTypeOf<"not-a-real-code">().not.toExtend<Keys>();
+  });
+
+  it("ErrorParams narrows for built-in codes and widens for custom", () => {
+    expectTypeOf<ErrorParams<"required">>().toEqualTypeOf<{ missing: string }>();
+    expectTypeOf<ErrorParams<"type">>().toEqualTypeOf<{ expected: string[]; actual: string }>();
+    // A custom / unknown code widens to CustomErrorParams.
+    expectTypeOf<ErrorParams<"my-custom-code">>().toEqualTypeOf<CustomErrorParams>();
   });
 
   it("demonstrates the read-side narrowing pattern", () => {

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -509,6 +509,7 @@ export function createValidator(
           children.push(
             createLeafError("query-param", ["query", key], `unknown query parameter "${key}"`, {
               name: key,
+              in: "query",
             }),
           );
         }
@@ -561,6 +562,7 @@ export function createValidator(
                   `missing required header "${name}"`,
                   {
                     name,
+                    in: "header",
                   },
                 ),
               );

--- a/packages/validator/test/error-codes.test.ts
+++ b/packages/validator/test/error-codes.test.ts
@@ -214,4 +214,114 @@ describe("BuiltInErrorParams registry cross-check", () => {
     expect(e?.code).toBe("request");
     expect(e?.params).toEqual({ method: "POST", pathPattern: "/items/{id}" });
   });
+
+  it("HTTP-layer emitted params conform to BuiltInErrorParams shapes", () => {
+    // Declared required keys per HTTP-layer code. Runtime assertion
+    // that the validator's emitted params include every documented key.
+    // Errors are emitted imperatively (not through generated JS), so
+    // TypeScript can't enforce the contract — this test is the backstop.
+    const requiredKeys: Record<string, readonly string[]> = {
+      route: ["method", "path"],
+      request: ["method", "pathPattern"],
+      response: ["status"],
+      status: ["status"],
+      "content-type": ["contentType"],
+      body: [],
+      "query-param": ["name", "in"],
+      "header-param": ["name", "in"],
+    };
+
+    const findLeaf = (err: ValidationError | null, code: string): ValidationError | undefined => {
+      if (err === null) return undefined;
+      let hit: ValidationError | undefined;
+      walkErrors(err, (node) => {
+        if (hit === undefined && node.code === code) hit = node;
+      });
+      return hit;
+    };
+
+    const check = (err: ValidationError | null, code: string): void => {
+      const node = findLeaf(err, code);
+      expect(node, `expected code=${code} in fixture`).toBeDefined();
+      for (const key of requiredKeys[code] ?? []) {
+        expect(node?.params, `code=${code} missing param '${key}'`).toHaveProperty(key);
+      }
+    };
+
+    // Fixture corpus that surfaces each HTTP-layer code at least once.
+    const specStrict = sampleSpec();
+    const v = createValidator(specStrict, { strictQueryParameters: true });
+    const vWithResponseHeader = createValidator({
+      openapi: "3.1.0",
+      info: { title: "t", version: "1" },
+      paths: {
+        "/r": {
+          get: {
+            responses: {
+              "200": {
+                description: "ok",
+                headers: { "X-Rate": { required: true, schema: { type: "string" } } },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    check(v.validateRequest({ method: "DELETE", path: "/nope" }), "route");
+    check(
+      v.validateRequest({
+        method: "POST",
+        path: "/items/1",
+        contentType: "application/json",
+      }),
+      "body",
+    );
+    check(
+      v.validateRequest({
+        method: "POST",
+        path: "/items/1",
+        contentType: "text/plain",
+        body: "x",
+      }),
+      "content-type",
+    );
+    check(
+      v.validateRequest({
+        method: "POST",
+        path: "/items/abc",
+        contentType: "application/json",
+        body: { name: "x" },
+      }),
+      "request",
+    );
+    // path-param / cookie-param only surface as leaves on missing-
+    // required parameter values. Path params can't be missing on a
+    // matched route (they're in the URL); cookie-param is similarly
+    // unreachable from a simple fixture. Present-but-invalid path /
+    // cookie values bubble up as schema leaves (`type`, etc.), not the
+    // `*-param` wrapper. Declared shape trusted by construction
+    // (same `{ name, in }` builder as the reachable siblings).
+    check(v.validateRequest({ method: "GET", path: "/items/1" }), "header-param");
+    // Strict query parameters — unknown key triggers query-param.
+    check(
+      v.validateRequest({
+        method: "GET",
+        path: "/items/1",
+        headers: { "x-tenant": "t1" },
+        query: { bogus: "x" },
+      }),
+      "query-param",
+    );
+    check(v.validateResponse({ method: "GET", path: "/items/1" }, { status: 500 }), "response");
+    check(v.validateResponse({ method: "GET", path: "/items/1" }, { status: 500 }), "status");
+    // Response-side missing required header — must carry name + in.
+    check(
+      vWithResponseHeader.validateResponse(
+        { method: "GET", path: "/r" },
+        { status: 200, headers: {} },
+      ),
+      "header-param",
+    );
+  });
 });


### PR DESCRIPTION
Combines #58 + #59 — same contract, same test.

## Summary

### #58 — index signature erased narrowing
`BuiltInErrorParams` ended with `[code: string]: Record<string, unknown>` as a "catch-all for custom codes." TypeScript's index-signature rules then:
- collapsed `ErrorParamsFor<someVariable>` to `Record<string, unknown>`
- widened `keyof BuiltInErrorParams` to `string`
- weakened the `as const satisfies ReadonlyArray<keyof BuiltInErrorParams>` check on `BUILT_IN_ERROR_CODES`

Drop the index signature. Add two siblings:
- `CustomErrorParams` — `Record<string, unknown>`, the escape hatch for unknown codes.
- `ErrorParams<Code extends string>` — conditional that narrows for built-in codes and widens to `CustomErrorParams` otherwise. Lets downstream code narrow through a variable, not just a string literal.

Declaration-merging continues to work for consumers augmenting the map with custom codes.

### #59 — runtime `*-param` drift
- `validator.ts:510` (strict-mode unknown query) emitted `{ name }` — declared shape was `{ name; in: "query" }`.
- `validator.ts:559-565` (missing response header) emitted `{ name }` — declared shape was `{ name; in: "header" }`.

Fixed both. Added an HTTP-layer params-shape conformance test in `error-codes.test.ts` that, for every reachable wrapper code, exercises a fixture and asserts the emitted `params` carries every declared required key. (`path-param` / `cookie-param` are declared but unreachable from the current validator — path params can't be missing on a matched route; cookie-param has no content-JSON emission path. Called out in a code comment.)

## Test plan
- [x] `pnpm test` (538/538 pass — three new assertions)
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] Type-level: `keyof BuiltInErrorParams` is now a finite union; `ErrorParams<T>` narrows for built-ins and widens for customs.

Closes #58
Closes #59