### PR TITLE
feat(schema): add compileAndCallSubschema helper; dedupe allOf/anyOf

### DIFF
--- a/packages/schema/src/keywords/composition.ts
+++ b/packages/schema/src/keywords/composition.ts
@@ -18,65 +18,41 @@ export const allOfKeyword: KeywordDefinition = {
     if (schemas.length === 0) return;
     const outProps = ctx.evaluatedPropertiesVar;
     const outItems = ctx.evaluatedItemsVar;
-    if (ctx.predicate) {
-      // Predicate mode: every branch must pass. A failure short-
-      // circuits the whole function with `return false;` — no need to
-      // gather per-branch errors or make a decision after the loop.
-      // Evaluated keys from each passing branch merge into the caller
-      // directly; if we ever return false before the merge, the keys
-      // we'd have collected are moot because the caller is about to
-      // return false itself.
-      schemas.forEach((sub) => {
-        const fn = ctx.compileSubschema(sub);
-        if (outProps === null && outItems === null) {
-          ctx.gen.line(`if (!${fn}(${ctx.data})) return false;`);
-          return;
-        }
-        const propsVar = ctx.gen.scope.name("bProps");
-        const itemsVar = ctx.gen.scope.name("bItems");
-        ctx.gen.const(propsVar, outProps !== null ? "new Set()" : "undefined");
-        ctx.gen.const(itemsVar, outItems !== null ? "new Set()" : "undefined");
-        ctx.gen.line(`if (!${fn}(${ctx.data}, ${propsVar}, ${itemsVar})) return false;`);
-        if (outProps !== null) ctx.gen.line(`for (const k of ${propsVar}) ${outProps}.add(k);`);
-        if (outItems !== null) ctx.gen.line(`for (const k of ${itemsVar}) ${outItems}.add(k);`);
-      });
-      return;
-    }
-    const errsVar = ctx.gen.scope.name("allOfErrs");
-    ctx.gen.const(errsVar, "[]");
-    // Annotations (evaluated keys/items) are only collected from
-    // subschemas that pass, per the 2020-12 spec. We give each branch
-    // its own Set and merge them into the enclosing scope only when the
-    // branch returns null.
+    // Tree mode collects per-branch errors; predicate short-circuits
+    // on first failure so there's nothing to collect.
+    const errsVar = ctx.predicate ? null : ctx.gen.scope.name("allOfErrs");
+    if (errsVar !== null) ctx.gen.const(errsVar, "[]");
     schemas.forEach((sub) => {
-      const fn = ctx.compileSubschema(sub);
-      const errVar = ctx.gen.scope.name("e");
-      const propsVar = ctx.gen.scope.name("bProps");
-      const itemsVar = ctx.gen.scope.name("bItems");
-      ctx.gen.const(propsVar, outProps !== null ? "new Set()" : "undefined");
-      ctx.gen.const(itemsVar, outItems !== null ? "new Set()" : "undefined");
-      ctx.gen.const(errVar, `${fn}(${ctx.data}, ${ctx.path}, ${propsVar}, ${itemsVar})`);
-      ctx.gen.if(
-        `${errVar} === null`,
-        (g) => {
-          if (outProps !== null) g.line(`for (const k of ${propsVar}) ${outProps}.add(k);`);
-          if (outItems !== null) g.line(`for (const k of ${itemsVar}) ${outItems}.add(k);`);
+      ctx.compileAndCallSubschema(sub, {
+        data: ctx.data,
+        onPass: (g, bProps, bItems) => {
+          if (outProps !== null && bProps !== null) {
+            g.line(`for (const k of ${bProps}) ${outProps}.add(k);`);
+          }
+          if (outItems !== null && bItems !== null) {
+            g.line(`for (const k of ${bItems}) ${outItems}.add(k);`);
+          }
         },
-        (g) => g.line(`${errsVar}.push(${errVar});`),
-      );
+        onFail: (g, errVar) => {
+          if (errVar === null) g.line("return false;");
+          else g.line(`${errsVar}.push(${errVar});`);
+        },
+      });
     });
-    const n = schemas.length;
-    ctx.gen.if(`${errsVar}.length > 0`, () => {
-      ctx.emitError(
-        "lift",
-        ctx.branchErrorExpr(
-          quoteString("allOf"),
-          `\`must satisfy all ${n} schemas (\${${errsVar}.length} failed)\``,
-          errsVar,
-          `{ total: ${n}, failed: ${errsVar}.length }`,
-        ),
-      );
-    });
+    if (errsVar !== null) {
+      const n = schemas.length;
+      ctx.gen.if(`${errsVar}.length > 0`, () => {
+        ctx.emitError(
+          "lift",
+          ctx.branchErrorExpr(
+            quoteString("allOf"),
+            `\`must satisfy all ${n} schemas (\${${errsVar}.length} failed)\``,
+            errsVar,
+            `{ total: ${n}, failed: ${errsVar}.length }`,
+          ),
+        );
+      });
+    }
   },
 };
 
@@ -95,62 +71,42 @@ export const anyOfKeyword: KeywordDefinition = {
     if (schemas.length === 0) return;
     const outProps = ctx.evaluatedPropertiesVar;
     const outItems = ctx.evaluatedItemsVar;
-    if (ctx.predicate) {
-      // Per 2020-12 annotations from passing branches merge into the
-      // caller; we still run every branch so the evaluated-keys tree
-      // reflects every branch that matched. When the caller isn't
-      // tracking, we stop at the first match.
-      const matched = ctx.gen.scope.name("matched");
-      ctx.gen.let(matched, "false");
-      schemas.forEach((sub) => {
-        const fn = ctx.compileSubschema(sub);
-        if (outProps === null && outItems === null) {
-          ctx.gen.line(`if (!${matched} && ${fn}(${ctx.data})) ${matched} = true;`);
-          return;
-        }
-        const propsVar = ctx.gen.scope.name("bProps");
-        const itemsVar = ctx.gen.scope.name("bItems");
-        ctx.gen.const(propsVar, outProps !== null ? "new Set()" : "undefined");
-        ctx.gen.const(itemsVar, outItems !== null ? "new Set()" : "undefined");
-        ctx.gen.if(`${fn}(${ctx.data}, ${propsVar}, ${itemsVar})`, (g) => {
+    const matched = ctx.gen.scope.name("matched");
+    ctx.gen.let(matched, "false");
+    // Tree mode collects per-branch errors for the final anyOf node;
+    // predicate returns false after the loop if none matched.
+    const errsVar = ctx.predicate ? null : ctx.gen.scope.name("anyOfErrs");
+    if (errsVar !== null) ctx.gen.const(errsVar, "[]");
+    schemas.forEach((sub) => {
+      ctx.compileAndCallSubschema(sub, {
+        data: ctx.data,
+        onPass: (g, bProps, bItems) => {
           g.line(`${matched} = true;`);
-          if (outProps !== null) g.line(`for (const k of ${propsVar}) ${outProps}.add(k);`);
-          if (outItems !== null) g.line(`for (const k of ${itemsVar}) ${outItems}.add(k);`);
-        });
+          if (outProps !== null && bProps !== null) {
+            g.line(`for (const k of ${bProps}) ${outProps}.add(k);`);
+          }
+          if (outItems !== null && bItems !== null) {
+            g.line(`for (const k of ${bItems}) ${outItems}.add(k);`);
+          }
+        },
+        onFail: (g, errVar) => {
+          if (errVar !== null) g.line(`${errsVar}.push(${errVar});`);
+          // predicate mode: no-op, the final `!matched` check handles it
+        },
       });
+    });
+    const n = schemas.length;
+    if (ctx.predicate) {
       ctx.gen.line(`if (!${matched}) return false;`);
       return;
     }
-    const errsVar = ctx.gen.scope.name("anyOfErrs");
-    const matched = ctx.gen.scope.name("matched");
-    ctx.gen.const(errsVar, "[]");
-    ctx.gen.let(matched, "false");
-    schemas.forEach((sub) => {
-      const fn = ctx.compileSubschema(sub);
-      const errVar = ctx.gen.scope.name("e");
-      const propsVar = ctx.gen.scope.name("bProps");
-      const itemsVar = ctx.gen.scope.name("bItems");
-      ctx.gen.const(propsVar, outProps !== null ? "new Set()" : "undefined");
-      ctx.gen.const(itemsVar, outItems !== null ? "new Set()" : "undefined");
-      ctx.gen.const(errVar, `${fn}(${ctx.data}, ${ctx.path}, ${propsVar}, ${itemsVar})`);
-      ctx.gen.if(
-        `${errVar} === null`,
-        (g) => {
-          g.line(`${matched} = true;`);
-          if (outProps !== null) g.line(`for (const k of ${propsVar}) ${outProps}.add(k);`);
-          if (outItems !== null) g.line(`for (const k of ${itemsVar}) ${outItems}.add(k);`);
-        },
-        (g) => g.line(`${errsVar}.push(${errVar});`),
-      );
-    });
-    const n = schemas.length;
     ctx.gen.if(`!${matched}`, () => {
       ctx.emitError(
         "lift",
         ctx.branchErrorExpr(
           quoteString("anyOf"),
           `\`must match at least one of ${n} schemas\``,
-          errsVar,
+          errsVar!,
           `{ total: ${n} }`,
         ),
       );

--- a/packages/schema/src/keywords/context.ts
+++ b/packages/schema/src/keywords/context.ts
@@ -1,6 +1,7 @@
 import type { SchemaObject, SchemaOrBoolean } from "@oav/core";
 import { NAMES, pathJoinExpr, rawExpr, type CodeGen } from "../codegen/index.js";
 import type {
+  CompileAndCallOptions,
   ErrorKind,
   KeywordCompileContext,
   KeywordDefinition,
@@ -490,6 +491,41 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     }
   };
 
+  const compileAndCallSubschema = (
+    schema: SchemaOrBoolean,
+    options: CompileAndCallOptions,
+  ): void => {
+    const fn = inputs.compileSubschema(schema);
+    // When the enclosing scope tracks evaluated props or items, each
+    // call gets its own branch-local Set so annotations from a failing
+    // branch don't leak into the caller. When tracking is off for both,
+    // we can skip the branch vars entirely — the sub-validator's trailing
+    // params default to `undefined`.
+    const needBranchVars = evaluatedPropertiesVar !== null || evaluatedItemsVar !== null;
+    const branchProps = needBranchVars ? inputs.gen.scope.name("bProps") : null;
+    const branchItems = needBranchVars ? inputs.gen.scope.name("bItems") : null;
+    if (branchProps !== null && branchItems !== null) {
+      inputs.gen.const(branchProps, evaluatedPropertiesVar !== null ? "new Set()" : "undefined");
+      inputs.gen.const(branchItems, evaluatedItemsVar !== null ? "new Set()" : "undefined");
+    }
+    const trailingArgs = needBranchVars ? `, ${branchProps!}, ${branchItems!}` : "";
+    if (predicate) {
+      inputs.gen.if(
+        `${fn}(${options.data}${trailingArgs})`,
+        (g) => options.onPass(g, branchProps, branchItems),
+        (g) => options.onFail(g, null, branchProps, branchItems),
+      );
+      return;
+    }
+    const errVar = inputs.gen.scope.name("e");
+    inputs.gen.const(errVar, `${fn}(${options.data}, ${inputs.path}${trailingArgs})`);
+    inputs.gen.if(
+      `${errVar} === null`,
+      (g) => options.onPass(g, branchProps, branchItems),
+      (g) => options.onFail(g, errVar, branchProps, branchItems),
+    );
+  };
+
   return {
     gen: inputs.gen,
     schema: inputs.schema,
@@ -500,6 +536,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     effectivePathExpr,
     errors: inputs.errors,
     compileSubschema: inputs.compileSubschema,
+    compileAndCallSubschema,
     resolveRef: inputs.resolveRef,
     evaluatedPropertiesVar,
     evaluatedItemsVar,

--- a/packages/schema/src/keywords/types.ts
+++ b/packages/schema/src/keywords/types.ts
@@ -39,6 +39,39 @@ export interface ValidateSubschemaOptions {
 }
 
 /**
+ * Options for
+ * {@link KeywordCompileContext.compileAndCallSubschema}.
+ *
+ * @public
+ */
+export interface CompileAndCallOptions {
+  /** JS expression for the data to pass to the sub-validator. */
+  data: string;
+  /**
+   * Emitted into the "sub passed" branch. Receives the per-branch
+   * evaluated-keys var names when the enclosing scope tracks either;
+   * `null` otherwise. Merge into the caller's `outProps` / `outItems`
+   * here — annotations from failing branches are not merged per the
+   * 2020-12 spec, so the helper only exposes them on the pass side.
+   */
+  onPass: (gen: CodeEmitter, branchProps: string | null, branchItems: string | null) => void;
+  /**
+   * Emitted into the "sub failed" branch. `errVar` is the name of the
+   * local const holding the sub-validator's returned error in tree
+   * mode, or `null` in predicate mode (which has nothing to pass).
+   * Keywords that short-circuit on failure in predicate mode emit
+   * `return false;` via the `gen` here; tree-mode keywords typically
+   * push `errVar` into their own errors array.
+   */
+  onFail: (
+    gen: CodeEmitter,
+    errVar: string | null,
+    branchProps: string | null,
+    branchItems: string | null,
+  ) => void;
+}
+
+/**
  * The narrow context passed to each keyword's `compile()` function. Keyword
  * authors see only these names — no reference to the compiler, the full
  * vocabulary, or the validator instance.
@@ -62,15 +95,32 @@ export interface KeywordCompileContext {
    * Compile a nested subschema to its own function and return the
    * function's identifier. The returned name is callable with
    * `(data, path)` inside generated code. Use this when a keyword
-   * needs the sub-validator's return value for its own logic —
-   * composition keywords (`allOf`, `anyOf`, `oneOf`, `if`/`then`/
-   * `else`) collect results per-branch to decide whether to emit a
-   * top-level error. For the common "validate this subschema against
-   * `dataExpr` and emit any errors" pattern, use
-   * {@link KeywordCompileContext.validateSubschema} — it's simpler
-   * and applies the subschema-inlining optimisation.
+   * needs direct access to the function name — most composition-style
+   * keywords are better served by
+   * {@link KeywordCompileContext.compileAndCallSubschema}, which also
+   * hides the predicate-vs-tree call-signature split.
    */
   compileSubschema(schema: SchemaOrBoolean): string;
+  /**
+   * Compile a subschema and emit a call + pass/fail branch, abstracting
+   * over the two call conventions:
+   *
+   * - Tree mode: `const ev = fn(data, path, bProps, bItems); if (ev === null) { onPass } else { onFail(ev) }`
+   * - Predicate: `if (fn(data, bProps, bItems)) { onPass } else { onFail(null) }`
+   *
+   * When the enclosing scope tracks evaluated properties or items, the
+   * helper allocates per-branch accumulator Sets and passes their names
+   * to the callbacks so the caller can merge them into its own outputs
+   * on the pass branch (the 2020-12 spec discards annotations from
+   * failing branches). When no tracking is active, both callbacks see
+   * `null` for the branch variables.
+   *
+   * The sub-validator is called once; what each branch does is
+   * keyword-specific — composition keywords push the error into a
+   * per-keyword errors array on fail, `not` emits a leaf on pass,
+   * etc. The abstraction deliberately stops at the call shape.
+   */
+  compileAndCallSubschema(schema: SchemaOrBoolean, options: CompileAndCallOptions): void;
   /**
    * Resolve a `$ref` (absolute URI or fragment) to a compiled function
    * name. Used by `$ref` and `$dynamicRef` keywords.


### PR DESCRIPTION
## Summary
Composition keywords shipped two near-identical ~40-line branches differing only in the sub-validator call convention (tree mode returns `ValidationError | null` with a `path` arg; predicate returns `boolean` without one) and in what they do on failure.

- Add `ctx.compileAndCallSubschema(schema, { data, onPass, onFail })`. It emits the call + pass/fail branch in whichever shape the active mode needs, allocates per-branch evaluated-keys accumulators when the enclosing scope tracks, and hands the caller the `errVar` (tree) or `null` (predicate) so the on-fail action can be expressed once.
- Rewrite `allOf` and `anyOf` on top of the helper (~60 lines each → ~40).

## What's intentionally out of scope

- `oneOf`: its predicate mode short-circuits on `matchCount > 1` inside the pass branch and *defers* annotation merge until after the loop; tree mode merges immediately. The two flows are genuinely different, not merely duplicative.
- `not`: passes no tracking args to the sub (the sub's annotations shouldn't contribute to the parent under `not` semantics). The helper's branch-local Set allocation would add wasted work here.
- `dependentSchemas`, `dependencies`, `if`/`then`/`else`: pass the caller's `outProps` / `outItems` *directly* rather than branch-local Sets — a different annotation regime from composition keywords.

The helper can grow an option (e.g. `skipEvaluatedKeys` / `inheritEvaluatedKeys`) to cover those call sites if follow-up work wants to converge them further.

## Test plan
- [x] `pnpm test` (538/538 pass — no behaviour change)
- [x] `pnpm lint`
- [x] `pnpm typecheck`

Closes #64