### PR TITLE
refactor(schema): stratify public surface; add internals subpath

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,12 @@ Both have their own `package.json` + `pnpm-workspace.yaml` (with empty
   the generated JS source, and `eval`s it through `new Function(deps, src)`.
   Boolean schemas (`true`/`false`) are first-class. `$ref` uses an
   identity-keyed cache so self-recursive refs emit normal recursive calls.
+  The public barrel holds what keyword authors need; codegen mechanics
+  (`NAMES`, `pathJoinExpr`, `rawExpr`, `quoteString`, runtime helpers,
+  `SchemaRegistry`, `SUBSCHEMA_*_POSITIONS`, `createKeywordContext`)
+  live behind the `@aahoughton/oav/schema/internals` subpath — reach
+  for them only when a plugin genuinely needs them (not covered by
+  semver).
 - **`@oav/formats`** — pure string validators; exported as a `Record<string,
 (s: string) => boolean>` suitable for `compileSchema`'s `formats` option.
 - **`@oav/spec`** — `DocumentReader` abstraction (file/http/memory/composite)

--- a/package.json
+++ b/package.json
@@ -50,6 +50,11 @@
       "import": "./dist/schema.js",
       "require": "./dist/schema.cjs"
     },
+    "./schema/internals": {
+      "types": "./dist/schema-internals.d.ts",
+      "import": "./dist/schema-internals.js",
+      "require": "./dist/schema-internals.cjs"
+    },
     "./spec": {
       "types": "./dist/spec.d.ts",
       "import": "./dist/spec.js",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -10,6 +10,10 @@
     ".": {
       "types": "./src/index.ts",
       "import": "./src/index.ts"
+    },
+    "./internals": {
+      "types": "./src/internals.ts",
+      "import": "./src/internals.ts"
     }
   },
   "dependencies": {

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,119 +1,165 @@
-export { NAMES, pathJoinExpr, quoteString, rawExpr } from "./codegen/index.js";
-export type {
-  CodeEmitter,
-  NameGenerator,
-  PathSegmentLike,
-  RawExpression,
-} from "./codegen/index.js";
+/**
+ * The public `@aahoughton/oav/schema` surface. Two audiences:
+ *
+ *   1. Compiler consumers — `compileSchema`, `CompiledSchema`,
+ *      `CompileOptions`, dialects. The minimum needed to turn a schema
+ *      into a validator.
+ *   2. Keyword authors — `KeywordDefinition`, `KeywordCompileContext`,
+ *      vocabulary URIs + vocab objects, the built-in keyword constants
+ *      (useful for reusing or composing them into a custom dialect),
+ *      the OAS 3.0 overrides.
+ *
+ * Codegen mechanics, runtime helpers, resolve internals, and the
+ * subschema-position constants live behind
+ * `@aahoughton/oav/schema/internals`. Reach for them when a custom
+ * plugin genuinely needs them, accepting that they're not covered by
+ * semver.
+ *
+ * @packageDocumentation
+ */
+
+// Compiler — turning schemas into validators.
 export {
   compileSchema,
-  createDeps,
-  deepEqual,
-  typeOf,
-  wrapErrors,
   type CompileOptions,
   type CompileStats,
   type CompiledPredicate,
   type CompiledSchema,
   type Validator,
-  type ValidatorDeps,
   type ValidationResult,
 } from "./compiler/index.js";
+
+// Keyword authoring — types + context seen inside `compile(ctx)`.
+export {
+  createCustomKeywordDefinition,
+  customKeywordVocabulary,
+  type CustomKeywordFailure,
+  type CustomKeywordValidator,
+} from "./keywords/custom.js";
+export type {
+  CompileAndCallOptions,
+  CompileRuntime,
+  Dialect,
+  DialectRules,
+  ErrorKind,
+  KeywordCompileContext,
+  KeywordDefinition,
+  ValidateSubschemaOptions,
+  Vocabulary,
+} from "./keywords/types.js";
+
+// Vocabulary URIs + built-in vocabularies + dialects.
 export {
   APPLICATOR_VOCAB,
   CORE_VALIDATION_VOCAB,
   CORE_VOCAB,
   FORMAT_ASSERTION_VOCAB,
   FORMAT_VOCAB,
+  META_DATA_VOCAB,
   OAS30_VOCAB,
   UNEVALUATED_VOCAB,
-  additionalPropertiesKeyword,
-  allOfKeyword,
-  anchorKeyword,
-  anyOfKeyword,
   applicatorVocabulary,
-  commentKeyword,
-  constKeyword,
-  containsKeyword,
   coreVocabulary,
-  createCustomKeywordDefinition,
-  createKeywordContext,
-  customKeywordVocabulary,
   defaultVocabularies,
-  defsKeyword,
+  formatAssertionVocabulary,
+  formatVocabulary,
+  jsonSchemaDialect,
+  metaDataVocabulary,
+  oas30Dialect,
+  oas30Vocabulary,
+  openapi31Dialect,
+  openapiMetaDataVocabulary,
+  unevaluatedVocabulary,
+  validationVocabulary,
+} from "./keywords/vocabulary.js";
+
+// Built-in keyword constants — reusable when composing a custom dialect.
+export {
+  maxItemsKeyword,
+  minItemsKeyword,
+  uniqueItemsKeyword,
+} from "./keywords/array-validation.js";
+export {
+  allOfKeyword,
+  anyOfKeyword,
   dependenciesKeyword,
   dependentRequiredKeyword,
   dependentSchemasKeyword,
-  discriminatorKeyword,
-  dynamicAnchorKeyword,
-  dynamicRefKeyword,
-  enumKeyword,
+  ifThenElseKeyword,
+  notKeyword,
+  oneOfKeyword,
+} from "./keywords/composition.js";
+export { constKeyword, enumKeyword } from "./keywords/equality.js";
+export { containsKeyword, itemsKeyword, prefixItemsKeyword } from "./keywords/items.js";
+export {
+  defaultKeyword,
+  deprecatedKeyword,
+  descriptionKeyword,
+  exampleKeyword,
+  examplesKeyword,
+  readOnlyKeyword,
+  titleKeyword,
+  writeOnlyKeyword,
+} from "./keywords/meta-data.js";
+export {
   exclusiveMaximumKeyword,
   exclusiveMinimumKeyword,
-  formatAssertionKeyword,
-  formatAssertionVocabulary,
-  formatKeyword,
-  formatVocabulary,
-  idKeyword,
-  ifThenElseKeyword,
-  itemsKeyword,
-  maxItemsKeyword,
-  maxLengthKeyword,
-  maxPropertiesKeyword,
   maximumKeyword,
-  minItemsKeyword,
-  minLengthKeyword,
-  minPropertiesKeyword,
   minimumKeyword,
   multipleOfKeyword,
-  notKeyword,
-  jsonSchemaDialect,
-  oas30Dialect,
+} from "./keywords/number.js";
+export {
   oas30ExclusiveMaximumKeyword,
   oas30ExclusiveMinimumKeyword,
   oas30MaximumKeyword,
   oas30MinimumKeyword,
   oas30NullableKeyword,
   oas30TypeKeyword,
-  oas30Vocabulary,
-  openapi31Dialect,
-  oneOfKeyword,
-  patternKeyword,
+} from "./keywords/oas30.js";
+export {
+  maxPropertiesKeyword,
+  minPropertiesKeyword,
+  requiredKeyword,
+} from "./keywords/object-validation.js";
+export {
+  additionalPropertiesKeyword,
   patternPropertiesKeyword,
-  prefixItemsKeyword,
   propertiesKeyword,
   propertyNamesKeyword,
-  refKeyword,
-  requiredKeyword,
-  schemaDialectKeyword,
-  typeKeyword,
-  unevaluatedItemsKeyword,
-  unevaluatedPropertiesKeyword,
-  unevaluatedVocabulary,
-  uniqueItemsKeyword,
-  validationVocabulary,
-  type CustomKeywordFailure,
-  type CustomKeywordValidator,
-  type Dialect,
-  type DialectRules,
-  type ErrorKind,
-  type KeywordCompileContext,
-  type KeywordContextInputs,
-  type KeywordDefinition,
-  type ValidateSubschemaOptions,
-  type Vocabulary,
-} from "./keywords/index.js";
+} from "./keywords/properties.js";
 export {
-  SchemaRegistry,
-  collectDynamicAnchors,
+  anchorKeyword,
+  commentKeyword,
+  defsKeyword,
+  dynamicAnchorKeyword,
+  dynamicRefKeyword,
+  idKeyword,
+  refKeyword,
+  schemaDialectKeyword,
+} from "./keywords/ref.js";
+export {
+  formatAssertionKeyword,
+  formatKeyword,
+  maxLengthKeyword,
+  minLengthKeyword,
+  patternKeyword,
+} from "./keywords/string.js";
+export { typeKeyword } from "./keywords/type.js";
+export { discriminatorKeyword } from "./keywords/discriminator.js";
+export { unevaluatedItemsKeyword, unevaluatedPropertiesKeyword } from "./keywords/unevaluated.js";
+
+// Ref resolution — needed by `@oav/validator` and any consumer wiring
+// up a custom spec loader. The lower-level `SchemaRegistry` /
+// `collectDynamicAnchors` primitives are in `./internals`.
+export {
   createRefResolver,
   resolve,
   type RefResolver,
   type ResolvedGraph,
   type ResolveOptions,
 } from "./resolve/index.js";
-export {
-  SUBSCHEMA_ARRAY_POSITIONS,
-  SUBSCHEMA_MAP_POSITIONS,
-  SUBSCHEMA_SINGLE_POSITIONS,
-} from "./subschema-positions.js";
+
+// Generic subschema walk — intended for linters / introspection /
+// tooling. For rewriting use cases, the raw `SUBSCHEMA_*_POSITIONS`
+// constants are in `./internals`.
+export { walkSubschemas, type SubschemaVisitor } from "./subschema-positions.js";

--- a/packages/schema/src/internals.ts
+++ b/packages/schema/src/internals.ts
@@ -1,0 +1,59 @@
+/**
+ * Internal re-exports for `@aahoughton/oav/schema/internals`. Exposes
+ * the codegen mechanics, runtime helpers, resolve internals, and
+ * subschema-position constants that sit below the public extension
+ * recipe. Reachable when you really need them — tests, advanced
+ * plugins, tooling that walks or rewrites schemas — but deliberately
+ * separated from the main `@aahoughton/oav/schema` barrel so the
+ * public surface matches what keyword authors actually need.
+ *
+ * Nothing here is covered by semver guarantees. Compare against the
+ * main barrel in `./index.ts` before importing from here.
+ *
+ * @packageDocumentation
+ */
+
+// Codegen mechanics — used by keyword authors that need to emit
+// non-boilerplate JS (path joining, string quoting, raw JS injection).
+export {
+  CodeGen,
+  NAMES,
+  Scope,
+  pathJoinExpr,
+  quoteString,
+  rawExpr,
+  type CodeEmitter,
+  type NameGenerator,
+  type PathSegmentLike,
+  type RawExpression,
+} from "./codegen/index.js";
+
+// Runtime helpers — the objects bundled into `deps` and fed to every
+// generated validator. Callers building custom compilers or dialect
+// harnesses can reach for these; normal consumers don't.
+export {
+  createDeps,
+  deepEqual,
+  typeOf,
+  wrapErrors,
+  type ValidatorDeps,
+} from "./compiler/runtime.js";
+
+// Resolve internals. `resolve` / `createRefResolver` are in the main
+// barrel (they're how the validator wires the compiler up); the
+// registry + dynamic-anchor collector are strictly internal.
+export { SchemaRegistry, collectDynamicAnchors } from "./resolve/index.js";
+
+// Keyword-context factory. Keyword authors receive a context (via
+// `compile(ctx)`); only the compiler (and tests that exercise a
+// keyword in isolation) need to build one.
+export { createKeywordContext, type KeywordContextInputs } from "./keywords/context.js";
+
+// Subschema-position constants — the raw sets of schema-valued keys.
+// Prefer the public `walkSubschemas` helper when a read-walk suffices;
+// reach for these only when you need to transform / rewrite.
+export {
+  SUBSCHEMA_ARRAY_POSITIONS,
+  SUBSCHEMA_MAP_POSITIONS,
+  SUBSCHEMA_SINGLE_POSITIONS,
+} from "./subschema-positions.js";

--- a/packages/schema/src/subschema-positions.ts
+++ b/packages/schema/src/subschema-positions.ts
@@ -1,3 +1,5 @@
+import type { SchemaOrBoolean } from "@oav/core";
+
 /**
  * Known JSON Schema 2020-12 (+ OpenAPI) positions that hold a single
  * subschema. Used by any tree-walker that needs to descend only through
@@ -41,3 +43,59 @@ export const SUBSCHEMA_MAP_POSITIONS = [
   "$defs",
   "definitions",
 ] as const;
+
+/**
+ * Visitor callback shape for {@link walkSubschemas}. Receives each
+ * visited subschema plus the dotted-path string leading to it (relative
+ * to the walk root — empty string for the root itself). Returning
+ * `false` from the visitor prunes the subtree; any other value (or
+ * `void`) continues the walk.
+ *
+ * @public
+ */
+export type SubschemaVisitor = (schema: SchemaOrBoolean, path: string) => void | boolean;
+
+/**
+ * Walk every subschema reachable from `root`, in pre-order, descending
+ * through every schema-valued key the JSON Schema 2020-12 vocabulary
+ * (plus the keys OpenAPI adds on top) declares. Boolean schemas and
+ * `$ref` nodes are visited but not descended.
+ *
+ * Intended for tooling — linters, introspection, tree rewriters — that
+ * would otherwise re-derive the set of schema-valued keys and risk
+ * drifting from the vocabulary. Callers that need to *rewrite* schemas
+ * in place can instead reach for the underlying
+ * `SUBSCHEMA_*_POSITIONS` constants exported from
+ * `@aahoughton/oav/schema/internals`.
+ *
+ * @public
+ */
+export function walkSubschemas(root: SchemaOrBoolean, visit: SubschemaVisitor): void {
+  const go = (node: SchemaOrBoolean, path: string): void => {
+    const keep = visit(node, path);
+    if (keep === false) return;
+    if (typeof node !== "object" || node === null || Array.isArray(node)) return;
+    const n = node as Record<string, unknown>;
+    for (const k of SUBSCHEMA_SINGLE_POSITIONS) {
+      const v = n[k];
+      if (v !== undefined) go(v as SchemaOrBoolean, path === "" ? k : `${path}.${k}`);
+    }
+    for (const k of SUBSCHEMA_ARRAY_POSITIONS) {
+      const v = n[k];
+      if (Array.isArray(v)) {
+        for (let i = 0; i < v.length; i += 1) {
+          go(v[i] as SchemaOrBoolean, path === "" ? `${k}[${i}]` : `${path}.${k}[${i}]`);
+        }
+      }
+    }
+    for (const k of SUBSCHEMA_MAP_POSITIONS) {
+      const v = n[k];
+      if (v !== null && typeof v === "object" && !Array.isArray(v)) {
+        for (const [kk, vv] of Object.entries(v as Record<string, unknown>)) {
+          go(vv as SchemaOrBoolean, path === "" ? `${k}.${kk}` : `${path}.${k}.${kk}`);
+        }
+      }
+    }
+  };
+  go(root, "");
+}

--- a/packages/schema/test/walk-subschemas.test.ts
+++ b/packages/schema/test/walk-subschemas.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { SchemaOrBoolean } from "@oav/core";
+import { walkSubschemas } from "../src/subschema-positions.js";
+
+describe("walkSubschemas", () => {
+  it("visits the root, then every schema-valued position in pre-order", () => {
+    const schema: SchemaOrBoolean = {
+      type: "object",
+      properties: {
+        a: { type: "string" },
+        b: { not: { type: "null" } },
+      },
+      allOf: [{ minProperties: 1 }, { maxProperties: 5 }],
+    };
+    const paths: string[] = [];
+    walkSubschemas(schema, (_node, path) => {
+      paths.push(path);
+    });
+    // Order: single-valued keys first, then array keys, then map keys —
+    // matches the SUBSCHEMA_{SINGLE,ARRAY,MAP}_POSITIONS iteration.
+    expect(paths).toEqual([
+      "",
+      "allOf[0]",
+      "allOf[1]",
+      "properties.a",
+      "properties.b",
+      "properties.b.not",
+    ]);
+  });
+
+  it("descends through map positions (patternProperties, dependentSchemas, $defs)", () => {
+    const schema: SchemaOrBoolean = {
+      $defs: { X: { type: "string" } },
+      patternProperties: { "^a": { type: "number" } },
+      dependentSchemas: { trigger: { minProperties: 1 } },
+    };
+    const paths: string[] = [];
+    walkSubschemas(schema, (_n, p) => {
+      paths.push(p);
+    });
+    expect(paths).toContain("$defs.X");
+    expect(paths).toContain("patternProperties.^a");
+    expect(paths).toContain("dependentSchemas.trigger");
+  });
+
+  it("honours a `false` return to prune the subtree", () => {
+    const schema: SchemaOrBoolean = {
+      properties: { a: { properties: { aa: { type: "string" } } } },
+    };
+    const paths: string[] = [];
+    walkSubschemas(schema, (_n, path) => {
+      paths.push(path);
+      if (path === "properties.a") return false; // don't descend into aa
+    });
+    expect(paths).toEqual(["", "properties.a"]);
+  });
+
+  it("visits boolean subschemas without descending", () => {
+    const schema: SchemaOrBoolean = {
+      properties: { forbidden: false, anything: true },
+    };
+    const visited: SchemaOrBoolean[] = [];
+    walkSubschemas(schema, (node) => {
+      visited.push(node);
+    });
+    expect(visited).toContain(false);
+    expect(visited).toContain(true);
+  });
+});

--- a/packages/validator/src/body-schema-transform.ts
+++ b/packages/validator/src/body-schema-transform.ts
@@ -19,12 +19,12 @@
  */
 
 import type { SchemaOrBoolean } from "@oav/core";
+import { type RefResolver } from "@oav/schema";
 import {
   SUBSCHEMA_ARRAY_POSITIONS,
   SUBSCHEMA_MAP_POSITIONS,
   SUBSCHEMA_SINGLE_POSITIONS,
-  type RefResolver,
-} from "@oav/schema";
+} from "@oav/schema/internals";
 
 /**
  * Which leg of the HTTP exchange a schema is being validated against.

--- a/src/schema-internals.ts
+++ b/src/schema-internals.ts
@@ -1,0 +1,1 @@
+export * from "../packages/schema/src/internals.js";

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -10,6 +10,7 @@
     "paths": {
       "@oav/core": ["./packages/core/src/index.ts"],
       "@oav/schema": ["./packages/schema/src/index.ts"],
+      "@oav/schema/internals": ["./packages/schema/src/internals.ts"],
       "@oav/formats": ["./packages/formats/src/index.ts"],
       "@oav/spec": ["./packages/spec/src/index.ts"],
       "@oav/router": ["./packages/router/src/index.ts"],

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,12 +5,13 @@ import { workspaceAliases } from "./workspace-aliases.js";
  * Single-package build for the publishable `oav`.
  *
  * Each entry becomes a subpath in the published package:
- *   src/index.ts  →  "oav"
- *   src/schema.ts →  "oav/schema"
- *   src/spec.ts   →  "oav/spec"
- *   src/formats.ts → "oav/formats"
- *   src/core.ts   →  "oav/core"
- *   src/cli.ts    →  "oav" binary
+ *   src/index.ts            →  "oav"
+ *   src/schema.ts           →  "oav/schema"
+ *   src/schema-internals.ts →  "oav/schema/internals"
+ *   src/spec.ts             →  "oav/spec"
+ *   src/formats.ts          →  "oav/formats"
+ *   src/core.ts             →  "oav/core"
+ *   src/cli.ts              →  "oav" binary
  *
  * The internal `@oav/*` workspace packages are redirected to their
  * source via the esbuild `alias` option, then bundled in as normal
@@ -21,6 +22,7 @@ export default defineConfig({
   entry: {
     index: "src/index.ts",
     schema: "src/schema.ts",
+    "schema-internals": "src/schema-internals.ts",
     spec: "src/spec.ts",
     formats: "src/formats.ts",
     core: "src/core.ts",

--- a/workspace-aliases.ts
+++ b/workspace-aliases.ts
@@ -8,7 +8,15 @@ import { resolve } from "node:path";
 const PACKAGES = ["core", "schema", "formats", "spec", "router", "validator", "cli"] as const;
 
 export function workspaceAliases(rootDir: string): Record<string, string> {
-  return Object.fromEntries(
-    PACKAGES.map((pkg) => [`@oav/${pkg}`, resolve(rootDir, "packages", pkg, "src", "index.ts")]),
+  // Sub-path barrel keys (more specific) come first so bundlers that
+  // match on longest prefix / insertion order pick `@oav/schema/internals`
+  // before the base `@oav/schema` alias.
+  const subpathEntries: Array<[string, string]> = [
+    ["@oav/schema/internals", resolve(rootDir, "packages", "schema", "src", "internals.ts")],
+  ];
+  const packageEntries = PACKAGES.map(
+    (pkg) =>
+      [`@oav/${pkg}`, resolve(rootDir, "packages", pkg, "src", "index.ts")] as [string, string],
   );
+  return Object.fromEntries([...subpathEntries, ...packageEntries]);
 }


### PR DESCRIPTION
## Summary
The `@aahoughton/oav/schema` barrel mixed three audiences in ~90 flat exports: compiler consumers, keyword authors, and codegen mechanics. All tagged `@public`; meanwhile the meta-data vocabulary exports a keyword author needs to assemble a custom dialect (`metaDataVocabulary`, `META_DATA_VOCAB`, `titleKeyword`, …) were missing.

Stratify along the natural seam:

- **`@aahoughton/oav/schema`** — what compiler consumers and keyword authors actually need. `compileSchema`, `CompiledSchema`, `Dialect`, `KeywordDefinition`, `KeywordCompileContext`, vocabulary URIs + vocab objects, every built-in keyword constant (including the meta-data ones, which were missing before), the ref-resolver primitives the validator wires up, and a new `walkSubschemas` generic read-walker.
- **`@aahoughton/oav/schema/internals`** — codegen mechanics (`NAMES`, `pathJoinExpr`, `quoteString`, `rawExpr`, `CodeGen`, `CodeEmitter`, `Scope`, …), runtime helpers (`createDeps`, `deepEqual`, `typeOf`, `wrapErrors`, `ValidatorDeps`), `SchemaRegistry` + `collectDynamicAnchors`, `createKeywordContext` + `KeywordContextInputs`, and the `SUBSCHEMA_*_POSITIONS` constants. Explicitly not covered by semver.
- `packages/validator/src/body-schema-transform.ts` switches from importing `SUBSCHEMA_*_POSITIONS` off the main barrel to the internals subpath — the only cross-package reach left, now clearly flagged.

Wired the subpath through every alias layer: `workspace-aliases.ts` (tsup + vitest), `tsconfig.build.json` paths, the schema sub-package's `exports` field, a new `tsup` entry point, and the main `package.json` exports field. Added `walk-subschemas.test.ts` covering pre-order traversal, map/array descent, subtree pruning, and boolean-schema visiting.

## Test plan
- [x] `pnpm test` (542/542 pass — four new walk tests)
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build` — produces `dist/schema-internals.{js,cjs,d.ts,d.cts}` as expected; main `dist/schema.d.ts` no longer re-exports internals.

Closes #57