### PR TITLE
refactor(validator): stratify public surface; add internals subpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,11 @@
       "import": "./dist/core.js",
       "require": "./dist/core.cjs"
     },
+    "./validator/internals": {
+      "types": "./dist/validator-internals.d.ts",
+      "import": "./dist/validator-internals.js",
+      "require": "./dist/validator-internals.cjs"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -10,6 +10,10 @@
     ".": {
       "types": "./src/index.ts",
       "import": "./src/index.ts"
+    },
+    "./internals": {
+      "types": "./src/internals.ts",
+      "import": "./src/internals.ts"
     }
   },
   "dependencies": {

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -1,21 +1,29 @@
-export { deserialize, matchMediaType, matchResponseKey } from "./deserialize.js";
+/**
+ * The public `@aahoughton/oav/validator` surface. One audience: callers
+ * building a request/response validator from a resolved OpenAPI
+ * document — `createValidator`, the `OavValidator` instance it returns,
+ * the options, and the Fetch-API adapters for consumers plugging the
+ * validator into Next.js / Hono / Bun / Deno handlers.
+ *
+ * Parameter deserialisation primitives, query-assembly helpers, and
+ * the operation-level `$ref` resolver live behind
+ * `@aahoughton/oav/validator/internals`. Reach for them only when a
+ * tool needs the same style/explode or `$ref` rules outside the normal
+ * validator flow; nothing there is covered by semver.
+ *
+ * @packageDocumentation
+ */
+
+export {
+  createValidator,
+  type OavValidator,
+  type ValidatorOptions,
+  type ValidatorStats,
+} from "./validator.js";
 export {
   httpRequestFromFetch,
   httpResponseFromFetch,
   readBodyFromFetch,
   type FetchRequestOptions,
 } from "./from-fetch.js";
-export {
-  assembleDeepObject,
-  assembleFormExplodedObject,
-  assembleObjectQueryParam,
-  coerceQueryScalar,
-} from "./query-assembly.js";
-export {
-  createValidator,
-  resolveOperationRef,
-  type OavValidator,
-  type ValidatorOptions,
-  type ValidatorStats,
-} from "./validator.js";
 export type { CustomKeywordFailure, CustomKeywordValidator } from "@oav/schema";

--- a/packages/validator/src/internals.ts
+++ b/packages/validator/src/internals.ts
@@ -1,0 +1,36 @@
+/**
+ * Internal re-exports for `@aahoughton/oav/validator/internals`. Exposes
+ * the parameter-deserialisation and query-assembly primitives that the
+ * validator uses to prepare values before schema compilation, plus the
+ * operation-level `$ref` resolver. Reachable when you need them —
+ * tests, advanced plugins, tooling that reuses the same style /
+ * explode rules outside the normal validator flow — but deliberately
+ * separated from the main `@aahoughton/oav/validator` barrel so the
+ * public surface matches what request/response-validation consumers
+ * actually need.
+ *
+ * Nothing here is covered by semver guarantees. Compare against the
+ * main barrel in `./index.ts` before importing from here.
+ *
+ * @packageDocumentation
+ */
+
+// Parameter deserialisation primitives: `style` + `explode`
+// interpretation, Content-Type negotiation, response-status key
+// matching (exact → NXX class → default).
+export { deserialize, matchMediaType, matchResponseKey } from "./deserialize.js";
+
+// Query-object assembly helpers. Handle the two OAS query shapes that
+// spread an object across multiple top-level keys: `style: form +
+// explode: true` (the default) and `style: deepObject`.
+export {
+  assembleDeepObject,
+  assembleFormExplodedObject,
+  assembleObjectQueryParam,
+  coerceQueryScalar,
+} from "./query-assembly.js";
+
+// Operation-level `$ref` resolver — used internally by the cache
+// builder; exposed so tests can exercise it without constructing a
+// full validator.
+export { resolveOperationRef } from "./operation-cache.js";

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -42,8 +42,6 @@ import {
 } from "./operation-cache.js";
 import { validateBody, validateParameter } from "./validate-step.js";
 
-export { resolveOperationRef } from "./operation-cache.js";
-
 /**
  * Pick the dialect for a given OpenAPI version. 3.1 and 3.2 share the
  * 2020-12-based dialect with format-assertion; 3.0 uses the OAS 3.0

--- a/packages/validator/test/query-assembly.test.ts
+++ b/packages/validator/test/query-assembly.test.ts
@@ -5,7 +5,7 @@ import {
   assembleFormExplodedObject,
   assembleObjectQueryParam,
   coerceQueryScalar,
-} from "../src/index.js";
+} from "../src/query-assembly.js";
 
 describe("coerceQueryScalar", () => {
   it("returns undefined for missing values", () => {

--- a/packages/validator/test/resolve-operation-ref.test.ts
+++ b/packages/validator/test/resolve-operation-ref.test.ts
@@ -1,6 +1,6 @@
 import type { ReferenceObject } from "@oav/core";
 import { describe, expect, it } from "vitest";
-import { resolveOperationRef } from "../src/index.js";
+import { resolveOperationRef } from "../src/operation-cache.js";
 
 /**
  * Direct tests for the operation-level `$ref` resolver that

--- a/src/validator-internals.ts
+++ b/src/validator-internals.ts
@@ -1,0 +1,1 @@
+export * from "../packages/validator/src/internals.js";

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -15,6 +15,7 @@
       "@oav/spec": ["./packages/spec/src/index.ts"],
       "@oav/router": ["./packages/router/src/index.ts"],
       "@oav/validator": ["./packages/validator/src/index.ts"],
+      "@oav/validator/internals": ["./packages/validator/src/internals.ts"],
       "@oav/cli": ["./packages/cli/src/index.ts"]
     }
   },

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,13 +5,14 @@ import { workspaceAliases } from "./workspace-aliases.js";
  * Single-package build for the publishable `oav`.
  *
  * Each entry becomes a subpath in the published package:
- *   src/index.ts            →  "oav"
- *   src/schema.ts           →  "oav/schema"
- *   src/schema-internals.ts →  "oav/schema/internals"
- *   src/spec.ts             →  "oav/spec"
- *   src/formats.ts          →  "oav/formats"
- *   src/core.ts             →  "oav/core"
- *   src/cli.ts              →  "oav" binary
+ *   src/index.ts               →  "oav"
+ *   src/schema.ts              →  "oav/schema"
+ *   src/schema-internals.ts    →  "oav/schema/internals"
+ *   src/spec.ts                →  "oav/spec"
+ *   src/formats.ts             →  "oav/formats"
+ *   src/core.ts                →  "oav/core"
+ *   src/validator-internals.ts →  "oav/validator/internals"
+ *   src/cli.ts                 →  "oav" binary
  *
  * The internal `@oav/*` workspace packages are redirected to their
  * source via the esbuild `alias` option, then bundled in as normal
@@ -26,6 +27,7 @@ export default defineConfig({
     spec: "src/spec.ts",
     formats: "src/formats.ts",
     core: "src/core.ts",
+    "validator-internals": "src/validator-internals.ts",
     cli: "src/cli.ts",
   },
   format: ["esm", "cjs"],

--- a/workspace-aliases.ts
+++ b/workspace-aliases.ts
@@ -9,10 +9,11 @@ const PACKAGES = ["core", "schema", "formats", "spec", "router", "validator", "c
 
 export function workspaceAliases(rootDir: string): Record<string, string> {
   // Sub-path barrel keys (more specific) come first so bundlers that
-  // match on longest prefix / insertion order pick `@oav/schema/internals`
-  // before the base `@oav/schema` alias.
+  // match on longest prefix / insertion order pick `@oav/<pkg>/internals`
+  // before the base `@oav/<pkg>` alias.
   const subpathEntries: Array<[string, string]> = [
     ["@oav/schema/internals", resolve(rootDir, "packages", "schema", "src", "internals.ts")],
+    ["@oav/validator/internals", resolve(rootDir, "packages", "validator", "src", "internals.ts")],
   ];
   const packageEntries = PACKAGES.map(
     (pkg) =>


### PR DESCRIPTION
## Summary
Same pattern as #57 (schema), applied to validator. The public barrel re-exported parameter-deserialisation primitives (`deserialize`, `matchMediaType`, `matchResponseKey`), query-assembly helpers (`assembleDeepObject`, `assembleFormExplodedObject`, `assembleObjectQueryParam`, `coerceQueryScalar`), and the operation-level `resolveOperationRef` (docstring-marked `@internal` but publicly advertised). None have a cross-package consumer — they're used only inside `validator.ts` itself plus a couple of unit tests.

- Moved them to **`@aahoughton/oav/validator/internals`**.
- The main `@aahoughton/oav/validator` barrel now exposes just the request/response-validation surface: `createValidator`, `OavValidator`, `ValidatorOptions`, `ValidatorStats`, the Fetch-API adapters, and the custom-keyword types re-exported from schema.
- Tests that previously imported these names from the main barrel now import from the specific source modules (`query-assembly.js`, `operation-cache.js`), matching the convention the rest of the test suite uses for package-internal helpers.
- Wired the subpath through `workspace-aliases.ts`, `tsconfig.build.json` paths, the validator sub-package's `exports` field, a `tsup` entry, and the main `package.json` exports.

## Test plan
- [x] `pnpm test` (542/542 pass)
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build` — produces `dist/validator-internals.{js,cjs,d.ts,d.cts}` alongside the existing schema-internals bundles.