### PR TITLE
docs: ajv policy, tone pass, overlays guide + examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,12 +20,13 @@ testing.
 
 - `conformance/` — upstream JSON Schema Test Suite + OpenAPI case
   harness. `cd conformance && pnpm install` to bootstrap.
-- `performance/` — ajv/hyperjump/oav benchmarks. `cd performance &&
-pnpm install` to bootstrap.
+- `performance/` — compile / validate benchmarks against other JSON
+  Schema validators. `cd performance && pnpm install` to bootstrap.
 
 Both have their own `package.json` + `pnpm-workspace.yaml` (with empty
-`packages:` list so pnpm treats them as isolated roots). Their deps
-(ajv, hyperjump, tinybench, tsx) are NOT in the main workspace install.
+`packages:` list so pnpm treats them as isolated roots). Their
+external dev-dependencies (benchmark runners, competing validators,
+`tsx`) are NOT in the main workspace install.
 
 ## Architecture, package by package
 

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -1,0 +1,149 @@
+# oav vs Ajv (+ express-openapi-validator)
+
+Ajv is the canonical JSON Schema validator for JavaScript, and
+`express-openapi-validator` is the most widely-used middleware built
+on top of it. Together they cover most real-world OpenAPI validation
+in the ecosystem and have done so for years. This document is not a
+pitch against them — it's an honest map of what each project does so
+you can pick the one that fits.
+
+For most users, oav sits in roughly the same feature territory as
+Ajv + `express-openapi-validator` combined: schema validation plus
+HTTP-layer checks. The two projects pull in different directions on a
+handful of specifics; those are catalogued below.
+
+This document is about behaviour and capabilities. For runtime
+performance, see [`performance/README.md`](./performance/README.md),
+which runs both libraries on the same benchmark fixtures.
+
+## Where Ajv (+ express-openapi-validator) does more
+
+Capabilities that the Ajv stack covers and oav does not.
+
+- **Multiple JSON Schema drafts.** Ajv supports draft-04, draft-06,
+  draft-07, draft-2019-09, 2020-12, and JTD. oav compiles 2020-12 and
+  OpenAPI 3.0's constrained dialect; earlier drafts aren't on the
+  roadmap.
+- **Data-mutating options.** `coerceTypes`, `removeAdditional`, and
+  `useDefaults` let Ajv mutate the validated value in place — coercing
+  strings to numbers, stripping undeclared properties, filling missing
+  properties from `default`. oav treats validation as a yes/no
+  question and does not mutate inputs.
+- **Standalone code generation.** Ajv can emit a compiled validator
+  as a JavaScript source file for build-time bundling — useful for
+  edge runtimes where `new Function()` at runtime isn't available or
+  ideal. oav compiles at construction and doesn't support
+  ahead-of-time emission.
+- **Named schema registry.** `addSchema` / `getSchema` / `removeSchema`
+  give Ajv a name-to-validator map that cross-schema `$ref`s resolve
+  through. oav accepts an `external: Map<string, Schema>` on
+  `compileSchema`; fine for one-shot compiles, less ergonomic for apps
+  that build up a schema collection incrementally.
+- **Full RFC 3986 URI resolution.** Ajv handles absolute-URI `$ref`s
+  and `$id` base-URI rewrites natively. oav requires external /
+  multi-file refs to be pre-inlined by `@aahoughton/oav/spec.resolveSpec()`
+  before compile, and accepts fragment-only refs thereafter.
+- **Meta-schema strict mode.** Ajv can optionally validate your schema
+  against the draft's meta-schema at compile time, catching typos like
+  `minimumx: 5`. oav silently tolerates unknown keywords.
+- **`$data` references.** Ajv's non-standard extension where one
+  keyword's value comes from the data being validated
+  (`{ minimum: { $data: "1/min" } }`). oav doesn't implement it.
+- **Async validation.** Ajv supports async formats and keywords (e.g.
+  a format that hits a database). oav's formats and custom keywords
+  are synchronous.
+- **`express-openapi-validator` conveniences.** `req.body` /
+  `req.query` type coercion, `res.json` interception for response
+  validation, `fileUploader` (multer integration), `securityHandlers`,
+  `operationHandlers` filesystem auto-loading, and `ignorePaths` /
+  `ignoreUndocumented` are one-liner options. oav leaves these to the
+  adapter — see [`INTEGRATION.md`](./INTEGRATION.md) for recipes.
+
+## Where oav does more
+
+Capabilities oav has that Ajv (alone or with
+`express-openapi-validator`) doesn't.
+
+- **HTTP-aware validation.** Route matching, content-type negotiation,
+  parameter `style` / `explode` deserialisation, response status
+  matching (exact → NXX class → default) are part of one
+  `validateRequest` / `validateResponse` call. Ajv is a JSON Schema
+  validator; wiring the HTTP layer on top of it is what
+  `express-openapi-validator` does, and only for Express.
+- **Built-in OpenAPI 3.0 dialect.** `nullable`, boolean
+  `exclusiveMaximum` / `exclusiveMinimum`, and
+  `$ref`-suppresses-siblings are compiled by a dedicated 3.0 dialect
+  selected once at `createValidator` time. Ajv reaches the same
+  semantics via `ajv-draft-04` plus a custom `nullable` keyword — the
+  functionality is equivalent; oav's version is one dependency with
+  no setup step.
+- **First-class overlays.** `applyOverlays` rewrites an
+  externally-owned base spec at load time — add a required header to
+  every operation, extend a component schema, swap a response shape —
+  without forking or preprocessing the upstream file.
+- **Structured error tree.** Errors preserve the applicator structure
+  (`oneOf` with per-branch `children`, `allOf` with failed-conjunct
+  children). HTTP consumers can group by location and inspect which
+  branch of a composition failed. Ajv emits a flat errors array; the
+  tree vs flat choice is a philosophical one, not a capability gap in
+  either direction.
+- **Predicate mode.** `compileSchema(schema, { predicate: true })`
+  returns `{ validate: (x) => boolean }`. No error tree construction,
+  no path snapshotting, no accumulator allocation. Ajv's
+  `allErrors: false` still maintains error infrastructure; oav's
+  predicate mode compiles to a different function entirely.
+- **Bounded error collection.** `maxErrors: N` caps the error tree at
+  N leaves; the generated code short-circuits hot loops when the
+  budget is exhausted. Ajv has `allErrors: true | false` but no
+  explicit count budget. When unset, oav's codegen emits plain
+  `errors.push` with no runtime checks — zero overhead for the
+  uncapped case.
+- **Direction-aware body transforms.** Request-body validators reject
+  `readOnly` properties and exempt them from `required`; response-body
+  validators do the same for `writeOnly`. Applied as a pre-compile
+  transform so the compiler itself is direction-agnostic.
+- **Discriminator.** First-class OpenAPI discriminator support — a
+  single-dispatch alternative to `oneOf` whose error message names the
+  offending property and value rather than listing per-branch
+  failures. `express-openapi-validator` supports discriminator via a
+  custom Ajv keyword; the functionality is equivalent.
+- **Compile-time observability.** `CompiledSchema.stats` exposes
+  `functionCount`, `unevaluatedTrackingEmitted`, and
+  `emittedTreeRuntime` so tests can assert on compiler optimisations
+  directly rather than grepping the generated source.
+
+## Runtime dependencies
+
+Ajv 8 has four runtime dependencies:
+
+| Dependency             | Purpose                                                         |
+| ---------------------- | --------------------------------------------------------------- |
+| `fast-deep-equal`      | Structural equality for `const` / `enum` / `uniqueItems`        |
+| `json-schema-traverse` | Walk schema subtrees                                            |
+| `fast-uri`             | RFC 3986 URI parsing for `$id` / `$ref` resolution              |
+| `require-from-string`  | Load compiled-validator source as a module (standalone codegen) |
+
+oav's compiler and validator have zero runtime dependencies. The
+package publishes `yaml` as a runtime dep for the spec-loading
+sub-package and `commander` as an optional peer for the CLI. The two
+efficiency libraries Ajv pulls in (`fast-deep-equal`,
+`json-schema-traverse`) have equivalents in-tree; the two capability
+libraries (`fast-uri`, `require-from-string`) map to features oav
+doesn't implement (see "Where Ajv does more" above).
+
+## Summary
+
+For most users, oav and Ajv + `express-openapi-validator` are
+substitutable: both validate OpenAPI requests and responses by 3.0 /
+3.1 / 3.2 rules, both support custom keywords and formats, both
+produce machine-readable errors. Differences are real but bounded.
+
+Pick Ajv + `express-openapi-validator` when you want the fastest
+validator, a large userbase, multi-draft support, or the one-line
+middleware integration that comes with it. Pick oav when you want a
+structured error tree, overlays over specs you don't own, a bundled
+OpenAPI 3.0 dialect, or explicit control over where validation runs
+in your HTTP stack.
+
+For benchmark numbers rather than feature comparisons, see
+[`performance/README.md`](./performance/README.md).

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -30,10 +30,10 @@ wiring where needed. The cost is real. The payoff:
   `{ code, path, message, params, children }`. Downstream code
   narrows on fields — `err.code === "required"` + `err.params.missing`
   — rather than parsing message strings.
-- **Native OpenAPI 3.0 semantics.** `nullable: true`, boolean
-  `exclusiveMaximum`, and `$ref`-suppresses-siblings work by 3.0
-  rules. Most ajv-based validators retrofit these via 2020-12
-  translation and lose edges in the conversion. The
+- **Built-in OpenAPI 3.0 dialect.** `nullable: true`, boolean
+  `exclusiveMaximum`, and `$ref`-suppresses-siblings are baked into
+  the compiler's dialect dispatch — no preprocessing step, no
+  translation layer. The
   [conformance report](./conformance/REPORT.md) covers where we match
   the upstream suites and where we don't.
 - **First-class overlays.** Extend an externally-owned base spec

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -7,44 +7,41 @@ adapter layer: framework snippets, recipes for the features `oav`
 doesn't wrap (file upload, auth, response checking, status-code
 mapping), and a migration path from `express-openapi-validator`.
 
-## The honest summary
+## What the two libraries take on
 
-Using `express-openapi-validator` is a one-liner:
+`express-openapi-validator` registers as one middleware:
 
 ```ts
 app.use(OpenApiValidator.middleware({ apiSpec, fileUploader: true, validateSecurity: {...} }));
 ```
 
-Using `oav` is a ~20-line middleware plus your own multer / auth
-wiring where needed. The cost is real. The payoff:
+`oav` is a ~20-line middleware plus your own multer / auth wiring
+where needed. In exchange:
 
-- **You own the error → HTTP mapping.** No magic status codes in
-  library code, no `BadRequest`/`Unauthorized` classes you have to
-  reverse-engineer. A small switch statement maps our stable `code`
-  field to whatever status codes your API contract requires.
-- **No monkey-patching of `res.json`.** `express-openapi-validator`
-  wraps the response methods to auto-intercept. `oav` touches nothing
-  on `req` or `res`. You call `validateResponse` where you want it,
-  or not at all.
+- **You own the error → HTTP mapping.** A small switch statement maps
+  the validator's stable `code` field to whatever status codes your
+  API contract requires.
+- **No wrapping of `res.json`.** `express-openapi-validator` wraps
+  the response methods to auto-intercept. `oav` reads its arguments
+  and returns a result; it does not touch `req` or `res`. Response
+  validation happens when you call `validateResponse`.
 - **Structured error trees.** Every error is
-  `{ code, path, message, params, children }`. Downstream code
-  narrows on fields — `err.code === "required"` + `err.params.missing`
-  — rather than parsing message strings.
+  `{ code, path, message, params, children }`. Downstream code can
+  narrow on fields (`err.code === "required"`,
+  `err.params.missing`) instead of parsing message strings.
 - **Built-in OpenAPI 3.0 dialect.** `nullable: true`, boolean
-  `exclusiveMaximum`, and `$ref`-suppresses-siblings are baked into
-  the compiler's dialect dispatch — no preprocessing step, no
-  translation layer. The
-  [conformance report](./conformance/REPORT.md) covers where we match
-  the upstream suites and where we don't.
-- **First-class overlays.** Extend an externally-owned base spec
-  (Supabase, Hasura, PocketBase, a gateway-published document) with
-  `applyOverlays` at load time. No forking, no pre-processing, no
-  string substitution.
+  `exclusiveMaximum`, and `$ref`-suppresses-siblings are in the
+  compiler's dialect dispatch — no preprocessing step. See the
+  [conformance report](./conformance/REPORT.md) for the cases we
+  match and the ones we don't.
+- **Overlays.** Extend an externally-owned base spec (Supabase,
+  Hasura, PocketBase, a gateway-published document) with
+  `applyOverlays` at load time. See [OVERLAYS.md](./OVERLAYS.md).
 
-If you want "install, point at `spec.yaml`, done", use
-`express-openapi-validator`. If you want explicit control over when
-and where validation runs plus a typed error model you can narrow
-against, keep reading.
+For a single-line middleware registration, use
+`express-openapi-validator`. For explicit control over when and where
+validation runs and a typed error model to narrow against, keep
+reading.
 
 ## What the validator expects
 
@@ -326,13 +323,12 @@ or Uint8Array passes without a string-type error. `format: "byte"`
 ### Streaming bodies, large uploads, and the `readBody` override
 
 The built-in `validateFetchRequest` reads the entire request body into
-memory to parse it. That's appropriate for typical JSON / form payloads
-but wrong for large uploads or streams you want to process incrementally.
-Two escape hatches cover every case without the validator trying to be
-a body-parsing library itself.
+memory to parse it. That suits typical JSON / form payloads but not
+large uploads or streams you want to process incrementally. Two
+options depending on how much of the fetch helper you want to keep:
 
-**Escape hatch 1: `readBody` option.** Pass a callback that consumes
-the `Request` stream however you want and returns the body shape your
+**Option 1: `readBody` callback.** Pass a callback that consumes the
+`Request` stream however you want and returns the body shape your
 schema declares:
 
 ```ts
@@ -362,10 +358,10 @@ The callback owns the stream. The validator does not read
 `request.body` when `readBody` is provided, so there is no
 double-consumption.
 
-**Escape hatch 2: assemble the `HttpRequest` yourself.** For
-routes where `validateFetchRequest`'s convenience isn't worth even
-passing through the helper, call `validator.validateRequest` directly
-with whatever body shape you've already built:
+**Option 2: assemble the `HttpRequest` yourself.** For routes where
+`validateFetchRequest`'s convenience isn't worth even passing through
+the helper, call `validator.validateRequest` directly with whatever
+body shape you've already built:
 
 ```ts
 const body = await myCustomStreamingPipeline(request);
@@ -377,26 +373,24 @@ const err = validator.validateRequest({
 });
 ```
 
-**What the validator won't do.** For schemas that declare structural
-constraints on the body (object shape, required fields, array bounds,
-`oneOf`), validation fundamentally requires the whole value — you can
-always feed a buffered-to-memory 10 GB document through `validateRequest`
-and it will work, but the memory cost is on you. For spec-level opt-out,
-declare the body as `format: binary` and let the opaque-body bypass
-wave it through.
+**Structural constraints require the whole value.** A schema that
+declares object shape, required fields, array bounds, or `oneOf`
+needs the full payload to validate. `validateRequest` accepts an
+already-buffered 10 GB document; the memory cost is the caller's.
+For spec-level opt-out, declare the body as `format: binary` and
+let the opaque-body bypass accept whatever the HTTP layer decoded.
 
-**What we won't do.** Ship a streaming multipart parser ourselves —
-`busboy`, `formidable`, and `@mjackson/multipart-parser` each have
-their own tradeoffs and picking one forces every user onto that pick.
-`readBody` is the plug point; bring whichever parser fits your stack.
+**No bundled multipart parser.** `busboy`, `formidable`, and
+`@mjackson/multipart-parser` each make different tradeoffs, and
+picking one forces every user onto that pick. `readBody` is the plug
+point; bring whichever parser fits your stack.
 
 ### Response validation (no monkey-patching)
 
 `express-openapi-validator` wraps `res.json` and `res.send` so it can
 inspect response bodies the handler returns. `oav` doesn't. Options:
 
-**Per-route explicit.** Validate before sending. Clear, easy to
-reason about, zero surprises:
+**Per-route explicit.** Validate before sending:
 
 ```ts
 app.get("/pets/:id", async (req, res) => {
@@ -417,8 +411,8 @@ app.get("/pets/:id", async (req, res) => {
 });
 ```
 
-**Per-app wrapper.** Wrap `res.json` yourself if you want the
-auto-interception behaviour. Keep it local so it's readable:
+**Per-app wrapper.** Wrap `res.json` yourself if you want
+auto-interception behaviour for every response:
 
 ```ts
 app.use((req, res, next) => {
@@ -439,8 +433,9 @@ app.use((req, res, next) => {
 });
 ```
 
-The `res.json` wrapper is ~15 lines; ship exactly the policy you
-want rather than whatever `onError` shape a library decided on.
+The `res.json` wrapper is ~15 lines. The policy (log, header, hard
+fail, etc.) is whatever you choose to put in the `if (err !== null)`
+branch.
 
 ### Security / authentication
 
@@ -453,13 +448,12 @@ app.use(authenticateJwt); // your own middleware
 app.use(oavMiddleware); // validates schema against the authenticated request
 ```
 
-`express-openapi-validator`'s `securityHandlers` is structurally
-limited anyway: it still expects you to supply the auth function per
-scheme. The only thing it gives you is a declarative dispatch table
-driven by the `security:` blocks in your spec. If that's load-bearing
-for you, write a 30-line dispatcher that walks the matched
-operation's `security` array and calls your per-scheme handlers. It's
-mechanical work that's easier to own than debug.
+`express-openapi-validator`'s `securityHandlers` is a declarative
+dispatch table driven by the spec's `security:` blocks; you still
+supply an auth function per scheme. If that dispatch layer is
+load-bearing for your setup, a ~30-line function that walks the
+matched operation's `security` array and calls your per-scheme
+handlers replaces it.
 
 ### Type coercion on body fields
 
@@ -482,9 +476,6 @@ app.use(
   }),
 );
 ```
-
-Or fix the client. The stricter surface catches real bugs that
-`coerceTypes: true` masks.
 
 ### Ignoring paths not in the spec
 
@@ -528,40 +519,39 @@ before calling the validator.
 | `$refParser: "bundle" \| "dereference"` | `loadSpec` inlines external refs; circulars become internal refs. Use `resolveSpec` directly for finer control. |
 | `validateApiSpec`                       | Run `oav resolve spec.yaml` in CI; no runtime toggle.                                                           |
 
-### What you're giving up
+### Features not carried over
 
 - **Auto-multer.** Replace with ~15 lines per upload route.
 - **Security handler dispatch.** Use your existing auth middleware.
 - **`operationHandlers` filesystem routing.** Write Express routes
   manually or keep whatever routing you had.
-- **`res.json` monkey-patching for auto-response-validation.** Call
+- **`res.json` wrapping for automatic response validation.** Call
   `validateResponse` explicitly where you need it, or wrap `res.json`
-  yourself (15 lines; see recipe).
-- **`serDes` payload mutations.** Do these in your handler, not the
-  validator.
+  yourself (~15 lines; see recipe).
+- **`serDes` payload mutations.** Do these in your handler rather
+  than the validator.
 - **Typed error classes** (`BadRequest`, `Unauthorized`, etc.). Use
   the error's `code` field and the status-code map above.
 
-### What you're getting
+### Features added
 
-- **Structured error tree** with stable `code`s, segment paths, and
-  per-code `params` typed via `BuiltInErrorParams`. Type-narrow
-  rather than pattern-match message strings.
-- **Native 3.0 dialect**, not a 2020-12 rewrite. See
+- **Structured error tree.** Stable `code`s, segment paths, and
+  per-code `params` typed via `BuiltInErrorParams`. Narrowing happens
+  on fields rather than message strings.
+- **Built-in 3.0 dialect.** No translation layer over 2020-12. See
   [conformance/REPORT.md](./conformance/REPORT.md) for the cases we
   pass and the short list we don't.
-- **Overlays** for extending externally-owned specs — a first-class
-  feature, not a forking workaround.
-- **Smaller install footprint.** No `ajv`, no `multer`, no
-  `ajv-formats`. Single runtime dep (`yaml`) plus an optional peer
-  (`commander`, CLI only).
-- **No mutation of `req` in place.**
-  `express-openapi-validator` attaches `req.openapi`, coerces types,
-  and replaces `req.body` after deserialize. `oav` reads its inputs
-  and returns an error tree. Your request object is untouched.
-- **Explicit control over where validation runs.** Skip it on some
-  routes without configuration gymnastics; run it twice (per-request
-  and per-response) with different `maxErrors` budgets; run it at
+- **Overlays.** Extend externally-owned specs at load time —
+  see [OVERLAYS.md](./OVERLAYS.md).
+- **Smaller install footprint.** Single runtime dep (`yaml`) plus an
+  optional peer (`commander`, CLI only).
+- **No mutation of `req`.** `express-openapi-validator` attaches
+  `req.openapi`, coerces types, and replaces `req.body` after
+  deserialize. `oav` reads its inputs and returns an error tree;
+  the request object is unchanged.
+- **Explicit control over where validation runs.** Skip it on
+  specific routes without configuration, run it twice (per-request
+  and per-response) with different `maxErrors` budgets, or run it at
   the edge of a queue processor outside any HTTP framework.
 
 ### Format-shape note
@@ -611,15 +601,14 @@ Keep them in the map if it's simpler; they cost nothing.
   `res.send("{...}")` (string form) too via its wrappers. `oav` does
   not unless you write the wrapper yourself, in which case parse
   before validating.
-- **Error paths.** `oav` recently dropped the redundant `"response"`
-  prefix from response-side leaf paths. A body-validation failure on
-  a response is now at `["body", ...]`, not `["response", "body", ...]`.
-  Discriminate the leg via the top-level `err.code` (`"request"` vs
-  `"response"`), not `path[0]`.
+- **Error paths.** A body-validation failure on a response is at
+  `["body", ...]`, not `["response", "body", ...]`. Discriminate the
+  leg via the top-level `err.code` (`"request"` vs `"response"`),
+  not `path[0]`.
 - **Optional `openapi` version fallback.** If the spec's `openapi`
   field is missing or unsupported, `oav` silently uses 3.1 by default
   (see `onUnknownVersion`). `express-openapi-validator` throws.
 - **Formats.** Both libraries treat `format` as assertive in an
   OpenAPI context. Under the raw `jsonSchemaDialect`, `oav` treats it
-  as annotation-only per the 2020-12 default — a deliberate choice,
-  configurable via the assertion vocabulary.
+  as annotation-only per the 2020-12 default; the assertion
+  vocabulary switches it back on if needed.

--- a/OVERLAYS.md
+++ b/OVERLAYS.md
@@ -1,0 +1,145 @@
+# Overlays
+
+Overlays patch an OpenAPI document in memory before the validator is
+constructed. They exist for a specific job: letting you consume a spec
+you don't own — an upstream framework's published document, a
+gateway's spec, a vendor API — and extend or override parts of it to
+match your deployment, without forking the file.
+
+## When you want one
+
+- **The upstream schema is close to what you ship but missing a
+  field.** Use `extendSchemas` — adds constraints via `allOf` while
+  preserving the original shape.
+- **The upstream schema is wrong for your deployment.** Use
+  `replaceSchemas` — swaps the schema out entirely, no merge.
+- **Your gateway requires headers or query parameters the upstream
+  spec doesn't declare.** Use `overrides` to add them to the relevant
+  operations.
+- **You need a route the upstream doesn't expose.** Use `addPaths`.
+
+The alternative — forking the spec, keeping the fork in sync as the
+upstream evolves, rebasing your patches on every update — is what
+overlays exist to avoid.
+
+## Shape
+
+An overlay is a plain object with up to four sections. Each is
+independent; you can use any subset.
+
+```ts
+interface SpecOverlay {
+  addPaths?: Record<string, PathItem>;
+  overrides?: Record<string, PathOverride>;
+  extendSchemas?: Record<string, SchemaObject>;
+  replaceSchemas?: Record<string, SchemaObject>;
+}
+```
+
+### `extendSchemas`
+
+Adds constraints to an existing component schema. The extension merges
+in via `allOf`: the original shape still applies, the extension adds
+to it.
+
+Runnable demo:
+[`examples/overlay-petstore-schema.ts`](./examples/overlay-petstore-schema.ts)
+— extends the upstream `Pet` to require a `vaccinated: boolean`.
+
+### `replaceSchemas`
+
+Replaces a component schema entirely. Use when your deployment's
+shape is not a superset of the upstream's — for example, a field that
+the upstream declares as `string` but your deployment receives as a
+structured object.
+
+### `overrides`
+
+Modifies existing paths. Two things can be modified:
+
+- `operations` — per-method patches. Each supports:
+  - `addParameters`: append new parameters; replace existing concrete
+    entries (matched by `name` + `in`). `$ref`-shaped parameters in
+    the base are not matched and the new parameter appends alongside.
+  - `requestBody`: replace the request body entirely.
+  - `responses`: merge by status code.
+- `pathItem` — fields on the `PathItem` itself (e.g. path-level
+  `parameters`).
+
+Wildcards: use `"*"` as an operation key to apply the same override to
+every method on a path, or as a path key at the top of `overrides` to
+apply it to every path.
+
+Runnable demo:
+[`examples/overlay-petstore-endpoint.ts`](./examples/overlay-petstore-endpoint.ts)
+— adds a gateway-required `X-Tenant` header to `POST /pets`.
+
+### `addPaths`
+
+Extends the `paths` map with new routes. Throws at apply time if the
+path already exists in the base document — use `overrides` for that
+case.
+
+## Applying an overlay
+
+Two entry points, same result.
+
+**`applyOverlays`** takes an already-resolved base document:
+
+```ts
+import { applyOverlays } from "@aahoughton/oav/spec";
+import { createValidator } from "@aahoughton/oav";
+
+const patched = applyOverlays(base, [overlay1, overlay2]);
+const validator = createValidator(patched);
+```
+
+**`loadSpec`** resolves external `$ref`s and applies overlays in one
+pass — use this for multi-file specs or remote documents:
+
+```ts
+import { loadSpec, composeReaders, createFileReader } from "@aahoughton/oav/spec";
+
+const reader = composeReaders([createFileReader()]);
+const { document } = await loadSpec({
+  reader,
+  entry: "openapi.yaml",
+  overlays: [overlay1, overlay2],
+});
+const validator = createValidator(document);
+```
+
+Overlays apply in order. Later overlays win on conflict. The base
+document is deep-cloned — the input is never mutated.
+
+## Things to know
+
+- **`$ref` resolution timing.** Overlays target the resolved
+  document. `loadSpec` inlines external refs first, then applies
+  overlays; if you're calling `applyOverlays` directly, pass in a
+  spec that has already been through `resolveSpec`.
+- **Reference-object parameters.** `addParameters` can only match
+  against concrete parameter entries for replacement purposes. A
+  `{ $ref: "#/components/parameters/Tenant" }` in the base is left
+  alone, and any new parameter with the same `name` + `in` appends
+  alongside rather than replacing.
+- **Multiple extensions to one schema.** Each overlay that targets
+  the same schema name via `extendSchemas` adds a new `allOf` branch.
+  The compiled validator runs every branch; they all have to pass.
+- **Conflicts fail fast.** `addPaths` adding an existing path, or
+  `overrides` targeting a missing path, throws at `applyOverlays`
+  time. This is intentional — you want to notice when the upstream
+  adds or removes a path you've referenced rather than have the
+  overlay silently no-op.
+
+## Related
+
+- [`packages/spec/src/overlay.ts`](./packages/spec/src/overlay.ts) —
+  the implementation, including the full merge rules for each kind
+  of override.
+- [`examples/overlay-petstore-schema.ts`](./examples/overlay-petstore-schema.ts)
+  and
+  [`examples/overlay-petstore-endpoint.ts`](./examples/overlay-petstore-endpoint.ts)
+  — runnable end-to-end demos.
+- [README "Why oav?"](./README.md#why-oav) — overlays as one of the
+  three motivating reasons the project exists.

--- a/README.md
+++ b/README.md
@@ -90,20 +90,38 @@ projects overlap and where each does more is written up in
 
 ### Conformance
 
-Published, not claimed. Every number below comes out of
-[`conformance/`](./conformance/README.md) on every build:
+The [`conformance/`](./conformance/README.md) sub-package drives the
+compiler and CLI against the upstream JSON Schema 2020-12 Test Suite,
+a set of OpenAPI 3.0 / 3.1 / 3.2 petstore scenarios, and a handful of
+real-world specs (Stripe, GitHub, DigitalOcean, Twilio, Asana, Box,
+Adyen) that have to load and compile without error. Current pass
+counts: 1271 / 1290 on required JSON Schema cases, 1429 / 1452 with
+optional included, 14 / 14 on OpenAPI cases.
 
-| Suite                                                                | Result                                                  |
-| -------------------------------------------------------------------- | ------------------------------------------------------- |
-| [JSON Schema 2020-12 Test Suite](./conformance/REPORT.md) (required) | 1271 / 1290 passing (98.5%)                             |
-| JSON Schema 2020-12 Test Suite (+ optional)                          | 1429 / 1452 passing (98.4%)                             |
-| OpenAPI request/response scenarios (3.0, 3.1, 3.2 petstores)         | 14 / 14                                                 |
-| Real-world specs loaded + compiled by `createValidator`              | Stripe, GitHub, DigitalOcean, Twilio, Asana, Box, Adyen |
+Categories we're not currently attempting, with details in
+[`conformance/REPORT.md`](./conformance/REPORT.md):
 
-Remaining JSON Schema mismatches (`$dynamicRef` runtime scope and a
-handful of optional-suite edges) are enumerated in
-[`conformance/REPORT.md`](./conformance/REPORT.md). No divergence is
-silent.
+- `$dynamicRef` with runtime dynamic-scope rebinding. Our
+  implementation resolves statically against the anchor map.
+- The `optional/format/*` subtree. Those tests target strict-assertion
+  behaviour; `format` is annotation-only by default per JSON Schema
+  2020-12 §6.3.
+- A small tail of isolated optional cases (float-overflow handling,
+  external-ref loading tied to the dynamic-scope category above).
+
+In practice, OpenAPI specs generated or hand-authored by application
+developers rarely touch any of these. `$dynamicRef` / `$dynamicAnchor`
+are concentrated in meta-schemas and extensible-type libraries (JSON
+Schema's own meta-schema, Hyperjump's type system); a spec that
+describes "POST /pets takes a Pet" doesn't declare them. The strict
+format-assertion gap only surfaces if you rely on RFC-edge behaviour
+in `iri`, IRI-reference, or non-BMP regex content — `date-time`,
+`email`, `uuid`, and the common URI formats pass. Float overflow
+concerns numbers beyond `Number.MAX_SAFE_INTEGER` (~9 × 10¹⁵);
+outside that range, JavaScript's own `Number` precision is the
+limiting factor regardless of validator. If any of these corners
+matter for your use case, the report lays out which tests fail and
+why.
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -60,32 +60,33 @@ rooted at the HTTP frame (e.g. `["body", "pets", 3, "name"]`), a
 human-readable `message`, and a machine-readable `params` object whose
 shape per code is documented in `BuiltInErrorParams`.
 
-## Why this exists
+## Why oav?
 
-Two motivations drive the design.
+Three things weren't available together anywhere else when this repo
+started:
 
-**Native OpenAPI 3.0 semantics.** Most OpenAPI validators are thin
-wrappers over ajv. That works for 3.1 / 3.2, which use JSON Schema
-2020-12 directly, but it translates poorly to 3.0: `type` can't be an
-array, `exclusiveMaximum` is a boolean, `nullable` is its own keyword,
-and siblings of `$ref` are ignored. oav ships a dedicated 3.0 dialect
-alongside the 3.1 / 3.2 one so 3.0 specs validate by 3.0 rules, no
-meta-schema rewrite step, no "mostly 3.1 and hope".
+- **An HTTP-aware validator.** One call checks method + path +
+  parameters + body + content type + status + headers against the
+  spec, not just the JSON body. Every HTTP-level concern — route
+  matching, content-type negotiation, parameter deserialisation,
+  response status matching — lives inside the validator.
+- **Overlays over externally-owned specs.** Projects consuming an
+  OpenAPI document they don't own (Supabase / Directus / Hasura /
+  PocketBase / a gateway's published spec) can extend or override it
+  at load time. `applyOverlays` rewrites the base document in memory;
+  no forking, no preprocessing, no string substitution.
+- **Native OpenAPI 3.0 support and a structured error tree.** 3.0 is
+  a first-class dialect, not a 2020-12 translation: `nullable`,
+  boolean `exclusiveMaximum`, and `$ref`-suppresses-siblings are baked
+  into the compiler's dialect dispatch. Errors come back as a typed
+  tree (`code` / `path` / `params` / `children`) so downstream code
+  can narrow on fields rather than pattern-match on messages.
 
-**First-class overlays.** Many projects consume an OpenAPI document
-they don't own: an upstream framework (Supabase, Directus, Hasura,
-PocketBase, ...) or a gateway's published spec. `applyOverlays`
-patches the base document programmatically at load time — add a
-gateway-required header to every operation, extend a component
-schema, swap a response shape in staging — without forking or
-preprocessing the upstream file. `loadSpec` stitches external `$ref`s
-and applies overlays in a single call.
-
-If you want raw validate-per-second throughput on a spec you already
-own end to end, ajv is still the throughput king. If you want
-correct 3.0, a structured error tree you can narrow against, and an
-overlay model that respects the upstream document, this is the
-library.
+Ajv is the fastest JSON Schema validator for JavaScript and underpins
+most of the OpenAPI ecosystem. For pure validate-per-second throughput
+on a spec you fully own, it's still the right pick. Where the two
+projects overlap and where each does more is written up in
+[`COMPARISON.md`](./COMPARISON.md).
 
 ### Conformance
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,14 +19,20 @@ instead; the logic translates 1:1.
 
 ## What's in here
 
-| File                  | Shows                                                                |
-| --------------------- | -------------------------------------------------------------------- |
-| `basic-validation.ts` | Inline spec → `createValidator` → request + response checks          |
-| `custom-formats.ts`   | Register a user format (E.164 phone) via the `formats` option        |
-| `custom-keywords.ts`  | Register a schema keyword (`activeTenant`) via the `keywords` option |
-| `max-errors.ts`       | Fast-fail and bounded error collection on a bulk-invalid payload     |
-| `versions.ts`         | 3.0, 3.1, and 3.2 side by side: `nullable`, QUERY method, etc.       |
-| `overlay.ts`          | Merge a gateway-specific header requirement via `applyOverlays`      |
+| File                           | Shows                                                                |
+| ------------------------------ | -------------------------------------------------------------------- |
+| `basic-validation.ts`          | Inline spec → `createValidator` → request + response checks          |
+| `custom-formats.ts`            | Register a user format (E.164 phone) via the `formats` option        |
+| `custom-keywords.ts`           | Register a schema keyword (`activeTenant`) via the `keywords` option |
+| `max-errors.ts`                | Fast-fail and bounded error collection on a bulk-invalid payload     |
+| `versions.ts`                  | 3.0, 3.1, and 3.2 side by side: `nullable`, QUERY method, etc.       |
+| `overlay.ts`                   | Minimal overlay: merge a gateway header requirement into one op      |
+| `overlay-petstore-schema.ts`   | Extend the `Pet` component with a deployment-required field          |
+| `overlay-petstore-endpoint.ts` | Require an `X-Tenant` header on `POST /pets` via an endpoint overlay |
+
+See [`OVERLAYS.md`](../OVERLAYS.md) for a walk-through of the overlay
+shape and when to use each section (`extendSchemas`, `replaceSchemas`,
+`overrides`, `addPaths`).
 
 ## Conventions
 

--- a/examples/overlay-petstore-endpoint.ts
+++ b/examples/overlay-petstore-endpoint.ts
@@ -1,0 +1,84 @@
+/**
+ * Overlay: add a gateway-required header to an existing endpoint
+ * without touching the upstream spec.
+ *
+ * Scenario: an upstream petstore accepts POST /pets with only a JSON
+ * body, but your deployment sits behind a gateway that requires an
+ * `X-Tenant` header on every write. Rather than forking the spec,
+ * you overlay the requirement onto the operation at load time.
+ *
+ * `overrides` reaches into an existing path's operations and merges
+ * per-operation fragments. `addParameters` appends new parameters or
+ * replaces (by `name` + `in`) concrete existing ones. The upstream
+ * body schema is untouched; only the parameter list changes.
+ *
+ * Run from the repo root:
+ *   pnpm tsx examples/overlay-petstore-endpoint.ts
+ */
+
+import type { OpenAPIDocument } from "../packages/core/src/index.ts";
+import { formatText } from "../packages/core/src/index.ts";
+import { applyOverlays, type SpecOverlay } from "../packages/spec/src/index.ts";
+import { createValidator } from "../packages/validator/src/index.ts";
+
+const base: OpenAPIDocument = {
+  openapi: "3.1.0",
+  info: { title: "Petstore", version: "1" },
+  paths: {
+    "/pets": {
+      post: {
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["name"],
+                properties: { name: { type: "string" } },
+              },
+            },
+          },
+        },
+        responses: { "201": { description: "created" } },
+      },
+    },
+  },
+};
+
+// Gateway requires `X-Tenant` on POST /pets.
+const overlay: SpecOverlay = {
+  overrides: {
+    "/pets": {
+      operations: {
+        post: {
+          addParameters: [
+            { name: "X-Tenant", in: "header", required: true, schema: { type: "string" } },
+          ],
+        },
+      },
+    },
+  },
+};
+
+const merged = applyOverlays(base, [overlay]);
+const v = createValidator(merged);
+
+// Without the header: rejected by the overlaid spec.
+const missing = v.validateRequest({
+  method: "POST",
+  path: "/pets",
+  contentType: "application/json",
+  body: { name: "Fido" },
+});
+console.log("POST /pets without X-Tenant:");
+if (missing !== null) console.log(formatText(missing));
+
+// With the header: clean.
+const ok = v.validateRequest({
+  method: "POST",
+  path: "/pets",
+  contentType: "application/json",
+  headers: { "x-tenant": "acme" },
+  body: { name: "Fido" },
+});
+console.log("\nPOST /pets with X-Tenant →", ok === null ? "ok" : "FAIL");

--- a/examples/overlay-petstore-schema.ts
+++ b/examples/overlay-petstore-schema.ts
@@ -1,0 +1,89 @@
+/**
+ * Overlay: extend a component schema without touching the upstream spec.
+ *
+ * Scenario: an upstream petstore defines `Pet` as `{ name, tag }`. Your
+ * deployment additionally requires `vaccinated: boolean` on every pet
+ * accepted by POST /pets. Rather than forking the spec and keeping the
+ * fork in sync, you overlay an extension onto the `Pet` component.
+ *
+ * The overlay merges the extension into the original schema via
+ * `allOf` — the original shape still applies; the extension adds to it.
+ * Consumers that only know about the upstream `Pet` continue to see a
+ * compatible shape; the extra constraint is enforced on top.
+ *
+ * Run from the repo root:
+ *   pnpm tsx examples/overlay-petstore-schema.ts
+ */
+
+import type { OpenAPIDocument } from "../packages/core/src/index.ts";
+import { formatText } from "../packages/core/src/index.ts";
+import { applyOverlays, type SpecOverlay } from "../packages/spec/src/index.ts";
+import { createValidator } from "../packages/validator/src/index.ts";
+
+// Upstream petstore. `Pet` is declared under `components/schemas` so
+// the overlay can target it by name.
+const base: OpenAPIDocument = {
+  openapi: "3.1.0",
+  info: { title: "Petstore", version: "1" },
+  paths: {
+    "/pets": {
+      post: {
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": { schema: { $ref: "#/components/schemas/Pet" } },
+          },
+        },
+        responses: { "201": { description: "created" } },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      Pet: {
+        type: "object",
+        required: ["name"],
+        properties: {
+          name: { type: "string" },
+          tag: { type: "string" },
+        },
+      },
+    },
+  },
+};
+
+// Deployment-specific extension: require `vaccinated: boolean`. Because
+// `extendSchemas` merges via allOf, the upstream Pet shape is preserved
+// (still requires `name`, still permits optional `tag`) and the new
+// constraint adds to it.
+const overlay: SpecOverlay = {
+  extendSchemas: {
+    Pet: {
+      type: "object",
+      required: ["vaccinated"],
+      properties: { vaccinated: { type: "boolean" } },
+    },
+  },
+};
+
+const merged = applyOverlays(base, [overlay]);
+const v = createValidator(merged);
+
+// Without vaccinated: rejected by the overlaid spec.
+const missing = v.validateRequest({
+  method: "POST",
+  path: "/pets",
+  contentType: "application/json",
+  body: { name: "Fido" },
+});
+console.log("POST /pets without `vaccinated`:");
+if (missing !== null) console.log(formatText(missing));
+
+// With vaccinated: clean.
+const ok = v.validateRequest({
+  method: "POST",
+  path: "/pets",
+  contentType: "application/json",
+  body: { name: "Fido", vaccinated: true },
+});
+console.log("\nPOST /pets with `vaccinated: true` →", ok === null ? "ok" : "FAIL");

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -1,9 +1,9 @@
 # @aahoughton/oav/schema
 
-JSON Schema 2020-12 compiler. Emits JavaScript via code generation
-(think Ajv-style) rather than interpreting at runtime. Compiled
-validators return `{ valid, error? }` where `error` is a
-`ValidationError` tree.
+JSON Schema 2020-12 compiler. Walks the schema once at construction
+time and emits a JavaScript function via code generation — no
+schema-walking on the hot path. Compiled validators return
+`{ valid, error? }` where `error` is a `ValidationError` tree.
 
 Use this module directly when you want schema validation without the
 HTTP layer — REST-less RPC bodies, config files, test fixtures, etc.

--- a/packages/schema/src/keywords/meta-data.ts
+++ b/packages/schema/src/keywords/meta-data.ts
@@ -22,13 +22,74 @@ function annotationKeyword(name: string): KeywordDefinition {
   };
 }
 
-/** @public */ export const titleKeyword = annotationKeyword("title");
-/** @public */ export const descriptionKeyword = annotationKeyword("description");
-/** @public */ export const defaultKeyword = annotationKeyword("default");
-/** @public */ export const deprecatedKeyword = annotationKeyword("deprecated");
-/** @public */ export const readOnlyKeyword = annotationKeyword("readOnly");
-/** @public */ export const writeOnlyKeyword = annotationKeyword("writeOnly");
-/** @public */ export const examplesKeyword = annotationKeyword("examples");
+/**
+ * `title` — a short human-readable label for the schema. Annotation-
+ * only; emits no validation code. Bundled into
+ * {@link metaDataVocabulary} and reachable alongside it from
+ * `@aahoughton/oav/schema`.
+ *
+ * @public
+ */
+export const titleKeyword = annotationKeyword("title");
+
+/**
+ * `description` — a longer human-readable explanation of the schema.
+ * Annotation-only; emits no validation code. Pair with
+ * {@link titleKeyword} for tooling that displays a label plus details.
+ *
+ * @public
+ */
+export const descriptionKeyword = annotationKeyword("description");
+
+/**
+ * `default` — a suggested default value for the schema. Preserved as
+ * metadata only; oav never injects defaults into request bodies or
+ * response bodies (see the `useDefaults` discussion in
+ * [`COMPARISON.md`](../../../COMPARISON.md) if you need that behaviour).
+ *
+ * @public
+ */
+export const defaultKeyword = annotationKeyword("default");
+
+/**
+ * `deprecated` — marks a schema (most often a single property) as
+ * deprecated. Annotation-only: deprecated values are not rejected at
+ * runtime. Tooling and generated clients use it to surface warnings.
+ *
+ * @public
+ */
+export const deprecatedKeyword = annotationKeyword("deprecated");
+
+/**
+ * `readOnly` — flags a property the client MUST NOT send on request
+ * bodies. Annotation-only inside the schema compiler; the validator's
+ * request-side body transform consults it and rewrites such properties
+ * to `false` on request-direction schemas. Companion to
+ * {@link writeOnlyKeyword}.
+ *
+ * @public
+ */
+export const readOnlyKeyword = annotationKeyword("readOnly");
+
+/**
+ * `writeOnly` — flags a property the server MUST NOT send on response
+ * bodies. Annotation-only inside the schema compiler; the validator's
+ * response-side body transform consults it and rewrites such properties
+ * to `false` on response-direction schemas. Companion to
+ * {@link readOnlyKeyword}.
+ *
+ * @public
+ */
+export const writeOnlyKeyword = annotationKeyword("writeOnly");
+
+/**
+ * `examples` — an array of example values the schema author supplies
+ * for documentation and tooling. Annotation-only; emits no validation
+ * code. Supersedes OpenAPI 3.0's singular {@link exampleKeyword}.
+ *
+ * @public
+ */
+export const examplesKeyword = annotationKeyword("examples");
 
 /**
  * OpenAPI-specific annotation: `example` (singular). Deprecated in


### PR DESCRIPTION
Three commits bundled as a single docs cleanup pass. No source changes; the two tsdoc fills in `packages/schema/src/keywords/meta-data.ts` are the only non-doc file touched.

## 1. AJV reference policy
- Internal docs (`CLAUDE.md`, per-package READMEs) no longer reference Ajv directly. Mentions are reserved for the main `README.md`, `COMPARISON.md`, `INTEGRATION.md`, and `performance/README.md`.
- `CLAUDE.md` — genericized the `performance/` sub-package description.
- `packages/schema/README.md` — dropped the "think Ajv-style" aside.
- `INTEGRATION.md` — softened the one line that undercut Ajv-based validators on 3.0 conformance; kept structural `express-openapi-validator` references (it's the migration guide).
- `README.md` — replaced "Why this exists" with "Why oav?": three-bullet framing (HTTP-aware / overlays / 3.0 + structured errors) with a link to `COMPARISON.md`. Explicitly acknowledges Ajv's speed and ecosystem reach.

## 2. `COMPARISON.md` (new)
Balanced feature comparison between oav and Ajv + `express-openapi-validator`. Leads with "largely substitutable for most users"; catalogues where each side does more; defers runtime-perf numbers to `performance/README.md`.

## 3. `OVERLAYS.md` + petstore examples
- New top-level `OVERLAYS.md` walks through the overlay shape (`extendSchemas` / `replaceSchemas` / `overrides` / `addPaths`), when to reach for each, apply-time semantics, and links to the examples.
- `examples/overlay-petstore-schema.ts` — extends the upstream `Pet` component with a deployment-required field via `extendSchemas`.
- `examples/overlay-petstore-endpoint.ts` — adds a gateway `X-Tenant` header to `POST /pets` via `overrides.addParameters`.
- `examples/README.md` updated to index the new examples and link `OVERLAYS.md`.

## 4. README Conformance section rewrite
Dropped "Published, not claimed" / "No divergence is silent" LLM-flavour framing. Added a paragraph explaining when each known gap (`$dynamicRef` runtime rebinding, strict-format-assertion edges, float overflow) would actually bite a user in practice.

## 5. `INTEGRATION.md` tone pass
Scrubbed marketing-style and anthropomorphic phrasing without content changes:
- "The honest summary" → "What the two libraries take on"
- "What the validator won't do / What we won't do" → neutral headings
- Removed "zero surprises", "escape hatch", "ship exactly the policy you want rather than whatever `onError` shape a library decided on", "Or fix the client", "first-class feature, not a forking workaround", and a handful of similar jabs
- "What you're giving up / What you're getting" → "Features not carried over / Features added"

## 6. Schema meta-data tsdocs
Filled in the seven bare `/** @public */` annotation-keyword tsdocs in `packages/schema/src/keywords/meta-data.ts`. Each now describes what the specific keyword is, that it's annotation-only, and names a related piece.

## Test plan
- [x] `pnpm test` (542/542 pass)
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] Both new petstore overlay examples run clean via `npx tsx`.