### PR TITLE
feat!: drop formatGithub / --format github

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,9 @@ external dev-dependencies (benchmark runners, competing validators,
 ## Architecture, package by package
 
 - **`@oav/core`** — pure types. `ValidationError` tree (children always an
-  array), path segments as `(string | number)[]`, and four formatters
-  (`formatText` / `formatJson` / `formatFlat` / `formatGithub`). Everything
-  else depends on this.
+  array), path segments as `(string | number)[]`, and three formatters
+  (`formatText` / `formatJson` / `formatFlat`). Everything else depends
+  on this.
 - **`@oav/schema`** — the JSON Schema 2020-12 compiler. Walks a schema,
   dispatches each keyword via `KeywordDefinition.compile(ctx)`, assembles
   the generated JS source, and `eval`s it through `new Function(deps, src)`.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ oav validate openapi.yaml --path "POST /pets" --body payload.json
 oav validate openapi.yaml --path "GET /pets" --response --status 200 --body resp.json
 ```
 
-Flags: `--format text|json|flat|github`, `--depth n`, `--overlay file`
+Flags: `--format text|json|flat`, `--depth n`, `--overlay file`
 (repeatable), `-o file`, `--quiet`. See
 [packages/cli/README.md](./packages/cli/README.md) for the full surface
 and the `.http` file format.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -35,13 +35,13 @@ Pass `-` as the file path to read from stdin (e.g. `--body -`).
 
 ## Flags
 
-| Flag                                | Meaning                                   |
-| ----------------------------------- | ----------------------------------------- |
-| `--format text\|json\|flat\|github` | Error rendering. Default `text`.          |
-| `--depth <n>`                       | Truncate error tree depth (text format).  |
-| `--overlay <file>`                  | Repeatable; applies overlays in order.    |
-| `-o <file>`                         | Write output to a file instead of stdout. |
-| `--quiet`                           | Exit code only, no stdout.                |
+| Flag                        | Meaning                                   |
+| --------------------------- | ----------------------------------------- |
+| `--format text\|json\|flat` | Error rendering. Default `text`.          |
+| `--depth <n>`               | Truncate error tree depth (text format).  |
+| `--overlay <file>`          | Repeatable; applies overlays in order.    |
+| `-o <file>`                 | Write output to a file instead of stdout. |
+| `--quiet`                   | Exit code only, no stdout.                |
 
 ## Exit codes
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -59,12 +59,11 @@ declaration merging.
 
 ## Formatters
 
-All four produce strings suitable for stdout / logs.
+All three produce strings suitable for stdout / logs.
 
 - `formatText(err, { maxDepth?, indent? })` — indented human-readable.
 - `formatJson(err)` — deep copy that round-trips through `JSON.stringify`.
 - `formatFlat(err)` — one line per leaf.
-- `formatGithub(err)` — GitHub Actions `::error::` annotations.
 
 `countErrors(err)` returns the total number of nodes in the tree.
 

--- a/packages/core/src/format-output.ts
+++ b/packages/core/src/format-output.ts
@@ -1,4 +1,4 @@
-import { formatFlat, formatGithub, formatJson, formatText } from "./format.js";
+import { formatFlat, formatJson, formatText } from "./format.js";
 import type { ValidationError } from "./errors.js";
 
 /**
@@ -9,7 +9,7 @@ import type { ValidationError } from "./errors.js";
  *
  * @public
  */
-export const KNOWN_OUTPUT_FORMATS = ["text", "json", "flat", "github"] as const;
+export const KNOWN_OUTPUT_FORMATS = ["text", "json", "flat"] as const;
 
 /**
  * Supported built-in output formats.
@@ -62,8 +62,6 @@ export function formatError(
       return JSON.stringify(formatJson(err), null, 2);
     case "flat":
       return formatFlat(err);
-    case "github":
-      return formatGithub(err);
     case "text":
     default:
       return formatText(err, depth !== undefined ? { maxDepth: depth } : {});

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -104,40 +104,6 @@ export function formatFlat(error: ValidationError): string {
 }
 
 /**
- * Render a {@link ValidationError} tree as a sequence of GitHub Actions
- * workflow commands, one `::error::` line per leaf.
- *
- * @remarks
- * Paths are emitted as the `title` field; the `file` field is left blank
- * because validation errors are data-level, not file-level. Callers who want
- * file annotations should post-process.
- *
- * @param error - Root of the error tree.
- * @returns A newline-separated string ready to print in a GitHub Actions run.
- *
- * @example
- * ```ts
- * console.log(formatGithub(rootError));
- * // ::error title=body.email::must match format "email"
- * ```
- *
- * @public
- */
-export function formatGithub(error: ValidationError): string {
-  const lines: string[] = [];
-  for (const leaf of collectLeaves(error)) {
-    const title = joinPath(leaf.path);
-    const message = escapeGithub(leaf.message);
-    if (title.length > 0) {
-      lines.push(`::error title=${escapeGithubProp(title)}::${message}`);
-    } else {
-      lines.push(`::error::${message}`);
-    }
-  }
-  return lines.join("\n");
-}
-
-/**
  * Count the nodes in a {@link ValidationError} tree (branches + leaves).
  *
  * @param error - Root of the error tree.
@@ -156,12 +122,4 @@ export function countErrors(error: ValidationError): number {
     n += 1;
   });
   return n;
-}
-
-function escapeGithub(value: string): string {
-  return value.replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
-}
-
-function escapeGithubProp(value: string): string {
-  return escapeGithub(value).replace(/:/g, "%3A").replace(/,/g, "%2C");
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,14 +15,7 @@ export {
   type ValidationError,
 } from "./errors.js";
 
-export {
-  countErrors,
-  formatFlat,
-  formatGithub,
-  formatJson,
-  formatText,
-  type FormatOptions,
-} from "./format.js";
+export { countErrors, formatFlat, formatJson, formatText, type FormatOptions } from "./format.js";
 
 export {
   formatError,

--- a/packages/core/test/format-output.test.ts
+++ b/packages/core/test/format-output.test.ts
@@ -21,10 +21,6 @@ describe("formatError", () => {
     expect(formatError(sample, "flat").split("\n")).toHaveLength(1);
   });
 
-  it("renders as GitHub Actions annotations", () => {
-    expect(formatError(sample, "github")).toContain("::error title=body.age::");
-  });
-
   it("respects depth truncation in text mode", () => {
     const out = formatError(sample, "text", 0);
     expect(out.split("\n").length).toBeLessThan(3);
@@ -41,10 +37,10 @@ describe("isOutputFormat", () => {
     expect(isOutputFormat("text")).toBe(true);
     expect(isOutputFormat("json")).toBe(true);
     expect(isOutputFormat("flat")).toBe(true);
-    expect(isOutputFormat("github")).toBe(true);
   });
 
   it("rejects unknown names", () => {
+    expect(isOutputFormat("github")).toBe(false);
     expect(isOutputFormat("xml")).toBe(false);
     expect(isOutputFormat("")).toBe(false);
   });

--- a/packages/core/test/format.test.ts
+++ b/packages/core/test/format.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createBranchError, createLeafError, type ValidationError } from "../src/errors.js";
-import { countErrors, formatFlat, formatGithub, formatJson, formatText } from "../src/format.js";
+import { countErrors, formatFlat, formatJson, formatText } from "../src/format.js";
 
 /** A realistic 4-level oneOf failure used by several formatter assertions. */
 function sampleTree(): ValidationError {
@@ -96,25 +96,6 @@ describe("formatFlat", () => {
       node = createBranchError(`level-${i}`, [], "branch", [node]);
     }
     expect(formatFlat(node)).toBe("deep.x — bad [type]");
-  });
-});
-
-describe("formatGithub", () => {
-  it("emits one ::error:: line per leaf with path as title", () => {
-    const out = formatGithub(sampleTree());
-    const lines = out.split("\n");
-    expect(lines).toHaveLength(2);
-    expect(lines[0]).toBe("::error title=body.purr::must be boolean");
-    expect(lines[1]).toBe('::error title=body::must have required property "bark"');
-  });
-
-  it("escapes CR, LF, and % in messages per GHA spec", () => {
-    const tree = createLeafError("x", [], "a\nb%c\rd");
-    expect(formatGithub(tree)).toBe("::error::a%0Ab%25c%0Dd");
-  });
-
-  it("omits the title when the path is empty", () => {
-    expect(formatGithub(createLeafError("x", [], "boom"))).toBe("::error::boom");
   });
 });
 


### PR DESCRIPTION
## Summary
The GitHub Actions output format emitted valid `::error title=...::` workflow commands but without file / line information, so the annotations showed up in the run-summary panel rather than as the inline PR-diff annotations that are the main draw of that GitHub feature. Without file + line, the output behaved like `--format flat` with a different prefix.

Rather than maintain a weak version of the format, remove it. A future version could add proper source-location tracking (position-preserving YAML/JSON parser, location propagation through the compiled validators) and reintroduce it then.

## Changes
- Removes `formatGithub` from `@aahoughton/oav/core`.
- Removes `"github"` from `KNOWN_OUTPUT_FORMATS`; `isOutputFormat` narrows to the three remaining formats (`text`, `json`, `flat`).
- Drops the `--format github` CLI option (Commander's `--format` validator rejects unknown values, so attempting it surfaces a usage error).
- Removes `formatGithub` tests and the `"github"` cases in `format-output.test` / `isOutputFormat` narrowing.
- Updates `README.md`, `packages/cli/README.md`, `packages/core/README.md`, and `CLAUDE.md` to reflect three formatters instead of four.

## Breaking
`formatGithub` was exported from `@aahoughton/oav/core`; `"github"` was a valid `OutputFormat`. Both are gone. Callers that still want that output shape can pass a custom renderer function:

```ts
formatError(err, (err) =>
  collectLeaves(err)
    .map((l) => `::error title=${joinPath(l.path)}::${l.message}`)
    .join("\n")
);
```

## Test plan
- [x] `pnpm test` (538/538 pass — four `formatGithub`-specific tests removed)
- [x] `pnpm lint`
- [x] `pnpm typecheck`