### PR TITLE
feat(router,validator): distinguish 405 method-not-allowed from 404

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -251,7 +251,9 @@ import type { ValidationError } from "@aahoughton/oav";
 function httpStatusFor(err: ValidationError): number {
   switch (err.code) {
     case "route":
-      return 404; // no matching method + path
+      return 404; // no path template matched
+    case "method":
+      return 405; // path matched but the verb isn't declared
     case "content-type":
       return 415; // request Content-Type not declared
     case "status":
@@ -262,15 +264,19 @@ function httpStatusFor(err: ValidationError): number {
 }
 ```
 
-`express-openapi-validator` distinguishes 404 (no path) from 405
-(path exists, wrong method). `oav` emits `code: "route"` for both.
-If you need 405 specifically, do a method-agnostic path check
-yourself:
+RFC 9110 requires the `Allow` response header on 405s. The `method`
+error's `params.allowed` is the uppercased list to send back:
 
 ```ts
-// Pseudocode: if the path matches ANY route at a different method, return 405.
-// oav's router doesn't expose this directly yet; a simple regex pass over
-// your own spec's path templates gets you there in ~10 lines.
+if (err.code === "method") {
+  const p = err.params as ErrorParamsFor<"method">;
+  res.setHeader("Allow", p.allowed.join(", "));
+  res
+    .status(405)
+    .type("application/problem+json")
+    .json(toProblemDetails(err, { instance: req.originalUrl }));
+  return;
+}
 ```
 
 For richer response envelopes, `toProblemDetails` produces
@@ -593,10 +599,11 @@ Keep them in the map if it's simpler; they cost nothing.
 
 ### Behavior differences to watch for
 
-- **404 vs 405.** `express-openapi-validator` returns 405 when the
-  path exists but the method doesn't. `oav` emits `code: "route"`
-  for both cases. Add a method-agnostic path check if you need 405
-  specifically.
+- **404 vs 405.** Both libraries distinguish them. `oav` emits
+  `code: "route"` for no path match and `code: "method"` for a path
+  that matched without the requested verb; the `method` error's
+  `params.allowed` is the uppercased method list, suitable for a
+  405's `Allow` response header.
 - **Response body interception.** `express-openapi-validator` catches
   `res.send("{...}")` (string form) too via its wrappers. `oav` does
   not unless you write the wrapper yourself, in which case parse

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -112,8 +112,15 @@ export interface BuiltInErrorParams {
   dependencies: { trigger: string; missing: string };
 
   // --- HTTP-level wrappers (emitted by @oav/validator) ---
-  /** No route matched `method` + `path`. */
+  /** No path template matched `path` — semantically HTTP 404. */
   route: { method: string; path: string };
+  /**
+   * Path template matched but the requested method isn't declared on
+   * it — semantically HTTP 405. `allowed` is the uppercase list of
+   * methods the matched path(s) do accept, suitable for an RFC 9110
+   * `Allow` response header.
+   */
+  method: { method: string; pathPattern: string; allowed: string[] };
   /**
    * Request body, leaf-only. Emitted when a `required: true` body is
    * absent on the request. When a present body fails schema validation,
@@ -202,6 +209,7 @@ export const BUILT_IN_ERROR_CODES = [
   "dependencies",
   // --- HTTP-level wrappers (emitted by @oav/validator) ---
   "route",
+  "method",
   "body",
   "request",
   "response",

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -1,6 +1,7 @@
 export {
   createRouter,
   parseTemplate,
+  type MethodNotAllowed,
   type RouteMatch,
   type Router,
   type Segment,

--- a/packages/router/src/matcher.ts
+++ b/packages/router/src/matcher.ts
@@ -8,7 +8,8 @@ import type { HttpMethod, OperationObject, PathItem } from "@oav/core";
 export type Segment = { kind: "literal"; value: string } | { kind: "template"; name: string };
 
 /**
- * Result of a successful route match.
+ * Result of a successful route match: the path template matched *and*
+ * the requested method is declared on it.
  *
  * `operation` and `pathItem` are the identical references supplied to
  * {@link createRouter}. Downstream consumers (notably `@oav/validator`)
@@ -19,6 +20,7 @@ export type Segment = { kind: "literal"; value: string } | { kind: "template"; n
  * @public
  */
 export interface RouteMatch {
+  kind: "match";
   operation: OperationObject;
   pathItem: PathItem;
   pathPattern: string;
@@ -26,13 +28,52 @@ export interface RouteMatch {
 }
 
 /**
- * The router interface. Returns `undefined` for unmatched routes.
+ * Result returned when the path template matched but the requested
+ * method isn't declared on it. Semantically a 405 Method Not Allowed
+ * rather than a 404. `allowed` is the union of HTTP methods declared
+ * across every path template that matched the request path, uppercased
+ * — suitable for an RFC 9110 `Allow` response header.
+ *
+ * @public
+ */
+export interface MethodNotAllowed {
+  kind: "method-not-allowed";
+  /** The most specific path template that matched. */
+  pathPattern: string;
+  /** Uppercased HTTP methods declared on matching path(s). */
+  allowed: string[];
+}
+
+/**
+ * The router interface. `match` returns:
+ *
+ * - `RouteMatch` — the path matched and the method is declared on it.
+ * - `MethodNotAllowed` — the path matched but no declared method
+ *   handles the request's verb. Callers map this to HTTP 405.
+ * - `undefined` — no path template matched at all. Callers map this
+ *   to HTTP 404.
  *
  * @public
  */
 export interface Router {
-  match(method: string, path: string): RouteMatch | undefined;
+  match(method: string, path: string): RouteMatch | MethodNotAllowed | undefined;
 }
+
+// HTTP methods to scan on a `PathItem` when collecting `allowed` for a
+// 405 response. Mirrors the `HttpMethod` union in @oav/core; kept local
+// here to avoid pulling an extra symbol across the package boundary
+// for a constant array.
+const ALL_METHODS: HttpMethod[] = [
+  "get",
+  "put",
+  "post",
+  "delete",
+  "options",
+  "head",
+  "patch",
+  "trace",
+  "query",
+];
 
 interface Route {
   segments: Segment[];
@@ -122,6 +163,15 @@ export function createRouter(paths: Record<string, PathItem>): Router {
       const stripped = path.split("?")[0] ?? path;
       const trimmed = stripped.replace(/^\/+/, "").replace(/\/+$/, "");
       const tokens = trimmed === "" ? [] : trimmed.split("/").map((s) => decodeURIComponent(s));
+
+      // If we scan every matching path without finding the method, we
+      // still want to report a 405 (not 404) and carry the union of
+      // declared methods across every path that matched structurally.
+      // `/items/42` and `/items/{id}` can both match `POST /items/42`
+      // even though neither declares POST.
+      let firstMatchedPattern: string | undefined;
+      const allowed = new Set<string>();
+
       for (const route of routes) {
         if (route.segments.length !== tokens.length) continue;
         const params: Record<string, string> = {};
@@ -150,12 +200,32 @@ export function createRouter(paths: Record<string, PathItem>): Router {
         if (operation === undefined && normMethod === "head") {
           operation = route.pathItem.get;
         }
-        if (operation === undefined) continue;
+        if (operation !== undefined) {
+          return {
+            kind: "match",
+            operation,
+            pathItem: route.pathItem,
+            pathPattern: route.pathPattern,
+            pathParams: params,
+          };
+        }
+
+        // Path matched but this path's method map doesn't include the
+        // request's verb. Remember the first (most-specific) matched
+        // pattern, union the declared methods, and keep scanning.
+        if (firstMatchedPattern === undefined) firstMatchedPattern = route.pathPattern;
+        for (const m of ALL_METHODS) {
+          if (route.pathItem[m] !== undefined) allowed.add(m.toUpperCase());
+        }
+        // GET implicitly answers HEAD (RFC 9110 §9.3.2).
+        if (route.pathItem.get !== undefined) allowed.add("HEAD");
+      }
+
+      if (firstMatchedPattern !== undefined) {
         return {
-          operation,
-          pathItem: route.pathItem,
-          pathPattern: route.pathPattern,
-          pathParams: params,
+          kind: "method-not-allowed",
+          pathPattern: firstMatchedPattern,
+          allowed: [...allowed].sort(),
         };
       }
       return undefined;

--- a/packages/router/test/router.test.ts
+++ b/packages/router/test/router.test.ts
@@ -46,9 +46,11 @@ describe("router", () => {
   });
 
   it("matches methods independently on the same path", () => {
-    expect(r.match("get", "/pets")?.operation.operationId).toBe("listPets");
-    expect(r.match("post", "/pets")?.operation.operationId).toBe("createPet");
-    expect(r.match("delete", "/pets")).toBeUndefined();
+    expect(r.match("get", "/pets")?.kind).toBe("match");
+    expect(r.match("post", "/pets")?.kind).toBe("match");
+    // DELETE isn't declared on /pets → method-not-allowed, not a path miss.
+    const m = r.match("delete", "/pets");
+    expect(m?.kind).toBe("method-not-allowed");
   });
 
   it("decodes percent-encoded segments", () => {
@@ -96,7 +98,9 @@ describe("router", () => {
   it("does not invent a HEAD route when the path has no GET", () => {
     const paths2: Record<string, PathItem> = { "/write-only": { post: op("post") } };
     const r2 = createRouter(paths2);
-    expect(r2.match("head", "/write-only")).toBeUndefined();
+    // Path matches; HEAD isn't implicitly available without GET → 405.
+    const m = r2.match("head", "/write-only");
+    expect(m?.kind).toBe("method-not-allowed");
   });
 
   it("matches path segments containing a literal colon", () => {
@@ -118,5 +122,45 @@ describe("router", () => {
         "/items/{slug}": { get: op("bySlug") },
       }),
     ).toThrow(/ambiguous/);
+  });
+
+  it("returns method-not-allowed with an allowed set (405 shape)", () => {
+    const m = r.match("delete", "/pets");
+    expect(m).toEqual({
+      kind: "method-not-allowed",
+      pathPattern: "/pets",
+      allowed: ["GET", "HEAD", "POST"],
+    });
+  });
+
+  it("unions allowed methods across every path template that matches the path", () => {
+    // /items/42 and /items/{id} both structurally match POST /items/42.
+    // Neither declares POST, so the allowed union is {GET (from /items/42),
+    // HEAD (implicit via GET), PUT (from /items/{id})}.
+    const rc = createRouter({
+      "/items/42": { get: op("literal") },
+      "/items/{id}": { put: op("byId") },
+    });
+    const m = rc.match("post", "/items/42");
+    expect(m).toEqual({
+      kind: "method-not-allowed",
+      pathPattern: "/items/42",
+      allowed: ["GET", "HEAD", "PUT"],
+    });
+  });
+
+  it("falls through to a matching method on a less-specific path", () => {
+    // /items/42 has GET only; /items/{id} has POST. A POST /items/42
+    // should hit the {id} route, not return method-not-allowed.
+    const rc = createRouter({
+      "/items/42": { get: op("literal") },
+      "/items/{id}": { post: op("byId") },
+    });
+    const m = rc.match("post", "/items/42");
+    expect(m?.kind).toBe("match");
+    if (m?.kind === "match") {
+      expect(m.operation.operationId).toBe("byId");
+      expect(m.pathPattern).toBe("/items/{id}");
+    }
   });
 });

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -376,6 +376,14 @@ export function createValidator(
         { method: req.method, path: req.path },
       );
     }
+    if (match.kind === "method-not-allowed") {
+      return createLeafError(
+        "method",
+        [],
+        `method ${req.method.toUpperCase()} not allowed on ${match.pathPattern}; allowed: ${match.allowed.join(", ")}`,
+        { method: req.method, pathPattern: match.pathPattern, allowed: match.allowed },
+      );
+    }
     const cache = cacheFor(match);
     const children: ValidationError[] = [];
 
@@ -421,6 +429,14 @@ export function createValidator(
         [],
         `no route matches ${req.method.toUpperCase()} ${req.path}`,
         { method: req.method, path: req.path },
+      );
+    }
+    if (match.kind === "method-not-allowed") {
+      return createLeafError(
+        "method",
+        [],
+        `method ${req.method.toUpperCase()} not allowed on ${match.pathPattern}; allowed: ${match.allowed.join(", ")}`,
+        { method: req.method, pathPattern: match.pathPattern, allowed: match.allowed },
       );
     }
     const cache = cacheFor(match);

--- a/packages/validator/test/error-codes.test.ts
+++ b/packages/validator/test/error-codes.test.ts
@@ -158,6 +158,7 @@ describe("BuiltInErrorParams registry cross-check", () => {
     };
 
     collect(v.validateRequest({ method: "DELETE", path: "/nope" })); // route
+    collect(v.validateRequest({ method: "DELETE", path: "/items/1" })); // method (405)
     collect(
       v.validateRequest({ method: "POST", path: "/items/1", contentType: "application/json" }),
     ); // body (missing required)
@@ -188,6 +189,7 @@ describe("BuiltInErrorParams registry cross-check", () => {
 
     for (const code of [
       "route",
+      "method",
       "body",
       "content-type",
       "request",
@@ -222,6 +224,7 @@ describe("BuiltInErrorParams registry cross-check", () => {
     // TypeScript can't enforce the contract — this test is the backstop.
     const requiredKeys: Record<string, readonly string[]> = {
       route: ["method", "path"],
+      method: ["method", "pathPattern", "allowed"],
       request: ["method", "pathPattern"],
       response: ["status"],
       status: ["status"],
@@ -269,6 +272,8 @@ describe("BuiltInErrorParams registry cross-check", () => {
     });
 
     check(v.validateRequest({ method: "DELETE", path: "/nope" }), "route");
+    // Path /items/{id} exists but declares only GET + POST; DELETE is 405.
+    check(v.validateRequest({ method: "DELETE", path: "/items/1" }), "method");
     check(
       v.validateRequest({
         method: "POST",

--- a/packages/validator/test/request.test.ts
+++ b/packages/validator/test/request.test.ts
@@ -45,6 +45,17 @@ describe("validateRequest", () => {
     expect(err?.code).toBe("route");
   });
 
+  it("errors with `method` (not `route`) when the path exists but the verb doesn't", () => {
+    // /pets declares GET + POST; DELETE is 405, not 404.
+    const err = v.validateRequest({ method: "DELETE", path: "/pets" });
+    expect(err?.code).toBe("method");
+    expect(err?.params).toMatchObject({
+      method: "DELETE",
+      pathPattern: "/pets",
+      allowed: ["GET", "HEAD", "POST"],
+    });
+  });
+
   it("errors for wrong Content-Type", () => {
     const err = v.validateRequest({
       method: "POST",


### PR DESCRIPTION
## Summary
The router previously collapsed "path exists, wrong method" and "no path match" into the same `return undefined` branch, and the validator emitted `code: "route"` for both. RFC 9110 distinguishes the two, and a 405 response MUST carry an `Allow` header listing the permitted methods — information the router already had and was dropping.

## Changes

### `@oav/router`
- `Router.match` now returns `RouteMatch | MethodNotAllowed | undefined`.
- `RouteMatch` gains a `kind: "match"` discriminator; new `MethodNotAllowed` interface carries `{ kind: "method-not-allowed"; pathPattern; allowed }`.
- When a path matches structurally but no declared method handles the request's verb, the matcher keeps scanning lower-specificity paths in case one of them does. Only after no match returns `MethodNotAllowed` with `allowed` = union of declared methods across every matched path (uppercased, suitable for an `Allow` header). GET implicitly contributes HEAD per RFC 9110 §9.3.2.

### `@oav/validator`
- Emits a new `"method"` code on the method-not-allowed branch, with `params { method, pathPattern, allowed }`. The existing `"route"` code is now reserved for the genuine no-path-match case.

### `@oav/core`
- Adds `"method"` to `BuiltInErrorParams` and `BUILT_IN_ERROR_CODES`.

### Tests
- Router: updated two tests whose assertions encoded the old return contract (method-miss ≡ undefined); added three new tests covering the 405 shape, the multi-path allowed-union, and the fall-through to a matching method on a less-specific path.
- Validator: new request-side test asserting code + params on an unsupported verb against an existing path; `error-codes.test` extended with the new code's shape conformance check.

### Docs
- `INTEGRATION.md` status-code recipe maps `"method"` → 405 and adds an RFC 9110 `Allow`-header example. The "404 vs 405" behaviour-difference bullet no longer describes oav collapsing the two.

## Breaking

`Router.match` return type changed:

```ts
// before
match(method, path): RouteMatch | undefined

// after
match(method, path): RouteMatch | MethodNotAllowed | undefined
```

Consumers that check `if (match === undefined)` and then read `match.operation` still work — but must now also distinguish the `method-not-allowed` case (narrowing via `match.kind === "match"` before reading operation fields). The in-tree `@oav/validator` already does this; no external consumers exist yet.

## Test plan
- [x] `pnpm test` (542/542 pass — three new router tests, one new validator test, error-codes shape check extended)
- [x] `pnpm lint`
- [x] `pnpm typecheck`