### PR TITLE
chore(schema,validator): align CompileOptions / ValidatorOptions shape

### DIFF
--- a/packages/schema/src/compiler/compiler.ts
+++ b/packages/schema/src/compiler/compiler.ts
@@ -112,49 +112,37 @@ export type CompiledPredicate = {
 /**
  * Options accepted by {@link compileSchema}.
  *
+ * @remarks
+ * Ordering convention (shared with
+ * {@link @aahoughton/oav!ValidatorOptions}):
+ *
+ *   1. Compile essentials — `dialect`.
+ *   2. Shared extension points — `formats`, `keywords`.
+ *   3. Error-collection policy — `maxErrors`.
+ *   4. Surface-specific extras last — here, `external`, `refResolver`,
+ *      `predicate`.
+ *
+ * Options common to both surfaces share names and positions so a
+ * reader of one declaration can predict the other. When adding a new
+ * option, put it in the section that matches its role and use the
+ * same name on the validator side if the concept applies there too.
+ *
  * @public
  */
 export interface CompileOptions {
+  // --- 1. Compile essentials ---
+
   /**
    * The dialect to compile against. Pick one of the built-ins
    * (`jsonSchemaDialect`, `openapi31Dialect`, `oas30Dialect`) or
    * construct a custom {@link Dialect}.
    */
   dialect: Dialect;
-  /** Additional external named schemas that `$ref` can resolve to. */
-  external?: Map<string, SchemaOrBoolean>;
+
+  // --- 2. Shared extension points ---
+
   /** Pre-registered format validators, keyed by format name. */
   formats?: Record<string, (value: string) => boolean>;
-  /** Custom ref resolver — overrides the default (which resolves fragments within the root). */
-  refResolver?: RefResolver;
-  /**
-   * Cap on the number of leaf errors collected per `validate()` call.
-   * Defaults to `Number.POSITIVE_INFINITY` (collect everything).
-   *
-   * When set to a finite value:
-   * - Once the cap is reached, further errors are dropped and
-   *   {@link ValidationResult.truncated} is set on the returned result.
-   * - Hot loops (array items, object properties, `allOf`/`anyOf`
-   *   branches) short-circuit as soon as the budget is exhausted, so
-   *   the CPU and memory cost of validating a huge payload is bounded.
-   *
-   * `maxErrors: 1` is the classic fast-fail mode.
-   */
-  maxErrors?: number;
-  /**
-   * When `true`, compile a boolean predicate rather than an
-   * error-collecting validator. The returned {@link CompiledPredicate}'s
-   * `validate(data)` returns `boolean` — no {@link ValidationError}
-   * tree is ever constructed, so consumers who only need a yes/no
-   * answer pay nothing for error-reporting machinery (leaf allocation,
-   * path snapshot, params object, message string).
-   *
-   * Mutually exclusive with a finite {@link CompileOptions.maxErrors}.
-   * Predicate mode already short-circuits at the first failure;
-   * combining the two is meaningless, so the compiler throws when
-   * both are supplied.
-   */
-  predicate?: boolean;
   /**
    * User-registered keywords, keyed by keyword name. Each validator is
    * invoked whenever its name appears as a property in a schema object.
@@ -173,6 +161,44 @@ export interface CompileOptions {
    * ```
    */
   keywords?: Record<string, CustomKeywordValidator>;
+
+  // --- 3. Error-collection policy ---
+
+  /**
+   * Cap on the number of leaf errors collected per `validate()` call.
+   * Defaults to `Number.POSITIVE_INFINITY` (collect everything).
+   *
+   * When set to a finite value:
+   * - Once the cap is reached, further errors are dropped and
+   *   {@link ValidationResult.truncated} is set on the returned result.
+   * - Hot loops (array items, object properties, `allOf`/`anyOf`
+   *   branches) short-circuit as soon as the budget is exhausted, so
+   *   the CPU and memory cost of validating a huge payload is bounded.
+   *
+   * `maxErrors: 1` is the classic fast-fail mode.
+   */
+  maxErrors?: number;
+
+  // --- 4. Schema-compile-specific extras ---
+
+  /** Additional external named schemas that `$ref` can resolve to. */
+  external?: Map<string, SchemaOrBoolean>;
+  /** Custom ref resolver — overrides the default (which resolves fragments within the root). */
+  refResolver?: RefResolver;
+  /**
+   * When `true`, compile a boolean predicate rather than an
+   * error-collecting validator. The returned {@link CompiledPredicate}'s
+   * `validate(data)` returns `boolean` — no {@link ValidationError}
+   * tree is ever constructed, so consumers who only need a yes/no
+   * answer pay nothing for error-reporting machinery (leaf allocation,
+   * path snapshot, params object, message string).
+   *
+   * Mutually exclusive with a finite {@link CompileOptions.maxErrors}.
+   * Predicate mode already short-circuits at the first failure;
+   * combining the two is meaningless, so the compiler throws when
+   * both are supplied.
+   */
+  predicate?: boolean;
 }
 
 /** @internal */

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -170,25 +170,27 @@ export interface ValidatorStats {
 /**
  * Options for {@link createValidator}.
  *
+ * @remarks
+ * Ordering convention (shared with
+ * {@link @aahoughton/oav/schema!CompileOptions}):
+ *
+ *   1. Compile essentials — `dialect`.
+ *   2. Shared extension points — `formats`, `keywords`.
+ *   3. Error-collection policy — `maxErrors`.
+ *   4. Surface-specific extras last — here, `strictQueryParameters`,
+ *      `onUnknownVersion`, `warn`.
+ *
+ * Options common to both surfaces share names and positions so a
+ * reader of one declaration can predict the other. When adding a new
+ * option, put it in the section that matches its role and use the
+ * same name on the compile-schema side if the concept applies there
+ * too.
+ *
  * @public
  */
 export interface ValidatorOptions {
-  /** Optional extra format validators merged on top of {@link builtInFormats}. */
-  formats?: Record<string, (value: string) => boolean>;
-  /** When `true`, reject unknown query parameters (default: `false`). */
-  strictQueryParameters?: boolean;
-  /**
-   * Cap on the number of leaf schema errors collected per
-   * `validateRequest` / `validateResponse` call. Defaults to uncapped.
-   *
-   * Set to `1` for fast-fail semantics, or to a small number (say 10)
-   * to bound CPU and memory on validation of very large payloads
-   * (e.g. a 10 MB array where every element has the same structural
-   * error). When the cap is hit, the returned error tree is marked
-   * with a `truncated: true` param on the root so consumers can tell
-   * the report was shortened.
-   */
-  maxErrors?: number;
+  // --- 1. Compile essentials ---
+
   /**
    * Override the schema dialect used to compile the spec's schemas.
    * By default the validator reads the spec's `openapi` version and
@@ -197,6 +199,11 @@ export interface ValidatorOptions {
    * {@link Dialect} or force a specific built-in.
    */
   dialect?: Dialect;
+
+  // --- 2. Shared extension points ---
+
+  /** Optional extra format validators merged on top of {@link builtInFormats}. */
+  formats?: Record<string, (value: string) => boolean>;
   /**
    * User-registered schema keywords. The record is keyed by keyword
    * name; each validator is invoked whenever that name appears in a
@@ -214,6 +221,26 @@ export interface ValidatorOptions {
    * ```
    */
   keywords?: Record<string, CustomKeywordValidator>;
+
+  // --- 3. Error-collection policy ---
+
+  /**
+   * Cap on the number of leaf schema errors collected per
+   * `validateRequest` / `validateResponse` call. Defaults to uncapped.
+   *
+   * Set to `1` for fast-fail semantics, or to a small number (say 10)
+   * to bound CPU and memory on validation of very large payloads
+   * (e.g. a 10 MB array where every element has the same structural
+   * error). When the cap is hit, the returned error tree is marked
+   * with a `truncated: true` param on the root so consumers can tell
+   * the report was shortened.
+   */
+  maxErrors?: number;
+
+  // --- 4. HTTP-validator-specific extras ---
+
+  /** When `true`, reject unknown query parameters (default: `false`). */
+  strictQueryParameters?: boolean;
   /**
    * How to handle a spec whose `openapi` field is missing, malformed,
    * or not one of the supported versions (3.0, 3.1, 3.2).


### PR DESCRIPTION
## Summary
Codify the ordering convention across the two main option-bags (`CompileOptions` on `compileSchema` and `ValidatorOptions` on `createValidator`) so a reader of one can predict the other.

Both now follow the same four-section layout:

1. **Compile essentials** — `dialect`
2. **Shared extension points** — `formats`, `keywords`
3. **Error-collection policy** — `maxErrors`
4. **Surface-specific extras** — `external` / `refResolver` / `predicate` on compile; `strictQueryParameters` / `onUnknownVersion` / `warn` on the validator

Options shared by both surfaces (`dialect`, `formats`, `keywords`, `maxErrors`) are named consistently already; this PR makes the positions match too. A convention comment at each interface declaration calls out the layout so future additions (#82 strict, #83 SchemaRegistry, #84 ignorePaths) land in the right section with matching names on both sides.

## Not a runtime change
Reordering fields in a TypeScript interface is type-only. Existing callers that pass options as object literals are unaffected — property ordering at the call site has never mattered. No source import paths change.

## Test plan
- [x] `pnpm test` (542/542 pass, unchanged)
- [x] `pnpm lint`
- [x] `pnpm typecheck`

Closes #86