### PR TITLE
feat(formats): export fromAjvFormats migration helper

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -579,17 +579,14 @@ formats: {
 }
 ```
 
-A three-line helper handles the conversion if you're migrating a
-map of ajv-shaped definitions without rewriting each one:
+When migrating a map of ajv-shaped definitions without rewriting each
+one, `@aahoughton/oav/formats` exports `fromAjvFormats` for the
+conversion:
 
 ```ts
-type AjvFormatDef = { type?: "string" | "number"; validate: (v: unknown) => boolean };
+import { fromAjvFormats } from "@aahoughton/oav/formats";
 
-function fromAjv(defs: Record<string, AjvFormatDef>): Record<string, (v: string) => boolean> {
-  return Object.fromEntries(Object.entries(defs).map(([k, d]) => [k, (v) => d.validate(v)]));
-}
-
-createValidator(spec, { formats: fromAjv(myAjvFormats) });
+createValidator(spec, { formats: fromAjvFormats(myAjvFormats) });
 ```
 
 `oav`'s `format` keyword only applies to string values (per JSON

--- a/packages/formats/src/index.ts
+++ b/packages/formats/src/index.ts
@@ -61,3 +61,55 @@ export const builtInFormats: Record<string, (value: string) => boolean> = {
   regex: validateRegex,
   uuid: validateUuid,
 };
+
+/**
+ * An Ajv-shaped format definition — `{ type, validate }`. oav's
+ * `format` keyword only applies to string values (per JSON Schema
+ * 2020-12 §6.3), so `type` is carried for shape compatibility but
+ * not acted on; non-string values skip format validation regardless.
+ *
+ * Ajv's adjacent `async` / `compare` fields aren't used by oav and
+ * are ignored by {@link fromAjvFormats}.
+ *
+ * @public
+ */
+export interface AjvFormatDef {
+  type?: "string" | "number";
+  validate: (value: unknown) => boolean;
+}
+
+/**
+ * Convert a map of Ajv-shaped format definitions to the plain
+ * predicate shape oav's `formats` option expects. One-way — pass the
+ * result straight into `createValidator` / `compileSchema`.
+ *
+ * Main audience: migrants from `ajv-formats` or
+ * `express-openapi-validator`'s `formats` option, who already have a
+ * `Record<string, { type, validate }>` lying around and would
+ * otherwise hand-roll the three-line conversion on every project.
+ *
+ * Non-boolean truthy returns from the source validator are coerced
+ * to `true` (some adapter packages in the wild return `1` / strings).
+ *
+ * @public
+ *
+ * @example
+ * ```ts
+ * import { createValidator } from "@aahoughton/oav";
+ * import { fromAjvFormats } from "@aahoughton/oav/formats";
+ *
+ * const validator = createValidator(spec, {
+ *   formats: fromAjvFormats(myAjvFormats),
+ * });
+ * ```
+ */
+export function fromAjvFormats(
+  defs: Record<string, AjvFormatDef>,
+): Record<string, (value: string) => boolean> {
+  return Object.fromEntries(
+    Object.entries(defs).map(([name, def]) => [
+      name,
+      (value: string) => Boolean(def.validate(value)),
+    ]),
+  );
+}

--- a/packages/formats/test/formats.test.ts
+++ b/packages/formats/test/formats.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   builtInFormats,
+  fromAjvFormats,
   validateDate,
   validateDateTime,
   validateDuration,
@@ -170,5 +171,42 @@ describe("builtInFormats map", () => {
       "uuid",
     ];
     for (const k of keys) expect(typeof builtInFormats[k]).toBe("function");
+  });
+});
+
+describe("fromAjvFormats", () => {
+  it("converts Ajv-shaped definitions to plain string predicates", () => {
+    const result = fromAjvFormats({
+      duration: { type: "string", validate: (v) => typeof v === "string" && v.startsWith("P") },
+    });
+    expect(typeof result.duration).toBe("function");
+    expect(result.duration?.("P1D")).toBe(true);
+    expect(result.duration?.("1D")).toBe(false);
+  });
+
+  it("coerces truthy non-boolean returns to true", () => {
+    const result = fromAjvFormats({
+      truthy: {
+        validate: (v) => (typeof v === "string" && v.length > 0 ? 1 : 0) as unknown as boolean,
+      },
+    });
+    expect(result.truthy?.("x")).toBe(true);
+    expect(result.truthy?.("")).toBe(false);
+  });
+
+  it("tolerates entries without `type`", () => {
+    const result = fromAjvFormats({
+      anything: { validate: () => true },
+    });
+    expect(result.anything?.("x")).toBe(true);
+  });
+
+  it("hands back a map directly usable by createValidator / compileSchema", () => {
+    const ajvMap = { foo: { type: "string" as const, validate: (v: unknown) => v === "foo" } };
+    const formats = fromAjvFormats(ajvMap);
+    // Shape matches what compileSchema expects: Record<string, (v: string) => boolean>
+    expect(Object.keys(formats)).toEqual(["foo"]);
+    expect(formats.foo?.("foo")).toBe(true);
+    expect(formats.foo?.("bar")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
Exports `fromAjvFormats` + `AjvFormatDef` from `@aahoughton/oav/formats` so migrants from `ajv-formats` or `express-openapi-validator`'s `formats` option can reach for a named helper instead of copy-pasting the three-line conversion out of `INTEGRATION.md`.

```ts
import { fromAjvFormats } from "@aahoughton/oav/formats";
import { createValidator } from "@aahoughton/oav";

createValidator(spec, { formats: fromAjvFormats(myAjvFormats) });
```

- Truthy non-boolean returns from the source validator are coerced to `true` (some ajv adapters return `1` or strings).
- Ajv-adjacent `async` / `compare` fields on an `AjvFormatDef` are silently ignored — oav formats are synchronous and `format` only runs on string values.
- `INTEGRATION.md`'s format-shape note replaces the inline snippet with an import pointer to the new helper.

## Test plan
- [x] `pnpm test` (546/546 pass — four new cases covering ajv shape conversion, truthy coercion, missing `type`, and round-trip usability with `compileSchema`'s `formats` option)
- [x] `pnpm lint`
- [x] `pnpm typecheck`

Closes #85