### PR TITLE
feat(validator): ignoreUndocumented / ignorePaths options

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -485,6 +485,27 @@ app.use(
 
 ### Ignoring paths not in the spec
 
+Two `createValidator` options cover the common cases directly:
+
+```ts
+// Skip every path the spec doesn't declare: equivalent to
+// express-openapi-validator's `ignoreUndocumented: true`.
+createValidator(spec, { ignoreUndocumented: true });
+
+// Predicate form for prefix / regex / allowlist filtering. Runs
+// before routing; returning `true` short-circuits to null.
+createValidator(spec, {
+  ignorePaths: (p) => p.startsWith("/internal/") || /^\/_debug\//.test(p),
+});
+```
+
+`ignorePaths` runs before the router; `ignoreUndocumented` only
+applies to paths the router couldn't match. Both leave `method`
+errors (405 — path exists, verb doesn't) alone.
+
+If you need branching based on the error rather than the path, fall
+back to the manual pattern:
+
 ```ts
 app.use(async (req, res, next) => {
   const err = validator.validateRequest({
@@ -495,10 +516,6 @@ app.use(async (req, res, next) => {
   // ... 4xx response as usual
 });
 ```
-
-This is the equivalent of `express-openapi-validator`'s
-`ignoreUndocumented: true`. For regex-based exclusions, short-circuit
-before calling the validator.
 
 ## Migration from express-openapi-validator
 

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -242,6 +242,27 @@ export interface ValidatorOptions {
   /** When `true`, reject unknown query parameters (default: `false`). */
   strictQueryParameters?: boolean;
   /**
+   * When `true`, an unmatched path no longer produces a `route` error —
+   * `validateRequest` / `validateResponse` return `null`. Mirrors
+   * `express-openapi-validator`'s `ignoreUndocumented`. Does not affect
+   * the `method` code: a path that matched but whose verb wasn't
+   * declared still surfaces (that's a 405, not an "undocumented route").
+   */
+  ignoreUndocumented?: boolean;
+  /**
+   * Predicate for finer control than {@link ValidatorOptions.ignoreUndocumented}.
+   * Runs before route matching; when it returns `true` for the request's
+   * `path`, the validator short-circuits and returns `null`. Useful for
+   * per-prefix allowlists ("skip anything under `/internal/`"),
+   * regex-driven exclusions, or keeping parts of the surface out of
+   * spec validation for staged rollout.
+   *
+   * When both `ignorePaths` and `ignoreUndocumented` are set,
+   * `ignorePaths` runs first. If the predicate does not skip,
+   * `ignoreUndocumented` still applies to a subsequent route miss.
+   */
+  ignorePaths?: (path: string) => boolean;
+  /**
    * How to handle a spec whose `openapi` field is missing, malformed,
    * or not one of the supported versions (3.0, 3.1, 3.2).
    *
@@ -394,8 +415,10 @@ export function createValidator(
   };
 
   const validateRequest = (req: HttpRequest): ValidationError | null => {
+    if (options.ignorePaths?.(req.path) === true) return null;
     const match = router.match(req.method, req.path);
     if (match === undefined) {
+      if (options.ignoreUndocumented === true) return null;
       return createLeafError(
         "route",
         [],
@@ -449,8 +472,10 @@ export function createValidator(
   };
 
   const validateResponse = (req: HttpRequest, res: HttpResponse): ValidationError | null => {
+    if (options.ignorePaths?.(req.path) === true) return null;
     const match = router.match(req.method, req.path);
     if (match === undefined) {
+      if (options.ignoreUndocumented === true) return null;
       return createLeafError(
         "route",
         [],

--- a/packages/validator/test/request.test.ts
+++ b/packages/validator/test/request.test.ts
@@ -56,6 +56,27 @@ describe("validateRequest", () => {
     });
   });
 
+  it("ignoreUndocumented: true suppresses the route error", () => {
+    const vi = createValidator(petSpec(), { ignoreUndocumented: true });
+    expect(vi.validateRequest({ method: "GET", path: "/nope" })).toBeNull();
+  });
+
+  it("ignoreUndocumented does not suppress the method error (405 still surfaces)", () => {
+    const vi = createValidator(petSpec(), { ignoreUndocumented: true });
+    const err = vi.validateRequest({ method: "DELETE", path: "/pets" });
+    expect(err?.code).toBe("method");
+  });
+
+  it("ignorePaths runs before routing and short-circuits to null", () => {
+    const vi = createValidator(petSpec(), {
+      ignorePaths: (p) => p.startsWith("/internal/"),
+    });
+    // /internal/* isn't in the spec; predicate matches → null
+    expect(vi.validateRequest({ method: "GET", path: "/internal/health" })).toBeNull();
+    // /nope isn't in the spec; predicate doesn't match → route error
+    expect(vi.validateRequest({ method: "GET", path: "/nope" })?.code).toBe("route");
+  });
+
   it("errors for wrong Content-Type", () => {
     const err = v.validateRequest({
       method: "POST",


### PR DESCRIPTION
## Summary
Two new `ValidatorOptions` short-circuits for the common "skip routes the spec doesn't document" pattern. Both land in the HTTP-validator-specific section per the #86 convention.

### `ignoreUndocumented: boolean`
When `true`, an unmatched path returns `null` instead of a `route` error. Mirrors `express-openapi-validator`'s option of the same name. `method-not-allowed` (405) still surfaces — a declared path with the wrong verb isn't "undocumented."

### `ignorePaths: (path) => boolean`
Predicate form for finer control: prefix filtering, regex, allowlists. Runs before route matching; returning `true` short-circuits to `null`. Works alongside `ignoreUndocumented` — predicate runs first, and `ignoreUndocumented` still applies to paths the predicate lets through if the router then misses.

```ts
createValidator(spec, { ignoreUndocumented: true });

createValidator(spec, {
  ignorePaths: (p) => p.startsWith("/internal/") || /^\/_debug\//.test(p),
});
```

### Docs
`INTEGRATION.md`'s "Ignoring paths not in the spec" section now leads with the two options and keeps the manual `err.code === "route"` pattern as a fallback for callers who need per-error-code branching.

## Test plan
- [x] `pnpm test` (549/549 pass — three new cases: `ignoreUndocumented` suppresses route error, does *not* suppress `method` error, and the predicate form)
- [x] `pnpm lint`
- [x] `pnpm typecheck`

Closes #84