### PR TITLE
feat(schema,validator): strict-mode schema linting

### DIFF
--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -43,9 +43,13 @@ Capabilities that the Ajv stack covers and oav does not.
   and `$id` base-URI rewrites natively. oav requires external /
   multi-file refs to be pre-inlined by `@aahoughton/oav/spec.resolveSpec()`
   before compile, and accepts fragment-only refs thereafter.
-- **Meta-schema strict mode.** Ajv can optionally validate your schema
-  against the draft's meta-schema at compile time, catching typos like
-  `minimumx: 5`. oav silently tolerates unknown keywords.
+- **Full meta-schema validation.** Ajv can validate your schema
+  against the draft's meta-schema at compile time, catching both
+  unknown-keyword typos and wrong value shapes (e.g. `minimum: "5"`
+  when it should be a number). oav ships a narrower `strict` option
+  that catches unknown-keyword typos (`minimumx: 5`) and flags
+  partially-implemented features; it doesn't yet check value shapes
+  against the meta-schema.
 - **`$data` references.** Ajv's non-standard extension where one
   keyword's value comes from the data being validated
   (`{ minimum: { $data: "1/min" } }`). oav doesn't implement it.

--- a/packages/schema/src/compiler/compiler.ts
+++ b/packages/schema/src/compiler/compiler.ts
@@ -14,6 +14,7 @@ import {
   SUBSCHEMA_ARRAY_POSITIONS,
   SUBSCHEMA_MAP_POSITIONS,
   SUBSCHEMA_SINGLE_POSITIONS,
+  walkSubschemas,
 } from "../subschema-positions.js";
 import { createDeps, type ValidatorDeps } from "./runtime.js";
 
@@ -22,6 +23,61 @@ import { createDeps, type ValidatorDeps } from "./runtime.js";
 // happens to contain "wrapErrors") don't count — every real emission
 // spells the helper as a bare identifier.
 const TREE_RUNTIME_HELPERS = /\b(?:createLeafError|createBranchError|wrapErrors)\b/;
+
+/**
+ * Default mode for {@link CompileOptions.strict}. Warns on partially-
+ * implemented keywords (currently `$dynamicRef`); silent on unknown
+ * keys. Callers opt into stricter behaviour with `"strict"` or opt
+ * out with `"off"`.
+ */
+const DEFAULT_STRICT_MODE = "warn-partial" as const;
+
+function runStrictLint(
+  schema: SchemaOrBoolean,
+  byKeyword: Map<string, KeywordDefinition>,
+  mode: "warn-partial" | "strict",
+): StrictIssue[] {
+  // The full set of names the active dialect recognises, including
+  // `implements` entries on existing definitions (e.g. `if` implements
+  // `then` + `else`; those don't have their own KeywordDefinition but
+  // are legitimate keys).
+  const known = new Set<string>(byKeyword.keys());
+  for (const def of byKeyword.values()) {
+    if (def.implements) for (const k of def.implements) known.add(k);
+  }
+
+  const issues: StrictIssue[] = [];
+  walkSubschemas(schema, (node, path) => {
+    if (typeof node !== "object" || node === null || Array.isArray(node)) return;
+    for (const key of Object.keys(node)) {
+      const def = byKeyword.get(key);
+      if (def?.partial !== undefined) {
+        issues.push({
+          code: "partial-feature",
+          keyword: key,
+          path,
+          message: `"${key}" is partially supported: ${def.partial}`,
+        });
+        continue;
+      }
+      if (mode !== "strict") continue;
+      if (known.has(key)) continue;
+      // `x-*` extensions are tolerated by OpenAPI convention; accept
+      // them in strict mode too.
+      if (key.startsWith("x-")) continue;
+      issues.push({
+        code: "unknown-keyword",
+        keyword: key,
+        path,
+        message:
+          path.length === 0
+            ? `unknown keyword "${key}" at <root>`
+            : `unknown keyword "${key}" at "${path}"`,
+      });
+    }
+  });
+  return issues;
+}
 
 /**
  * Result of compiling a JSON Schema 2020-12 document. The shape mirrors what
@@ -72,6 +128,38 @@ export interface CompileStats {
    * mode contract can be asserted without grepping the generated JS.
    */
   emittedTreeRuntime: boolean;
+  /**
+   * Warnings produced by {@link CompileOptions.strict}. Empty unless
+   * strict mode is active and found something to flag. Never contains
+   * compile-blocking issues — strict mode only reports; the caller
+   * decides whether to treat any entry as fatal.
+   */
+  strictIssues: readonly StrictIssue[];
+}
+
+/**
+ * A single finding from strict-mode schema linting (see
+ * {@link CompileOptions.strict}).
+ *
+ * @public
+ */
+export interface StrictIssue {
+  /**
+   * - `"partial-feature"`: the schema uses a keyword flagged as
+   *   partially-implemented (e.g. `$dynamicRef` without runtime
+   *   dynamic-scope rebinding). Compile still succeeds; the emitted
+   *   validator's semantics for this keyword may not match the spec.
+   * - `"unknown-keyword"`: the schema declares a key that's not in the
+   *   active dialect, not an `x-*` extension, and not a standard
+   *   `$`-prefixed metadata key. Likely a typo.
+   */
+  code: "partial-feature" | "unknown-keyword";
+  /** The offending keyword / key name as written in the schema. */
+  keyword: string;
+  /** Dotted path from the root schema to the subschema holding the key. */
+  path: string;
+  /** Human-readable explanation. */
+  message: string;
 }
 
 /**
@@ -178,6 +266,19 @@ export interface CompileOptions {
    * `maxErrors: 1` is the classic fast-fail mode.
    */
   maxErrors?: number;
+  /**
+   * Compile-time schema linting. All modes collect to
+   * {@link CompileStats.strictIssues} rather than throwing.
+   *
+   * - `"off"`: silence on everything (pre-v-strict behaviour).
+   * - `"warn-partial"` (default): warn on keywords flagged as
+   *   partially-implemented (currently `$dynamicRef` — its runtime
+   *   dynamic-scope rebinding is not emitted).
+   * - `"strict"`: warn on partial features AND unknown keys (keys not
+   *   in the active dialect, not `x-*` extensions, not standard
+   *   `$`-prefixed metadata). Catches typos like `minimumx: 5`.
+   */
+  strict?: "off" | "warn-partial" | "strict";
 
   // --- 4. Schema-compile-specific extras ---
 
@@ -418,10 +519,14 @@ export function compileSchema(
   const rootName = compileValidator(schema, state);
 
   const wholeSource = assembleSource(state, rootName);
+  const strictMode = options.strict ?? DEFAULT_STRICT_MODE;
+  const strictIssues: readonly StrictIssue[] =
+    strictMode === "off" ? [] : runStrictLint(schema, byKeyword, strictMode);
   const stats: CompileStats = {
     functionCount: state.nextFn,
     unevaluatedTrackingEmitted: state.unevaluatedEmitted,
     emittedTreeRuntime: TREE_RUNTIME_HELPERS.test(wholeSource),
+    strictIssues,
   };
   if (predicate) {
     const factory = new Function(NAMES.DEPS, wholeSource) as (

--- a/packages/schema/src/compiler/index.ts
+++ b/packages/schema/src/compiler/index.ts
@@ -4,6 +4,7 @@ export {
   type CompileStats,
   type CompiledPredicate,
   type CompiledSchema,
+  type StrictIssue,
   type ValidationResult,
 } from "./compiler.js";
 export {

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -25,6 +25,7 @@ export {
   type CompileStats,
   type CompiledPredicate,
   type CompiledSchema,
+  type StrictIssue,
   type Validator,
   type ValidationResult,
 } from "./compiler/index.js";

--- a/packages/schema/src/keywords/ref.ts
+++ b/packages/schema/src/keywords/ref.ts
@@ -46,6 +46,8 @@ export const refKeyword: KeywordDefinition = {
 export const dynamicRefKeyword: KeywordDefinition = {
   keyword: "$dynamicRef",
   vocabulary: CORE_VOCAB,
+  partial:
+    "resolves statically against the anchor map; runtime dynamic-scope rebinding is not implemented",
   compile(ctx) {
     const ref = ctx.schema as string;
     compileRefCall(ctx, ref);

--- a/packages/schema/src/keywords/types.ts
+++ b/packages/schema/src/keywords/types.ts
@@ -326,6 +326,18 @@ export interface KeywordDefinition {
    * should also have an empty `compile`.
    */
   annotation?: boolean;
+  /**
+   * Short explanation when this keyword is only partially supported —
+   * the compiler accepts and dispatches it, but the emitted validation
+   * doesn't fully match the spec. Surfaced via the compile-time strict
+   * mode (see {@link CompileOptions.strict}) so users know they're
+   * getting degraded semantics rather than a silent fallback.
+   *
+   * Example: `$dynamicRef` sets `partial` because the implementation
+   * resolves statically against the anchor map rather than walking the
+   * runtime dynamic scope.
+   */
+  partial?: string;
 }
 
 /**

--- a/packages/schema/test/strict-mode.test.ts
+++ b/packages/schema/test/strict-mode.test.ts
@@ -1,0 +1,103 @@
+/* eslint-disable unicorn/no-thenable -- `then` is a JSON Schema keyword here */
+import { describe, expect, it } from "vitest";
+import type { SchemaOrBoolean } from "@oav/core";
+import { compileSchema } from "../src/compiler/compiler.js";
+import { jsonSchemaDialect } from "../src/keywords/vocabulary.js";
+
+describe("strict mode", () => {
+  const lint = (schema: SchemaOrBoolean, mode?: "off" | "warn-partial" | "strict") =>
+    compileSchema(schema, { dialect: jsonSchemaDialect, strict: mode }).stats.strictIssues;
+
+  // Schemas that use $dynamicRef need a $dynamicAnchor somewhere
+  // reachable. A self-anchored root works for both test cases.
+  const dynamicSchema = {
+    $dynamicAnchor: "meta",
+    properties: { next: { $dynamicRef: "#meta" } },
+    minimumx: 5, // also a typo
+  } as unknown as SchemaOrBoolean;
+
+  it("defaults to warn-partial — flags $dynamicRef but not unknown keywords", () => {
+    const issues = compileSchema(dynamicSchema, { dialect: jsonSchemaDialect }).stats.strictIssues;
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      code: "partial-feature",
+      keyword: "$dynamicRef",
+    });
+  });
+
+  it('"off" produces no issues even for clear problems', () => {
+    const issues = lint(dynamicSchema, "off");
+    expect(issues).toEqual([]);
+  });
+
+  it('"strict" flags unknown keywords in addition to partial features', () => {
+    const issues = lint({ minimumx: 5, minimum: 0 } as unknown as SchemaOrBoolean, "strict");
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      code: "unknown-keyword",
+      keyword: "minimumx",
+    });
+    expect(issues[0]?.message).toContain("<root>");
+  });
+
+  it('"strict" tolerates x-* extensions', () => {
+    const issues = lint(
+      { "x-codeSamples": [{ lang: "ts", source: "" }], minimum: 0 } as unknown as SchemaOrBoolean,
+      "strict",
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('"strict" tolerates the standard $-prefixed metadata keys', () => {
+    const issues = lint(
+      {
+        $id: "https://example.com/s",
+        $schema: "https://json-schema.org/draft/2020-12/schema",
+        $comment: "note",
+        $defs: { x: { type: "string" } },
+        title: "t",
+      } as unknown as SchemaOrBoolean,
+      "strict",
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it("walks into nested subschema positions", () => {
+    const issues = lint(
+      {
+        properties: {
+          a: { type: "string", minLenght: 3 }, // typo
+        },
+      } as unknown as SchemaOrBoolean,
+      "strict",
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      code: "unknown-keyword",
+      keyword: "minLenght",
+      path: "properties.a",
+    });
+  });
+
+  it("tolerates `then` / `else` alongside `if` via implements", () => {
+    const schema = {
+      if: { type: "string" },
+      then: { minLength: 1 },
+      else: { type: "number" },
+    } as unknown as SchemaOrBoolean;
+    expect(lint(schema, "strict")).toEqual([]);
+  });
+
+  it("does not descend into `enum` / `const` / `default` values", () => {
+    // Literal values happen to contain a key called `minimumx`; the
+    // linter must not mistake them for schema objects.
+    const issues = lint(
+      {
+        const: { minimumx: 5 },
+        enum: [{ minimumx: 5 }, { nopenotaschema: true }],
+      } as unknown as SchemaOrBoolean,
+      "strict",
+    );
+    expect(issues).toEqual([]);
+  });
+});

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -23,6 +23,7 @@ import {
   type CustomKeywordValidator,
   type Dialect,
   type RefResolver,
+  type StrictIssue,
 } from "@oav/schema";
 import { deserialize, matchMediaType, matchResponseKey } from "./deserialize.js";
 import {
@@ -165,6 +166,18 @@ export interface ValidatorStats {
    * `createValidator` time, so on a fresh validator this is always `0`.
    */
   responseBodiesCompiled: number;
+  /**
+   * Live array of strict-mode issues surfaced by
+   * {@link ValidatorOptions.strict}. Grows as schemas compile (request
+   * / path / header / query schemas at construction; response-body
+   * schemas lazily on first use). An empty array when `strict: "off"`
+   * or when the linter found nothing to flag.
+   *
+   * Schema paths are the full path inside each compiled schema, not
+   * HTTP-frame-prefixed — the linter runs over raw JSON Schema, not
+   * OpenAPI.
+   */
+  strictIssues: readonly StrictIssue[];
 }
 
 /**
@@ -236,6 +249,18 @@ export interface ValidatorOptions {
    * the report was shortened.
    */
   maxErrors?: number;
+  /**
+   * Compile-time schema linting applied to every schema the validator
+   * compiles (request parameters / body; response headers; response
+   * bodies lazily). Issues surface via
+   * {@link ValidatorStats.strictIssues}; no throws.
+   *
+   * - `"off"`: silence on everything.
+   * - `"warn-partial"` (default): warn on keywords flagged as
+   *   partially-implemented (currently `$dynamicRef`).
+   * - `"strict"`: warn on partial features AND unknown keys.
+   */
+  strict?: "off" | "warn-partial" | "strict";
 
   // --- 4. HTTP-validator-specific extras ---
 
@@ -334,7 +359,14 @@ export function createValidator(
   const graph = resolve(spec as unknown as SchemaOrBoolean);
   const refResolver: RefResolver = createRefResolver(graph);
 
-  const stats: ValidatorStats = { responseBodiesCompiled: 0 };
+  // Live array. Compile closure appends on each miss; consumers read
+  // `validator.stats.strictIssues` at any point to see what's been
+  // flagged so far.
+  const strictIssues: StrictIssue[] = [];
+  const stats: ValidatorStats = {
+    responseBodiesCompiled: 0,
+    strictIssues,
+  };
 
   const compiledCache = new Map<SchemaOrBoolean, CompiledSchema>();
   const compile = (
@@ -349,8 +381,10 @@ export function createValidator(
       refResolver: resolver,
       maxErrors: options.maxErrors,
       keywords: options.keywords,
+      strict: options.strict,
     });
     compiledCache.set(schema, c);
+    for (const issue of c.stats.strictIssues) strictIssues.push(issue);
     return c;
   };
 

--- a/packages/validator/test/request.test.ts
+++ b/packages/validator/test/request.test.ts
@@ -77,6 +77,38 @@ describe("validateRequest", () => {
     expect(vi.validateRequest({ method: "GET", path: "/nope" })?.code).toBe("route");
   });
 
+  it('strict: "strict" surfaces unknown-keyword issues through validator.stats', () => {
+    const spec: OpenAPIDocument = {
+      openapi: "3.1.0",
+      info: { title: "t", version: "1" },
+      paths: {
+        "/p": {
+          post: {
+            requestBody: {
+              required: true,
+              content: {
+                "application/json": {
+                  // minLenght is a typo (the actual keyword is minLength).
+                  schema: {
+                    type: "string",
+                    minLenght: 3,
+                  } as unknown as OpenAPIDocument["components"],
+                },
+              },
+            },
+            responses: { "200": { description: "ok" } },
+          },
+        },
+      },
+    };
+    const vi = createValidator(spec, { strict: "strict" });
+    // Schemas compile lazily — first touch to the route triggers it.
+    vi.validateRequest({ method: "POST", path: "/p", contentType: "application/json", body: "x" });
+    const unknown = vi.stats.strictIssues.find((i) => i.code === "unknown-keyword");
+    expect(unknown).toBeDefined();
+    expect(unknown?.keyword).toBe("minLenght");
+  });
+
   it("errors for wrong Content-Type", () => {
     const err = v.validateRequest({
       method: "POST",


### PR DESCRIPTION
## Summary
Compile-time schema linting with three levels:

```ts
strict?: "off" | "warn-partial" | "strict"
```

- **`"off"`** — silent on everything (pre-change behaviour).
- **`"warn-partial"`** (new default) — warn on keywords flagged `partial`: currently just `$dynamicRef`, which resolves statically against the anchor map rather than walking the runtime dynamic scope.
- **`"strict"`** — warn on partial features AND unknown keys (keys not in the active dialect, not `x-*` extensions, not standard `$`-prefixed metadata).

Issues surface via `CompileStats.strictIssues` (`compileSchema`) and `ValidatorStats.strictIssues` (`createValidator`, live array appended to as schemas compile). Nothing throws — the caller decides whether to log, fail CI, or ignore.

## Implementation pieces

- `KeywordDefinition.partial?: string` — tagged on `$dynamicRef` with a one-line explanation.
- `StrictIssue` type (`code: "partial-feature" | "unknown-keyword"`, `keyword`, `path`, `message`) exported from `@aahoughton/oav/schema`.
- `strict` option added to `CompileOptions` and `ValidatorOptions` at the positions the #86 ordering convention reserves.
- `walkSubschemas`-based linter runs once per compile; descends only through schema-valued positions so literal values under `enum` / `const` / `default` / `examples` aren't mistaken for schemas.
- `then` / `else` handled via `KeywordDefinition.implements` so they aren't flagged as unknown.

## Default change
`"warn-partial"` becomes the default. New warnings channel, no throws, no compile failures — existing tests pass unchanged because nobody reads `stats.strictIssues` today.

## COMPARISON.md update
The "Meta-schema strict mode" bullet in "Where Ajv does more" softens from "oav silently tolerates unknown keywords" to: oav catches unknown-keyword typos and partial-feature use; it doesn't yet validate value shapes (`minimum: "5"` when it should be a number) against the meta-schema the way Ajv does. Honest about what's covered.

## Test plan
- [x] `pnpm test` (558/558 — 9 new cases: default behaviour, `"off"` silences everything, `"strict"` catches unknown keys, `x-*` + `$`-metadata tolerated, nested subschema walk, `then`/`else` exemption, non-schema value positions not descended into, validator-level surfacing via `stats.strictIssues`)
- [x] `pnpm lint`
- [x] `pnpm typecheck`

Closes #82