### PR TITLE
chore: release-flow fixes — ignore CHANGELOG, prune stale configs, gate npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,13 @@ jobs:
 
   publish:
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    # Intentionally gated off until the package is ready for npm. The
+    # release-please job above still creates git tags, GitHub Releases,
+    # and CHANGELOG entries on every merged release PR — only the
+    # actual `pnpm publish` step is suppressed. To ship to npm, change
+    # the condition back to:
+    #   needs.release-please.outputs.release_created == 'true'
+    if: false
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -8,6 +8,7 @@
     "node_modules/",
     "coverage/",
     "JSON-Schema-Test-Suite/",
-    "AUTONOMOUS-BUILD-PROMPT.md"
+    "AUTONOMOUS-BUILD-PROMPT.md",
+    "CHANGELOG.md"
   ]
 }

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -7,8 +7,7 @@
     "dist/",
     "node_modules/",
     "coverage/",
-    "JSON-Schema-Test-Suite/",
-    "AUTONOMOUS-BUILD-PROMPT.md",
+    "conformance/JSON-Schema-Test-Suite/",
     "CHANGELOG.md"
   ]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -16,5 +16,5 @@
     "builtin": true,
     "node": true
   },
-  "ignorePatterns": ["dist/", "node_modules/", "coverage/", "JSON-Schema-Test-Suite/"]
+  "ignorePatterns": ["dist/", "node_modules/", "coverage/", "conformance/JSON-Schema-Test-Suite/"]
 }


### PR DESCRIPTION
## Summary
Three related fixes to the release flow, all in `.github/` / config files.

### 1. Ignore `CHANGELOG.md` in oxfmt
release-please generates `CHANGELOG.md` with its own formatting conventions. `oxfmt --check` rejected the generated form, failing `pnpm lint` on every release PR. Caught by the current oav-2.0.0 release PR failing lint on approval.

### 2. Prune stale entries from `.oxfmtrc.json` + `.oxlintrc.json`
- Drop `AUTONOMOUS-BUILD-PROMPT.md` from the oxfmt ignore list — the file no longer exists.
- Tighten `JSON-Schema-Test-Suite/` to `conformance/JSON-Schema-Test-Suite/` in both configs. The directory only lives there, and the fully-qualified path is unambiguous about basename-vs-root matching.

### 3. Gate the npm publish job
Not ready to publish to npm yet, but still want release-please to cut tags + CHANGELOG entries on merge. Added `if: false` to the publish job in `.github/workflows/release.yml` with an inline comment showing the one-line flip back. release-please keeps generating git tags, GitHub Releases, and CHANGELOG entries on every merged release PR — only the actual `pnpm publish` step is suppressed. Going public later is a one-line change.

## Test plan
- [x] `pnpm lint` — passes locally with the new ignore list.
- [x] Publish gate is config-only; no tests affected.

## Unblocks
- The oav-2.0.0 release PR's `ci / lint` job (was failing on the changelog).
- Future release PRs proceed cleanly without accidentally publishing to npm.