### PR TITLE
chore(release): drop component prefix from release-please tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,7 @@
       "draft": false,
       "prerelease": false,
       "include-v-in-tag": true,
+      "include-component-in-tag": false,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary
Adds `"include-component-in-tag": false` to `release-please-config.json` so future releases tag as `v2.1.0` / `v2.2.0` instead of `oav-v2.1.0`. The component prefix was a monorepo-style artifact — useful when several packages share a repo, unnecessary for a single-package project, and incompatible with tooling that expects semver-shaped tags.

Why it matters:
- npm's `github:owner/repo#semver:<range>` ref selector only recognises git-dep tags that parse as semver. `v2.0.0` does; `oav-v2.0.0` doesn't.
- Renovate / Dependabot "latest version" detection scans tags for semver-shaped ones.
- GitHub's release UI renders `v<number>` tags nicely in changelog generators / badge services.

## Manual cleanup already done
- `oav-v2.0.0` tag re-cut as `v2.0.0` pointing at the same commit SHA.
- GitHub Release re-pointed via `gh release edit oav-v2.0.0 --tag v2.0.0` and retitled `v2.0.0`.
- `oav-v2.0.0` tag deleted locally and on the remote.
- `.release-please-manifest.json` unchanged (`"." : "2.0.0"`). release-please computes the next version from the manifest + git log and tags it per the new format.

## Test plan
No code affected. Verify on next release PR that the proposed tag is `v<major>.<minor>.<patch>`.