### PR TITLE
fix(cli): the "-o" arg should redirect stdout, not duplicate it

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { KNOWN_OUTPUT_FORMATS, isOutputFormat, type OutputFormat } from "@oav/core";
 import {
   compileCommand,
+  defaultCommandIo,
   resolveCommand,
   validateCommand,
   type CommandIo,
@@ -21,20 +22,11 @@ function isStandaloneDialect(v: string): v is StandaloneDialect {
  */
 export interface BuildProgramOptions {
   /**
-   * I/O substrate. Defaults to the real filesystem + stdin via
-   * {@link defaultCommandIo}. Tests can pass an in-memory substitute
-   * so argv-level coverage doesn't need `pnpm build` + `spawnSync`.
+   * I/O substrate. Defaults to the real filesystem + stdin +
+   * process.stdout/stderr via {@link defaultCommandIo}. Tests can pass
+   * an in-memory substitute that captures writes for assertion.
    */
   io?: CommandIo;
-  /**
-   * stdout writer. Defaults to `process.stdout.write`. In-process
-   * tests can capture output by passing a buffered writer.
-   */
-  stdout?: (chunk: string) => void;
-  /**
-   * stderr writer. Defaults to `process.stderr.write`.
-   */
-  stderr?: (chunk: string) => void;
   /**
    * Exit handler. Defaults to `process.exit`. In-process tests should
    * pass a throwing implementation so the test harness observes the
@@ -45,15 +37,16 @@ export interface BuildProgramOptions {
 
 /**
  * Build the Commander program. Exported so tests can invoke the program
- * without spawning a child process; pass `{ io, stdout, stderr, exit }`
- * to route all side-effects through in-process collaborators.
+ * without spawning a child process; pass `{ io, exit }` to route all
+ * side-effects through in-process collaborators. Commands write their
+ * primary output through `io.stdout` (or the file sink when `-o` is
+ * set) and their errors through `io.stderr` — this CLI layer only
+ * handles argv-parsing usage errors + the final `exit` call.
  *
  * @public
  */
 export function buildProgram(options: BuildProgramOptions = {}): Command {
-  const io = options.io;
-  const stdout = options.stdout ?? ((s) => process.stdout.write(s));
-  const stderr = options.stderr ?? ((s) => process.stderr.write(s));
+  const io = options.io ?? defaultCommandIo();
   const exit = options.exit ?? ((code) => process.exit(code));
 
   const program = new Command();
@@ -78,7 +71,6 @@ export function buildProgram(options: BuildProgramOptions = {}): Command {
         },
         io,
       );
-      if (res.output !== undefined && !opts.quiet) stdout(res.output + "\n");
       exit(res.exitCode);
     });
 
@@ -112,7 +104,7 @@ export function buildProgram(options: BuildProgramOptions = {}): Command {
       try {
         mode = deriveMode(opts);
       } catch (err) {
-        stderr(`error: ${(err as Error).message}\n`);
+        io.stderr(`error: ${(err as Error).message}\n`);
         exit(3);
         return;
       }
@@ -130,9 +122,6 @@ export function buildProgram(options: BuildProgramOptions = {}): Command {
         },
         io,
       );
-      if (res.output !== undefined && !opts.quiet && res.output !== "") {
-        stdout(res.output + "\n");
-      }
       exit(res.exitCode);
     });
 
@@ -158,11 +147,6 @@ export function buildProgram(options: BuildProgramOptions = {}): Command {
         },
         io,
       );
-      if (res.output !== undefined && res.exitCode !== 0) {
-        stderr(res.output + "\n");
-      } else if (res.output !== undefined) {
-        stdout(res.output + "\n");
-      }
       exit(res.exitCode);
     });
 

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -30,18 +30,22 @@ export interface CommandOptions {
 }
 
 /**
- * Output of a command invocation: the exit code + optional rendered text.
+ * Output of a command invocation: just the exit code. Commands write
+ * their primary output through {@link CommandIo.stdout} (or the file
+ * sink when `--output` is set); errors go through
+ * {@link CommandIo.stderr}. Nothing is returned for the CLI layer to
+ * echo.
  *
  * @public
  */
 export interface CommandResult {
   exitCode: number;
-  output?: string;
 }
 
 /**
  * I/O substrate the commands talk to. Defaults to the local
- * filesystem + stdin; tests can pass an in-memory substitute.
+ * filesystem + stdin/stdout/stderr; tests can pass an in-memory
+ * substitute that captures writes for assertion.
  *
  * @public
  */
@@ -49,6 +53,8 @@ export interface CommandIo {
   reader: DocumentReader;
   readText(pathOrDash: string): Promise<string>;
   writeText(path: string, content: string): Promise<void>;
+  stdout: (chunk: string) => void;
+  stderr: (chunk: string) => void;
 }
 
 async function readAllStdin(): Promise<string> {
@@ -73,7 +79,32 @@ export function defaultCommandIo(): CommandIo {
     async writeText(path: string, content: string) {
       await writeFile(path, content);
     },
+    stdout: (chunk) => void process.stdout.write(chunk),
+    stderr: (chunk) => void process.stderr.write(chunk),
   };
+}
+
+/**
+ * Pick the primary output sink for a command:
+ * - `--output FILE` → write to file (unconditional; `--quiet` doesn't
+ *   suppress a deliberate file write).
+ * - else if `--quiet` → swallow.
+ * - else → `io.stdout`.
+ *
+ * Commands write exactly once through this sink, so `-o` naturally
+ * redirects the "would go to stdout" content to a file without
+ * duplicating it.
+ */
+function primarySink(
+  io: CommandIo,
+  opts: { output?: string; quiet: boolean },
+): (content: string) => Promise<void> | void {
+  if (opts.output !== undefined) {
+    const path = opts.output;
+    return (content) => io.writeText(path, content);
+  }
+  if (opts.quiet) return () => {};
+  return io.stdout;
 }
 
 /**
@@ -101,8 +132,8 @@ export async function resolveCommand(
     overlays: overlayDocs,
   });
   const out = JSON.stringify(document, null, 2);
-  if (args.options.output !== undefined) await io.writeText(args.options.output, out + "\n");
-  return { exitCode: 0, output: args.options.quiet ? undefined : out };
+  await primarySink(io, args.options)(out + "\n");
+  return { exitCode: 0 };
 }
 
 /**
@@ -155,13 +186,15 @@ export async function validateCommand(
       { status: args.mode.status, contentType: "application/json", body },
     );
   } else {
-    return { exitCode: 3, output: "validate: no action specified" };
+    io.stderr("validate: no action specified\n");
+    return { exitCode: 3 };
   }
 
-  if (err === null) return { exitCode: 0, output: args.options.quiet ? undefined : "" };
+  // Silence on success — no bare-newline leak, matches Unix convention.
+  if (err === null) return { exitCode: 0 };
   const rendered = formatError(err, args.options.format, args.options.depth);
-  if (args.options.output !== undefined) await io.writeText(args.options.output, rendered + "\n");
-  return { exitCode: 1, output: args.options.quiet ? undefined : rendered };
+  await primarySink(io, args.options)(rendered + "\n");
+  return { exitCode: 1 };
 }
 
 function tryJson(raw: string): unknown {
@@ -208,20 +241,20 @@ export async function compileCommand(
   try {
     parsed = JSON.parse(raw);
   } catch (err) {
-    return {
-      exitCode: 3,
-      output: `compile: ${args.schema} is not valid JSON (${(err as Error).message})`,
-    };
+    io.stderr(`compile: ${args.schema} is not valid JSON (${(err as Error).message})\n`);
+    return { exitCode: 3 };
   }
   let source: string;
   try {
     source = emitStandalone(parsed as SchemaOrBoolean, { dialect: args.dialect ?? "2020-12" });
   } catch (err) {
-    return { exitCode: 3, output: `compile: ${(err as Error).message}` };
+    io.stderr(`compile: ${(err as Error).message}\n`);
+    return { exitCode: 3 };
   }
   if (args.output !== undefined) {
     await io.writeText(args.output, source);
     return { exitCode: 0 };
   }
-  return { exitCode: 0, output: source };
+  io.stdout(source);
+  return { exitCode: 0 };
 }

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { buildProgram } from "../src/cli.js";
-import type { CommandIo } from "../src/commands.js";
-import { memoryIo } from "./fixtures.js";
+import { memoryIo, type MemoryIo } from "./fixtures.js";
 
 /**
  * Argv-level coverage of the Commander program. Previously the CLI
@@ -16,7 +15,7 @@ interface Captured {
   exitCode: number | undefined;
 }
 
-async function runCli(argv: string[], io: CommandIo): Promise<Captured> {
+async function runCli(argv: string[], mem: MemoryIo): Promise<Captured> {
   const out: Captured = { stdout: "", stderr: "", exitCode: undefined };
   class ExitTrap extends Error {
     constructor(public code: number) {
@@ -24,13 +23,7 @@ async function runCli(argv: string[], io: CommandIo): Promise<Captured> {
     }
   }
   const program = buildProgram({
-    io,
-    stdout: (c) => {
-      out.stdout += c;
-    },
-    stderr: (c) => {
-      out.stderr += c;
-    },
+    io: mem.io,
     exit: (code) => {
       throw new ExitTrap(code);
     },
@@ -44,6 +37,8 @@ async function runCli(argv: string[], io: CommandIo): Promise<Captured> {
       throw err;
     }
   }
+  out.stdout = mem.stdout.value;
+  out.stderr = mem.stderr.value;
   return out;
 }
 
@@ -73,95 +68,104 @@ const spec = {
 
 describe("buildProgram — argv-level", () => {
   it("resolve prints the stitched document and exits 0", async () => {
-    const { io } = memoryIo([["spec.json", spec]]);
-    const out = await runCli(["resolve", "spec.json"], io);
+    const mem = memoryIo([["spec.json", spec]]);
+    const out = await runCli(["resolve", "spec.json"], mem);
     expect(out.exitCode).toBe(0);
     const doc = JSON.parse(out.stdout);
     expect(doc.paths["/pets"]).toBeDefined();
   });
 
-  it("validate --path/--body happy path exits 0", async () => {
-    const { io } = memoryIo(
-      [["spec.json", spec]],
-      [["body.json", JSON.stringify({ name: "Fido" })]],
-    );
+  it("resolve -o writes to the file and stays silent on stdout", async () => {
+    const mem = memoryIo([["spec.json", spec]]);
+    const out = await runCli(["resolve", "spec.json", "-o", "resolved.json"], mem);
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout).toBe("");
+    expect(mem.writes).toHaveLength(1);
+    expect(mem.writes[0]?.[0]).toBe("resolved.json");
+    expect(mem.writes[0]?.[1]).toContain('"openapi"');
+  });
+
+  it("validate --path/--body happy path exits 0 and stays silent", async () => {
+    const mem = memoryIo([["spec.json", spec]], [["body.json", JSON.stringify({ name: "Fido" })]]);
     const out = await runCli(
       ["validate", "spec.json", "--path", "POST /pets", "--body", "body.json"],
-      io,
+      mem,
     );
     expect(out.stderr, `stderr: ${out.stderr}`).toBe("");
+    expect(out.stdout).toBe("");
     expect(out.exitCode).toBe(0);
   });
 
   it("validate --path/--body failure exits 1 and prints an error", async () => {
-    const { io } = memoryIo([["spec.json", spec]], [["body.json", JSON.stringify({})]]);
+    const mem = memoryIo([["spec.json", spec]], [["body.json", JSON.stringify({})]]);
     const out = await runCli(
       ["validate", "spec.json", "--path", "POST /pets", "--body", "body.json"],
-      io,
+      mem,
     );
     expect(out.exitCode).toBe(1);
     expect(out.stdout).toContain("required");
   });
 
   it("validate without --request or --path is a usage error (exit 3)", async () => {
-    const { io } = memoryIo([["spec.json", spec]]);
-    const out = await runCli(["validate", "spec.json"], io);
+    const mem = memoryIo([["spec.json", spec]]);
+    const out = await runCli(["validate", "spec.json"], mem);
     expect(out.exitCode).toBe(3);
     expect(out.stderr).toContain("provide either --request");
   });
 
   it("validate --response requires --status", async () => {
-    const { io } = memoryIo([["spec.json", spec]], [["body.json", "{}"]]);
+    const mem = memoryIo([["spec.json", spec]], [["body.json", "{}"]]);
     const out = await runCli(
       ["validate", "spec.json", "--path", "POST /pets", "--body", "body.json", "--response"],
-      io,
+      mem,
     );
     expect(out.exitCode).toBe(3);
     expect(out.stderr).toContain("--response requires --status");
   });
 
   it("validate --format rejects unknown formats with a usage error", async () => {
-    const { io } = memoryIo([["spec.json", spec]], [["body.json", "{}"]]);
+    const mem = memoryIo([["spec.json", spec]], [["body.json", "{}"]]);
     // Commander surfaces its own error for argument-validator throws; exit 3
     // is driven by our catch block.
     await expect(
       runCli(
         ["validate", "spec.json", "--path", "POST /pets", "--body", "body.json", "--format", "xml"],
-        io,
+        mem,
       ),
     ).rejects.toThrow(/unknown format: xml/);
   });
 
   it("compile emits an ESM module for a JSON Schema to stdout", async () => {
     const schema = { type: "object", required: ["name"], properties: { name: { type: "string" } } };
-    const { io } = memoryIo([], [["schema.json", JSON.stringify(schema)]]);
-    const out = await runCli(["compile", "schema.json"], io);
+    const mem = memoryIo([], [["schema.json", JSON.stringify(schema)]]);
+    const out = await runCli(["compile", "schema.json"], mem);
     expect(out.exitCode).toBe(0);
     expect(out.stdout).toContain("export { validate };");
     expect(out.stdout).toContain("import { builtInFormats");
   });
 
-  it("compile -o writes the module to the given path", async () => {
+  it("compile -o writes the module to the given path and stays silent on stdout", async () => {
     const schema = { type: "integer" };
-    const { io, writes } = memoryIo([], [["schema.json", JSON.stringify(schema)]]);
-    const out = await runCli(["compile", "schema.json", "-o", "v.mjs"], io);
+    const mem = memoryIo([], [["schema.json", JSON.stringify(schema)]]);
+    const out = await runCli(["compile", "schema.json", "-o", "v.mjs"], mem);
     expect(out.exitCode).toBe(0);
-    expect(writes).toHaveLength(1);
-    expect(writes[0]?.[0]).toBe("v.mjs");
-    expect(writes[0]?.[1]).toContain("export { validate };");
+    expect(out.stdout).toBe("");
+    expect(mem.writes).toHaveLength(1);
+    expect(mem.writes[0]?.[0]).toBe("v.mjs");
+    expect(mem.writes[0]?.[1]).toContain("export { validate };");
   });
 
   it("compile rejects an unknown --dialect with a usage error", async () => {
-    const { io } = memoryIo([], [["schema.json", "{}"]]);
-    await expect(runCli(["compile", "schema.json", "--dialect", "draft-07"], io)).rejects.toThrow(
+    const mem = memoryIo([], [["schema.json", "{}"]]);
+    await expect(runCli(["compile", "schema.json", "--dialect", "draft-07"], mem)).rejects.toThrow(
       /unknown dialect: draft-07/,
     );
   });
 
   it("compile surfaces unknown-format errors on stderr with exit 3", async () => {
     const schema = { type: "string", format: "phone-number" };
-    const { io } = memoryIo([], [["schema.json", JSON.stringify(schema)]]);
-    const out = await runCli(["compile", "schema.json"], io);
+    const mem = memoryIo([], [["schema.json", JSON.stringify(schema)]]);
+    const out = await runCli(["compile", "schema.json"], mem);
     expect(out.exitCode).toBe(3);
     expect(out.stderr).toContain("phone-number");
     expect(out.stderr).toContain("built-in");

--- a/packages/cli/test/commands.test.ts
+++ b/packages/cli/test/commands.test.ts
@@ -6,7 +6,7 @@ const textOpts: CommandOptions = { format: "text", quiet: false };
 
 describe("resolveCommand", () => {
   it("stitches overlays into the resolved spec", async () => {
-    const { io } = memoryIo([
+    const { io, stdout } = memoryIo([
       [
         "spec.json",
         {
@@ -25,14 +25,13 @@ describe("resolveCommand", () => {
       io,
     );
     expect(result.exitCode).toBe(0);
-    expect(result.output).toBeDefined();
-    const doc = JSON.parse(result.output ?? "");
+    const doc = JSON.parse(stdout.value);
     expect(doc.paths["/pets"]).toBeDefined();
     expect(doc.paths["/health"]).toBeDefined();
   });
 
-  it("writes the resolved spec to the output path when given", async () => {
-    const { io, writes } = memoryIo([
+  it("writes the resolved spec to the output path when given and stays silent on stdout", async () => {
+    const { io, writes, stdout } = memoryIo([
       [
         "spec.json",
         {
@@ -42,17 +41,20 @@ describe("resolveCommand", () => {
         },
       ],
     ]);
-    await resolveCommand(
+    const result = await resolveCommand(
       { spec: "spec.json", overlays: [], options: { ...textOpts, output: "out.json" } },
       io,
     );
+    expect(result.exitCode).toBe(0);
     expect(writes).toHaveLength(1);
     expect(writes[0]?.[0]).toBe("out.json");
     expect(writes[0]?.[1]).toContain('"openapi"');
+    // Regression: `-o` used to write both to the file AND stdout.
+    expect(stdout.value).toBe("");
   });
 
-  it("suppresses stdout output when --quiet is set", async () => {
-    const { io } = memoryIo([
+  it("suppresses stdout when --quiet is set", async () => {
+    const { io, stdout } = memoryIo([
       [
         "spec.json",
         {
@@ -66,7 +68,8 @@ describe("resolveCommand", () => {
       { spec: "spec.json", overlays: [], options: { ...textOpts, quiet: true } },
       io,
     );
-    expect(result.output).toBeUndefined();
+    expect(result.exitCode).toBe(0);
+    expect(stdout.value).toBe("");
   });
 });
 
@@ -93,8 +96,8 @@ describe("validateCommand", () => {
     };
   }
 
-  it("exits 0 when the body satisfies the schema", async () => {
-    const { io } = memoryIo(
+  it("exits 0 when the body satisfies the schema, with nothing on stdout", async () => {
+    const { io, stdout } = memoryIo(
       [["spec.json", specWithRequiredBody()]],
       [["body.json", '{"name":"a"}']],
     );
@@ -108,10 +111,12 @@ describe("validateCommand", () => {
       io,
     );
     expect(result.exitCode).toBe(0);
+    // Silence on success — no bare newline leak.
+    expect(stdout.value).toBe("");
   });
 
   it("exits 1 when the body is missing a required field", async () => {
-    const { io } = memoryIo([["spec.json", specWithRequiredBody()]], [["body.json", "{}"]]);
+    const { io, stdout } = memoryIo([["spec.json", specWithRequiredBody()]], [["body.json", "{}"]]);
     const result = await validateCommand(
       {
         spec: "spec.json",
@@ -122,11 +127,14 @@ describe("validateCommand", () => {
       io,
     );
     expect(result.exitCode).toBe(1);
-    expect(result.output).toMatch(/required/i);
+    expect(stdout.value).toMatch(/required/i);
   });
 
-  it("writes the rendered error to --output when given", async () => {
-    const { io, writes } = memoryIo([["spec.json", specWithRequiredBody()]], [["body.json", "{}"]]);
+  it("writes the rendered error to --output when given and stays silent on stdout", async () => {
+    const { io, writes, stdout } = memoryIo(
+      [["spec.json", specWithRequiredBody()]],
+      [["body.json", "{}"]],
+    );
     const result = await validateCommand(
       {
         spec: "spec.json",
@@ -140,5 +148,7 @@ describe("validateCommand", () => {
     expect(writes).toHaveLength(1);
     expect(writes[0]?.[0]).toBe("err.txt");
     expect(writes[0]?.[1]).toMatch(/required/i);
+    // Regression: `-o` used to write both to the file AND stdout.
+    expect(stdout.value).toBe("");
   });
 });

--- a/packages/cli/test/fixtures.ts
+++ b/packages/cli/test/fixtures.ts
@@ -5,12 +5,18 @@ import type { CommandIo } from "../src/commands.js";
  * Shared helpers for the CLI test suite. The two callers
  * (`cli.test.ts` argv coverage, `commands.test.ts` in-process coverage)
  * both need a `CommandIo` wired to in-memory documents, text files, and
- * a write sink — factored out here so the helpers can't drift.
+ * capture buffers for stdout / stderr / file writes — factored out
+ * here so the helpers can't drift.
  */
 
 export interface MemoryIo {
   io: CommandIo;
+  /** `-o FILE` writes land here as `[path, content]` pairs. */
   writes: Array<[string, string]>;
+  /** Captured stdout payload (concatenated, in write order). */
+  stdout: { value: string };
+  /** Captured stderr payload (concatenated, in write order). */
+  stderr: { value: string };
   textMap: Map<string, string>;
 }
 
@@ -21,6 +27,8 @@ export function memoryIo(
   const reader: DocumentReader = createMemoryReader(new Map(entries));
   const textMap = new Map(textFiles);
   const writes: Array<[string, string]> = [];
+  const stdout = { value: "" };
+  const stderr = { value: "" };
   return {
     io: {
       reader,
@@ -32,8 +40,16 @@ export function memoryIo(
       async writeText(path: string, content: string) {
         writes.push([path, content]);
       },
+      stdout: (chunk: string) => {
+        stdout.value += chunk;
+      },
+      stderr: (chunk: string) => {
+        stderr.value += chunk;
+      },
     },
     writes,
+    stdout,
+    stderr,
     textMap,
   };
 }


### PR DESCRIPTION
Closes #100.

## Summary

`oav resolve spec -o FILE` and `oav validate ... -o FILE` used to write the output to FILE **and** echo it to stdout. `compile -o` already behaved correctly — the drift was inconsistent and surprising.

## Fix

Treat stdout as the default sink; let `-o` replace it. Commands write their primary output exactly once through a sink picked at the top:

- `-o FILE` → file writer
- else if `--quiet` → no-op
- else → `io.stdout`

The CLI layer stops echoing `result.output`; commands now write their own output (or errors via `io.stderr`) and return just an exit code.

## Shape changes

- `CommandResult` collapses to `{ exitCode }`.
- `CommandIo` gains required `stdout` / `stderr` sinks; `writeText` stays for `-o`. `defaultCommandIo` wires them to `process.stdout.write` / `process.stderr.write`.
- `BuildProgramOptions` loses separate `stdout` / `stderr` options — tests pass a capturing `io` instead.
- `validate` is silent on success (no bare-newline leak onto stdout; matches Unix convention).
- `compile`'s error path calls `io.stderr(...)` directly instead of smuggling a message through `output` with exit code 3.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — 577 pass (was 576; added regression coverage for `-o` not duplicating stdout + silence-on-success)
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] Conformance harness passes
- [x] Manual: `oav resolve spec.yaml -o foo` writes `foo` and leaves stdout empty