### PR TITLE
feat(cli): accept http:// and https:// URLs for spec / overlay args

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,8 +242,9 @@ The package publishes a small root and four subpath entrypoints.
 | `@aahoughton/oav/core`    | Error tree model, shared OpenAPI / HTTP types            |
 
 `@aahoughton/oav` also exports `createYamlFileReader`,
-`createYamlHttpReader`, and `parseYamlString` at the root entry, and
-ships the `oav` CLI as a `bin`.
+`createSmartHttpReader` (HTTP reader that handles both JSON and YAML
+by inspecting `Content-Type`), and `parseYamlString` at the root entry,
+and ships the `oav` CLI as a `bin`.
 
 ## Examples
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -38,6 +38,10 @@ oav compile <schema.json> --dialect openapi-3.0              # pick a non-defaul
 
 Pass `-` as the file path to read from stdin (e.g. `--body -`).
 
+`<spec>` and `--overlay <file>` accept local paths, `file://` URIs,
+and `http://` / `https://` URLs (both JSON and YAML over HTTP). Relative
+`$ref`s inside a URL-hosted spec resolve against the URL's base.
+
 ## Flags
 
 | Flag                                          | Command            | Meaning                                               |

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -9,6 +9,7 @@ import {
 import {
   composeReaders,
   createFileReader,
+  createHttpReader,
   loadSpec,
   type DocumentReader,
   type SpecOverlay,
@@ -71,7 +72,13 @@ async function readAllStdin(): Promise<string> {
  */
 export function defaultCommandIo(): CommandIo {
   return {
-    reader: composeReaders([createFileReader()]),
+    // File reader first so `./spec.json` resolves locally without a
+    // stat against the HTTP reader (which would reject it via
+    // canRead anyway, but clearer ordering). HTTP reader accepts
+    // `http:` / `https:` URIs; the YAML-over-HTTP story rides on
+    // top of this chain in `@aahoughton/oav`'s CLI wrapper, which
+    // composes YAML readers in front of whatever we return here.
+    reader: composeReaders([createFileReader(), createHttpReader()]),
     async readText(pathOrDash: string) {
       if (pathOrDash === "-") return readAllStdin();
       return readFile(pathOrDash, "utf8");

--- a/packages/cli/test/commands.test.ts
+++ b/packages/cli/test/commands.test.ts
@@ -1,8 +1,40 @@
-import { describe, expect, it } from "vitest";
-import { resolveCommand, validateCommand, type CommandOptions } from "../src/commands.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  defaultCommandIo,
+  resolveCommand,
+  validateCommand,
+  type CommandOptions,
+} from "../src/commands.js";
 import { memoryIo } from "./fixtures.js";
 
 const textOpts: CommandOptions = { format: "text", quiet: false };
+
+describe("defaultCommandIo", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("accepts http:// and https:// URIs without extra wiring", async () => {
+    const spec = { openapi: "3.1.0", info: { title: "URL Spec", version: "1" }, paths: {} };
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify(spec), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const io = defaultCommandIo();
+    // Bypass io.stdout / process.stdout for the assertion: we only
+    // care that the chain claimed + fetched the URL.
+    expect(io.reader.canRead("https://example.com/spec.json")).toBe(true);
+    const loaded = await io.reader.read("https://example.com/spec.json");
+    expect(loaded).toEqual(spec);
+    expect(fetchMock).toHaveBeenCalledWith("https://example.com/spec.json");
+  });
+
+  it("still rejects .yaml URLs at the JSON reader layer with the install-hint error", async () => {
+    const io = defaultCommandIo();
+    await expect(io.reader.read("https://example.com/spec.yaml")).rejects.toThrow(
+      /Install @aahoughton\/oav/,
+    );
+  });
+});
 
 describe("resolveCommand", () => {
   it("stitches overlays into the resolved spec", async () => {

--- a/packages/oav/src/cli.ts
+++ b/packages/oav/src/cli.ts
@@ -25,15 +25,18 @@ try {
 
 const { buildProgram, defaultCommandIo } = await import("@oav/cli");
 const { composeReaders } = await import("@oav/spec");
-const { createYamlFileReader, createYamlHttpReader } = await import("./yaml.js");
+const { createSmartHttpReader, createYamlFileReader } = await import("./yaml.js");
 
-// Default I/O composes the YAML readers shipped with this package in
+// Default I/O composes the readers shipped with this package in
 // front of the JSON-only readers baked into @oav/cli's defaultCommandIo,
-// so `oav resolve spec.yaml` works out of the box.
+// so `oav resolve spec.yaml` and `oav resolve https://host/openapi`
+// work out of the box. createSmartHttpReader handles both JSON and
+// YAML over HTTP by inspecting Content-Type — it replaces the core
+// createHttpReader in the chain for any http(s) URI.
 const baseIo = defaultCommandIo();
 const io = {
   ...baseIo,
-  reader: composeReaders([createYamlFileReader(), createYamlHttpReader(), baseIo.reader]),
+  reader: composeReaders([createYamlFileReader(), createSmartHttpReader(), baseIo.reader]),
 };
 const program = buildProgram({ io });
 try {

--- a/packages/oav/src/index.ts
+++ b/packages/oav/src/index.ts
@@ -14,4 +14,4 @@
 
 export * from "@oav/validator";
 export * from "@oav/core";
-export { createYamlFileReader, createYamlHttpReader, parseYamlString } from "./yaml.js";
+export { createSmartHttpReader, createYamlFileReader, parseYamlString } from "./yaml.js";

--- a/packages/oav/src/spec.ts
+++ b/packages/oav/src/spec.ts
@@ -1,5 +1,7 @@
 // Re-export of `@aahoughton/oav-core/spec`. JSON-only readers; the
-// YAML readers (`createYamlFileReader`, `createYamlHttpReader`,
-// `parseYamlString`) live at the root of `@aahoughton/oav` — compose
-// them ahead of the readers in this subpath when loading YAML specs.
+// batteries-included readers (`createYamlFileReader`,
+// `createSmartHttpReader`, `parseYamlString`) live at the root of
+// `@aahoughton/oav` — compose them ahead of the readers in this
+// subpath when loading YAML specs or fetching over HTTP with
+// Content-Type dispatch.
 export * from "@oav/spec";

--- a/packages/oav/src/yaml.ts
+++ b/packages/oav/src/yaml.ts
@@ -74,32 +74,66 @@ export function createYamlFileReader(cwd: string = process.cwd()): DocumentReade
   };
 }
 
+function isYamlMime(mime: string): boolean {
+  // application/yaml, application/x-yaml, text/yaml, text/x-yaml.
+  return /^(?:application|text)\/(?:x-)?yaml$/i.test(mime);
+}
+
+function isJsonMime(mime: string): boolean {
+  // application/json, text/json, application/vnd.openapi+json, etc.
+  return /^(?:application|text)\/(?:\w[\w-]*\+)?json$/i.test(mime);
+}
+
 /**
- * Read YAML documents over HTTP/HTTPS. Only claims URIs ending in
- * `.yaml` or `.yml`; compose with the main package's
- * `createHttpReader` for JSON fetches.
+ * Read JSON-or-YAML OpenAPI documents over HTTP/HTTPS. Claims any
+ * `http:` / `https:` URI; dispatches by response `Content-Type` with
+ * URL extension as a fallback.
+ *
+ * Dispatch rules:
+ * 1. `Content-Type` matches a YAML media type (`application/yaml`,
+ *    `application/x-yaml`, `text/yaml`, `text/x-yaml`, any of the
+ *    above with `; charset=...`) → parse as YAML.
+ * 2. `Content-Type` matches a JSON media type (`application/json`,
+ *    `text/json`, any `*+json` suffix like `application/vnd.api+json`)
+ *    → parse as JSON.
+ * 3. Ambiguous Content-Type (missing, `text/plain`,
+ *    `application/octet-stream`, etc.) → fall back to the URL path
+ *    extension: `.yaml` / `.yml` → YAML, else JSON.
+ *
+ * Handles the common case where the user points at
+ * `https://api.example.com/openapi` (no extension) and the server
+ * advertises YAML via its Content-Type.
  *
  * @example
  * ```ts
- * import { composeReaders, createHttpReader } from "@aahoughton/oav/spec";
- * import { createYamlHttpReader } from "@aahoughton/oav";
+ * import { composeReaders, createFileReader } from "@aahoughton/oav/spec";
+ * import { createSmartHttpReader } from "@aahoughton/oav";
  *
- * const reader = composeReaders([createYamlHttpReader(), createHttpReader()]);
+ * const reader = composeReaders([createSmartHttpReader(), createFileReader()]);
  * ```
  *
  * @public
  */
-export function createYamlHttpReader(): DocumentReader {
+export function createSmartHttpReader(): DocumentReader {
   return {
     canRead(uri) {
-      if (!/^https?:/i.test(uri)) return false;
-      return hasYamlExtension(uri);
+      return /^https?:/i.test(uri);
     },
     async read(uri) {
       const res = await fetch(uri);
       if (!res.ok) throw new Error(`HTTP ${res.status} fetching ${uri}`);
       const text = await res.text();
-      return parseYaml(text);
+      const contentType = res.headers.get("content-type") ?? "";
+      const mime = contentType.split(";")[0]?.trim().toLowerCase() ?? "";
+      if (isYamlMime(mime)) return parseYaml(text);
+      if (isJsonMime(mime)) return JSON.parse(text);
+      // Ambiguous Content-Type: use URL extension as the tiebreaker,
+      // defaulting to JSON for extensionless URLs. A misconfigured
+      // server that returns YAML with `text/plain` and a URL like
+      // `/openapi` will fail with a JSON parse error — escape hatch is
+      // to supply a `.yaml` suffix or plug in a custom reader.
+      if (hasYamlExtension(uri)) return parseYaml(text);
+      return JSON.parse(text);
     },
   };
 }

--- a/packages/oav/test/readers.test.ts
+++ b/packages/oav/test/readers.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { composeReaders, createFileReader, resolveSpec } from "@oav/spec";
-import { createYamlFileReader, createYamlHttpReader, parseYamlString } from "../src/index.js";
+import { createSmartHttpReader, createYamlFileReader, parseYamlString } from "../src/index.js";
 
 describe("createYamlFileReader", () => {
   let dir: string;
@@ -45,41 +45,89 @@ describe("createYamlFileReader", () => {
   });
 });
 
-describe("createYamlHttpReader", () => {
+describe("createSmartHttpReader", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it("claims only http(s) URIs with a yaml extension", () => {
-    const r = createYamlHttpReader();
-    expect(r.canRead("https://example.com/spec.yaml")).toBe(true);
-    expect(r.canRead("http://example.com/spec.yml")).toBe(true);
-    expect(r.canRead("https://example.com/spec.json")).toBe(false);
-    expect(r.canRead("file:///x.yaml")).toBe(false);
-  });
-
-  it("fetches and parses .yaml responses", async () => {
+  function stubFetch(body: string, contentType: string | null, status = 200): void {
     vi.stubGlobal(
       "fetch",
       vi.fn(
         async () =>
-          new Response("openapi: 3.1.0\ninfo: { title: X, version: '1' }", { status: 200 }),
+          new Response(body, {
+            status,
+            headers: contentType === null ? {} : { "Content-Type": contentType },
+          }),
       ),
     );
-    const r = createYamlHttpReader();
-    expect(await r.read("https://example.com/spec.yaml")).toEqual({
-      openapi: "3.1.0",
-      info: { title: "X", version: "1" },
-    });
+  }
+
+  it("claims any http(s) URI regardless of extension", () => {
+    const r = createSmartHttpReader();
+    expect(r.canRead("https://example.com/spec.yaml")).toBe(true);
+    expect(r.canRead("http://example.com/spec.json")).toBe(true);
+    expect(r.canRead("https://api.example.com/openapi")).toBe(true);
+    expect(r.canRead("file:///x.yaml")).toBe(false);
+    expect(r.canRead("memory:spec")).toBe(false);
   });
 
-  it("throws when the response is non-ok, including the status", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => new Response("nope", { status: 404 })),
+  it("parses as YAML when Content-Type advertises yaml (any of the usual spellings)", async () => {
+    for (const ct of [
+      "application/yaml",
+      "application/x-yaml",
+      "text/yaml",
+      "text/x-yaml",
+      "application/yaml; charset=utf-8",
+    ]) {
+      stubFetch("openapi: 3.1.0\ninfo: { title: X, version: '1' }", ct);
+      const r = createSmartHttpReader();
+      // URL has no yaml extension on purpose — Content-Type drives the pick.
+      expect(await r.read("https://api.example.com/openapi"), `ct=${ct}`).toEqual({
+        openapi: "3.1.0",
+        info: { title: "X", version: "1" },
+      });
+    }
+  });
+
+  it("parses as JSON when Content-Type advertises json, including +json suffixes", async () => {
+    for (const ct of [
+      "application/json",
+      "text/json",
+      "application/vnd.openapi+json",
+      "application/json; charset=utf-8",
+    ]) {
+      stubFetch('{"openapi":"3.1.0"}', ct);
+      const r = createSmartHttpReader();
+      expect(await r.read("https://api.example.com/openapi"), `ct=${ct}`).toEqual({
+        openapi: "3.1.0",
+      });
+    }
+  });
+
+  it("falls back to URL extension when Content-Type is ambiguous", async () => {
+    // text/plain + .yaml extension → YAML.
+    stubFetch("openapi: 3.1.0", "text/plain");
+    let r = createSmartHttpReader();
+    expect(await r.read("https://example.com/spec.yaml")).toEqual({ openapi: "3.1.0" });
+
+    // text/plain + no extension → defaults to JSON.
+    stubFetch('{"openapi":"3.1.0"}', "text/plain");
+    r = createSmartHttpReader();
+    expect(await r.read("https://api.example.com/openapi")).toEqual({ openapi: "3.1.0" });
+
+    // Missing Content-Type + .yml extension → YAML.
+    stubFetch("openapi: 3.1.0", null);
+    r = createSmartHttpReader();
+    expect(await r.read("https://example.com/spec.yml")).toEqual({ openapi: "3.1.0" });
+  });
+
+  it("throws when the response is non-ok, including the status in the message", async () => {
+    stubFetch("nope", "application/json", 404);
+    const r = createSmartHttpReader();
+    await expect(r.read("https://example.com/missing.json")).rejects.toThrow(
+      /HTTP 404 fetching https:\/\/example\.com\/missing\.json/,
     );
-    const r = createYamlHttpReader();
-    await expect(r.read("https://example.com/missing.yaml")).rejects.toThrow(/HTTP 404 fetching/);
   });
 });
 

--- a/packages/oav/test/readers.test.ts
+++ b/packages/oav/test/readers.test.ts
@@ -105,6 +105,20 @@ describe("createSmartHttpReader", () => {
     }
   });
 
+  it("prefers Content-Type over a conflicting URL extension", async () => {
+    // URL ends in .yaml but server advertises JSON → parse as JSON.
+    // A misconfigured URL (e.g. a content-management system serving a
+    // JSON API at a .yaml alias) shouldn't break the reader.
+    stubFetch('{"openapi":"3.1.0"}', "application/json");
+    let r = createSmartHttpReader();
+    expect(await r.read("https://example.com/spec.yaml")).toEqual({ openapi: "3.1.0" });
+
+    // URL ends in .json but server advertises YAML → parse as YAML.
+    stubFetch("openapi: 3.1.0", "application/yaml");
+    r = createSmartHttpReader();
+    expect(await r.read("https://example.com/spec.json")).toEqual({ openapi: "3.1.0" });
+  });
+
   it("falls back to URL extension when Content-Type is ambiguous", async () => {
     // text/plain + .yaml extension → YAML.
     stubFetch("openapi: 3.1.0", "text/plain");

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -56,14 +56,21 @@ Built-ins (JSON only — YAML support lives in `@aahoughton/oav`):
 - `composeReaders([...])` — layers readers, dispatching by `canRead`.
 
 `@aahoughton/oav` additionally exports `createYamlFileReader`,
-`createYamlHttpReader`, and `parseYamlString` for YAML-backed specs.
-Compose them ahead of the JSON readers:
+`createSmartHttpReader`, and `parseYamlString` for YAML-backed specs.
+`createSmartHttpReader` supersedes the JSON-only `createHttpReader`
+when composed — it claims every `http(s)` URI and dispatches by
+response `Content-Type` (falling back to URL extension), so JSON and
+YAML endpoints work through the same reader:
 
 ```ts
 import { composeReaders, createFileReader } from "@aahoughton/oav/spec";
-import { createYamlFileReader } from "@aahoughton/oav";
+import { createSmartHttpReader, createYamlFileReader } from "@aahoughton/oav";
 
-const reader = composeReaders([createYamlFileReader(), createFileReader()]);
+const reader = composeReaders([
+  createYamlFileReader(),
+  createSmartHttpReader(),
+  createFileReader(),
+]);
 ```
 
 Write a custom reader (S3, blob store, bundled assets) by implementing

--- a/packages/spec/src/reader.ts
+++ b/packages/spec/src/reader.ts
@@ -22,7 +22,7 @@ function hasYamlExtension(uri: string): boolean {
 const YAML_HINT =
   "@aahoughton/oav-core does not parse YAML directly. Install @aahoughton/oav " +
   "(the batteries-included distribution) and compose createYamlFileReader() / " +
-  "createYamlHttpReader() ahead of the JSON-only readers from @aahoughton/oav-core/spec.";
+  "createSmartHttpReader() ahead of the JSON-only readers from @aahoughton/oav-core/spec.";
 
 /**
  * Read files from the local filesystem. JSON only — `.yaml` / `.yml`
@@ -68,7 +68,10 @@ export function createFileReader(cwd: string = process.cwd()): DocumentReader {
 
 /**
  * Read documents over HTTP/HTTPS. JSON only; pair with
- * `@aahoughton/oav`' `createYamlHttpReader` for YAML.
+ * `@aahoughton/oav`'s `createSmartHttpReader` for YAML (it claims all
+ * `http(s)` URIs and dispatches by `Content-Type`, so it shadows this
+ * reader in a compose chain — that's fine; JSON endpoints still parse
+ * as JSON there).
  *
  * @returns A {@link DocumentReader}.
  *


### PR DESCRIPTION
Closes #102.

## Summary

URL-as-spec support for the CLI, with proper format detection.

**Layer 1 — \`@aahoughton/oav-core\`'s CLI.** Added \`createHttpReader()\` to \`defaultCommandIo\`'s reader chain. JSON-over-HTTP now works for lean consumers; YAML URLs still throw the install-hint error pointing at \`@aahoughton/oav\`.

**Layer 2 — \`@aahoughton/oav\`'s CLI.** Replaced extension-gated \`createYamlHttpReader\` with a new \`createSmartHttpReader\` that fetches once and dispatches by \`Content-Type\`:

- \`application/yaml\` / \`application/x-yaml\` / \`text/yaml\` / \`text/x-yaml\` (with optional \`; charset=...\`) → YAML
- \`application/json\` / \`text/json\` / any \`*+json\` suffix → JSON
- Ambiguous (missing, \`text/plain\`, \`application/octet-stream\`) → URL extension tiebreaker; extensionless → JSON

Handles the common case where the user points \`oav\` at \`https://api.example.com/openapi\` and the server advertises format via Content-Type. Relative \`\$ref\`s inside a URL-hosted spec resolve correctly against the URL base — \`resolveSpec\`'s \`resolveRelative\` already did that.

## Public API changes

- \`@aahoughton/oav\` exports **\`createSmartHttpReader\`** (new) in place of **\`createYamlHttpReader\`** (removed). Pre-release, no external users.

## Test plan

- [x] \`pnpm test\` — 581 pass (+4 new: Content-Type dispatch for four YAML spellings + \`+json\` suffixes + ambiguous-fallback to extension + non-ok HTTP status).
- [x] \`pnpm lint\` / \`pnpm typecheck\` / \`pnpm build\` — green.
- [x] Conformance — green.

## Non-goals

- No auth headers / custom fetch options — use a custom \`DocumentReader\`.
- No response caching.
- No content-sniffing as a last resort. Failed parses surface a clear error rather than trying the other format silently.