### PR TITLE
feat(validator): shape-only security validation (bearer, basic, apiKey)

### DIFF
--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -53,7 +53,7 @@ schema.json -o v.mjs`) that covers the edge-runtime / build-time-
   unknown-keyword typos and wrong value shapes (e.g. `minimum: "5"`
   when it should be a number). oav ships a narrower `strict` option
   that catches unknown-keyword typos (`minimumx: 5`) and flags
-  partially-implemented features; it doesn't yet check value shapes
+  partially-implemented features; it doesn't check value shapes
   against the meta-schema.
 - **`$data` references.** Ajv's non-standard extension where one
   keyword's value comes from the data being validated

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -63,7 +63,9 @@ schema.json -o v.mjs`) that covers the edge-runtime / build-time-
   are synchronous.
 - **`express-openapi-validator` conveniences.** `req.body` /
   `req.query` type coercion, `res.json` interception for response
-  validation, `fileUploader` (multer integration), `securityHandlers`,
+  validation, `fileUploader` (multer integration), `securityHandlers`
+  (credential-verifying dispatch — oav does shape-only security
+  validation but doesn't verify credentials),
   `operationHandlers` filesystem auto-loading, and `ignorePaths` /
   `ignoreUndocumented` are one-liner options. oav leaves these to the
   adapter — see [`INTEGRATION.md`](./INTEGRATION.md) for recipes.

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -256,6 +256,8 @@ function httpStatusFor(err: ValidationError): number {
       return 405; // path matched but the verb isn't declared
     case "content-type":
       return 415; // request Content-Type not declared
+    case "security":
+      return 401; // declared security scheme isn't satisfied (shape check)
     case "status":
       return 500; // response-side: spec doesn't declare this status
     default:
@@ -445,21 +447,40 @@ branch.
 
 ### Security / authentication
 
-`oav` has no `securityHandlers` option and does not interpret
-`components.securitySchemes`. Run your auth middleware first and
-treat auth as orthogonal to schema validation:
+`oav` performs **shape-only** security validation: it confirms the
+request carries the credential location declared by the spec (a
+`Bearer` token in `Authorization`, the declared apiKey header / query
+/ cookie, a base64 `Basic user:pass` pair), but it does **not** verify
+the credential itself. That's your auth middleware's job; keep it
+upstream of the validator.
 
 ```ts
-app.use(authenticateJwt); // your own middleware
-app.use(oavMiddleware); // validates schema against the authenticated request
+app.use(authenticateJwt); // verifies tokens, populates req.user
+app.use(oavMiddleware); // shape + schema checks
 ```
 
-`express-openapi-validator`'s `securityHandlers` is a declarative
-dispatch table driven by the spec's `security:` blocks; you still
-supply an auth function per scheme. If that dispatch layer is
-load-bearing for your setup, a ~30-line function that walks the
-matched operation's `security` array and calls your per-scheme
-handlers replaces it.
+The shape check runs automatically against each operation's
+`security:` (or document-level `security:` when the operation doesn't
+override). Supported:
+
+- `http` with `scheme: "bearer"` — requires `Authorization: Bearer <non-empty>`.
+- `http` with `scheme: "basic"` — requires `Authorization: Basic <base64>`; the base64 must decode to a `user:pass` shape (no credential verification).
+- `apiKey` in `header`, `query`, or `cookie` — declared name must be present and non-empty.
+
+`oauth2`, `openIdConnect`, and `mutualTLS` schemes are accepted in the
+spec but not shape-checked at the validator layer. Failures surface as
+a single leaf error with `code: "security"` and `path: ["security"]`,
+mapping to HTTP 401 in the default status recipe.
+
+Disable with `createValidator(spec, { validateSecurity: false })` if
+you want schema checks only.
+
+`express-openapi-validator`'s `securityHandlers` is a _credential-
+verifying_ dispatch table — you supply an auth function per scheme and
+eov calls it. `oav` has no equivalent; that role stays with your auth
+middleware. A ~30-line function that walks the matched operation's
+`security` array and dispatches per scheme replaces it if you want the
+declarative shape.
 
 ### Type coercion on body fields
 
@@ -521,26 +542,27 @@ app.use(async (req, res, next) => {
 
 ### Option map
 
-| `express-openapi-validator` option      | `oav` equivalent                                                                                                |
-| --------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `apiSpec` (path/URL/object)             | `loadSpec({ reader, entry })` + `createValidator(doc)`                                                          |
-| `validateRequests: true`                | `validator.validateRequest(...)` in your middleware                                                             |
-| `validateResponses: true`               | `validator.validateResponse(...)` in handler or a `res.json` wrapper (see recipes)                              |
-| `validateRequests.allErrors`            | Default — `oav` always collects every leaf. Bound cost with `maxErrors: N`.                                     |
-| `validateRequests.coerceTypes`          | Query scalars coerced by default; body coercion not supported.                                                  |
-| `validateRequests.removeAdditional`     | Not supported. `additionalProperties: false` rejects; there is no silent-drop mode.                             |
-| `validateRequests.discriminator`        | Native, always on for OpenAPI specs.                                                                            |
-| `formats`                               | `createValidator(spec, { formats: { ... } })` — see [format-shape note](#format-shape-note) below.              |
-| `validateFormats: "fast" \| "full"`     | N/A — single-pass validation; the built-in formats are RFC-sourced.                                             |
-| `ajvFormats`                            | Pass custom format functions via the `formats` option — see [format-shape note](#format-shape-note) below.      |
-| `serDes`                                | Not supported. Pre- or post-transform the payload in your handler if you need `Date` / `ObjectId` / etc.        |
-| `validateSecurity.handlers`             | Your own auth middleware, run before the validator.                                                             |
-| `fileUploader: true`                    | Your own multer middleware (see [recipe](#file-uploads-with-multer)).                                           |
-| `operationHandlers`                     | Your own Express routes. `oav` doesn't auto-load handlers from the filesystem.                                  |
-| `ignorePaths` (regex/fn)                | Short-circuit in your middleware before calling `validateRequest`.                                              |
-| `ignoreUndocumented`                    | `if (err.code === "route") return next()`.                                                                      |
-| `$refParser: "bundle" \| "dereference"` | `loadSpec` inlines external refs; circulars become internal refs. Use `resolveSpec` directly for finer control. |
-| `validateApiSpec`                       | Run `oav resolve spec.yaml` in CI; no runtime toggle.                                                           |
+| `express-openapi-validator` option      | `oav` equivalent                                                                                                                  |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `apiSpec` (path/URL/object)             | `loadSpec({ reader, entry })` + `createValidator(doc)`                                                                            |
+| `validateRequests: true`                | `validator.validateRequest(...)` in your middleware                                                                               |
+| `validateResponses: true`               | `validator.validateResponse(...)` in handler or a `res.json` wrapper (see recipes)                                                |
+| `validateRequests.allErrors`            | Default — `oav` always collects every leaf. Bound cost with `maxErrors: N`.                                                       |
+| `validateRequests.coerceTypes`          | Query scalars coerced by default; body coercion not supported.                                                                    |
+| `validateRequests.removeAdditional`     | Not supported. `additionalProperties: false` rejects; there is no silent-drop mode.                                               |
+| `validateRequests.discriminator`        | Native, always on for OpenAPI specs.                                                                                              |
+| `formats`                               | `createValidator(spec, { formats: { ... } })` — see [format-shape note](#format-shape-note) below.                                |
+| `validateFormats: "fast" \| "full"`     | N/A — single-pass validation; the built-in formats are RFC-sourced.                                                               |
+| `ajvFormats`                            | Pass custom format functions via the `formats` option — see [format-shape note](#format-shape-note) below.                        |
+| `serDes`                                | Not supported. Pre- or post-transform the payload in your handler if you need `Date` / `ObjectId` / etc.                          |
+| `validateSecurity: true`                | Default — shape-only checks for `bearer` / `basic` / `apiKey`. Opt out with `createValidator(spec, { validateSecurity: false })`. |
+| `validateSecurity.handlers`             | Your own auth middleware, run before the validator — `oav` only checks credential **shape**, not validity.                        |
+| `fileUploader: true`                    | Your own multer middleware (see [recipe](#file-uploads-with-multer)).                                                             |
+| `operationHandlers`                     | Your own Express routes. `oav` doesn't auto-load handlers from the filesystem.                                                    |
+| `ignorePaths` (regex/fn)                | Short-circuit in your middleware before calling `validateRequest`.                                                                |
+| `ignoreUndocumented`                    | `if (err.code === "route") return next()`.                                                                                        |
+| `$refParser: "bundle" \| "dereference"` | `loadSpec` inlines external refs; circulars become internal refs. Use `resolveSpec` directly for finer control.                   |
+| `validateApiSpec`                       | Run `oav resolve spec.yaml` in CI; no runtime toggle.                                                                             |
 
 ### Features not carried over
 

--- a/OVERLAYS.md
+++ b/OVERLAYS.md
@@ -141,5 +141,5 @@ document is deep-cloned — the input is never mutated.
   and
   [`examples/overlay-petstore-endpoint.ts`](./examples/overlay-petstore-endpoint.ts)
   — runnable end-to-end demos.
-- [README "Why oav?"](./README.md#why-oav) — overlays as one of the
-  three motivating reasons the project exists.
+- [README "Why (yet another) OpenAPI validator?"](./README.md#why-yet-another-openapi-validator) —
+  overlays as one of the three motivating reasons the project exists.

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ shape per code is documented in `BuiltInErrorParams`.
 
 ## Why oav?
 
-Three things weren't available together anywhere else when this repo
-started:
+Three things `oav` brings together that aren't jointly available
+elsewhere in the JavaScript ecosystem:
 
 - **An HTTP-aware validator.** One call checks method + path +
   parameters + body + content type + status + headers against the

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ rooted at the HTTP frame (e.g. `["body", "pets", 3, "name"]`), a
 human-readable `message`, and a machine-readable `params` object whose
 shape per code is documented in `BuiltInErrorParams`.
 
-## Why oav?
+## Why (yet another) OpenAPI validator?
 
 Three things `oav` brings together that aren't jointly available
 elsewhere in the JavaScript ecosystem:

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -141,6 +141,15 @@ export interface BuiltInErrorParams {
   "query-param": { name: string; in: "query" };
   "header-param": { name: string; in: "header" };
   "cookie-param": { name: string; in: "cookie" };
+  /**
+   * No declared security requirement was satisfied by the request
+   * (shape-only check — presence / format of the declared credential
+   * location, not credential verification). `declared` lists the
+   * alternatives tried: each inner array is a single requirement
+   * (AND across its scheme names), the outer array is the OR set.
+   * Maps to HTTP 401.
+   */
+  security: { declared: string[][] };
 }
 
 /**
@@ -219,6 +228,7 @@ export const BUILT_IN_ERROR_CODES = [
   "query-param",
   "header-param",
   "cookie-param",
+  "security",
 ] as const satisfies ReadonlyArray<keyof BuiltInErrorParams>;
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,6 +58,8 @@ export type {
   ResponseObject,
   SchemaObject,
   SchemaOrBoolean,
+  SecurityRequirementObject,
+  SecuritySchemeObject,
   ServerObject,
   TagObject,
 } from "./types.js";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -155,11 +155,65 @@ export interface OpenAPIDocument {
   paths?: Record<string, PathItem>;
   components?: ComponentsObject;
   tags?: TagObject[];
+  /**
+   * Top-level security requirement. Each element is an alternative
+   * (OR-connected); schemes within an element are AND-connected. Empty
+   * array means "no authentication required"; operations can override
+   * via their own `security` field. See
+   * {@link SecurityRequirementObject}.
+   */
+  security?: SecurityRequirementObject[];
   /** 3.1+: declared webhooks. Absent in 3.0. */
   webhooks?: Record<string, PathItem | ReferenceObject>;
   /** 3.1+: overrides the default schema dialect URI. Absent in 3.0. */
   jsonSchemaDialect?: string;
   [extension: `x-${string}`]: JsonValue | undefined;
+}
+
+/**
+ * A single security requirement, shared by top-level and operation-level
+ * `security` fields. Maps scheme name (keyed into
+ * `components.securitySchemes`) to required scopes (empty array for
+ * non-OAuth2 schemes).
+ *
+ * An operation's `security` is an array of these; the operation passes
+ * if **any** one of them is satisfied (OR semantics). Within a single
+ * requirement, **all** listed schemes must be satisfied (AND).
+ *
+ * @public
+ */
+export type SecurityRequirementObject = Record<string, string[]>;
+
+/**
+ * A security scheme definition, declared in
+ * {@link ComponentsObject.securitySchemes}. Referenced by name from a
+ * {@link SecurityRequirementObject}.
+ *
+ * oav's validator performs shape-only checks on `http` (bearer / basic)
+ * and `apiKey` schemes — it confirms the request carries the declared
+ * credential location and format, but does not verify the credential
+ * itself. `oauth2`, `openIdConnect`, and `mutualTLS` are accepted in
+ * the spec but not shape-checked at the validator layer; credential
+ * verification (and scope checking for oauth2) is the app's
+ * responsibility.
+ *
+ * @public
+ */
+export interface SecuritySchemeObject {
+  type: "http" | "apiKey" | "oauth2" | "openIdConnect" | "mutualTLS";
+  description?: string;
+  /** `http` schemes: e.g. `"bearer"` or `"basic"`. Required on `http`. */
+  scheme?: string;
+  /** `http` schemes: the token format hint (e.g. `"JWT"`). Informational. */
+  bearerFormat?: string;
+  /** `apiKey` schemes: the parameter name. Required on `apiKey`. */
+  name?: string;
+  /** `apiKey` schemes: where the parameter lives. Required on `apiKey`. */
+  in?: "header" | "query" | "cookie";
+  /** `oauth2` schemes: flow definitions. Not validated at the shape level. */
+  flows?: unknown;
+  /** `openIdConnect` schemes: discovery URL. Not validated at the shape level. */
+  openIdConnectUrl?: string;
 }
 
 /**
@@ -205,6 +259,7 @@ export interface ComponentsObject {
   requestBodies?: Record<string, RequestBodyObject>;
   responses?: Record<string, ResponseObject>;
   headers?: Record<string, HeaderObject>;
+  securitySchemes?: Record<string, SecuritySchemeObject | ReferenceObject>;
 }
 
 /**
@@ -262,6 +317,13 @@ export interface OperationObject {
   parameters?: (ParameterObject | ReferenceObject)[];
   requestBody?: RequestBodyObject | ReferenceObject;
   responses?: Record<string, ResponseObject | ReferenceObject>;
+  /**
+   * Per-operation security requirement. Overrides the document-level
+   * {@link OpenAPIDocument.security}. An explicit empty array opts the
+   * operation out of the top-level requirement. See
+   * {@link SecurityRequirementObject}.
+   */
+  security?: SecurityRequirementObject[];
   deprecated?: boolean;
 }
 

--- a/packages/validator/src/operation-cache.ts
+++ b/packages/validator/src/operation-cache.ts
@@ -10,6 +10,7 @@ import { resolveJsonPointer } from "@oav/core";
 import type { RouteMatch } from "@oav/router";
 import type { CompiledSchema } from "@oav/schema";
 import type { BodyDirection } from "./body-schema-transform.js";
+import type { CompiledSecurity } from "./security.js";
 
 /**
  * Pre-compiled lookup tables for a single operation. The validator's
@@ -27,6 +28,13 @@ export interface OperationCache {
   requestBody: RequestBodyObject | undefined;
   bodyValidators: Map<string, CompiledSchema>;
   responses: Map<string, ResponseCompiled>;
+  /**
+   * Pre-compiled shape-only security check, or `undefined` when the
+   * operation has no effective security requirement (either because
+   * nothing was declared, it's opted out via `security: []`, or the
+   * `validateSecurity` option is `false`).
+   */
+  security: CompiledSecurity | undefined;
 }
 
 /**
@@ -176,6 +184,11 @@ export function buildOperationCache(
     requestBody,
     bodyValidators,
     responses,
+    // Security is populated by `createValidator` after this call
+    // returns — `buildOperationCache` deliberately doesn't see the full
+    // document (it only needs the `RouteMatch` subtree) so the field
+    // starts out undefined.
+    security: undefined,
   };
 }
 

--- a/packages/validator/src/security.ts
+++ b/packages/validator/src/security.ts
@@ -1,0 +1,227 @@
+import {
+  createLeafError,
+  type HttpRequest,
+  type OpenAPIDocument,
+  type OperationObject,
+  type ReferenceObject,
+  type SecurityRequirementObject,
+  type SecuritySchemeObject,
+  type ValidationError,
+} from "@oav/core";
+
+/**
+ * Shape-only security check precompiled from a single OpenAPI security
+ * scheme definition. Returns `null` when the request carries the
+ * declared credential (presence + structural shape only); returns a
+ * short human-readable reason when it doesn't. Credential verification
+ * (token validity, API key lookup, password match) is outside scope —
+ * that's the app's auth middleware.
+ *
+ * @internal
+ */
+interface CompiledSchemeCheck {
+  scheme: string;
+  check: (req: HttpRequest) => string | null;
+}
+
+/**
+ * One security requirement: an AND of `CompiledSchemeCheck`s. All must
+ * return `null` for the requirement to be satisfied.
+ *
+ * @internal
+ */
+export interface CompiledSecurityRequirement {
+  schemes: CompiledSchemeCheck[];
+}
+
+/**
+ * A pre-compiled, operation-level security check. An OR across one or
+ * more `CompiledSecurityRequirement`s — at least one must fully satisfy
+ * for the request to pass. `null` (stored as `undefined` on
+ * `OperationCache`) means "no security required" and skips the check.
+ *
+ * @internal
+ */
+export type CompiledSecurity = CompiledSecurityRequirement[];
+
+/**
+ * Compile the effective security for one operation. Applies OAS
+ * precedence: operation-level `security` (including an explicit empty
+ * array opt-out) overrides `document.security`. Unknown scheme names
+ * compile to always-failing checks so a typo produces a 401 rather
+ * than silently passing.
+ *
+ * Returns `undefined` when no requirement applies (no check emitted at
+ * request time) — distinct from an empty array, which is never returned
+ * here: empty means "no security" and we fold that into `undefined`.
+ *
+ * @internal
+ */
+export function compileOperationSecurity(
+  operation: OperationObject,
+  document: OpenAPIDocument,
+  resolveRef: <T>(v: T | ReferenceObject | undefined) => T | undefined,
+): CompiledSecurity | undefined {
+  const effective = operation.security ?? document.security;
+  if (effective === undefined || effective.length === 0) return undefined;
+
+  const schemes = document.components?.securitySchemes ?? {};
+  const resolvedSchemes: Record<string, SecuritySchemeObject | undefined> = {};
+  for (const [name, raw] of Object.entries(schemes)) {
+    resolvedSchemes[name] = resolveRef<SecuritySchemeObject>(raw);
+  }
+
+  return effective.map((req) => compileRequirement(req, resolvedSchemes));
+}
+
+function compileRequirement(
+  req: SecurityRequirementObject,
+  schemes: Record<string, SecuritySchemeObject | undefined>,
+): CompiledSecurityRequirement {
+  const compiled: CompiledSchemeCheck[] = [];
+  for (const name of Object.keys(req)) {
+    const scheme = schemes[name];
+    compiled.push(compileSchemeCheck(name, scheme));
+  }
+  return { schemes: compiled };
+}
+
+function compileSchemeCheck(
+  name: string,
+  scheme: SecuritySchemeObject | undefined,
+): CompiledSchemeCheck {
+  if (scheme === undefined) {
+    return {
+      scheme: name,
+      check: () => `"${name}" is not declared in components.securitySchemes`,
+    };
+  }
+  switch (scheme.type) {
+    case "http":
+      if (scheme.scheme?.toLowerCase() === "bearer") return bearerCheck(name);
+      if (scheme.scheme?.toLowerCase() === "basic") return basicCheck(name);
+      // Other http schemes (digest, mutual, etc.) aren't shape-checked
+      // in v1. Accept to avoid false 401s on schemes we don't yet
+      // understand.
+      return { scheme: name, check: () => null };
+    case "apiKey":
+      return apiKeyCheck(name, scheme);
+    // oauth2 / openIdConnect / mutualTLS: v1 non-goals. See oav#104.
+    // Treat as pass rather than block, so specs using them continue
+    // to validate requests without security producing spurious 401s.
+    default:
+      return { scheme: name, check: () => null };
+  }
+}
+
+function bearerCheck(name: string): CompiledSchemeCheck {
+  return {
+    scheme: name,
+    check: (req) => {
+      const auth = getHeader(req, "authorization");
+      if (auth === undefined) return `missing "Authorization: Bearer ..." header`;
+      if (!/^bearer\s+\S/i.test(auth)) return `"Authorization" is not a Bearer token`;
+      return null;
+    },
+  };
+}
+
+function basicCheck(name: string): CompiledSchemeCheck {
+  return {
+    scheme: name,
+    check: (req) => {
+      const auth = getHeader(req, "authorization");
+      if (auth === undefined) return `missing "Authorization: Basic ..." header`;
+      const m = /^basic\s+(\S+)$/i.exec(auth);
+      if (!m) return `"Authorization" is not a Basic credential`;
+      const decoded = tryBase64Decode(m[1]!);
+      if (decoded === undefined) return `"Authorization: Basic" value is not valid base64`;
+      if (!decoded.includes(":")) return `"Authorization: Basic" is not "user:pass" shape`;
+      return null;
+    },
+  };
+}
+
+function apiKeyCheck(name: string, scheme: SecuritySchemeObject): CompiledSchemeCheck {
+  const keyName = scheme.name;
+  const keyIn = scheme.in;
+  if (!keyName || !keyIn) {
+    // Malformed scheme definition: emit a failure rather than silently
+    // treating every request as passing the check.
+    return {
+      scheme: name,
+      check: () => `apiKey scheme "${name}" is missing required "name" or "in"`,
+    };
+  }
+  return {
+    scheme: name,
+    check: (req) => {
+      const v = pickApiKey(req, keyIn, keyName);
+      if (v === undefined || v === "") return `missing ${keyIn} "${keyName}"`;
+      return null;
+    },
+  };
+}
+
+function getHeader(req: HttpRequest, lowered: string): string | undefined {
+  const raw = req.headers?.[lowered];
+  if (raw === undefined) return undefined;
+  return Array.isArray(raw) ? raw[0] : raw;
+}
+
+function pickApiKey(
+  req: HttpRequest,
+  loc: "header" | "query" | "cookie",
+  name: string,
+): string | undefined {
+  if (loc === "header") return getHeader(req, name.toLowerCase());
+  if (loc === "query") {
+    const q = req.query?.[name];
+    return Array.isArray(q) ? q[0] : q;
+  }
+  return req.cookies?.[name];
+}
+
+function tryBase64Decode(s: string): string | undefined {
+  try {
+    // `atob` is available in Node 16+ and in every modern browser /
+    // runtime — avoid a `Buffer` import to keep this file portable.
+    return atob(s);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Evaluate a compiled security plan against a request. OR across
+ * requirements: the first passing requirement short-circuits to `null`
+ * (success). If all fail, returns a single leaf `security` error
+ * describing the declared alternatives.
+ *
+ * @internal
+ */
+export function checkSecurity(
+  compiled: CompiledSecurity,
+  req: HttpRequest,
+): ValidationError | null {
+  const reasons: string[] = [];
+  const declared: string[][] = [];
+  for (const requirement of compiled) {
+    const schemeNames = requirement.schemes.map((s) => s.scheme);
+    declared.push(schemeNames);
+    const failures: string[] = [];
+    for (const s of requirement.schemes) {
+      const r = s.check(req);
+      if (r !== null) failures.push(`${s.scheme}: ${r}`);
+    }
+    if (failures.length === 0) return null; // first satisfying alternative wins
+    reasons.push(failures.join(" AND "));
+  }
+  const message =
+    declared.length === 1
+      ? `request failed security validation (${reasons[0]})`
+      : `request failed security validation; no declared alternative matched: ${reasons
+          .map((r, i) => `[${i}] ${r}`)
+          .join(" | ")}`;
+  return createLeafError("security", ["security"], message, { declared });
+}

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -41,6 +41,7 @@ import {
   resolveOperationRef,
   type OperationCache,
 } from "./operation-cache.js";
+import { checkSecurity, compileOperationSecurity } from "./security.js";
 import { validateBody, validateParameter } from "./validate-step.js";
 
 /**
@@ -264,6 +265,26 @@ export interface ValidatorOptions {
 
   // --- 4. HTTP-validator-specific extras ---
 
+  /**
+   * Reject requests that don't satisfy the declared
+   * {@link OperationObject.security} (or document-level
+   * {@link OpenAPIDocument.security} when the operation doesn't override).
+   * **Shape-only**: the check confirms the request carries the declared
+   * credential (e.g. a `Bearer` token in `Authorization`, the declared
+   * apiKey header) — it does not verify the credential itself. Credential
+   * verification stays with the app's auth middleware.
+   *
+   * Supported schemes: `http` with `scheme: "bearer"` or `"basic"`, and
+   * `apiKey` in header / query / cookie. `oauth2`, `openIdConnect`, and
+   * `mutualTLS` are accepted in the spec but not shape-checked at the
+   * validator layer.
+   *
+   * Defaults to `true` — migrating
+   * `express-openapi-validator`-with-`validateSecurity` consumers get
+   * the behaviour they're used to without extra wiring. Set `false` to
+   * bypass the check entirely.
+   */
+  validateSecurity?: boolean;
   /** When `true`, reject unknown query parameters (default: `false`). */
   strictQueryParameters?: boolean;
   /**
@@ -440,10 +461,15 @@ export function createValidator(
 
   const operationCache = new WeakMap<OperationObject, OperationCache>();
 
+  const validateSecurity = options.validateSecurity !== false;
+
   const cacheFor = (pathMatch: RouteMatch): OperationCache => {
     const existing = operationCache.get(pathMatch.operation);
     if (existing !== undefined) return existing;
     const cache = buildOperationCache(pathMatch, { resolveRef, compile, compileForDirection });
+    if (validateSecurity) {
+      cache.security = compileOperationSecurity(pathMatch.operation, spec, resolveRef);
+    }
     operationCache.set(pathMatch.operation, cache);
     return cache;
   };
@@ -470,6 +496,22 @@ export function createValidator(
     }
     const cache = cacheFor(match);
     const children: ValidationError[] = [];
+
+    // Security check first and short-circuit: an auth failure makes
+    // every parameter / body diagnostic noise, and the client can't act
+    // on the latter without fixing the former.
+    if (cache.security !== undefined) {
+      const securityErr = checkSecurity(cache.security, req);
+      if (securityErr !== null) {
+        return createBranchError(
+          "request",
+          [],
+          `${req.method.toUpperCase()} ${match.pathPattern}: request validation failed`,
+          [securityErr],
+          { method: req.method, pathPattern: match.pathPattern },
+        );
+      }
+    }
 
     for (const p of cache.parameters) {
       const err = validateParameter(p, req, match, cache);

--- a/packages/validator/test/security.test.ts
+++ b/packages/validator/test/security.test.ts
@@ -1,0 +1,331 @@
+import type { ErrorParamsFor, OpenAPIDocument, ValidationError } from "@oav/core";
+import { describe, expect, it } from "vitest";
+import { createValidator } from "../src/validator.js";
+
+/**
+ * Shape-only security validation coverage — bearer / basic / apiKey.
+ * Credential verification is explicitly out of scope; these tests only
+ * exercise presence + structural shape of the declared credential
+ * location.
+ */
+
+function specWith(
+  securitySchemes: Record<string, unknown>,
+  operationSecurity: Array<Record<string, string[]>> | undefined,
+  topLevelSecurity?: Array<Record<string, string[]>>,
+): OpenAPIDocument {
+  const doc: OpenAPIDocument = {
+    openapi: "3.1.0",
+    info: { title: "t", version: "1" },
+    components: { securitySchemes: securitySchemes as never },
+    paths: {
+      "/ping": {
+        get: {
+          ...(operationSecurity !== undefined ? { security: operationSecurity } : {}),
+          responses: { "200": { description: "ok" } },
+        },
+      },
+    },
+  };
+  if (topLevelSecurity !== undefined) doc.security = topLevelSecurity;
+  return doc;
+}
+
+function firstLeaf(err: ValidationError | null): ValidationError | null {
+  if (err === null) return null;
+  if (err.children.length === 0) return err;
+  return firstLeaf(err.children[0] ?? null);
+}
+
+describe("security validation: bearer (http / bearer)", () => {
+  const spec = specWith({ bearerAuth: { type: "http", scheme: "bearer" } }, [{ bearerAuth: [] }]);
+  const v = createValidator(spec);
+
+  it("accepts Authorization: Bearer <token>", () => {
+    expect(
+      v.validateRequest({
+        method: "GET",
+        path: "/ping",
+        headers: { authorization: "Bearer abc.def.ghi" },
+      }),
+    ).toBeNull();
+  });
+
+  it("is case-insensitive on the scheme keyword", () => {
+    expect(
+      v.validateRequest({
+        method: "GET",
+        path: "/ping",
+        headers: { authorization: "bearer abc" },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects when the Authorization header is absent", () => {
+    const err = v.validateRequest({ method: "GET", path: "/ping" });
+    expect(err?.code).toBe("request");
+    const leaf = firstLeaf(err);
+    expect(leaf?.code).toBe("security");
+    const params = leaf?.params as ErrorParamsFor<"security">;
+    expect(params.declared).toEqual([["bearerAuth"]]);
+  });
+
+  it("rejects a non-Bearer Authorization header", () => {
+    const err = v.validateRequest({
+      method: "GET",
+      path: "/ping",
+      headers: { authorization: "Basic dXNlcjpwYXNz" },
+    });
+    expect(firstLeaf(err)?.code).toBe("security");
+  });
+
+  it("rejects Bearer with an empty token", () => {
+    const err = v.validateRequest({
+      method: "GET",
+      path: "/ping",
+      headers: { authorization: "Bearer " },
+    });
+    expect(firstLeaf(err)?.code).toBe("security");
+  });
+});
+
+describe("security validation: basic (http / basic)", () => {
+  const spec = specWith({ basicAuth: { type: "http", scheme: "basic" } }, [{ basicAuth: [] }]);
+  const v = createValidator(spec);
+
+  it("accepts a well-formed Basic credential", () => {
+    const creds = Buffer.from("user:pass").toString("base64");
+    expect(
+      v.validateRequest({
+        method: "GET",
+        path: "/ping",
+        headers: { authorization: `Basic ${creds}` },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects a Basic header whose payload isn't base64", () => {
+    const err = v.validateRequest({
+      method: "GET",
+      path: "/ping",
+      headers: { authorization: "Basic not!!base64@@" },
+    });
+    expect(firstLeaf(err)?.code).toBe("security");
+  });
+
+  it("rejects a Basic header whose base64 lacks the 'user:pass' colon", () => {
+    const payload = Buffer.from("nousercolonhere").toString("base64");
+    const err = v.validateRequest({
+      method: "GET",
+      path: "/ping",
+      headers: { authorization: `Basic ${payload}` },
+    });
+    expect(firstLeaf(err)?.code).toBe("security");
+  });
+
+  it("rejects when the Authorization header is absent", () => {
+    const err = v.validateRequest({ method: "GET", path: "/ping" });
+    expect(firstLeaf(err)?.code).toBe("security");
+  });
+});
+
+describe("security validation: apiKey", () => {
+  it("header: missing rejects; present accepts", () => {
+    const spec = specWith({ apiKeyAuth: { type: "apiKey", in: "header", name: "X-API-Key" } }, [
+      { apiKeyAuth: [] },
+    ]);
+    const v = createValidator(spec);
+    expect(v.validateRequest({ method: "GET", path: "/ping" })?.code).toBe("request");
+    expect(
+      v.validateRequest({ method: "GET", path: "/ping", headers: { "x-api-key": "abc" } }),
+    ).toBeNull();
+  });
+
+  it("header: empty string is treated as missing", () => {
+    const spec = specWith({ apiKeyAuth: { type: "apiKey", in: "header", name: "X-API-Key" } }, [
+      { apiKeyAuth: [] },
+    ]);
+    const v = createValidator(spec);
+    const err = v.validateRequest({
+      method: "GET",
+      path: "/ping",
+      headers: { "x-api-key": "" },
+    });
+    expect(firstLeaf(err)?.code).toBe("security");
+  });
+
+  it("query: missing rejects; present accepts", () => {
+    const spec = specWith({ apiKeyAuth: { type: "apiKey", in: "query", name: "api_key" } }, [
+      { apiKeyAuth: [] },
+    ]);
+    const v = createValidator(spec);
+    expect(v.validateRequest({ method: "GET", path: "/ping" })?.code).toBe("request");
+    expect(
+      v.validateRequest({ method: "GET", path: "/ping", query: { api_key: "abc" } }),
+    ).toBeNull();
+  });
+
+  it("cookie: missing rejects; present accepts", () => {
+    const spec = specWith({ apiKeyAuth: { type: "apiKey", in: "cookie", name: "session" } }, [
+      { apiKeyAuth: [] },
+    ]);
+    const v = createValidator(spec);
+    expect(v.validateRequest({ method: "GET", path: "/ping" })?.code).toBe("request");
+    expect(
+      v.validateRequest({ method: "GET", path: "/ping", cookies: { session: "abc" } }),
+    ).toBeNull();
+  });
+});
+
+describe("security validation: OR across alternatives, AND within", () => {
+  const spec = specWith(
+    {
+      bearerAuth: { type: "http", scheme: "bearer" },
+      apiKeyAuth: { type: "apiKey", in: "header", name: "X-API-Key" },
+    },
+    [{ bearerAuth: [] }, { apiKeyAuth: [] }],
+  );
+  const v = createValidator(spec);
+
+  it("either scheme on its own satisfies the operation", () => {
+    expect(
+      v.validateRequest({
+        method: "GET",
+        path: "/ping",
+        headers: { authorization: "Bearer a" },
+      }),
+    ).toBeNull();
+    expect(
+      v.validateRequest({
+        method: "GET",
+        path: "/ping",
+        headers: { "x-api-key": "a" },
+      }),
+    ).toBeNull();
+  });
+
+  it("neither present rejects; declared lists both alternatives", () => {
+    const err = v.validateRequest({ method: "GET", path: "/ping" });
+    const leaf = firstLeaf(err);
+    expect(leaf?.code).toBe("security");
+    const params = leaf?.params as ErrorParamsFor<"security">;
+    expect(params.declared).toEqual([["bearerAuth"], ["apiKeyAuth"]]);
+  });
+
+  it("AND within a single requirement: missing one fails", () => {
+    const andSpec = specWith(
+      {
+        bearerAuth: { type: "http", scheme: "bearer" },
+        apiKeyAuth: { type: "apiKey", in: "header", name: "X-API-Key" },
+      },
+      [{ bearerAuth: [], apiKeyAuth: [] }],
+    );
+    const andV = createValidator(andSpec);
+
+    // Only the bearer is present — AND fails.
+    const err = andV.validateRequest({
+      method: "GET",
+      path: "/ping",
+      headers: { authorization: "Bearer a" },
+    });
+    expect(firstLeaf(err)?.code).toBe("security");
+
+    // Both present — passes.
+    expect(
+      andV.validateRequest({
+        method: "GET",
+        path: "/ping",
+        headers: { authorization: "Bearer a", "x-api-key": "k" },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("security validation: top-level vs operation-level", () => {
+  it("operation `security: []` opts out of a top-level requirement", () => {
+    const spec = specWith(
+      { bearerAuth: { type: "http", scheme: "bearer" } },
+      [], // explicit opt-out on the operation
+      [{ bearerAuth: [] }], // top-level requirement
+    );
+    const v = createValidator(spec);
+    expect(v.validateRequest({ method: "GET", path: "/ping" })).toBeNull();
+  });
+
+  it("operation inherits top-level security when it doesn't declare its own", () => {
+    const spec = specWith(
+      { bearerAuth: { type: "http", scheme: "bearer" } },
+      undefined, // operation omits the field
+      [{ bearerAuth: [] }],
+    );
+    const v = createValidator(spec);
+    expect(v.validateRequest({ method: "GET", path: "/ping" })?.code).toBe("request");
+  });
+});
+
+describe("security validation: configuration", () => {
+  it("validateSecurity: false bypasses the check entirely", () => {
+    const spec = specWith({ bearerAuth: { type: "http", scheme: "bearer" } }, [{ bearerAuth: [] }]);
+    const v = createValidator(spec, { validateSecurity: false });
+    expect(v.validateRequest({ method: "GET", path: "/ping" })).toBeNull();
+  });
+
+  it("an undeclared scheme name fails the check (fail-closed, no silent pass)", () => {
+    const spec = specWith({ bearerAuth: { type: "http", scheme: "bearer" } }, [{ typoAuth: [] }]);
+    const v = createValidator(spec);
+    const err = v.validateRequest({ method: "GET", path: "/ping" });
+    expect(firstLeaf(err)?.code).toBe("security");
+  });
+
+  it("short-circuits before parameter / body checks — only a security error surfaces", () => {
+    const doc: OpenAPIDocument = {
+      openapi: "3.1.0",
+      info: { title: "t", version: "1" },
+      components: {
+        securitySchemes: { bearerAuth: { type: "http", scheme: "bearer" } },
+      },
+      paths: {
+        "/echo": {
+          post: {
+            security: [{ bearerAuth: [] }],
+            requestBody: {
+              required: true,
+              content: {
+                "application/json": {
+                  schema: { type: "object", required: ["name"] },
+                },
+              },
+            },
+            responses: { "200": { description: "ok" } },
+          },
+        },
+      },
+    };
+    const v = createValidator(doc);
+    const err = v.validateRequest({
+      method: "POST",
+      path: "/echo",
+      contentType: "application/json",
+      body: {}, // missing `name` — normally a second error
+    });
+    // Only one child error (security); body violation is suppressed.
+    expect(err?.code).toBe("request");
+    expect(err?.children).toHaveLength(1);
+    expect(err?.children[0]?.code).toBe("security");
+  });
+
+  it("oauth2 / openIdConnect schemes are accepted but not shape-checked", () => {
+    const spec = specWith(
+      {
+        oauth: {
+          type: "oauth2",
+          flows: { implicit: { authorizationUrl: "https://example.com/auth", scopes: {} } },
+        },
+      },
+      [{ oauth: ["read"] }],
+    );
+    const v = createValidator(spec);
+    // No headers / query — oauth2 isn't shape-checked, so pass.
+    expect(v.validateRequest({ method: "GET", path: "/ping" })).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #104.

## Summary

Closes the \`validateSecurity\` gap against express-openapi-validator. The validator now checks that incoming requests carry the credential **location** declared for the operation — without verifying the credential itself (that's the app's auth middleware's job).

## What's covered

| Scheme | Shape check |
|---|---|
| \`http\` + \`scheme: \"bearer\"\` | \`Authorization: Bearer <non-empty>\` |
| \`http\` + \`scheme: \"basic\"\` | \`Authorization: Basic <base64>\`; decoded payload must contain \`user:pass\` colon |
| \`apiKey\` in \`header\` / \`query\` / \`cookie\` | Declared name present and non-empty |

OR across alternatives (first match wins); AND within a single requirement.

- Operation-level \`security\` overrides document-level.
- \`security: []\` explicitly opts out.
- Unknown scheme names fail closed (typos become 401s, not silent passes).
- Short-circuits before parameter / body checks — an auth failure makes the rest noise.

## Non-goals (deferred)

- \`oauth2\` / \`openIdConnect\` / \`mutualTLS\` schemes — accepted in the spec, not shape-checked. Separate issue if the demand surfaces.
- Credential verification / token validation — stays with the app.
- OAuth scope checking — needs \`securityHandlers\`, also deferred.

## API

\`\`\`ts
createValidator(spec, { validateSecurity: true });  // default
createValidator(spec, { validateSecurity: false }); // opt out
\`\`\`

Failures surface as a leaf error with \`code: \"security\"\`, \`path: [\"security\"]\`, \`params: { declared: string[][] }\`. Added to \`BuiltInErrorParams\` + \`BUILT_IN_ERROR_CODES\`. Default \`httpStatusFor\` recipe in INTEGRATION.md maps it to 401.

## Test plan

- [x] 22 new tests covering bearer / basic / apiKey / OR / AND / opt-out / fail-closed / short-circuit / oauth-pass-through.
- [x] \`pnpm test\` — 604 total (up from 582).
- [x] \`pnpm lint\` / \`pnpm typecheck\` / \`pnpm build\` green.
- [x] Existing tests all unchanged — the feature is inert for specs without \`security\` declarations.

## Docs

- INTEGRATION.md: \`httpStatusFor\` recipe adds \`security → 401\`; Security section rewritten; migration table adds the \`validateSecurity: true\` row.
- COMPARISON.md: \`securityHandlers\` gap reframed (we now do shape; credential verification stays with the app).