### PR TITLE
feat(spec): fill the overlay verb matrix — add, augment, replace, remove

### DIFF
--- a/OVERLAYS.md
+++ b/OVERLAYS.md
@@ -3,82 +3,136 @@
 Overlays patch an OpenAPI document in memory before the validator is
 constructed. They exist for a specific job: letting you consume a spec
 you don't own — an upstream framework's published document, a
-gateway's spec, a vendor API — and extend or override parts of it to
-match your deployment, without forking the file.
+gateway's spec, a vendor API — and add, augment, replace, or remove
+parts of it to match your deployment, without forking the file.
 
 ## When you want one
 
+- **Your deployment requires headers or query parameters the upstream
+  spec doesn't declare.** Use `overrides` with `upsertParameters`.
 - **The upstream schema is close to what you ship but missing a
   field.** Use `extendSchemas` — adds constraints via `allOf` while
   preserving the original shape.
 - **The upstream schema is wrong for your deployment.** Use
   `replaceSchemas` — swaps the schema out entirely, no merge.
-- **Your gateway requires headers or query parameters the upstream
-  spec doesn't declare.** Use `overrides` to add them to the relevant
-  operations.
 - **You need a route the upstream doesn't expose.** Use `addPaths`.
+- **Upstream declares something you want gone** — a parameter you
+  don't accept, a response status you never return, a path you don't
+  serve. Use one of the `remove*` verbs.
+- **An operation needs a complete rewrite** rather than piecemeal
+  patching. Use `overrides.operations.<method>.replace`.
 
 The alternative — forking the spec, keeping the fork in sync as the
 upstream evolves, rebasing your patches on every update — is what
 overlays exist to avoid.
 
-## Shape
+## Verb matrix
 
-An overlay is a plain object with up to four sections. Each is
-independent; you can use any subset.
+Every overlay verb falls into one of four categories.
+
+| Target                | add                | augment                  | replace                            | remove              |
+| --------------------- | ------------------ | ------------------------ | ---------------------------------- | ------------------- |
+| Paths                 | `addPaths`         | (via `overrides`)        | (via `overrides.replace`)          | `removePaths`       |
+| Component schemas     | —                  | `extendSchemas`          | `replaceSchemas`                   | `removeSchemas`     |
+| Operations            | —                  | (via additive op fields) | `overrides.operations.<m>.replace` | (via `removePaths`) |
+| Parameters (per op)   | `upsertParameters` | —                        | `upsertParameters`                 | `removeParameters`  |
+| Request body (per op) | —                  | —                        | `requestBody`                      | —                   |
+| Responses (per op)    | `responses`        | —                        | `responses`                        | `removeResponses`   |
+
+## Shape
 
 ```ts
 interface SpecOverlay {
   addPaths?: Record<string, PathItem>;
+  removePaths?: string[];
   overrides?: Record<string, PathOverride>;
   extendSchemas?: Record<string, SchemaObject>;
   replaceSchemas?: Record<string, SchemaObject>;
+  removeSchemas?: string[];
+}
+
+interface PathOverride {
+  operations?: Partial<Record<HttpMethod, OperationOverride>>;
+  pathItem?: Partial<PathItem>;
+}
+
+interface OperationOverride {
+  replace?: OperationObject;
+  upsertParameters?: ParameterObject[];
+  removeParameters?: Array<{ name: string; in: ParameterLocation }>;
+  requestBody?: RequestBodyObject;
+  responses?: Record<string, ResponseObject>;
+  removeResponses?: string[];
 }
 ```
 
-### `extendSchemas`
+Each field is independent; use any subset.
 
-Adds constraints to an existing component schema. The extension merges
-in via `allOf`: the original shape still applies, the extension adds
-to it.
+### `addPaths` / `removePaths`
 
-Runnable demo:
-[`examples/overlay-petstore-schema.ts`](./examples/overlay-petstore-schema.ts)
-— extends the upstream `Pet` to require a `vaccinated: boolean`.
+Add new routes or drop upstream ones. Both fail fast: `addPaths`
+throws if a target path already exists; `removePaths` throws if it
+doesn't. The fail-fast choice is deliberate — you want the overlay to
+notice when upstream shifts a path you've referenced instead of
+silently no-op'ing.
 
-### `replaceSchemas`
+### `extendSchemas` / `replaceSchemas` / `removeSchemas`
 
-Replaces a component schema entirely. Use when your deployment's
-shape is not a superset of the upstream's — for example, a field that
-the upstream declares as `string` but your deployment receives as a
-structured object.
+Patch the `components.schemas` map. `extend` wraps the original in
+`allOf`, keeping upstream constraints plus yours. `replace` swaps
+wholesale. `remove` drops the entry (throws if the name isn't
+present). Multiple overlays targeting the same schema via `extend`
+stack — each adds a new `allOf` branch.
 
 ### `overrides`
 
-Modifies existing paths. Two things can be modified:
+Patches existing paths. Two things can be modified:
 
-- `operations` — per-method patches. Each supports:
-  - `addParameters`: append new parameters; replace existing concrete
-    entries (matched by `name` + `in`). `$ref`-shaped parameters in
-    the base are not matched and the new parameter appends alongside.
-  - `requestBody`: replace the request body entirely.
-  - `responses`: merge by status code.
+- `operations` — per-method patches (see below).
 - `pathItem` — fields on the `PathItem` itself (e.g. path-level
   `parameters`).
 
-Wildcards: use `"*"` as an operation key to apply the same override to
-every method on a path, or as a path key at the top of `overrides` to
-apply it to every path.
+Wildcards: use `"*"` as an operation key to apply the same override
+to every method on a path, or as a path key at the top of `overrides`
+to apply it to every path.
+
+#### Per-operation verbs
+
+- **`replace`** — wholesale swap of the `OperationObject`. Cannot be
+  combined with the additive / removal fields below in the same
+  operation override; setting both throws at apply time.
+- **`upsertParameters`** — append new parameters or replace existing
+  concrete entries by (`name`, `in`). `{ $ref: … }` parameters in the
+  base can't be matched without resolution; new parameters with the
+  same key append alongside refs rather than replacing them.
+- **`removeParameters`** — drop parameters by (`name`, `in`). Silent
+  no-op on missing entries (wildcards fan out to many operations).
+- **`requestBody`** — replace the request body entirely.
+- **`responses`** — merge by status code; override wins on clashes.
+- **`removeResponses`** — drop status codes. Silent no-op on missing.
+
+### `replace` — the nuclear option
+
+```ts
+const overlay: SpecOverlay = {
+  overrides: {
+    "/pets": {
+      operations: {
+        post: { replace: { responses: { "201": { description: "created" } } } },
+        // other methods on /pets untouched
+      },
+    },
+  },
+};
+```
+
+Use when the upstream `OperationObject` is so different from what
+your deployment serves that patching it piecewise is noisier than
+starting fresh.
 
 Runnable demo:
 [`examples/overlay-petstore-endpoint.ts`](./examples/overlay-petstore-endpoint.ts)
 — adds a gateway-required `X-Tenant` header to `POST /pets`.
-
-### `addPaths`
-
-Extends the `paths` map with new routes. Throws at apply time if the
-path already exists in the base document — use `overrides` for that
-case.
 
 ## Applying an overlay
 
@@ -118,25 +172,30 @@ document is deep-cloned — the input is never mutated.
   document. `loadSpec` inlines external refs first, then applies
   overlays; if you're calling `applyOverlays` directly, pass in a
   spec that has already been through `resolveSpec`.
-- **Reference-object parameters.** `addParameters` can only match
+- **Internal `$ref`s stay internal.** `#/components/...` refs aren't
+  inlined by the resolver, so editing an operation's response entry
+  in place doesn't affect other operations that reference the same
+  component — a handy way to augment one endpoint's response shape
+  via `allOf` + the shared `$ref` without mutating the shared
+  component for everyone else.
+- **Reference-object parameters.** `upsertParameters` can only match
   against concrete parameter entries for replacement purposes. A
   `{ $ref: "#/components/parameters/Tenant" }` in the base is left
   alone, and any new parameter with the same `name` + `in` appends
-  alongside rather than replacing.
+  alongside rather than replacing. `removeParameters` follows the
+  same rule.
 - **Multiple extensions to one schema.** Each overlay that targets
   the same schema name via `extendSchemas` adds a new `allOf` branch.
   The compiled validator runs every branch; they all have to pass.
-- **Conflicts fail fast.** `addPaths` adding an existing path, or
-  `overrides` targeting a missing path, throws at `applyOverlays`
-  time. This is intentional — you want to notice when the upstream
-  adds or removes a path you've referenced rather than have the
-  overlay silently no-op.
+- **Same-overlay conflicts fail fast.** `addPaths` + `removePaths`
+  naming the same path, or `replaceSchemas` + `removeSchemas` naming
+  the same schema, throws at apply time. Contradictory intents in a
+  single overlay are almost certainly bugs.
 
 ## Related
 
 - [`packages/spec/src/overlay.ts`](./packages/spec/src/overlay.ts) —
-  the implementation, including the full merge rules for each kind
-  of override.
+  the implementation, including the full merge rules for each verb.
 - [`examples/overlay-petstore-schema.ts`](./examples/overlay-petstore-schema.ts)
   and
   [`examples/overlay-petstore-endpoint.ts`](./examples/overlay-petstore-endpoint.ts)

--- a/examples/overlay-petstore-endpoint.ts
+++ b/examples/overlay-petstore-endpoint.ts
@@ -8,8 +8,8 @@
  * you overlay the requirement onto the operation at load time.
  *
  * `overrides` reaches into an existing path's operations and merges
- * per-operation fragments. `addParameters` appends new parameters or
- * replaces (by `name` + `in`) concrete existing ones. The upstream
+ * per-operation fragments. `upsertParameters` appends new parameters
+ * or replaces (by `name` + `in`) concrete existing ones. The upstream
  * body schema is untouched; only the parameter list changes.
  *
  * Run from the repo root:
@@ -51,7 +51,7 @@ const overlay: SpecOverlay = {
     "/pets": {
       operations: {
         post: {
-          addParameters: [
+          upsertParameters: [
             { name: "X-Tenant", in: "header", required: true, schema: { type: "string" } },
           ],
         },

--- a/examples/overlay.ts
+++ b/examples/overlay.ts
@@ -41,7 +41,7 @@ const overlay: SpecOverlay = {
     "/widgets": {
       operations: {
         get: {
-          addParameters: [
+          upsertParameters: [
             { name: "X-Request-Id", in: "header", required: true, schema: { type: "string" } },
           ],
         },

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -89,7 +89,7 @@ const overlay: SpecOverlay = {
     "/pets": {
       operations: {
         get: {
-          addParameters: [{ name: "X-Tenant", in: "header", schema: { type: "string" } }],
+          upsertParameters: [{ name: "X-Tenant", in: "header", schema: { type: "string" } }],
         },
       },
     },
@@ -97,7 +97,7 @@ const overlay: SpecOverlay = {
       // wildcard applies to every path
       operations: {
         post: {
-          addParameters: [{ name: "trace", in: "header", schema: { type: "string" } }],
+          upsertParameters: [{ name: "trace", in: "header", schema: { type: "string" } }],
         },
       },
     },

--- a/packages/spec/src/overlay.ts
+++ b/packages/spec/src/overlay.ts
@@ -2,6 +2,7 @@ import type {
   HttpMethod,
   OpenAPIDocument,
   OperationObject,
+  ParameterLocation,
   ParameterObject,
   PathItem,
   RequestBodyObject,
@@ -22,30 +23,59 @@ export interface PathOverride {
 }
 
 /**
- * Recipe for merging into a single {@link OperationObject}.
+ * Recipe for patching a single {@link OperationObject}. Each field is
+ * independent; use any subset. Supported verbs across the patchable
+ * slots are summarised below.
+ *
+ * Conflict rules applied by {@link applyOverlays}:
+ * - `replace` is wholesale and cannot be combined with the additive /
+ *   removal fields below. Setting both throws at apply time.
+ * - `removeParameters` / `removeResponses` silently no-op when the
+ *   target isn't present — wildcard overrides (`"*"`) fan out to many
+ *   operations and can't assume every target has the same surface.
  *
  * @public
  */
 export interface OperationOverride {
-  /** Parameters to add/replace. Replacement is by (`name`, `in`) pair. */
-  addParameters?: ParameterObject[];
+  /** Replace the whole OperationObject. Mutually exclusive with the additive / remove fields. */
+  replace?: OperationObject;
+  /**
+   * Add-or-replace parameters by (`name`, `in`). Existing entries with
+   * the same key are overwritten; anything else appends.
+   * Reference-object entries (`{ $ref: … }`) in the base can't be
+   * matched without resolution, so new parameters with the same key
+   * append alongside them rather than replacing.
+   */
+  upsertParameters?: ParameterObject[];
+  /** Remove parameters by (`name`, `in`). Silent no-op on missing entries. */
+  removeParameters?: Array<{ name: string; in: ParameterLocation }>;
   /** Replace the request body entirely. */
   requestBody?: RequestBodyObject;
-  /** Merge-by-key (status code) into responses. */
+  /** Merge-by-status-code into responses. Status codes present in both base and override take the override. */
   responses?: Record<string, ResponseObject>;
+  /** Remove response status codes. Silent no-op on missing entries. */
+  removeResponses?: string[];
 }
 
 /**
- * A spec overlay: instructions to patch the base OpenAPI document. Overlays
- * apply in order; later overlays win on conflict.
+ * A spec overlay: instructions to patch the base OpenAPI document.
+ * Overlays apply in order; later overlays win on conflict.
  *
  * @public
  */
 export interface SpecOverlay {
+  /** Add new paths. Throws if a target path already exists in the base document. */
   addPaths?: Record<string, PathItem>;
+  /** Remove paths. Throws if a target path isn't present in the base document. */
+  removePaths?: string[];
+  /** Per-path modifications; see {@link PathOverride}. */
   overrides?: Record<string, PathOverride>;
+  /** Extend a component schema via `allOf` (original + extension both apply). */
   extendSchemas?: Record<string, SchemaObject>;
+  /** Replace a component schema wholesale. */
   replaceSchemas?: Record<string, SchemaObject>;
+  /** Remove component schemas. Throws if a target schema isn't present. */
+  removeSchemas?: string[];
 }
 
 const METHODS: HttpMethod[] = ["get", "put", "post", "delete", "options", "head", "patch", "trace"];
@@ -73,21 +103,32 @@ export function applyOverlays(base: OpenAPIDocument, overlays: SpecOverlay[]): O
 }
 
 function applyOverlay(doc: OpenAPIDocument, overlay: SpecOverlay): OpenAPIDocument {
+  assertNoSelfConflict(overlay);
   const next: OpenAPIDocument = { ...doc };
+  const paths: Record<string, PathItem> = { ...next.paths };
+  let pathsChanged = false;
 
   if (overlay.addPaths) {
-    const paths: Record<string, PathItem> = { ...next.paths };
     for (const [path, item] of Object.entries(overlay.addPaths)) {
       if (paths[path] !== undefined) {
         throw new Error(`overlay conflict: path ${path} already exists in the base document`);
       }
       paths[path] = item;
+      pathsChanged = true;
     }
-    next.paths = paths;
+  }
+
+  if (overlay.removePaths) {
+    for (const path of overlay.removePaths) {
+      if (paths[path] === undefined) {
+        throw new Error(`overlay removePaths targets unknown path ${path}`);
+      }
+      delete paths[path];
+      pathsChanged = true;
+    }
   }
 
   if (overlay.overrides) {
-    const paths: Record<string, PathItem> = { ...next.paths };
     for (const [pathPattern, override] of Object.entries(overlay.overrides)) {
       const matches = pathPattern === "*" ? Object.keys(paths) : [pathPattern];
       for (const path of matches) {
@@ -96,12 +137,14 @@ function applyOverlay(doc: OpenAPIDocument, overlay: SpecOverlay): OpenAPIDocume
           throw new Error(`overlay override targets unknown path ${path}`);
         }
         paths[path] = applyPathOverride(item, override);
+        pathsChanged = true;
       }
     }
-    next.paths = paths;
   }
 
-  if (overlay.extendSchemas || overlay.replaceSchemas) {
+  if (pathsChanged) next.paths = paths;
+
+  if (overlay.extendSchemas || overlay.replaceSchemas || overlay.removeSchemas) {
     const components = { ...next.components };
     const schemas: Record<string, SchemaObject> = {
       ...((components.schemas ?? {}) as Record<string, SchemaObject>),
@@ -117,11 +160,49 @@ function applyOverlay(doc: OpenAPIDocument, overlay: SpecOverlay): OpenAPIDocume
     for (const [name, replacement] of Object.entries(overlay.replaceSchemas ?? {})) {
       schemas[name] = replacement;
     }
+    for (const name of overlay.removeSchemas ?? []) {
+      if (schemas[name] === undefined) {
+        throw new Error(`overlay removeSchemas targets unknown schema ${name}`);
+      }
+      delete schemas[name];
+    }
     components.schemas = schemas;
     next.components = components;
   }
 
   return next;
+}
+
+/**
+ * Hard-reject overlays whose own fields contradict each other before
+ * we start mutating anything. A contradictory overlay is almost
+ * certainly a consumer bug, and silently picking a winner would hide
+ * it; surfacing the conflict with a location message is cheaper.
+ */
+function assertNoSelfConflict(overlay: SpecOverlay): void {
+  if (overlay.addPaths && overlay.removePaths) {
+    for (const p of overlay.removePaths) {
+      if (p in overlay.addPaths) {
+        throw new Error(`overlay self-conflict: addPaths and removePaths both name ${p}`);
+      }
+    }
+  }
+  if (overlay.replaceSchemas && overlay.removeSchemas) {
+    for (const name of overlay.removeSchemas) {
+      if (name in overlay.replaceSchemas) {
+        throw new Error(
+          `overlay self-conflict: replaceSchemas and removeSchemas both name ${name}`,
+        );
+      }
+    }
+  }
+  if (overlay.extendSchemas && overlay.removeSchemas) {
+    for (const name of overlay.removeSchemas) {
+      if (name in overlay.extendSchemas) {
+        throw new Error(`overlay self-conflict: extendSchemas and removeSchemas both name ${name}`);
+      }
+    }
+  }
 }
 
 function applyPathOverride(item: PathItem, override: PathOverride): PathItem {
@@ -144,10 +225,27 @@ function applyPathOverride(item: PathItem, override: PathOverride): PathItem {
 }
 
 function applyOperationOverride(op: OperationObject, override: OperationOverride): OperationObject {
+  if (override.replace !== undefined) {
+    for (const key of [
+      "upsertParameters",
+      "removeParameters",
+      "requestBody",
+      "responses",
+      "removeResponses",
+    ] as const) {
+      if (override[key] !== undefined) {
+        throw new Error(
+          `overlay conflict: OperationOverride.replace cannot be combined with ${key}`,
+        );
+      }
+    }
+    return override.replace;
+  }
+
   const next: OperationObject = { ...op };
-  if (override.addParameters) {
+  if (override.upsertParameters) {
     const existing = [...(op.parameters ?? [])];
-    for (const newParam of override.addParameters) {
+    for (const newParam of override.upsertParameters) {
       // Reference-object entries (`{ $ref: … }`) can't be matched by
       // (name, in) without resolving them; overlays apply pre-resolve
       // so we just skip matching against refs and append / overwrite
@@ -160,9 +258,30 @@ function applyOperationOverride(op: OperationObject, override: OperationOverride
     }
     next.parameters = existing;
   }
+  if (override.removeParameters) {
+    const existing = next.parameters ?? op.parameters ?? [];
+    const filtered = existing.filter(
+      (p) =>
+        !("name" in p) ||
+        !override.removeParameters!.some((r) => r.name === p.name && r.in === p.in),
+    );
+    if (filtered.length !== existing.length) next.parameters = filtered;
+  }
   if (override.requestBody) next.requestBody = override.requestBody;
   if (override.responses) {
     next.responses = { ...op.responses, ...override.responses };
+  }
+  if (override.removeResponses) {
+    const source = next.responses ?? op.responses ?? {};
+    const copy: Record<string, (typeof source)[string]> = { ...source };
+    let removed = false;
+    for (const status of override.removeResponses) {
+      if (status in copy) {
+        delete copy[status];
+        removed = true;
+      }
+    }
+    if (removed) next.responses = copy;
   }
   return next;
 }

--- a/packages/spec/test/overlay.test.ts
+++ b/packages/spec/test/overlay.test.ts
@@ -43,14 +43,14 @@ describe("applyOverlays", () => {
     ).toThrow(/already exists/);
   });
 
-  it("overrides.addParameters appends, replacing same (name,in) pairs", () => {
+  it("overrides.upsertParameters appends new and replaces by (name, in)", () => {
     const patched = applyOverlays(base(), [
       {
         overrides: {
           "/pets": {
             operations: {
               get: {
-                addParameters: [
+                upsertParameters: [
                   { name: "limit", in: "query", schema: { type: "string" } },
                   { name: "X-Tenant", in: "header", schema: { type: "string" } },
                 ],
@@ -73,7 +73,9 @@ describe("applyOverlays", () => {
         overrides: {
           "*": {
             operations: {
-              get: { addParameters: [{ name: "trace", in: "header", schema: { type: "string" } }] },
+              get: {
+                upsertParameters: [{ name: "trace", in: "header", schema: { type: "string" } }],
+              },
             },
           },
         },
@@ -100,5 +102,109 @@ describe("applyOverlays", () => {
       { replaceSchemas: { Pet: { type: "string" } } },
     ]);
     expect(patched.components?.schemas?.["Pet"]).toEqual({ type: "string" });
+  });
+
+  it("removePaths drops the target path; missing target throws", () => {
+    const patched = applyOverlays(base(), [{ removePaths: ["/pets"] }]);
+    expect(patched.paths?.["/pets"]).toBeUndefined();
+
+    expect(() => applyOverlays(base(), [{ removePaths: ["/missing"] }])).toThrow(
+      /removePaths targets unknown path/,
+    );
+  });
+
+  it("removeSchemas drops the target schema; missing target throws", () => {
+    const patched = applyOverlays(base(), [{ removeSchemas: ["Pet"] }]);
+    expect(patched.components?.schemas?.["Pet"]).toBeUndefined();
+
+    expect(() => applyOverlays(base(), [{ removeSchemas: ["Missing"] }])).toThrow(
+      /removeSchemas targets unknown schema/,
+    );
+  });
+
+  it("addPaths + removePaths naming the same path in one overlay throws", () => {
+    expect(() =>
+      applyOverlays(base(), [
+        {
+          addPaths: { "/foo": { get: { responses: { "200": { description: "ok" } } } } },
+          removePaths: ["/foo"],
+        },
+      ]),
+    ).toThrow(/self-conflict/);
+  });
+
+  it("replaceSchemas + removeSchemas naming the same schema in one overlay throws", () => {
+    expect(() =>
+      applyOverlays(base(), [
+        { replaceSchemas: { Pet: { type: "string" } }, removeSchemas: ["Pet"] },
+      ]),
+    ).toThrow(/self-conflict/);
+  });
+
+  it("removeParameters drops by (name, in); missing entries silently no-op", () => {
+    const patched = applyOverlays(base(), [
+      {
+        overrides: {
+          "/pets": {
+            operations: {
+              get: {
+                removeParameters: [
+                  { name: "limit", in: "query" },
+                  { name: "nope", in: "header" }, // not present → no-op
+                ],
+              },
+            },
+          },
+        },
+      },
+    ]);
+    expect(patched.paths?.["/pets"]?.get?.parameters ?? []).toHaveLength(0);
+  });
+
+  it("removeResponses drops status codes; missing entries silently no-op", () => {
+    const patched = applyOverlays(base(), [
+      {
+        overrides: {
+          "/pets": {
+            operations: {
+              post: { removeResponses: ["201", "404"] },
+            },
+          },
+        },
+      },
+    ]);
+    const responses = patched.paths?.["/pets"]?.post?.responses ?? {};
+    expect(responses["201"]).toBeUndefined();
+    expect(Object.keys(responses)).not.toContain("404");
+  });
+
+  it("operation-level replace: wholesale swap; conflict with additive fields throws", () => {
+    const replacement = {
+      operationId: "listPets",
+      responses: { "200": { description: "fresh" } },
+    };
+    const patched = applyOverlays(base(), [
+      { overrides: { "/pets": { operations: { get: { replace: replacement } } } } },
+    ]);
+    expect(patched.paths?.["/pets"]?.get).toEqual(replacement);
+    // post unchanged
+    expect(patched.paths?.["/pets"]?.post?.responses?.["201"]).toBeDefined();
+
+    expect(() =>
+      applyOverlays(base(), [
+        {
+          overrides: {
+            "/pets": {
+              operations: {
+                get: {
+                  replace: replacement,
+                  upsertParameters: [{ name: "x", in: "header", schema: { type: "string" } }],
+                },
+              },
+            },
+          },
+        },
+      ]),
+    ).toThrow(/replace cannot be combined with upsertParameters/);
   });
 });


### PR DESCRIPTION
Closes #106.

## Summary

The overlay verb surface had accreted asymmetries — schemas could be extended and replaced but not removed; paths could be added but not removed; operations had no verbs at all; \`addParameters\` silently did \"add or replace by (name, in)\". This PR fills the matrix.

| Target | add | augment | replace | remove |
|---|---|---|---|---|
| Paths | \`addPaths\` | (via \`overrides\`) | (via \`overrides.replace\`) | **\`removePaths\`** |
| Component schemas | — | \`extendSchemas\` | \`replaceSchemas\` | **\`removeSchemas\`** |
| Operations | — | (additive) | **\`overrides.operations.<m>.replace\`** | (via \`removePaths\`) |
| Parameters (per op) | \`upsertParameters\` | — | \`upsertParameters\` | **\`removeParameters\`** |
| Request body | — | — | \`requestBody\` | — |
| Responses | \`responses\` | — | \`responses\` | **\`removeResponses\`** |

Bold = new in this PR.

## Conflict rules

- **Top-level remove targets throw on missing** — \`removePaths\`, \`removeSchemas\`. Stale overlay entries surface as errors; symmetric with the existing \`overrides\` throw-on-missing-path semantics.
- **Per-operation removes silently no-op on missing** — \`removeParameters\`, \`removeResponses\`. Wildcard overrides (\`\"*\"\`) fan out to operations that may not share the same surface.
- **\`OperationOverride.replace\` is wholesale.** Combining it with any additive / removal field in the same override throws.
- **Same-overlay self-conflicts throw** — e.g. \`addPaths\` + \`removePaths\` naming the same path.

## API change: \`addParameters\` → \`upsertParameters\`

Straight rename, no alias — package is pre-release, no external callers pinned on the old name. The behavior was always \"add-or-replace by (name, in)\"; the new name stops lying about it.

## Test plan

- [x] 7 new test cases in \`packages/spec/test/overlay.test.ts\` covering the new verbs, the self-conflict checks, and the wholesale-replace path.
- [x] Existing tests updated for the \`addParameters\` → \`upsertParameters\` rename; semantics unchanged.
- [x] \`pnpm test\` — 611 total (up from 604).
- [x] \`pnpm lint\` / \`pnpm typecheck\` / \`pnpm build\` green.

## Docs

- \`OVERLAYS.md\` rewritten with the verb matrix and per-verb sections, and a callout explaining the \"augment one endpoint's response without mutating a shared \`$ref\`\" pattern.
- \`packages/spec/README.md\` updated for the rename.
- \`examples/overlay.ts\` and \`examples/overlay-petstore-endpoint.ts\` updated for the rename.

## Non-goals

Nested \`{ add?, remove?, replace? }\` sub-object DSL (Option B from the design analysis), and JSON-Patch-style op-list (Option C). Left alone — the current flat-verb convention is readable and consumers can \`Ctrl-F\` one field name at a time.