### PR TITLE
feat(validator): getOperation introspection + examples/spec-digest.ts

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -328,6 +328,56 @@ rewritten to an "accept anything" schema before compile, so a Buffer
 or Uint8Array passes without a string-type error. `format: "byte"`
 (base64) still validates as a string.
 
+### Deriving middleware config from the spec
+
+Multer's `limits.fileSize` and the spec's `maxLength` on a
+`format: binary` field are two copies of the same number. To keep
+them from drifting, derive the middleware limit from the spec at
+startup:
+
+```ts
+import multer from "multer";
+import { createValidator } from "@aahoughton/oav";
+import { digestOperation } from "./spec-digest"; // copied from examples/spec-digest.ts
+
+const validator = createValidator(spec);
+
+const info = validator.getOperation({ method: "POST", path: "/uploads" });
+if (info === null) throw new Error("no matching operation for /uploads");
+
+const digest = digestOperation(info.operation);
+const maxBytes = digest.bodyLimits["multipart/form-data"]?.maxBytes;
+if (maxBytes === undefined) {
+  throw new Error("spec must declare `maxLength` on the upload's binary field");
+}
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: maxBytes },
+});
+
+app.post("/uploads", upload.any() /* validator + handler as above */);
+```
+
+`getOperation` returns the resolved, overlay-applied
+`OperationObject` for a (method, path) pair. It does the route-match
+
+- `$ref` resolution + overlay application that validation does, but
+  hands the result back as plain OpenAPI shapes — read whatever
+  declaration you need. `digestOperation` (see
+  [`examples/spec-digest.ts`](./examples/spec-digest.ts)) is a ~80-line
+  recipe that pulls the common middleware-config facts into a flat
+  shape: content types, body limits, required headers, security. Copy
+  it into your project and adjust the interpretation choices
+  (`maxLength`-as-bytes vs code points, which `x-*` extensions to
+  recognise, etc.) to fit your domain.
+
+The getter is startup-time introspection, not part of validation. Its
+job is to make the spec the single source of truth for middleware
+configuration — multer's `fileSize`, body-parser content types, auth
+middleware assertions — so duplicated magic numbers can't drift
+against the validator's own view.
+
 ### Streaming bodies, large uploads, and the `readBody` override
 
 The built-in `validateFetchRequest` reads the entire request body into

--- a/examples/spec-digest.ts
+++ b/examples/spec-digest.ts
@@ -1,0 +1,151 @@
+/**
+ * Example: derive middleware config from an OpenAPI spec at startup.
+ *
+ * `digestOperation` walks an {@link OperationObject} once and returns
+ * a small, flat object the calling code can match against its
+ * framework's configuration (multer limits, body-parser content
+ * types, auth-middleware expectations). One source of truth: the
+ * spec; the middleware reads it instead of hardcoding duplicates.
+ *
+ * This file is **documentation, not library API.** Copy it into your
+ * project and adapt the interpretation choices — what `maxLength`
+ * means on a binary field, which `x-*` extensions to recognise, how
+ * nested `properties` roll up — to match your domain. Keeping those
+ * decisions in application code (rather than in oav) avoids baking
+ * one team's conventions into every team's startup.
+ *
+ * Run from the repo root:
+ *   pnpm tsx examples/spec-digest.ts
+ */
+
+import type {
+  OpenAPIDocument,
+  OperationObject,
+  ParameterObject,
+  SchemaObject,
+  SecurityRequirementObject,
+} from "../packages/core/src/index.ts";
+import { createValidator } from "../packages/validator/src/index.ts";
+
+/**
+ * Flat summary of the declaration-time facts a handler wiring step
+ * usually needs. Extend with whatever your middleware cares about.
+ */
+export interface OperationDigest {
+  operationId?: string;
+  deprecated: boolean;
+  /** Media types declared on the operation's request body. */
+  requestContentTypes: string[];
+  /** Per content-type, the spec-declared body size ceiling (if any). */
+  bodyLimits: Record<string, { maxBytes?: number }>;
+  /** Required header parameters (by spec name). */
+  requiredHeaders: string[];
+  /**
+   * Security requirements: outer array is the OR-set of alternatives,
+   * inner array is the AND-set of scheme names within one alternative.
+   */
+  security: string[][];
+}
+
+export function digestOperation(op: OperationObject): OperationDigest {
+  return {
+    operationId: op.operationId,
+    deprecated: op.deprecated === true,
+    requestContentTypes: Object.keys(op.requestBody?.content ?? {}),
+    bodyLimits: bodyLimitsByMediaType(op),
+    requiredHeaders: (op.parameters ?? [])
+      .filter((p): p is ParameterObject => "name" in p && p.in === "header" && p.required === true)
+      .map((p) => p.name),
+    security: (op.security ?? []).map((req: SecurityRequirementObject) => Object.keys(req)),
+  };
+}
+
+/**
+ * Walk every media-type entry on the request body and pull out the
+ * smallest declared `maxLength` on a `format: binary` / `format: byte`
+ * field. Returns a map so consumers that send different content types
+ * to different middleware (multer for `multipart/form-data`,
+ * `express.raw()` for `application/octet-stream`) can look up each
+ * one independently.
+ */
+function bodyLimitsByMediaType(op: OperationObject): Record<string, { maxBytes?: number }> {
+  const out: Record<string, { maxBytes?: number }> = {};
+  for (const [mediaType, mto] of Object.entries(op.requestBody?.content ?? {})) {
+    out[mediaType] = { maxBytes: declaredMaxBytes(mto.schema) };
+  }
+  return out;
+}
+
+/**
+ * Recursive scan of a schema for a `maxLength` on a binary/byte
+ * field. `maxLength` on a `format: binary` field is the OpenAPI
+ * convention for byte-count; on a plain string it means code
+ * points. This recipe treats only the binary case as a byte ceiling
+ * — your domain may want to recognise an `x-max-bytes` extension, a
+ * custom annotation keyword, or something else entirely.
+ */
+function declaredMaxBytes(schema: SchemaObject | boolean | undefined): number | undefined {
+  if (!schema || typeof schema !== "object") return undefined;
+  if (
+    (schema.format === "binary" || schema.format === "byte") &&
+    typeof schema.maxLength === "number"
+  ) {
+    return schema.maxLength;
+  }
+  for (const child of Object.values(schema.properties ?? {})) {
+    const found = declaredMaxBytes(child as SchemaObject);
+    if (found !== undefined) return found;
+  }
+  if (schema.items !== undefined) {
+    const found = declaredMaxBytes(schema.items as SchemaObject);
+    if (found !== undefined) return found;
+  }
+  return undefined;
+}
+
+// ──── Demo: inline spec, digest, print ────────────────────────────
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const spec: OpenAPIDocument = {
+    openapi: "3.1.0",
+    info: { title: "Uploads", version: "1" },
+    components: {
+      securitySchemes: {
+        bearerAuth: { type: "http", scheme: "bearer" },
+      },
+    },
+    paths: {
+      "/uploads": {
+        post: {
+          operationId: "uploadDocument",
+          security: [{ bearerAuth: [] }],
+          parameters: [
+            { name: "X-Tenant", in: "header", required: true, schema: { type: "string" } },
+          ],
+          requestBody: {
+            required: true,
+            content: {
+              "multipart/form-data": {
+                schema: {
+                  type: "object",
+                  required: ["file"],
+                  properties: {
+                    file: { type: "string", format: "binary", maxLength: 10 * 1024 * 1024 },
+                  },
+                },
+              },
+            },
+          },
+          responses: { "201": { description: "created" } },
+        },
+      },
+    },
+  };
+
+  const validator = createValidator(spec);
+  const info = validator.getOperation({ method: "POST", path: "/uploads" });
+  if (info === null) throw new Error("no matching operation");
+
+  const digest = digestOperation(info.operation);
+  console.log(JSON.stringify(digest, null, 2));
+}

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -7,6 +7,7 @@ import {
   type OpenAPIDocument,
   type OpenAPIVersion,
   type OperationObject,
+  type PathItem,
   type ReferenceObject,
   type SchemaOrBoolean,
   type ValidationError,
@@ -137,6 +138,35 @@ export interface OavValidator {
     request: Request,
     response: Response,
   ): Promise<{ ok: true; body: T } | { ok: false; error: ValidationError }>;
+  /**
+   * Look up the effective operation declaration for a method + path.
+   * Returns the resolved (`$ref`s followed) and overlay-applied
+   * {@link OperationObject}, the matched path pattern, and the
+   * enclosing {@link PathItem}. Returns `null` when no operation
+   * matches (either the path doesn't match any template or the
+   * method isn't declared on it).
+   *
+   * Startup-time introspection, not a validation step: the spec is
+   * frozen at `createValidator` time, so this is safe to call once
+   * during application init and cache the result. Callers typically
+   * use it to derive middleware configuration (multer limits,
+   * accepted content types, required headers) from the same source
+   * of truth the validator uses.
+   *
+   * Uses the same per-operation cache the validation path uses;
+   * repeated calls are O(route-match) with no extra compilation.
+   *
+   * @example
+   * ```ts
+   * const info = validator.getOperation({ method: "POST", path: "/uploads" });
+   * const mediaTypes = Object.keys(info?.operation.requestBody?.content ?? {});
+   * ```
+   */
+  getOperation(req: { method: string; path: string }): {
+    pathPattern: string;
+    pathItem: PathItem;
+    operation: OperationObject;
+  } | null;
   /**
    * The OpenAPI version detected from the spec's `openapi` field, or
    * `undefined` when the field was missing/malformed and the validator
@@ -687,11 +717,29 @@ export function createValidator(
     return { ok: false, error };
   };
 
+  const getOperation = (req: {
+    method: string;
+    path: string;
+  }): { pathPattern: string; pathItem: PathItem; operation: OperationObject } | null => {
+    const match = router.match(req.method, req.path);
+    if (match === undefined || match.kind === "method-not-allowed") return null;
+    // Warm the per-operation cache so `getOperation` and subsequent
+    // validation share a single compiled plan. Doesn't force response
+    // compilation (still lazy on first `validateResponse`).
+    cacheFor(match);
+    return {
+      pathPattern: match.pathPattern,
+      pathItem: match.pathItem,
+      operation: match.operation,
+    };
+  };
+
   return {
     validateRequest,
     validateResponse,
     validateFetchRequest,
     validateFetchResponse,
+    getOperation,
     detectedVersion,
     stats,
   };

--- a/packages/validator/test/get-operation.test.ts
+++ b/packages/validator/test/get-operation.test.ts
@@ -1,0 +1,119 @@
+import type { OpenAPIDocument } from "@oav/core";
+import { describe, expect, it } from "vitest";
+import { applyOverlays } from "@oav/spec";
+import { createValidator } from "../src/validator.js";
+
+/**
+ * Startup-time introspection: `getOperation` returns the resolved +
+ * overlay-applied `OperationObject` for a (method, path) pair.
+ * Consumers use it to derive middleware config (multer limits,
+ * accepted content types, required headers) from the same source of
+ * truth the validator uses.
+ */
+
+function uploadSpec(): OpenAPIDocument {
+  return {
+    openapi: "3.1.0",
+    info: { title: "uploads", version: "1" },
+    paths: {
+      "/uploads": {
+        post: {
+          operationId: "uploadOne",
+          requestBody: {
+            required: true,
+            content: {
+              "multipart/form-data": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    file: { type: "string", format: "binary", maxLength: 2_000_000 },
+                  },
+                },
+              },
+            },
+          },
+          responses: { "201": { description: "ok" } },
+        },
+      },
+      "/items/{id}": {
+        get: {
+          operationId: "getItem",
+          parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+          responses: { "200": { description: "ok" } },
+        },
+      },
+    },
+  };
+}
+
+describe("OavValidator.getOperation", () => {
+  it("returns the operation + path metadata for a matching request", () => {
+    const v = createValidator(uploadSpec());
+    const info = v.getOperation({ method: "POST", path: "/uploads" });
+    expect(info).not.toBeNull();
+    expect(info?.pathPattern).toBe("/uploads");
+    expect(info?.operation.operationId).toBe("uploadOne");
+    const mediaTypes = Object.keys(info?.operation.requestBody?.content ?? {});
+    expect(mediaTypes).toEqual(["multipart/form-data"]);
+  });
+
+  it("returns null for an unknown path", () => {
+    const v = createValidator(uploadSpec());
+    expect(v.getOperation({ method: "GET", path: "/nope" })).toBeNull();
+  });
+
+  it("returns null for a path that matches but a method that isn't declared", () => {
+    const v = createValidator(uploadSpec());
+    // /items/{id} declares GET only.
+    expect(v.getOperation({ method: "DELETE", path: "/items/42" })).toBeNull();
+  });
+
+  it("resolves path templates: /items/42 matches /items/{id}", () => {
+    const v = createValidator(uploadSpec());
+    const info = v.getOperation({ method: "GET", path: "/items/42" });
+    expect(info?.pathPattern).toBe("/items/{id}");
+    expect(info?.operation.operationId).toBe("getItem");
+  });
+
+  it("reflects overlays applied before createValidator", () => {
+    const patched = applyOverlays(uploadSpec(), [
+      {
+        overrides: {
+          "/uploads": {
+            operations: {
+              post: {
+                upsertParameters: [
+                  {
+                    name: "X-Tenant",
+                    in: "header",
+                    required: true,
+                    schema: { type: "string" },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    ]);
+    const v = createValidator(patched);
+    const info = v.getOperation({ method: "POST", path: "/uploads" });
+    const headers = (info?.operation.parameters ?? []).filter(
+      (p) => "in" in p && p.in === "header",
+    );
+    expect(headers).toHaveLength(1);
+    expect(headers[0] && "name" in headers[0] ? headers[0].name : undefined).toBe("X-Tenant");
+  });
+
+  it("reads spec-declared body size limits for middleware wiring (multer-style)", () => {
+    const v = createValidator(uploadSpec());
+    const info = v.getOperation({ method: "POST", path: "/uploads" });
+    // The user walks the schema the way their middleware needs; the
+    // point of the getter is just that the walk sees the post-overlay
+    // operation without the consumer rediscovering path matching.
+    const schema = info?.operation.requestBody?.content["multipart/form-data"]?.schema as
+      | { properties?: { file?: { maxLength?: number } } }
+      | undefined;
+    expect(schema?.properties?.file?.maxLength).toBe(2_000_000);
+  });
+});


### PR DESCRIPTION
Closes #109.

## Summary

Adds \`validator.getOperation({ method, path })\` for startup-time introspection of the resolved + overlay-applied OperationObject, and ships \`examples/spec-digest.ts\` as the copy-and-adapt recipe for the common extraction pattern.

## API

\`\`\`ts
validator.getOperation({ method: \"POST\", path: \"/uploads\" });
// → { pathPattern, pathItem, operation } | null
\`\`\`

Reuses the per-operation cache that validation builds. Free after the first touch, no extra compilation, no performance impact on the request path.

## Motivating use case: multer limits

Spec declares \`maxLength: 2_000_000\` on a \`format: binary\` field; multer needs the same number as \`limits.fileSize\`. Today they're two copies that can drift. With this PR:

\`\`\`ts
const info = validator.getOperation({ method: \"POST\", path: \"/uploads\" });
const maxBytes = digestOperation(info.operation).bodyLimits[\"multipart/form-data\"]?.maxBytes;
const upload = multer({ limits: { fileSize: maxBytes } });
\`\`\`

One source of truth, multer reads from it. INTEGRATION.md has the full wiring pattern under a new \"Deriving middleware config from the spec\" section.

## Why a getter, not specialized helpers

\`operationLimits()\` / \`requiredHeaders()\` / \`acceptedMediaTypes()\` would each bake oav's interpretation of a domain choice (what does \`maxLength\` mean on a binary field? bytes or code points? which \`x-*\` extensions count?) into the library surface. The single getter lets consumers read whatever declaration they need while keeping interpretation in application code where it can evolve.

## examples/spec-digest.ts

The recipe (~100 lines) walks an OperationObject and returns \`{ operationId, deprecated, requestContentTypes, bodyLimits, requiredHeaders, security }\`. **Doc, not API** — shipped in \`examples/\` so it's versioned with the docs, not SemVer'd with the package. Consumers copy into their project and own the interpretation choices. If one team's recipe starts looking like everyone else's, that's evidence to promote later.

## Test plan

- [x] 6 new tests for \`getOperation\` covering: matching operations, unknown path (null), method-not-allowed (null), path template resolution (\`/items/42\` → \`/items/{id}\`), overlay reflection, and the multer-limit extraction pattern.
- [x] \`pnpm test\` — 617 total (up from 611).
- [x] \`pnpm lint\` / \`pnpm typecheck\` / \`pnpm build\` green.
- [x] \`examples/spec-digest.ts\` runs end-to-end via \`npx tsx\` and prints the expected digest against an inline spec.

## Docs

- INTEGRATION.md: new \"Deriving middleware config from the spec\" section, placed next to the existing \"File uploads with multer\" recipe, with a concrete wiring example that reads \`maxBytes\` from the spec and passes it to multer.