### PR TITLE
feat: add httpStatusFor + allowHeaderFor helpers; documentation pass

### DIFF
--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -3,14 +3,12 @@
 Ajv is the canonical JSON Schema validator for JavaScript, and
 `express-openapi-validator` is the most widely-used middleware built
 on top of it. Together they cover most real-world OpenAPI validation
-in the ecosystem and have done so for years. This document is not a
-pitch against them — it's an honest map of what each project does so
-you can pick the one that fits.
+in the ecosystem and have done so for years. This document maps what
+each project does so you can pick the one that fits.
 
-For most users, oav sits in roughly the same feature territory as
-Ajv + `express-openapi-validator` combined: schema validation plus
-HTTP-layer checks. The two projects pull in different directions on a
-handful of specifics; those are catalogued below.
+oav covers the same ground as Ajv + `express-openapi-validator`
+combined — schema validation plus HTTP-layer checks — and trades
+differently on a handful of specifics, catalogued below.
 
 This document is about behaviour and capabilities. For runtime
 performance, see [`performance/README.md`](./performance/README.md),
@@ -22,23 +20,23 @@ Capabilities that the Ajv stack covers and oav does not.
 
 - **Multiple JSON Schema drafts.** Ajv supports draft-04, draft-06,
   draft-07, draft-2019-09, 2020-12, and JTD. oav compiles 2020-12 and
-  OpenAPI 3.0's constrained dialect; earlier drafts aren't on the
-  roadmap.
+  OpenAPI 3.0's constrained dialect only; earlier drafts and JTD are
+  not supported.
 - **Data-mutating options.** `coerceTypes`, `removeAdditional`, and
   `useDefaults` let Ajv mutate the validated value in place — coercing
   strings to numbers, stripping undeclared properties, filling missing
   properties from `default`. oav treats validation as a yes/no
   question and does not mutate inputs.
-- **Standalone code generation.** Ajv ships a programmatic
+- **Ahead-of-time code generation.** Ajv ships a programmatic
   `standaloneCode` API plus Node APIs that emit compiled validators
   as module source. oav ships a CLI equivalent (`oav compile
 schema.json -o v.mjs`) that covers the edge-runtime / build-time-
   bundling story for a single JSON Schema at a time. Ajv's
   programmatic surface is richer — batch emission, multiple schemas
-  per file, CommonJS output — and oav's emitted module still imports
-  runtime helpers from `@aahoughton/oav/*` rather than being fully
-  self-contained. For most "prepare a validator at build time" use
-  cases the CLI is enough.
+  per file, CommonJS output — and Ajv's output can be made fully
+  self-contained; oav's emitted module imports runtime helpers from
+  `@aahoughton/oav/*`. For most "prepare a validator at build time"
+  use cases the CLI is enough.
 - **Named schema registry.** `addSchema` / `getSchema` / `removeSchema`
   give Ajv a name-to-validator map that cross-schema `$ref`s resolve
   through. oav accepts an `external: Map<string, Schema>` on
@@ -94,10 +92,10 @@ Capabilities oav has that Ajv (alone or with
   without forking or preprocessing the upstream file.
 - **Structured error tree.** Errors preserve the applicator structure
   (`oneOf` with per-branch `children`, `allOf` with failed-conjunct
-  children). HTTP consumers can group by location and inspect which
-  branch of a composition failed. Ajv emits a flat errors array; the
-  tree vs flat choice is a philosophical one, not a capability gap in
-  either direction.
+  children). HTTP consumers can group by HTTP location
+  (`body.items[3].name`, `query.limit`) and inspect which branch of a
+  composition failed without parsing message strings. Ajv emits a
+  flat errors array.
 - **Predicate mode.** `compileSchema(schema, { predicate: true })`
   returns `{ validate: (x) => boolean }`. No error tree construction,
   no path snapshotting, no accumulator allocation. Ajv's
@@ -146,10 +144,10 @@ have equivalents in-tree; the two capability libraries (`fast-uri`,
 
 ## Summary
 
-For most users, oav and Ajv + `express-openapi-validator` are
-substitutable: both validate OpenAPI requests and responses by 3.0 /
-3.1 / 3.2 rules, both support custom keywords and formats, both
-produce machine-readable errors. Differences are real but bounded.
+oav and Ajv + `express-openapi-validator` cover the same ground: both
+validate OpenAPI requests and responses by 3.0 / 3.1 / 3.2 rules,
+both support custom keywords and formats, both produce
+machine-readable errors. Differences are real but bounded.
 
 Pick Ajv + `express-openapi-validator` when you want the fastest
 validator, a large userbase, multi-draft support, or the one-line

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,21 +65,3 @@ Releases are automated. You don't bump versions or tag manually.
 3. When you're ready to release, merge that PR. Release-please tags
    the commit, creates a GitHub Release, and the publish workflow
    pushes the package to npm.
-
-## Manual one-time GitHub setup
-
-Some things can't live in-repo:
-
-- **Branch protection on `main`**: require PR, require status checks
-  (`ci / lint`, `ci / typecheck`, `ci / test (22)`, `ci / test (24)`,
-  `ci / build`, `ci / conformance`, `ci / pack-smoke`,
-  `pr-title / lint`), require branches up-to-date, disallow
-  force-push, linear history.
-- **Secret**: `NPM_TOKEN` — an automation token from
-  `npmjs.com/settings/<you>/tokens` with publish scope for
-  `@aahoughton/*`.
-- **Repo → Settings → Actions → General → Workflow permissions**:
-  default is "Read", plus enable "Allow GitHub Actions to create and
-  approve pull requests" (needed for release-please to open its
-  release PR). Individual workflows grant themselves write scopes via
-  their `permissions:` blocks.

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -210,10 +210,16 @@ you want `application/problem+json` for those too.
 
 ### Next.js (App Router), Hono, Bun, Deno
 
-These frameworks expose a Web Standards `Request` per route, and there
-is no middleware chain to hang a one-time adapter off. Use
-`validator.validateFetchRequest` directly in each route handler. It
-reads `request.url`, `request.headers`, and the body (dispatching on
+These frameworks dispatch to Web Standards `Request` handlers per
+route. Each also has a cross-cutting hook — Next.js's `proxy.ts`
+(renamed from `middleware.ts` in Next 16; both still work), Hono's
+`app.use('*', ...)`, Bun / Deno framework-specific hooks — so you
+can pick. Use per-route when you want the `<Body>` generic to flow
+into the typed success branch; use the cross-cutting hook when you'd
+rather register the adapter once.
+
+Per-route form with `validator.validateFetchRequest<T>`. It reads
+`request.url`, `request.headers`, and the body (dispatching on
 `Content-Type`: JSON, `*+json`, URL-encoded, multipart, text, or raw
 bytes) and returns a discriminated union.
 
@@ -254,10 +260,40 @@ Three things to know:
   `?ids=1&ids=2` into `query.ids = ["1", "2"]`. Single values stay
   strings.
 
-**Next.js-specific note.** Validate inside the route handler, not
-in the top-level `middleware.ts` — validation needs the matched
-operation and the parsed body, and both are only known once the
-request reaches its route.
+**Next.js — cross-cutting alternative.** `proxy.ts` (or
+`middleware.ts` on Next 15) runs on every request. Since Next 15
+middleware supports the Node runtime and Next buffers the body,
+you can put the adapter there instead:
+
+```ts
+// proxy.ts (Next 16+) / middleware.ts (Next 15)
+import { allowHeaderFor, httpStatusFor, toProblemDetails } from "@aahoughton/oav";
+import { NextResponse, type NextRequest } from "next/server";
+import { validator } from "@/lib/validator";
+
+export const config = {
+  runtime: "nodejs",
+  matcher: "/:path*",
+};
+
+export async function middleware(request: NextRequest) {
+  const result = await validator.validateFetchRequest(request);
+  if (result.ok) return NextResponse.next();
+  const allow = allowHeaderFor(result.error);
+  const headers: Record<string, string> = { "Content-Type": "application/problem+json" };
+  if (allow !== undefined) headers["Allow"] = allow;
+  return new NextResponse(
+    JSON.stringify(toProblemDetails(result.error, { instance: request.url })),
+    { status: httpStatusFor(result.error), headers },
+  );
+}
+```
+
+Pick one: per-route gives you `<T>`-typed bodies; the cross-cutting
+hook gives you one-and-done registration but the handler doesn't see
+a typed body (middleware and handler both read the request, and Next
+clones between them — but the per-route handler can't know what the
+middleware validated).
 
 **Fully bespoke body handling.** If the built-in body parsing doesn't
 fit (e.g. you want to stream-process a large JSON payload or handle
@@ -271,9 +307,40 @@ const { httpRequest } = await httpRequestFromFetch(request);
 const err = validator.validateRequest(httpRequest);
 ```
 
-Hono has `.use()` middleware and can use the Express-style adapter
-above if you prefer a single registration point. The per-route
-`validateFetchRequest` still wins on generic-driven body typing.
+**Hono — cross-cutting alternative.** `app.use('*', mw)` can host
+the adapter. Hono parallels the per-route Standard-Schema validator
+pattern (`@hono/zod-validator` etc.), so per-route with a typed
+`<T>` is the native idiom and `c.req.valid('json')` is the
+community muscle memory; oav's `validateFetchRequest<T>` slots into
+the same shape via `c.req.raw`.
+
+**Hono gotcha**: `c.req.raw.body` is a one-shot stream. Don't run
+`validateFetchRequest` in BOTH global middleware AND a per-route
+handler on the same request — the handler's call sees a consumed
+body and fails. Pick one. If using global middleware, stash the
+validated body for handlers:
+
+```ts
+const app = new Hono<{ Variables: { validatedBody: unknown } }>();
+app.use("*", async (c, next) => {
+  const result = await validator.validateFetchRequest(c.req.raw);
+  if (result.ok) {
+    c.set("validatedBody", result.body);
+    return next();
+  }
+  // ...problem+json response
+});
+app.post("/pets", (c) => {
+  const body = c.get("validatedBody") as CreatePet;
+  return c.json({ id: "pet_1", name: body.name }, 201);
+});
+```
+
+**Bun / Deno.** Pick a framework (Hono, Elysia on Bun; Hono, Oak on
+Deno) and use its hook idiom — same guidance as above, just under a
+different name. For a raw `Bun.serve` / `Deno.serve` handler,
+`validateFetchRequest` is the natural fit; there's no hook layer to
+register against.
 
 **Validating upstream responses.** The symmetric method
 `validateFetchResponse(request, response)` runs the response side of

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -74,38 +74,32 @@ children hang off `body`, `query.<name>`, `headers.<name>`, etc.
 
 ## Supporting helpers used below
 
-The framework adapters share two helpers:
+Both shipped from `@aahoughton/oav`:
 
-- **`httpStatusFor(err)`** — maps a `ValidationError`'s `code` to the
-  right HTTP status. Define it once and reuse across handlers; the
-  [Status-code mapping recipe](#status-code-mapping) shows the full
-  switch. A minimal version:
+- **`httpStatusFor(err, overrides?)`** — maps a `ValidationError`
+  tree to an HTTP status: `route` → 404, `method` → 405, `security`
+  (leaf) → 401, `content-type` (leaf) → 415, `status` (leaf) → 500,
+  everything else → 400. Pass `{ default: 422 }` (or any other key)
+  to override a slot. The helper inspects the tree correctly —
+  writing this switch by hand is a common mistake, because
+  `"content-type"` / `"security"` / `"status"` appear as leaves
+  under a top-level `"request"` / `"response"` branch, not as
+  `err.code` directly.
 
-  ```ts
-  import type { ValidationError } from "@aahoughton/oav";
+- **`allowHeaderFor(err)`** — returns the `Allow` header value for a
+  405 (RFC 9110 §15.5.6 requires it) or `undefined` otherwise.
 
-  const httpStatusFor = (err: ValidationError): number =>
-    err.code === "route"
-      ? 404
-      : err.code === "method"
-        ? 405
-        : err.code === "content-type"
-          ? 415
-          : err.code === "security"
-            ? 401
-            : err.code === "status"
-              ? 500
-              : 400;
-  ```
-
-- **`toProblemDetails(err, opts?)`** — imported from
-  `@aahoughton/oav`; renders the error tree as an
+- **`toProblemDetails(err, opts?)`** — renders the error tree as an
   [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html)
   `application/problem+json` body with the failing leaves carried in
   an `issues` field (a non-standard field alongside the required
   ones).
 
-The adapters below assume both are in scope.
+```ts
+import { allowHeaderFor, httpStatusFor, toProblemDetails } from "@aahoughton/oav";
+```
+
+The adapters below assume all three are in scope.
 
 ## Framework adapters
 
@@ -115,7 +109,7 @@ Express 5 is promise-native: async middleware that throws routes to
 the error handler automatically.
 
 ```ts
-import { toProblemDetails } from "@aahoughton/oav";
+import { allowHeaderFor, httpStatusFor, toProblemDetails } from "@aahoughton/oav";
 
 app.use(async (req, res, next) => {
   const err = validator.validateRequest({
@@ -128,6 +122,8 @@ app.use(async (req, res, next) => {
     cookies: req.cookies,
   });
   if (err === null) return next();
+  const allow = allowHeaderFor(err);
+  if (allow !== undefined) res.setHeader("Allow", allow);
   res
     .status(httpStatusFor(err))
     .type("application/problem+json")
@@ -137,6 +133,21 @@ app.use(async (req, res, next) => {
 
 Requires `express.json()` registered before this middleware (and
 `cookie-parser` if you use the `cookies` field).
+
+**Two known sharp edges with stock `express.json()`:**
+
+1. **`express.json()` only parses JSON content-types.** If a client
+   sends `Content-Type: text/plain` (or anything else your spec
+   doesn't declare), `req.body` is left empty and oav reports
+   "missing required request body" rather than a 415. To get
+   accurate 415 responses, register `express.raw({ type: '*/*' })`
+   on the non-JSON content types you want oav to gate, or parse
+   the body yourself in middleware and hand it to `validateRequest`.
+2. **Malformed JSON throws before oav runs.** `express.json()`
+   throws a `SyntaxError` on bad JSON, and Express's default error
+   handler emits an HTML page. Install an Express error middleware
+   to convert it to `application/problem+json` upstream of the
+   validator.
 
 ### Express 4
 
@@ -149,6 +160,8 @@ app.use((req, res, next) => {
   try {
     const err = validator.validateRequest(/* same as Express 5 */);
     if (err === null) return next();
+    const allow = allowHeaderFor(err);
+    if (allow !== undefined) res.setHeader("Allow", allow);
     res
       .status(httpStatusFor(err))
       .type("application/problem+json")
@@ -158,6 +171,8 @@ app.use((req, res, next) => {
   }
 });
 ```
+
+The same two body-parser caveats apply as for Express 5.
 
 ### Fastify
 
@@ -176,6 +191,8 @@ fastify.addHook("preValidation", async (request, reply) => {
     body: request.body,
   });
   if (err !== null) {
+    const allow = allowHeaderFor(err);
+    if (allow !== undefined) reply.header("Allow", allow);
     return reply
       .code(httpStatusFor(err))
       .type("application/problem+json")
@@ -186,7 +203,10 @@ fastify.addHook("preValidation", async (request, reply) => {
 
 Fastify parses JSON bodies automatically; for other formats register
 the appropriate content-type parser (`@fastify/formbody`, etc.)
-ahead of the hook.
+ahead of the hook. Fastify's own JSON-parse-error response (shape:
+`{ statusCode, code: "FST_ERR_CTP_INVALID_JSON_BODY", ... }`) fires
+before `preValidation` runs; register `fastify.setErrorHandler` if
+you want `application/problem+json` for those too.
 
 ### Next.js (App Router), Hono, Bun, Deno
 
@@ -199,18 +219,20 @@ bytes) and returns a discriminated union.
 
 ```ts
 // app/pets/route.ts
-import { toProblemDetails } from "@aahoughton/oav";
+import { allowHeaderFor, httpStatusFor, toProblemDetails } from "@aahoughton/oav";
 import { validator } from "@/lib/validator";
-import { httpStatusFor } from "@/lib/status";
 
 type CreatePet = { name: string; tag?: string };
 
 export async function POST(request: Request) {
   const result = await validator.validateFetchRequest<CreatePet>(request);
   if (!result.ok) {
+    const allow = allowHeaderFor(result.error);
+    const headers: Record<string, string> = { "Content-Type": "application/problem+json" };
+    if (allow !== undefined) headers["Allow"] = allow;
     return Response.json(toProblemDetails(result.error, { instance: request.url }), {
       status: httpStatusFor(result.error),
-      headers: { "Content-Type": "application/problem+json" },
+      headers,
     });
   }
   const { body } = result; // typed as CreatePet
@@ -276,50 +298,60 @@ updating the document.
 
 ### Status-code mapping
 
-`ValidationError.code` is stable and small. Most users can get by
-with this:
+Use `httpStatusFor` from `@aahoughton/oav`:
 
 ```ts
-import type { ValidationError } from "@aahoughton/oav";
+import { httpStatusFor, toProblemDetails } from "@aahoughton/oav";
 
-function httpStatusFor(err: ValidationError): number {
-  switch (err.code) {
-    case "route":
-      return 404; // no path template matched
-    case "method":
-      return 405; // path matched but the verb isn't declared
-    case "content-type":
-      return 415; // request Content-Type not declared
-    case "security":
-      return 401; // declared security scheme isn't satisfied (shape check)
-    case "status":
-      return 500; // response-side: spec doesn't declare this status
-    default:
-      return 400; // schema violation, missing required, etc.
-  }
+const err = validator.validateRequest(httpRequest);
+if (err !== null) {
+  res
+    .status(httpStatusFor(err))
+    .type("application/problem+json")
+    .json(toProblemDetails(err, { instance: req.originalUrl }));
 }
 ```
 
-RFC 9110 requires the `Allow` response header on 405s. The `method`
-error's `params.allowed` is the uppercased list to send back:
+Default mapping:
+
+| `err` shape                     | Status |
+| ------------------------------- | ------ |
+| top-level `code: "route"`       | 404    |
+| top-level `code: "method"`      | 405    |
+| any leaf `code: "security"`     | 401    |
+| any leaf `code: "content-type"` | 415    |
+| any leaf `code: "status"`       | 500    |
+| otherwise                       | 400    |
+
+Override any slot with the second argument — e.g. APIs that use 422
+for schema errors:
 
 ```ts
-if (err.code === "method") {
-  const p = err.params as ErrorParamsFor<"method">;
-  res.setHeader("Allow", p.allowed.join(", "));
-  res
-    .status(405)
-    .type("application/problem+json")
-    .json(toProblemDetails(err, { instance: req.originalUrl }));
-  return;
-}
+httpStatusFor(err, { default: 422 });
+```
+
+Why not write the switch by hand? The obvious `switch (err.code)`
+misses `content-type`, `security`, and `status` — those codes are
+leaves under a top-level `"request"` / `"response"` wrapper, not the
+top-level code itself. `httpStatusFor` handles the tree shape
+correctly.
+
+RFC 9110 requires the `Allow` response header on 405s. Use
+`allowHeaderFor` to get the comma-joined value:
+
+```ts
+import { allowHeaderFor } from "@aahoughton/oav";
+
+const allow = allowHeaderFor(err);
+if (allow !== undefined) res.setHeader("Allow", allow);
 ```
 
 For richer response envelopes, `toProblemDetails` produces
 [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html)
 `application/problem+json` with the failing leaves as an `issues`
-extension member. `collectIssues` is the raw flat leaf list if you
-want to roll your own response shape.
+field (a non-standard field alongside the required ones).
+`collectIssues` is the raw flat leaf list if you want to roll your
+own response shape.
 
 ### File uploads with multer
 
@@ -329,7 +361,7 @@ body for the validator call.
 
 ```ts
 import multer from "multer";
-import { createValidator, toProblemDetails } from "@aahoughton/oav";
+import { createValidator, httpStatusFor, toProblemDetails } from "@aahoughton/oav";
 
 const upload = multer({ storage: multer.memoryStorage() });
 

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -32,8 +32,8 @@ where needed. In exchange:
 - **Built-in OpenAPI 3.0 dialect.** `nullable: true`, boolean
   `exclusiveMaximum`, and `$ref`-suppresses-siblings are in the
   compiler's dialect dispatch — no preprocessing step. See the
-  [conformance report](./conformance/REPORT.md) for the cases we
-  match and the ones we don't.
+  [conformance report](./conformance/REPORT.md) for pass / fail
+  counts by category.
 - **Overlays.** Extend an externally-owned base spec (Supabase,
   Hasura, PocketBase, a gateway-published document) with
   `applyOverlays` at load time. See [OVERLAYS.md](./OVERLAYS.md).
@@ -72,6 +72,41 @@ Both methods return `null` on success or a `ValidationError` tree on
 failure. The top-level node's `code` is `"request"` or `"response"`;
 children hang off `body`, `query.<name>`, `headers.<name>`, etc.
 
+## Supporting helpers used below
+
+The framework adapters share two helpers:
+
+- **`httpStatusFor(err)`** — maps a `ValidationError`'s `code` to the
+  right HTTP status. Define it once and reuse across handlers; the
+  [Status-code mapping recipe](#status-code-mapping) shows the full
+  switch. A minimal version:
+
+  ```ts
+  import type { ValidationError } from "@aahoughton/oav";
+
+  const httpStatusFor = (err: ValidationError): number =>
+    err.code === "route"
+      ? 404
+      : err.code === "method"
+        ? 405
+        : err.code === "content-type"
+          ? 415
+          : err.code === "security"
+            ? 401
+            : err.code === "status"
+              ? 500
+              : 400;
+  ```
+
+- **`toProblemDetails(err, opts?)`** — imported from
+  `@aahoughton/oav`; renders the error tree as an
+  [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html)
+  `application/problem+json` body with the failing leaves carried in
+  an `issues` field (a non-standard field alongside the required
+  ones).
+
+The adapters below assume both are in scope.
+
 ## Framework adapters
 
 ### Express 5
@@ -101,9 +136,7 @@ app.use(async (req, res, next) => {
 ```
 
 Requires `express.json()` registered before this middleware (and
-`cookie-parser` if you use the `cookies` field). `httpStatusFor`
-is the one-line mapping function from the
-[status-code mapping recipe](#status-code-mapping).
+`cookie-parser` if you use the `cookies` field).
 
 ### Express 4
 
@@ -199,9 +232,10 @@ Three things to know:
   `?ids=1&ids=2` into `query.ids = ["1", "2"]`. Single values stay
   strings.
 
-**Next.js-specific note.** The top-level `middleware.ts` runs on the
-Edge runtime and doesn't know which route matched yet. Validate
-inside the route handler, not in `middleware.ts`.
+**Next.js-specific note.** Validate inside the route handler, not
+in the top-level `middleware.ts` — validation needs the matched
+operation and the parsed body, and both are only known once the
+request reaches its route.
 
 **Fully bespoke body handling.** If the built-in body parsing doesn't
 fit (e.g. you want to stream-process a large JSON payload or handle
@@ -360,17 +394,16 @@ app.post("/uploads", upload.any() /* validator + handler as above */);
 ```
 
 `getOperation` returns the resolved, overlay-applied
-`OperationObject` for a (method, path) pair. It does the route-match
-
-- `$ref` resolution + overlay application that validation does, but
-  hands the result back as plain OpenAPI shapes — read whatever
-  declaration you need. `digestOperation` (see
-  [`examples/spec-digest.ts`](./examples/spec-digest.ts)) is a ~80-line
-  recipe that pulls the common middleware-config facts into a flat
-  shape: content types, body limits, required headers, security. Copy
-  it into your project and adjust the interpretation choices
-  (`maxLength`-as-bytes vs code points, which `x-*` extensions to
-  recognise, etc.) to fit your domain.
+`OperationObject` for a (method, path) pair. It does the same
+route-match + `$ref` resolution + overlay application that validation
+does, but hands the result back as plain OpenAPI shapes — read
+whatever declaration you need. `digestOperation` (see
+[`examples/spec-digest.ts`](./examples/spec-digest.ts)) is a recipe
+that pulls the common middleware-config facts into a flat shape:
+content types, body limits, required headers, security. Copy it into
+your project and adjust the interpretation choices
+(`maxLength`-as-bytes vs code points, which `x-*` extensions to
+recognise, etc.) to fit your domain.
 
 The getter is startup-time introspection, not part of validation. Its
 job is to make the spec the single source of truth for middleware
@@ -528,31 +561,26 @@ you want schema checks only.
 `express-openapi-validator`'s `securityHandlers` is a _credential-
 verifying_ dispatch table — you supply an auth function per scheme and
 eov calls it. `oav` has no equivalent; that role stays with your auth
-middleware. A ~30-line function that walks the matched operation's
-`security` array and dispatches per scheme replaces it if you want the
-declarative shape.
+middleware. If you want the declarative shape, write a small function
+that walks the matched operation's `security` array (via
+`validator.getOperation`) and dispatches per scheme.
 
 ### Type coercion on body fields
 
 Neither validator coerces `{"age": "42"}` to `{"age": 42}` on request
-bodies by default; `express-openapi-validator` has
-`validateRequests.coerceTypes` for this, `oav` doesn't.
+bodies by default; `express-openapi-validator` has a
+`validateRequests.coerceTypes` option for this, `oav` has no
+equivalent.
 
 Query parameters are different: `oav` auto-coerces scalar query
 params per their declared type (`type: integer` → `Number(raw)`,
 `type: boolean` → `true`/`false`). Only bodies are strict.
 
-If you need loose body coercion, do it in a pre-middleware:
-
-```ts
-app.use(
-  express.json({
-    reviver: (key, value) => {
-      /* your coercion */ return value;
-    },
-  }),
-);
-```
+If you need loose body coercion, coerce in your handler after
+parsing but before calling downstream logic, or in an
+`express.json({ reviver })` callback wired per route. Both keep the
+coercion decision out of the validator and in the code that
+understands your wire format.
 
 ### Ignoring paths not in the spec
 
@@ -592,27 +620,54 @@ app.use(async (req, res, next) => {
 
 ### Option map
 
-| `express-openapi-validator` option      | `oav` equivalent                                                                                                                  |
-| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `apiSpec` (path/URL/object)             | `loadSpec({ reader, entry })` + `createValidator(doc)`                                                                            |
-| `validateRequests: true`                | `validator.validateRequest(...)` in your middleware                                                                               |
-| `validateResponses: true`               | `validator.validateResponse(...)` in handler or a `res.json` wrapper (see recipes)                                                |
-| `validateRequests.allErrors`            | Default — `oav` always collects every leaf. Bound cost with `maxErrors: N`.                                                       |
-| `validateRequests.coerceTypes`          | Query scalars coerced by default; body coercion not supported.                                                                    |
-| `validateRequests.removeAdditional`     | Not supported. `additionalProperties: false` rejects; there is no silent-drop mode.                                               |
-| `validateRequests.discriminator`        | Native, always on for OpenAPI specs.                                                                                              |
-| `formats`                               | `createValidator(spec, { formats: { ... } })` — see [format-shape note](#format-shape-note) below.                                |
-| `validateFormats: "fast" \| "full"`     | N/A — single-pass validation; the built-in formats are RFC-sourced.                                                               |
-| `ajvFormats`                            | Pass custom format functions via the `formats` option — see [format-shape note](#format-shape-note) below.                        |
-| `serDes`                                | Not supported. Pre- or post-transform the payload in your handler if you need `Date` / `ObjectId` / etc.                          |
-| `validateSecurity: true`                | Default — shape-only checks for `bearer` / `basic` / `apiKey`. Opt out with `createValidator(spec, { validateSecurity: false })`. |
-| `validateSecurity.handlers`             | Your own auth middleware, run before the validator — `oav` only checks credential **shape**, not validity.                        |
-| `fileUploader: true`                    | Your own multer middleware (see [recipe](#file-uploads-with-multer)).                                                             |
-| `operationHandlers`                     | Your own Express routes. `oav` doesn't auto-load handlers from the filesystem.                                                    |
-| `ignorePaths` (regex/fn)                | Short-circuit in your middleware before calling `validateRequest`.                                                                |
-| `ignoreUndocumented`                    | `if (err.code === "route") return next()`.                                                                                        |
-| `$refParser: "bundle" \| "dereference"` | `loadSpec` inlines external refs; circulars become internal refs. Use `resolveSpec` directly for finer control.                   |
-| `validateApiSpec`                       | Run `oav resolve spec.yaml` in CI; no runtime toggle.                                                                             |
+#### Spec loading
+
+| `express-openapi-validator` option      | `oav` equivalent                                                                                                |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `apiSpec` (path/URL/object)             | `loadSpec({ reader, entry })` + `createValidator(doc)`                                                          |
+| `$refParser: "bundle" \| "dereference"` | `loadSpec` inlines external refs; circulars become internal refs. Use `resolveSpec` directly for finer control. |
+| `validateApiSpec`                       | Run `oav resolve spec.yaml` in CI; no runtime toggle.                                                           |
+
+#### Request validation
+
+| `express-openapi-validator` option  | `oav` equivalent                                                                                          |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `validateRequests: true`            | `validator.validateRequest(...)` in your middleware.                                                      |
+| `validateRequests.allErrors`        | Default — `oav` always collects every leaf. Bound cost with `maxErrors: N`.                               |
+| `validateRequests.coerceTypes`      | Query scalars coerced by default; body coercion not supported (see recipe).                               |
+| `validateRequests.removeAdditional` | Not supported. `additionalProperties: false` rejects; there is no silent-drop mode.                       |
+| `validateRequests.discriminator`    | Native, always on for OpenAPI specs.                                                                      |
+| `serDes`                            | Not supported. Pre- or post-transform the payload in your handler if you need `Date` / `ObjectId` / etc.  |
+| `ignorePaths` (regex/fn)            | `createValidator(spec, { ignorePaths: (p) => ... })` — predicate that short-circuits before routing.      |
+| `ignoreUndocumented`                | `createValidator(spec, { ignoreUndocumented: true })` — returns `null` on paths the router doesn't match. |
+
+#### Response validation
+
+| `express-openapi-validator` option | `oav` equivalent                                                                    |
+| ---------------------------------- | ----------------------------------------------------------------------------------- |
+| `validateResponses: true`          | `validator.validateResponse(...)` in handler or a `res.json` wrapper (see recipes). |
+
+#### Formats and custom keywords
+
+| `express-openapi-validator` option  | `oav` equivalent                                                                                           |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `formats`                           | `createValidator(spec, { formats: { ... } })` — see [format-shape note](#format-shape-note) below.         |
+| `validateFormats: "fast" \| "full"` | N/A — single-pass validation; the built-in formats are RFC-sourced.                                        |
+| `ajvFormats`                        | Pass custom format functions via the `formats` option — see [format-shape note](#format-shape-note) below. |
+
+#### Security and file uploads
+
+| `express-openapi-validator` option | `oav` equivalent                                                                                                                  |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `validateSecurity: true`           | Default — shape-only checks for `bearer` / `basic` / `apiKey`. Opt out with `createValidator(spec, { validateSecurity: false })`. |
+| `validateSecurity.handlers`        | Your own auth middleware, run before the validator — `oav` only checks credential **shape**, not validity.                        |
+| `fileUploader: true`               | Your own multer middleware (see [recipe](#file-uploads-with-multer)).                                                             |
+
+#### Handler wiring
+
+| `express-openapi-validator` option | `oav` equivalent                                                               |
+| ---------------------------------- | ------------------------------------------------------------------------------ |
+| `operationHandlers`                | Your own Express routes. `oav` doesn't auto-load handlers from the filesystem. |
 
 ### Features not carried over
 
@@ -634,8 +689,8 @@ app.use(async (req, res, next) => {
   per-code `params` typed via `BuiltInErrorParams`. Narrowing happens
   on fields rather than message strings.
 - **Built-in 3.0 dialect.** No translation layer over 2020-12. See
-  [conformance/REPORT.md](./conformance/REPORT.md) for the cases we
-  pass and the short list we don't.
+  [conformance/REPORT.md](./conformance/REPORT.md) for pass / fail
+  counts by category.
 - **Overlays.** Extend externally-owned specs at load time —
   see [OVERLAYS.md](./OVERLAYS.md).
 - **Smaller install footprint.** Single runtime dep (`yaml`) plus an

--- a/OVERLAYS.md
+++ b/OVERLAYS.md
@@ -39,6 +39,38 @@ Every overlay verb falls into one of four categories.
 | Request body (per op) | —                  | —                        | `requestBody`                      | —                   |
 | Responses (per op)    | `responses`        | —                        | `responses`                        | `removeResponses`   |
 
+## Applying an overlay
+
+Two entry points, same result.
+
+**`applyOverlays`** takes an already-resolved base document:
+
+```ts
+import { applyOverlays } from "@aahoughton/oav/spec";
+import { createValidator } from "@aahoughton/oav";
+
+const patched = applyOverlays(base, [overlay1, overlay2]);
+const validator = createValidator(patched);
+```
+
+**`loadSpec`** resolves external `$ref`s and applies overlays in one
+pass — use this for multi-file specs or remote documents:
+
+```ts
+import { loadSpec, composeReaders, createFileReader } from "@aahoughton/oav/spec";
+
+const reader = composeReaders([createFileReader()]);
+const { document } = await loadSpec({
+  reader,
+  entry: "openapi.yaml",
+  overlays: [overlay1, overlay2],
+});
+const validator = createValidator(document);
+```
+
+Overlays apply in order. Later overlays win on conflict. The base
+document is deep-cloned — the input is never mutated.
+
 ## Shape
 
 ```ts
@@ -111,7 +143,7 @@ to apply it to every path.
 - **`responses`** — merge by status code; override wins on clashes.
 - **`removeResponses`** — drop status codes. Silent no-op on missing.
 
-### `replace` — the nuclear option
+### Full operation replacement
 
 ```ts
 const overlay: SpecOverlay = {
@@ -133,38 +165,6 @@ starting fresh.
 Runnable demo:
 [`examples/overlay-petstore-endpoint.ts`](./examples/overlay-petstore-endpoint.ts)
 — adds a gateway-required `X-Tenant` header to `POST /pets`.
-
-## Applying an overlay
-
-Two entry points, same result.
-
-**`applyOverlays`** takes an already-resolved base document:
-
-```ts
-import { applyOverlays } from "@aahoughton/oav/spec";
-import { createValidator } from "@aahoughton/oav";
-
-const patched = applyOverlays(base, [overlay1, overlay2]);
-const validator = createValidator(patched);
-```
-
-**`loadSpec`** resolves external `$ref`s and applies overlays in one
-pass — use this for multi-file specs or remote documents:
-
-```ts
-import { loadSpec, composeReaders, createFileReader } from "@aahoughton/oav/spec";
-
-const reader = composeReaders([createFileReader()]);
-const { document } = await loadSpec({
-  reader,
-  entry: "openapi.yaml",
-  overlays: [overlay1, overlay2],
-});
-const validator = createValidator(document);
-```
-
-Overlays apply in order. Later overlays win on conflict. The base
-document is deep-cloned — the input is never mutated.
 
 ## Things to know
 
@@ -194,11 +194,7 @@ document is deep-cloned — the input is never mutated.
 
 ## Related
 
-- [`packages/spec/src/overlay.ts`](./packages/spec/src/overlay.ts) —
-  the implementation, including the full merge rules for each verb.
 - [`examples/overlay-petstore-schema.ts`](./examples/overlay-petstore-schema.ts)
   and
   [`examples/overlay-petstore-endpoint.ts`](./examples/overlay-petstore-endpoint.ts)
   — runnable end-to-end demos.
-- [README "Why (yet another) OpenAPI validator?"](./README.md#why-yet-another-openapi-validator) —
-  overlays as one of the three motivating reasons the project exists.

--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ npm install @aahoughton/oav
 npm install @aahoughton/oav-core           # lean install, JSON-only
 ```
 
-`@aahoughton/oav` re-exports everything from `@aahoughton/oav-core` at
-matching subpaths, so the code samples below work verbatim against
-either package — just swap the import specifier. If you plan to use the
-CLI, add `commander`:
+`@aahoughton/oav` re-exports `@aahoughton/oav-core` at matching
+subpaths. Samples below use `@aahoughton/oav`; on the lean package,
+substitute `@aahoughton/oav-core` in imports that don't touch the
+YAML readers (`createYamlFileReader`, `createSmartHttpReader`) or
+the CLI. If you plan to use the CLI, add `commander`:
 
 ```bash
 npm install @aahoughton/oav commander
@@ -49,10 +50,12 @@ npm install @aahoughton/oav commander
 
 ```ts
 import { createValidator, createYamlFileReader, formatText } from "@aahoughton/oav";
-import { composeReaders, createFileReader, loadSpec } from "@aahoughton/oav/spec";
+import { loadSpec } from "@aahoughton/oav/spec";
 
-const reader = composeReaders([createYamlFileReader(), createFileReader()]);
-const { document } = await loadSpec({ reader, entry: "openapi.yaml" });
+const { document } = await loadSpec({
+  reader: createYamlFileReader(),
+  entry: "openapi.yaml",
+});
 const validator = createValidator(document);
 
 const err = validator.validateRequest({
@@ -65,6 +68,10 @@ const err = validator.validateRequest({
 
 if (err !== null) console.error(formatText(err));
 ```
+
+For a multi-file spec or a spec hosted over HTTP, compose readers:
+`composeReaders([createYamlFileReader(), createSmartHttpReader(), createFileReader()])`
+handles local YAML, remote JSON / YAML, and local JSON transparently.
 
 `validateRequest` / `validateResponse` return `null` on success or a
 `ValidationError` tree on failure. Every error carries a stable `code`
@@ -101,21 +108,20 @@ on a spec you fully own, it's still the right pick. Where the two
 projects overlap and where each does more is written up in
 [`COMPARISON.md`](./COMPARISON.md).
 
-### Conformance
+## Conformance
 
 The [`conformance/`](./conformance/README.md) sub-package drives the
 compiler and CLI against the upstream JSON Schema 2020-12 Test Suite,
 a set of OpenAPI 3.0 / 3.1 / 3.2 petstore scenarios, and a handful of
 real-world specs (Stripe, GitHub, DigitalOcean, Twilio, Asana, Box,
-Adyen) that have to load and compile without error. Current pass
-counts: 1271 / 1290 on required JSON Schema cases, 1429 / 1452 with
-optional included, 14 / 14 on OpenAPI cases.
+Adyen) that have to load and compile without error. See
+[`conformance/REPORT.md`](./conformance/REPORT.md) for pass / fail
+counts by category.
 
-Categories we're not currently attempting, with details in
-[`conformance/REPORT.md`](./conformance/REPORT.md):
+Categories oav does not aim to cover:
 
-- `$dynamicRef` with runtime dynamic-scope rebinding. Our
-  implementation resolves statically against the anchor map.
+- `$dynamicRef` with runtime dynamic-scope rebinding. oav resolves
+  statically against the anchor map.
 - The `optional/format/*` subtree. Those tests target strict-assertion
   behaviour; `format` is annotation-only by default per JSON Schema
   2020-12 §6.3.
@@ -128,7 +134,7 @@ are concentrated in meta-schemas and extensible-type libraries (JSON
 Schema's own meta-schema, Hyperjump's type system); a spec that
 describes "POST /pets takes a Pet" doesn't declare them. The strict
 format-assertion gap only surfaces if you rely on RFC-edge behaviour
-in `iri`, IRI-reference, or non-BMP regex content — `date-time`,
+in `iri` / `iri-reference` or non-BMP regex content — `date-time`,
 `email`, `uuid`, and the common URI formats pass. Float overflow
 concerns numbers beyond `Number.MAX_SAFE_INTEGER` (~9 × 10¹⁵);
 outside that range, JavaScript's own `Number` precision is the
@@ -143,7 +149,7 @@ oav resolve openapi.yaml
 oav validate openapi.yaml --request req.http
 oav validate openapi.yaml --path "POST /pets" --body payload.json
 oav validate openapi.yaml --path "GET /pets" --response --status 200 --body resp.json
-oav compile schema.json -o validator.mjs                    # standalone ES module, no runtime `new Function()`
+oav compile schema.json -o validator.mjs                    # ES module with no runtime `new Function()` (imports runtime helpers from @aahoughton/oav)
 ```
 
 Flags: `--format text|json|flat`, `--depth n`, `--overlay file`
@@ -170,14 +176,17 @@ one of the built-in dialects (`jsonSchemaDialect`, `openapi31Dialect`,
 
 ## Configuring the validator
 
-| Option                  | Effect                                                         |
-| ----------------------- | -------------------------------------------------------------- |
-| `dialect`               | Force a specific schema dialect, bypassing version detection.  |
-| `formats`               | Extra string format validators merged on top of the built-ins. |
-| `keywords`              | Register user-defined schema keywords (see below).             |
-| `maxErrors`             | Cap on leaf errors; `1` is fast-fail, default is uncapped.     |
-| `strictQueryParameters` | Reject undeclared query parameters. Default `false`.           |
-| `onUnknownVersion`      | Policy for specs with missing/unsupported `openapi`.           |
+| Option                  | Effect                                                                                                 |
+| ----------------------- | ------------------------------------------------------------------------------------------------------ |
+| `dialect`               | Force a specific schema dialect, bypassing version detection.                                          |
+| `formats`               | Extra string format validators merged on top of the built-ins.                                         |
+| `keywords`              | Register user-defined schema keywords (see below).                                                     |
+| `maxErrors`             | Cap on leaf errors; `1` is fast-fail, default is uncapped.                                             |
+| `strictQueryParameters` | Reject undeclared query parameters. Default `false`.                                                   |
+| `validateSecurity`      | Shape-only security check (bearer / basic / apiKey). Default `true`; set `false` to skip.              |
+| `ignoreUndocumented`    | Return `null` on requests whose path the router can't match. Default `false`.                          |
+| `ignorePaths`           | Predicate `(path) => boolean`; returning `true` short-circuits validation to `null` before routing.    |
+| `onUnknownVersion`      | Policy for specs with missing/unsupported `openapi`: `"fallback31"` (default), `"warn"`, or `"throw"`. |
 
 ### Custom keywords
 
@@ -210,22 +219,53 @@ short-circuit once the budget is exhausted. Results carry
 
 `oav` is a validator, not a middleware package: you write a short
 adapter between your framework and `validateRequest` /
-`validateResponse`. See [**INTEGRATION.md**](./INTEGRATION.md) for:
+`validateResponse`. An Express 5 adapter is about this long:
 
-- Copy-paste adapters for Express 4, Express 5, Fastify, and
-  Next.js / Hono / Bun / Deno.
+```ts
+import { toProblemDetails, type ValidationError } from "@aahoughton/oav";
+
+const httpStatusFor = (err: ValidationError): number =>
+  err.code === "route"
+    ? 404
+    : err.code === "method"
+      ? 405
+      : err.code === "content-type"
+        ? 415
+        : err.code === "security"
+          ? 401
+          : 400;
+
+app.use(async (req, res, next) => {
+  const err = validator.validateRequest({
+    method: req.method,
+    path: req.path,
+    query: req.query as Record<string, string | string[]>,
+    headers: req.headers as Record<string, string | string[]>,
+    contentType: req.get("content-type") ?? undefined,
+    body: req.body,
+  });
+  if (err === null) return next();
+  res
+    .status(httpStatusFor(err))
+    .type("application/problem+json")
+    .json(toProblemDetails(err, { instance: req.originalUrl }));
+});
+```
+
+See [**INTEGRATION.md**](./INTEGRATION.md) for:
+
+- Adapters for Express 4, Fastify, Next.js, Hono, Bun, and Deno.
 - Recipes for file uploads (multer), response validation, security,
-  ignoring paths, and status-code mapping.
+  ignoring paths, and the full status-code switch.
 - A migration table from `express-openapi-validator`, including
   where oav is stricter or more conformant and where you'll do more
   wiring by hand.
 
-The short version: `oav` is not a drop-in for
-`express-openapi-validator`. You own the error → HTTP mapping, you
-wire up multer if you need file uploads, and you run your own auth
-middleware. In exchange you get a structured error tree, native
-OpenAPI 3.0 semantics, overlays, and no monkey-patching of `req` or
-`res`.
+`oav` is not a drop-in for `express-openapi-validator`: you own the
+error → HTTP mapping, you wire up multer if you need file uploads,
+and you run your own auth middleware. In exchange you get a
+structured error tree, native OpenAPI 3.0 semantics, overlays, and
+no monkey-patching of `req` or `res`.
 
 ## Modules
 
@@ -261,6 +301,10 @@ Runnable, self-contained TypeScript examples in
 | `overlay.ts`          | Apply a spec overlay before validating               |
 
 ## Known limitations
+
+Runtime-behaviour corners. For a feature-scope comparison against
+Ajv (draft versions, `$data`, async validation, etc.) see
+[COMPARISON.md](./COMPARISON.md).
 
 - `$dynamicRef` behaves like `$ref` with anchor lookup — no runtime
   dynamic-scope traversal.

--- a/README.md
+++ b/README.md
@@ -222,18 +222,7 @@ adapter between your framework and `validateRequest` /
 `validateResponse`. An Express 5 adapter is about this long:
 
 ```ts
-import { toProblemDetails, type ValidationError } from "@aahoughton/oav";
-
-const httpStatusFor = (err: ValidationError): number =>
-  err.code === "route"
-    ? 404
-    : err.code === "method"
-      ? 405
-      : err.code === "content-type"
-        ? 415
-        : err.code === "security"
-          ? 401
-          : 400;
+import { allowHeaderFor, httpStatusFor, toProblemDetails } from "@aahoughton/oav";
 
 app.use(async (req, res, next) => {
   const err = validator.validateRequest({
@@ -245,6 +234,8 @@ app.use(async (req, res, next) => {
     body: req.body,
   });
   if (err === null) return next();
+  const allow = allowHeaderFor(err);
+  if (allow !== undefined) res.setHeader("Allow", allow);
   res
     .status(httpStatusFor(err))
     .type("application/problem+json")

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,9 @@
 # Examples
 
 Self-contained TypeScript examples that exercise the most common
-`oav` entry points. Each file is runnable on its own (no build step,
-no external services) and prints what it did to stdout.
+`oav` entry points. Each file loads a spec from [`specs/`](./specs)
+and prints what it did to stdout — the same pattern a real application
+uses, so the example code translates 1:1 into production use.
 
 ## Running
 
@@ -17,20 +18,22 @@ The examples import from `packages/*/src` directly so they work without
 `import { ... } from "@aahoughton/oav"` / `"@aahoughton/oav/spec"`
 instead; the logic translates 1:1. Consumers on the lean
 `@aahoughton/oav-core` package can substitute `@aahoughton/oav-core`
-in the same import specifiers, provided they stay on JSON specs.
+for `@aahoughton/oav` in import specifiers that don't touch
+`createYamlFileReader` (oav-core is JSON-only).
 
 ## What's in here
 
-| File                           | Shows                                                                |
-| ------------------------------ | -------------------------------------------------------------------- |
-| `basic-validation.ts`          | Inline spec → `createValidator` → request + response checks          |
-| `custom-formats.ts`            | Register a user format (E.164 phone) via the `formats` option        |
-| `custom-keywords.ts`           | Register a schema keyword (`activeTenant`) via the `keywords` option |
-| `max-errors.ts`                | Fast-fail and bounded error collection on a bulk-invalid payload     |
-| `versions.ts`                  | 3.0, 3.1, and 3.2 side by side: `nullable`, QUERY method, etc.       |
-| `overlay.ts`                   | Minimal overlay: merge a gateway header requirement into one op      |
-| `overlay-petstore-schema.ts`   | Extend the `Pet` component with a deployment-required field          |
-| `overlay-petstore-endpoint.ts` | Require an `X-Tenant` header on `POST /pets` via an endpoint overlay |
+| File                           | Spec                  | Shows                                                                               |
+| ------------------------------ | --------------------- | ----------------------------------------------------------------------------------- |
+| `basic-validation.ts`          | `petstore.yaml`       | Load a spec → `createValidator` → request + response checks                         |
+| `custom-formats.ts`            | `contacts.yaml`       | Register a user format (E.164 phone) via the `formats` option                       |
+| `custom-keywords.ts`           | `widgets.yaml`        | Register a schema keyword (`activeTenant`) via the `keywords` option                |
+| `max-errors.ts`                | `items.yaml`          | Fast-fail and bounded error collection on a bulk-invalid payload                    |
+| `versions.ts`                  | `pets-3.{0,1,2}.yaml` | 3.0, 3.1, and 3.2 side by side: `nullable`, QUERY method, etc.                      |
+| `overlay.ts`                   | `petstore.yaml`       | Minimal overlay: merge a gateway header requirement into one op                     |
+| `overlay-petstore-schema.ts`   | `petstore.yaml`       | Extend the `Pet` component with a deployment-required field                         |
+| `overlay-petstore-endpoint.ts` | `petstore.yaml`       | Require an `X-Tenant` header on `POST /pets` via an endpoint overlay                |
+| `spec-digest.ts`               | `uploads.yaml`        | Derive middleware config (multer limits, required headers) from the spec at startup |
 
 See [`OVERLAYS.md`](../OVERLAYS.md) for a walk-through of the overlay
 shape and when to use each section (`extendSchemas`, `replaceSchemas`,
@@ -38,7 +41,8 @@ shape and when to use each section (`extendSchemas`, `replaceSchemas`,
 
 ## Conventions
 
-- Inline OpenAPI documents keep everything in one file — swap the
-  inline doc for `loadSpec(...)` to read from disk or HTTP.
+- Specs live in [`specs/`](./specs) as YAML files, loaded via
+  `loadSpec` + `createYamlFileReader`. The same pattern works for a
+  real application's spec; swap the entry path.
 - Success paths print `ok`; failure paths print the formatted error
   tree so you can see what the validator surfaces.

--- a/examples/basic-validation.ts
+++ b/examples/basic-validation.ts
@@ -1,45 +1,20 @@
 /**
- * Basic HTTP validation: build a validator from an inline OpenAPI 3.1
- * document and check one valid + one invalid request, then a response.
+ * Basic HTTP validation: load a petstore spec from disk, build a
+ * validator, and check one valid + one invalid request, then a response.
  *
  * Run from the repo root:
  *   pnpm tsx examples/basic-validation.ts
  */
 
-import type { OpenAPIDocument } from "../packages/core/src/index.ts";
+import { fileURLToPath } from "node:url";
 import { formatText } from "../packages/core/src/index.ts";
+import { createYamlFileReader } from "../packages/oav/src/yaml.ts";
+import { loadSpec } from "../packages/spec/src/index.ts";
 import { createValidator } from "../packages/validator/src/index.ts";
 
-const spec: OpenAPIDocument = {
-  openapi: "3.1.0",
-  info: { title: "Pets", version: "1" },
-  paths: {
-    "/pets": {
-      post: {
-        requestBody: {
-          required: true,
-          content: {
-            "application/json": {
-              schema: {
-                type: "object",
-                required: ["name"],
-                properties: {
-                  name: { type: "string", minLength: 1 },
-                  tag: { type: "string" },
-                },
-              },
-            },
-          },
-        },
-        responses: {
-          "201": { description: "created" },
-        },
-      },
-    },
-  },
-};
-
-const v = createValidator(spec);
+const specPath = fileURLToPath(new URL("./specs/petstore.yaml", import.meta.url));
+const { document } = await loadSpec({ reader: createYamlFileReader(), entry: specPath });
+const v = createValidator(document);
 
 const valid = v.validateRequest({
   method: "POST",

--- a/examples/custom-formats.ts
+++ b/examples/custom-formats.ts
@@ -8,39 +8,18 @@
  *   pnpm tsx examples/custom-formats.ts
  */
 
-import type { OpenAPIDocument } from "../packages/core/src/index.ts";
+import { fileURLToPath } from "node:url";
 import { formatText } from "../packages/core/src/index.ts";
+import { createYamlFileReader } from "../packages/oav/src/yaml.ts";
+import { loadSpec } from "../packages/spec/src/index.ts";
 import { createValidator } from "../packages/validator/src/index.ts";
 
-const spec: OpenAPIDocument = {
-  openapi: "3.1.0",
-  info: { title: "Contacts", version: "1" },
-  paths: {
-    "/contacts": {
-      post: {
-        requestBody: {
-          required: true,
-          content: {
-            "application/json": {
-              schema: {
-                type: "object",
-                required: ["phone"],
-                properties: {
-                  phone: { type: "string", format: "e164-phone" },
-                },
-              },
-            },
-          },
-        },
-        responses: { "201": { description: "created" } },
-      },
-    },
-  },
-};
+const specPath = fileURLToPath(new URL("./specs/contacts.yaml", import.meta.url));
+const { document } = await loadSpec({ reader: createYamlFileReader(), entry: specPath });
 
 const e164 = (s: string): boolean => /^\+[1-9]\d{6,14}$/.test(s);
 
-const v = createValidator(spec, {
+const v = createValidator(document, {
   formats: { "e164-phone": e164 },
 });
 

--- a/examples/custom-keywords.ts
+++ b/examples/custom-keywords.ts
@@ -8,8 +8,10 @@
  *   pnpm tsx examples/custom-keywords.ts
  */
 
-import type { OpenAPIDocument } from "../packages/core/src/index.ts";
+import { fileURLToPath } from "node:url";
 import { formatText } from "../packages/core/src/index.ts";
+import { createYamlFileReader } from "../packages/oav/src/yaml.ts";
+import { loadSpec } from "../packages/spec/src/index.ts";
 import { createValidator } from "../packages/validator/src/index.ts";
 import type { CustomKeywordValidator } from "../packages/validator/src/index.ts";
 
@@ -21,39 +23,10 @@ const activeTenant: CustomKeywordValidator = (data) => {
   return { message: `tenant "${data}" is not active`, params: { tenantId: data } };
 };
 
-const spec: OpenAPIDocument = {
-  openapi: "3.1.0",
-  info: { title: "Multi-tenant API", version: "1" },
-  paths: {
-    "/widgets": {
-      post: {
-        requestBody: {
-          required: true,
-          content: {
-            "application/json": {
-              schema: {
-                type: "object",
-                required: ["tenantId"],
-                properties: {
-                  // Custom keyword in action:
-                  tenantId: {
-                    type: "string",
-                    pattern: "^t_[a-z0-9]+$",
-                    activeTenant: true,
-                  } as Record<string, unknown>,
-                  name: { type: "string" },
-                },
-              },
-            },
-          },
-        },
-        responses: { "201": { description: "created" } },
-      },
-    },
-  },
-};
+const specPath = fileURLToPath(new URL("./specs/widgets.yaml", import.meta.url));
+const { document } = await loadSpec({ reader: createYamlFileReader(), entry: specPath });
 
-const v = createValidator(spec, {
+const v = createValidator(document, {
   keywords: { activeTenant },
 });
 

--- a/examples/max-errors.ts
+++ b/examples/max-errors.ts
@@ -8,42 +8,20 @@
  *   pnpm tsx examples/max-errors.ts
  */
 
-import type { OpenAPIDocument } from "../packages/core/src/index.ts";
+import { fileURLToPath } from "node:url";
 import { collectLeaves } from "../packages/core/src/index.ts";
+import { createYamlFileReader } from "../packages/oav/src/yaml.ts";
+import { loadSpec } from "../packages/spec/src/index.ts";
 import { createValidator } from "../packages/validator/src/index.ts";
 
-const spec: OpenAPIDocument = {
-  openapi: "3.1.0",
-  info: { title: "Bulk", version: "1" },
-  paths: {
-    "/items": {
-      post: {
-        requestBody: {
-          required: true,
-          content: {
-            "application/json": {
-              schema: {
-                type: "array",
-                items: {
-                  type: "object",
-                  required: ["id"],
-                  properties: { id: { type: "integer" } },
-                },
-              },
-            },
-          },
-        },
-        responses: { "201": { description: "created" } },
-      },
-    },
-  },
-};
+const specPath = fileURLToPath(new URL("./specs/items.yaml", import.meta.url));
+const { document } = await loadSpec({ reader: createYamlFileReader(), entry: specPath });
 
 // 50 array items, all missing the required `id` field.
 const bulk = Array.from({ length: 50 }, () => ({ name: "whatever" }));
 
 const runAndCount = (label: string, maxErrors: number | undefined): void => {
-  const v = createValidator(spec, maxErrors === undefined ? {} : { maxErrors });
+  const v = createValidator(document, maxErrors === undefined ? {} : { maxErrors });
   const start = performance.now();
   const err = v.validateRequest({
     method: "POST",

--- a/examples/overlay-petstore-endpoint.ts
+++ b/examples/overlay-petstore-endpoint.ts
@@ -16,34 +16,17 @@
  *   pnpm tsx examples/overlay-petstore-endpoint.ts
  */
 
-import type { OpenAPIDocument } from "../packages/core/src/index.ts";
+import { fileURLToPath } from "node:url";
 import { formatText } from "../packages/core/src/index.ts";
-import { applyOverlays, type SpecOverlay } from "../packages/spec/src/index.ts";
+import { createYamlFileReader } from "../packages/oav/src/yaml.ts";
+import { applyOverlays, loadSpec, type SpecOverlay } from "../packages/spec/src/index.ts";
 import { createValidator } from "../packages/validator/src/index.ts";
 
-const base: OpenAPIDocument = {
-  openapi: "3.1.0",
-  info: { title: "Petstore", version: "1" },
-  paths: {
-    "/pets": {
-      post: {
-        requestBody: {
-          required: true,
-          content: {
-            "application/json": {
-              schema: {
-                type: "object",
-                required: ["name"],
-                properties: { name: { type: "string" } },
-              },
-            },
-          },
-        },
-        responses: { "201": { description: "created" } },
-      },
-    },
-  },
-};
+const specPath = fileURLToPath(new URL("./specs/petstore.yaml", import.meta.url));
+const { document: base } = await loadSpec({
+  reader: createYamlFileReader(),
+  entry: specPath,
+});
 
 // Gateway requires `X-Tenant` on POST /pets.
 const overlay: SpecOverlay = {

--- a/examples/overlay-petstore-schema.ts
+++ b/examples/overlay-petstore-schema.ts
@@ -15,42 +15,17 @@
  *   pnpm tsx examples/overlay-petstore-schema.ts
  */
 
-import type { OpenAPIDocument } from "../packages/core/src/index.ts";
+import { fileURLToPath } from "node:url";
 import { formatText } from "../packages/core/src/index.ts";
-import { applyOverlays, type SpecOverlay } from "../packages/spec/src/index.ts";
+import { createYamlFileReader } from "../packages/oav/src/yaml.ts";
+import { applyOverlays, loadSpec, type SpecOverlay } from "../packages/spec/src/index.ts";
 import { createValidator } from "../packages/validator/src/index.ts";
 
-// Upstream petstore. `Pet` is declared under `components/schemas` so
-// the overlay can target it by name.
-const base: OpenAPIDocument = {
-  openapi: "3.1.0",
-  info: { title: "Petstore", version: "1" },
-  paths: {
-    "/pets": {
-      post: {
-        requestBody: {
-          required: true,
-          content: {
-            "application/json": { schema: { $ref: "#/components/schemas/Pet" } },
-          },
-        },
-        responses: { "201": { description: "created" } },
-      },
-    },
-  },
-  components: {
-    schemas: {
-      Pet: {
-        type: "object",
-        required: ["name"],
-        properties: {
-          name: { type: "string" },
-          tag: { type: "string" },
-        },
-      },
-    },
-  },
-};
+const specPath = fileURLToPath(new URL("./specs/petstore.yaml", import.meta.url));
+const { document: base } = await loadSpec({
+  reader: createYamlFileReader(),
+  entry: specPath,
+});
 
 // Deployment-specific extension: require `vaccinated: boolean`. Because
 // `extendSchemas` merges via allOf, the upstream Pet shape is preserved

--- a/examples/overlay.ts
+++ b/examples/overlay.ts
@@ -8,37 +8,23 @@
  *   pnpm tsx examples/overlay.ts
  */
 
-import type { OpenAPIDocument } from "../packages/core/src/index.ts";
+import { fileURLToPath } from "node:url";
 import { formatText } from "../packages/core/src/index.ts";
-import { applyOverlays, type SpecOverlay } from "../packages/spec/src/index.ts";
+import { createYamlFileReader } from "../packages/oav/src/yaml.ts";
+import { applyOverlays, loadSpec, type SpecOverlay } from "../packages/spec/src/index.ts";
 import { createValidator } from "../packages/validator/src/index.ts";
 
-const base: OpenAPIDocument = {
-  openapi: "3.1.0",
-  info: { title: "Widgets", version: "1" },
-  paths: {
-    "/widgets": {
-      get: {
-        responses: {
-          "200": {
-            description: "ok",
-            content: {
-              "application/json": {
-                schema: { type: "array", items: { type: "object" } },
-              },
-            },
-          },
-        },
-      },
-    },
-  },
-};
+const specPath = fileURLToPath(new URL("./specs/petstore.yaml", import.meta.url));
+const { document: base } = await loadSpec({
+  reader: createYamlFileReader(),
+  entry: specPath,
+});
 
-// Gateway adds `X-Request-Id` to every operation in prod. Rather than
-// edit the base spec, we overlay the requirement in at load time.
+// Gateway adds `X-Request-Id` to every GET in prod. Rather than edit the
+// base spec, overlay the requirement in at load time.
 const overlay: SpecOverlay = {
   overrides: {
-    "/widgets": {
+    "/pets": {
       operations: {
         get: {
           upsertParameters: [
@@ -54,14 +40,14 @@ const merged = applyOverlays(base, [overlay]);
 const v = createValidator(merged);
 
 // Without the header — should fail.
-const missing = v.validateRequest({ method: "GET", path: "/widgets" });
+const missing = v.validateRequest({ method: "GET", path: "/pets" });
 console.log("without X-Request-Id:");
 if (missing !== null) console.log(formatText(missing));
 
 // With the header — clean.
 const ok = v.validateRequest({
   method: "GET",
-  path: "/widgets",
+  path: "/pets",
   headers: { "x-request-id": "abc-123" },
 });
 console.log("\nwith X-Request-Id →", ok === null ? "ok" : "FAIL");

--- a/examples/spec-digest.ts
+++ b/examples/spec-digest.ts
@@ -18,13 +18,15 @@
  *   pnpm tsx examples/spec-digest.ts
  */
 
+import { fileURLToPath } from "node:url";
 import type {
-  OpenAPIDocument,
   OperationObject,
   ParameterObject,
   SchemaObject,
   SecurityRequirementObject,
 } from "../packages/core/src/index.ts";
+import { createYamlFileReader } from "../packages/oav/src/yaml.ts";
+import { loadSpec } from "../packages/spec/src/index.ts";
 import { createValidator } from "../packages/validator/src/index.ts";
 
 /**
@@ -103,46 +105,13 @@ function declaredMaxBytes(schema: SchemaObject | boolean | undefined): number | 
   return undefined;
 }
 
-// ──── Demo: inline spec, digest, print ────────────────────────────
+// ──── Demo: load spec, digest, print ──────────────────────────────
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  const spec: OpenAPIDocument = {
-    openapi: "3.1.0",
-    info: { title: "Uploads", version: "1" },
-    components: {
-      securitySchemes: {
-        bearerAuth: { type: "http", scheme: "bearer" },
-      },
-    },
-    paths: {
-      "/uploads": {
-        post: {
-          operationId: "uploadDocument",
-          security: [{ bearerAuth: [] }],
-          parameters: [
-            { name: "X-Tenant", in: "header", required: true, schema: { type: "string" } },
-          ],
-          requestBody: {
-            required: true,
-            content: {
-              "multipart/form-data": {
-                schema: {
-                  type: "object",
-                  required: ["file"],
-                  properties: {
-                    file: { type: "string", format: "binary", maxLength: 10 * 1024 * 1024 },
-                  },
-                },
-              },
-            },
-          },
-          responses: { "201": { description: "created" } },
-        },
-      },
-    },
-  };
+  const specPath = fileURLToPath(new URL("./specs/uploads.yaml", import.meta.url));
+  const { document } = await loadSpec({ reader: createYamlFileReader(), entry: specPath });
 
-  const validator = createValidator(spec);
+  const validator = createValidator(document);
   const info = validator.getOperation({ method: "POST", path: "/uploads" });
   if (info === null) throw new Error("no matching operation");
 

--- a/examples/specs/contacts.yaml
+++ b/examples/specs/contacts.yaml
@@ -1,0 +1,22 @@
+openapi: "3.1.0"
+info:
+  title: Contacts
+  version: "1"
+paths:
+  /contacts:
+    post:
+      summary: Create a contact
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [phone]
+              properties:
+                phone:
+                  type: string
+                  format: e164-phone
+      responses:
+        "201":
+          description: created

--- a/examples/specs/items.yaml
+++ b/examples/specs/items.yaml
@@ -1,0 +1,23 @@
+openapi: "3.1.0"
+info:
+  title: Bulk
+  version: "1"
+paths:
+  /items:
+    post:
+      summary: Bulk-create items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: object
+                required: [id]
+                properties:
+                  id:
+                    type: integer
+      responses:
+        "201":
+          description: created

--- a/examples/specs/pets-3.0.yaml
+++ b/examples/specs/pets-3.0.yaml
@@ -1,0 +1,28 @@
+openapi: "3.0.3"
+info:
+  title: Pets 3.0
+  version: "1"
+paths:
+  /pets:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                tag:
+                  type: string
+                  nullable: true
+                priority:
+                  type: integer
+                  maximum: 10
+                  exclusiveMaximum: true
+      responses:
+        "201":
+          description: created

--- a/examples/specs/pets-3.1.yaml
+++ b/examples/specs/pets-3.1.yaml
@@ -1,0 +1,27 @@
+openapi: "3.1.0"
+info:
+  title: Pets 3.1
+  version: "1"
+paths:
+  /pets:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                tag:
+                  type: ["string", "null"]
+                priority:
+                  type: integer
+                  maximum: 10
+                  exclusiveMaximum: 10
+      responses:
+        "201":
+          description: created

--- a/examples/specs/pets-3.2.yaml
+++ b/examples/specs/pets-3.2.yaml
@@ -1,0 +1,21 @@
+openapi: "3.2.0"
+info:
+  title: Pets 3.2
+  version: "1"
+paths:
+  /pets/search:
+    query:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [filter]
+              properties:
+                filter:
+                  type: string
+                  minLength: 1
+      responses:
+        "200":
+          description: ok

--- a/examples/specs/petstore.yaml
+++ b/examples/specs/petstore.yaml
@@ -1,0 +1,39 @@
+openapi: "3.1.0"
+info:
+  title: Petstore
+  version: "1"
+paths:
+  /pets:
+    get:
+      summary: List pets
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+    post:
+      summary: Create a pet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        "201":
+          description: created
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+          minLength: 1
+        tag:
+          type: string

--- a/examples/specs/uploads.yaml
+++ b/examples/specs/uploads.yaml
@@ -1,0 +1,36 @@
+openapi: "3.1.0"
+info:
+  title: Uploads
+  version: "1"
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+paths:
+  /uploads:
+    post:
+      operationId: uploadDocument
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: X-Tenant
+          in: header
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  maxLength: 10485760
+      responses:
+        "201":
+          description: created

--- a/examples/specs/widgets.yaml
+++ b/examples/specs/widgets.yaml
@@ -1,0 +1,25 @@
+openapi: "3.1.0"
+info:
+  title: Multi-tenant API
+  version: "1"
+paths:
+  /widgets:
+    post:
+      summary: Create a widget
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [tenantId]
+              properties:
+                tenantId:
+                  type: string
+                  pattern: "^t_[a-z0-9]+$"
+                  activeTenant: true
+                name:
+                  type: string
+      responses:
+        "201":
+          description: created

--- a/examples/versions.ts
+++ b/examples/versions.ts
@@ -1,6 +1,6 @@
 /**
  * Multi-version support: the same conceptual "create a pet" operation,
- * written three different ways, one per OpenAPI version. The validator
+ * declared three different ways, one per OpenAPI version. The validator
  * reads `openapi` once at construction and picks the right dialect —
  * no per-request branching.
  *
@@ -12,38 +12,18 @@
  *   pnpm tsx examples/versions.ts
  */
 
-import type { OpenAPIDocument } from "../packages/core/src/index.ts";
+import { fileURLToPath } from "node:url";
 import { formatText } from "../packages/core/src/index.ts";
+import { createYamlFileReader } from "../packages/oav/src/yaml.ts";
+import { loadSpec } from "../packages/spec/src/index.ts";
 import { createValidator } from "../packages/validator/src/index.ts";
 
+const reader = createYamlFileReader();
+const specUrl = (name: string): string =>
+  fileURLToPath(new URL(`./specs/${name}`, import.meta.url));
+
 // --- OpenAPI 3.0.x ---------------------------------------------------------
-const spec30: OpenAPIDocument = {
-  openapi: "3.0.3",
-  info: { title: "Pets 3.0", version: "1" },
-  paths: {
-    "/pets": {
-      post: {
-        requestBody: {
-          required: true,
-          content: {
-            "application/json": {
-              schema: {
-                type: "object",
-                required: ["name"],
-                properties: {
-                  name: { type: "string", minLength: 1 },
-                  tag: { type: "string", nullable: true }, // 3.0 flavour
-                  priority: { type: "integer", maximum: 10, exclusiveMaximum: true },
-                },
-              },
-            },
-          },
-        },
-        responses: { "201": { description: "created" } },
-      },
-    },
-  },
-};
+const { document: spec30 } = await loadSpec({ reader, entry: specUrl("pets-3.0.yaml") });
 const v30 = createValidator(spec30);
 console.log(
   "3.0.3  tag=null        →",
@@ -70,33 +50,7 @@ console.log(
 );
 
 // --- OpenAPI 3.1.x ---------------------------------------------------------
-const spec31: OpenAPIDocument = {
-  openapi: "3.1.0",
-  info: { title: "Pets 3.1", version: "1" },
-  paths: {
-    "/pets": {
-      post: {
-        requestBody: {
-          required: true,
-          content: {
-            "application/json": {
-              schema: {
-                type: "object",
-                required: ["name"],
-                properties: {
-                  name: { type: "string", minLength: 1 },
-                  tag: { type: ["string", "null"] }, // JSON Schema 2020-12 way
-                  priority: { type: "integer", maximum: 10, exclusiveMaximum: 10 },
-                },
-              },
-            },
-          },
-        },
-        responses: { "201": { description: "created" } },
-      },
-    },
-  },
-};
+const { document: spec31 } = await loadSpec({ reader, entry: specUrl("pets-3.1.yaml") });
 const v31 = createValidator(spec31);
 console.log(
   "3.1.0  tag=null        →",
@@ -111,30 +65,7 @@ console.log(
 );
 
 // --- OpenAPI 3.2.x ---------------------------------------------------------
-const spec32: OpenAPIDocument = {
-  openapi: "3.2.0",
-  info: { title: "Pets 3.2", version: "1" },
-  paths: {
-    "/pets/search": {
-      query: {
-        // <-- New in 3.2
-        requestBody: {
-          required: true,
-          content: {
-            "application/json": {
-              schema: {
-                type: "object",
-                required: ["filter"],
-                properties: { filter: { type: "string", minLength: 1 } },
-              },
-            },
-          },
-        },
-        responses: { "200": { description: "ok" } },
-      },
-    },
-  },
-};
+const { document: spec32 } = await loadSpec({ reader, entry: specUrl("pets-3.2.yaml") });
 const v32 = createValidator(spec32);
 const r = v32.validateRequest({
   method: "QUERY",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -32,7 +32,7 @@ oav validate <spec> --request req.http                       # full HTTP request
 oav validate <spec> --path "POST /pets" --body body.json     # request body for a known route
 oav validate <spec> --path "GET /pets" --response --status 200 --body resp.json
 
-oav compile <schema.json> -o v.mjs                           # emit a standalone validator module
+oav compile <schema.json> -o v.mjs                           # emit a validator module
 oav compile <schema.json> --dialect openapi-3.0              # pick a non-default dialect
 ```
 
@@ -41,6 +41,9 @@ Pass `-` as the file path to read from stdin (e.g. `--body -`).
 `<spec>` and `--overlay <file>` accept local paths, `file://` URIs,
 and `http://` / `https://` URLs (both JSON and YAML over HTTP). Relative
 `$ref`s inside a URL-hosted spec resolve against the URL's base.
+
+`--request` takes a `.http` file — see [`.http` file format](#http-file-format)
+below for the expected shape.
 
 ## Flags
 
@@ -55,12 +58,13 @@ and `http://` / `https://` URLs (both JSON and YAML over HTTP). Relative
 
 ## `compile` output
 
-`oav compile <schema.json>` emits an ESM module that exports a
+`oav compile <schema.json>` emits an ESM module exporting a
 `validate(data)` function whose behaviour matches the dynamic
-`compileSchema(schema).validate(data)`, but which performs no
-`new Function()` call at load time. Useful for edge runtimes
-(Cloudflare Workers, Vercel Edge) where runtime code generation is
-forbidden or undesirable.
+`compileSchema(schema).validate(data)`, but with no `new Function()`
+call at load time. Useful for edge runtimes (Cloudflare Workers,
+Vercel Edge) where runtime code generation is forbidden or undesirable.
+The emitted module imports runtime helpers from `@aahoughton/oav/*`;
+it is not a fully self-contained bundle.
 
 Constraints on the input schema:
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -73,8 +73,16 @@ All three produce strings suitable for stdout / logs.
 
 ## HTTP response helpers
 
-For rendering validation failures as an HTTP response body:
+For rendering validation failures as an HTTP response:
 
+- `httpStatusFor(err, overrides?)` — maps a `ValidationError` tree to
+  an HTTP status code. Defaults: `route` → 404, `method` → 405,
+  `security` → 401, `content-type` → 415, `status` → 500, else 400.
+  Correctly inspects the tree shape (some codes appear as leaves
+  under a top-level `"request"` / `"response"` branch, not as
+  `err.code`). Pass `{ default: 422 }` etc. to override a slot.
+- `allowHeaderFor(err)` — returns the comma-joined `Allow` header
+  value for a 405, or `undefined` otherwise (RFC 9110 §15.5.6).
 - `toProblemDetails(err, { type?, title?, status?, instance? })` — RFC
   9457 `application/problem+json` envelope with a typed `issues` array
   as an extension member. Defaults: `about:blank` type,

--- a/packages/core/src/http-status.ts
+++ b/packages/core/src/http-status.ts
@@ -1,0 +1,106 @@
+import { collectLeaves, type ValidationError } from "./errors.js";
+
+/**
+ * Default mapping from {@link ValidationError} shape to HTTP status
+ * code. Consumers can override any key via the second argument to
+ * {@link httpStatusFor}.
+ *
+ * @public
+ */
+export interface HttpStatusMap {
+  /** Router couldn't match the request path to any declared route. */
+  route: number;
+  /** Path matched but the requested method isn't declared on it. */
+  method: number;
+  /** Request `Content-Type` isn't in the declared `requestBody.content` set. */
+  "content-type": number;
+  /** Declared security scheme's credential location is missing or malformed. */
+  security: number;
+  /** Response (response-side only): spec declares no entry for the received status. */
+  status: number;
+  /** Anything else — schema violations, missing required fields, etc. */
+  default: number;
+}
+
+/**
+ * Default HTTP status mapping used by {@link httpStatusFor}.
+ *
+ * @public
+ */
+export const DEFAULT_HTTP_STATUS_MAP: HttpStatusMap = {
+  route: 404,
+  method: 405,
+  "content-type": 415,
+  security: 401,
+  status: 500,
+  default: 400,
+};
+
+/**
+ * Map a {@link ValidationError} to an HTTP status code.
+ *
+ * Handles the tree wrapping that bites consumers who write the
+ * obvious switch: `route` and `method` appear as the top-level leaf
+ * (router short-circuits), but `content-type`, `security`, and
+ * response-side `status` are wrapped inside a top-level
+ * `createBranchError("request", ...)` or `"response"` branch. This
+ * helper inspects the top-level code for the unwrapped cases and
+ * falls back to a leaf scan for the wrapped ones, then resolves to
+ * a status from {@link DEFAULT_HTTP_STATUS_MAP} (or the caller's
+ * overrides).
+ *
+ * Resolution order matches the HTTP gate semantics — 404 → 405 →
+ * 415 → 401 → 500 → 400:
+ *
+ * ```ts
+ * import { httpStatusFor } from "@aahoughton/oav";
+ *
+ * const err = validator.validateRequest(httpRequest);
+ * if (err !== null) {
+ *   res.status(httpStatusFor(err)).json(toProblemDetails(err));
+ * }
+ * ```
+ *
+ * Override any slot — e.g. APIs that use 422 for schema errors:
+ *
+ * ```ts
+ * httpStatusFor(err, { default: 422 });
+ * ```
+ *
+ * @public
+ */
+export function httpStatusFor(err: ValidationError, overrides?: Partial<HttpStatusMap>): number {
+  const map =
+    overrides === undefined
+      ? DEFAULT_HTTP_STATUS_MAP
+      : { ...DEFAULT_HTTP_STATUS_MAP, ...overrides };
+  if (err.code === "route") return map.route;
+  if (err.code === "method") return map.method;
+  // Dive into the wrapper for codes that never appear at the top level.
+  // Priority order matches the HTTP gate ladder: 401 before 415 before 500.
+  const leaves = collectLeaves(err);
+  if (leaves.some((l) => l.code === "security")) return map.security;
+  if (leaves.some((l) => l.code === "content-type")) return map["content-type"];
+  if (leaves.some((l) => l.code === "status")) return map.status;
+  return map.default;
+}
+
+/**
+ * Return the comma-separated value for an `Allow` response header
+ * when the error is a 405 (RFC 9110 §15.5.6 requires it), or
+ * `undefined` otherwise.
+ *
+ * ```ts
+ * const allow = allowHeaderFor(err);
+ * if (allow !== undefined) res.setHeader("Allow", allow);
+ * res.status(httpStatusFor(err)).json(toProblemDetails(err));
+ * ```
+ *
+ * @public
+ */
+export function allowHeaderFor(err: ValidationError): string | undefined {
+  if (err.code !== "method") return undefined;
+  const allowed = (err.params as { allowed?: unknown }).allowed;
+  if (!Array.isArray(allowed)) return undefined;
+  return allowed.join(", ");
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,6 +33,13 @@ export {
   type ValidationIssue,
 } from "./problem-details.js";
 
+export {
+  allowHeaderFor,
+  DEFAULT_HTTP_STATUS_MAP,
+  httpStatusFor,
+  type HttpStatusMap,
+} from "./http-status.js";
+
 export { resolveJsonPointer } from "./json-pointer.js";
 
 export { detectOpenAPIVersion, type OpenAPIVersion } from "./version.js";

--- a/packages/core/test/http-status.test.ts
+++ b/packages/core/test/http-status.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { createBranchError, createLeafError } from "../src/errors.js";
+import { allowHeaderFor, DEFAULT_HTTP_STATUS_MAP, httpStatusFor } from "../src/http-status.js";
+
+// Mirrors the tree shape the validator produces: "route"/"method" are
+// returned as a top-level leaf; everything else is wrapped in a
+// "request" (or "response") branch.
+
+describe("httpStatusFor", () => {
+  it("returns 404 for a top-level route error", () => {
+    const err = createLeafError("route", [], "no match", { method: "GET", path: "/x" });
+    expect(httpStatusFor(err)).toBe(404);
+  });
+
+  it("returns 405 for a top-level method error", () => {
+    const err = createLeafError("method", [], "verb not allowed", {
+      method: "PATCH",
+      pathPattern: "/pets",
+      allowed: ["GET", "POST"],
+    });
+    expect(httpStatusFor(err)).toBe(405);
+  });
+
+  it("returns 415 for a content-type leaf nested under a request wrapper", () => {
+    const err = createBranchError("request", [], "request validation failed", [
+      createLeafError("content-type", ["body"], "Content-Type not accepted", {
+        contentType: "text/plain",
+        accepted: ["application/json"],
+      }),
+    ]);
+    expect(httpStatusFor(err)).toBe(415);
+  });
+
+  it("returns 401 for a security leaf nested under a request wrapper", () => {
+    const err = createBranchError("request", [], "request validation failed", [
+      createLeafError("security", ["security"], "missing credential", {}),
+    ]);
+    expect(httpStatusFor(err)).toBe(401);
+  });
+
+  it("returns 500 for a status leaf nested under a response wrapper", () => {
+    const err = createBranchError("response", [], "response validation failed", [
+      createLeafError("status", [], "no response declared for 418", { status: 418 }),
+    ]);
+    expect(httpStatusFor(err)).toBe(500);
+  });
+
+  it("returns 400 for anything else — schema violations, missing required, etc.", () => {
+    const err = createBranchError("request", [], "request validation failed", [
+      createLeafError("required", ["body"], "missing name", { missing: "name" }),
+      createLeafError("type", ["body", "age"], "must be number", {
+        expected: ["number"],
+        actual: "string",
+      }),
+    ]);
+    expect(httpStatusFor(err)).toBe(400);
+  });
+
+  it("prefers 415 over 400 when a content-type leaf coexists with schema leaves", () => {
+    const err = createBranchError("request", [], "request validation failed", [
+      createLeafError("content-type", ["body"], "Content-Type not accepted", {
+        contentType: "text/plain",
+        accepted: ["application/json"],
+      }),
+      createLeafError("required", ["body"], "missing name", { missing: "name" }),
+    ]);
+    expect(httpStatusFor(err)).toBe(415);
+  });
+
+  it("prefers 401 (security) over 415 (content-type) when both leaves are present", () => {
+    // HTTP gate semantics: auth is the stricter gate ("we can't even tell
+    // what you're asking for"), and 401 should surface ahead of 415. In
+    // practice the validator short-circuits on security before checking
+    // content-type, so both rarely coexist — but the helper's priority
+    // guarantees the behaviour regardless.
+    const err = createBranchError("request", [], "request validation failed", [
+      createLeafError("content-type", ["body"], "Content-Type not accepted", {
+        contentType: "text/plain",
+        accepted: ["application/json"],
+      }),
+      createLeafError("security", ["security"], "missing credential", {}),
+    ]);
+    expect(httpStatusFor(err)).toBe(401);
+  });
+
+  it("applies overrides for individual slots", () => {
+    const err = createBranchError("request", [], "request validation failed", [
+      createLeafError("required", ["body"], "missing name", { missing: "name" }),
+    ]);
+    expect(httpStatusFor(err, { default: 422 })).toBe(422);
+  });
+
+  it("applies overrides without affecting unrelated slots", () => {
+    const route = createLeafError("route", [], "no match", { method: "GET", path: "/x" });
+    expect(httpStatusFor(route, { default: 422 })).toBe(404);
+  });
+
+  it("exposes DEFAULT_HTTP_STATUS_MAP for introspection", () => {
+    expect(DEFAULT_HTTP_STATUS_MAP).toEqual({
+      route: 404,
+      method: 405,
+      "content-type": 415,
+      security: 401,
+      status: 500,
+      default: 400,
+    });
+  });
+});
+
+describe("allowHeaderFor", () => {
+  it("returns the allowed-methods list as a comma-separated string for a method error", () => {
+    const err = createLeafError("method", [], "verb not allowed", {
+      method: "PATCH",
+      pathPattern: "/pets",
+      allowed: ["GET", "HEAD", "POST"],
+    });
+    expect(allowHeaderFor(err)).toBe("GET, HEAD, POST");
+  });
+
+  it("returns undefined when the error is not a method error", () => {
+    const err = createLeafError("route", [], "no match", { method: "GET", path: "/x" });
+    expect(allowHeaderFor(err)).toBeUndefined();
+  });
+
+  it("returns undefined when the method error has no allowed array (shouldn't happen in practice)", () => {
+    const err = createLeafError("method" as "route", [], "verb not allowed", {
+      method: "PATCH",
+      path: "/pets",
+    });
+    expect(allowHeaderFor(err)).toBeUndefined();
+  });
+});

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -1,12 +1,13 @@
-# @aahoughton/oav (router)
+# @oav/router
 
-Trie-based OpenAPI path matcher. Internal dependency of the validator;
-exported for tools that want to resolve `method + path` to an operation
-without running validation.
+> **Internal package — not published.** `@oav/router` is a workspace-private
+> dependency of `@aahoughton/oav`; it does not appear on npm and has no
+> published subpath. This README documents the internal surface for
+> contributors navigating the monorepo. Third-party consumers get the
+> router's functionality transparently via `createValidator`.
 
-Note: the router is not published under its own subpath. Third-party
-consumers typically never need it directly — `createValidator` wires it
-up. The README is here for contributors navigating the monorepo.
+Trie-based OpenAPI path matcher. Resolves `method + path` to the
+matching `OperationObject` in the spec.
 
 ```ts
 // Internal usage inside the monorepo

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -96,29 +96,16 @@ Return `true` for valid, `false` for a generic failure, or
 `{ message?, params? }` for a custom error leaf. Names that collide
 with a built-in keyword throw at construction.
 
-### Lower-level extensions
+### Advanced: full `KeywordDefinition`
 
-Write a full `KeywordDefinition` for applicator keywords, evaluation
-tracking, or custom emit shapes. The `compile(ctx)` function receives a
-`KeywordCompileContext` with a deliberately narrow surface:
+The function form above covers most custom keywords. For applicator
+keywords (ones that descend into subschemas), evaluation-key tracking,
+or custom emit shapes, pass a full `KeywordDefinition` instead — the
+`compile(ctx)` function receives a `KeywordCompileContext` that lets
+you emit generated code directly.
 
-| Member                                                  | Purpose                                                                                                                         |
-| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `ctx.gen`                                               | Code emitter (`CodeEmitter` interface).                                                                                         |
-| `ctx.schema`, `ctx.parentSchema`                        | The keyword's value and the surrounding object.                                                                                 |
-| `ctx.data`, `ctx.path`, `ctx.errors`                    | JS expressions for the data / path / errors accumulator.                                                                        |
-| `ctx.emitError(kind, expr)`                             | Push a `ValidationError` expression. `kind`: `"leaf"` (counts toward `maxErrors`) or `"lift"` (already-counted, unconditional). |
-| `ctx.errorStatement(kind, expr)`                        | String form of `emitError` for inline source composition.                                                                       |
-| `ctx.validateSubschema(schema, dataExpr, { segment? })` | Descend into a subschema and emit any errors. Inlines when simple.                                                              |
-| `ctx.compileSubschema(schema)`                          | Lower-level: returns a function name. Use when the caller needs the sub-validator's return value (composition keywords).        |
-| `ctx.withPathSegment(seg, () => …)`                     | Scoped path push/pop — errors emitted in the body get the extended path.                                                        |
-| `ctx.resolveRef(ref)`                                   | Resolve a `$ref` to a compiled function name.                                                                                   |
-| `ctx.evaluatedPropertiesVar` / `evaluatedItemsVar`      | Raw variable names (or `null`) for `unevaluated*` tracking.                                                                     |
-| `ctx.emitBudgetBreak()`                                 | Short-circuit hot loops once `maxErrors` is exhausted.                                                                          |
-
-When adding a new built-in keyword, also add an entry to
-`BuiltInErrorParams` in `@aahoughton/oav/core` documenting the shape of
-its `params` object.
+This is a contributor-facing surface; the full compile-context API and
+flag reference live in [`CLAUDE.md`](../../CLAUDE.md#how-to-add-a-new-keyword).
 
 ## Error-collection modes
 
@@ -135,4 +122,3 @@ budget checks.
 `$ref` / `$dynamicRef` compile to function calls through a
 schema-identity-keyed cache, so a self-referential schema emits a
 normal recursive call rather than blowing the stack at compile time.
-See `resolve()` / `createRefResolver()` for the resolution pipeline.

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -7,9 +7,12 @@ this when you want to stitch a spec together before handing it to
 This module is available at matching subpaths in both
 `@aahoughton/oav/spec` and `@aahoughton/oav-core/spec`. The examples
 below import from `@aahoughton/oav`; substitute `@aahoughton/oav-core`
-if you're on the lean package — with the caveat that `oav-core` ships
-JSON readers only (YAML paths throw an install-hint error; install
-`@aahoughton/oav` or bring your own YAML reader).
+if you're on the lean package.
+
+> **oav-core ships JSON readers only.** Calling `createFileReader()` or
+> `createHttpReader()` on a `.yaml` / `.yml` path throws an install-hint
+> error. For YAML support, install `@aahoughton/oav` (for the bundled
+> `createYamlFileReader`) or register your own YAML reader.
 
 ## Loading a spec
 
@@ -121,6 +124,5 @@ the validator and schema compiler follow them at runtime via a
 ref-resolution cache keyed on schema identity, so self-recursive
 schemas compile to normal recursive calls.
 
-Circular external references are rewritten to synthetic internal
-refs (`#/$defs/__ext__/<uri>`) during resolution, so the final
-document is always self-contained.
+Circular external references are rewritten to internal anchors
+during resolution, so the final document is always self-contained.

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -40,12 +40,10 @@ Native OpenAPI 3.0 dialect alongside 3.1 / 3.2, so `nullable`,
 boolean `exclusiveMaximum`, and `$ref`-suppresses-siblings work by
 3.0 rules rather than via a 2020-12 translation shim. Pairs with
 [`@aahoughton/oav/spec`](../spec/README.md)'s `applyOverlays` for
-patching externally-owned base specs at load time. Published
-conformance numbers (98.5% on the 1290-case JSON Schema Test Suite,
-100% on the OpenAPI request/response cases) live at
+patching externally-owned base specs at load time. Pass counts against
+the upstream test suites live in
 [`conformance/REPORT.md`](../../conformance/REPORT.md). The
-[top-level README](../../README.md#why-this-exists) has the full
-rationale.
+[top-level README](../../README.md) has the full rationale.
 
 ## Features
 
@@ -67,16 +65,30 @@ rationale.
 - **Format validators**: the `@aahoughton/oav/formats` built-ins merged
   with any extras passed via `options.formats`.
 
+## Validator methods
+
+| Method                                        | Purpose                                                                                                                                 |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `validateRequest(req)`                        | Check an `HttpRequest` against the spec. Returns `null` on success or a `ValidationError` tree.                                         |
+| `validateResponse(req, res)`                  | Check an `HttpResponse` against the spec (request is used only for method + path). Returns `null` or a tree.                            |
+| `validateFetchRequest<T>(request, opts?)`     | Convenience for Web Standards `Request`: reads URL, headers, body; returns a discriminated union with a typed body. See INTEGRATION.md. |
+| `validateFetchResponse<T>(request, response)` | Symmetric Web Standards `Response` check. Useful for contract-testing an upstream.                                                      |
+| `getOperation({ method, path })`              | Startup-time introspection: returns the resolved, overlay-applied `OperationObject` + matched template for a (method, path) pair.       |
+| `detectedVersion`                             | The `openapi` string detected on construction, or `undefined` for an unrecognised / missing version (see `onUnknownVersion`).           |
+
 ## Options
 
-| Option                  | Effect                                                                |
-| ----------------------- | --------------------------------------------------------------------- |
-| `dialect`               | Force a specific {@link Dialect}, bypassing version detection.        |
-| `formats`               | Extra string format validators merged with `@aahoughton/oav/formats`. |
-| `keywords`              | User-registered schema keywords (see below).                          |
-| `maxErrors`             | Cap on leaf errors; `1` is fast-fail. Default: uncapped.              |
-| `strictQueryParameters` | Reject undeclared query parameters. Default `false`.                  |
-| `onUnknownVersion`      | `"fallback31"` \| `"warn"` \| `"throw"` when `openapi` is missing.    |
+| Option                  | Effect                                                                                                             |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `dialect`               | Force a specific {@link Dialect}, bypassing version detection.                                                     |
+| `formats`               | Extra string format validators merged with `@aahoughton/oav/formats`.                                              |
+| `keywords`              | User-registered schema keywords (see below).                                                                       |
+| `maxErrors`             | Cap on leaf errors; `1` is fast-fail. Default: uncapped.                                                           |
+| `strictQueryParameters` | Reject undeclared query parameters. Default `false`.                                                               |
+| `validateSecurity`      | Shape-only security check (bearer / basic / apiKey credential location). Default `true`; set `false` to skip.      |
+| `ignoreUndocumented`    | Return `null` on requests whose path the router can't match. Default `false`.                                      |
+| `ignorePaths`           | `(path: string) => boolean` predicate that short-circuits validation when it returns `true` (runs before routing). |
+| `onUnknownVersion`      | `"fallback31"` \| `"warn"` \| `"throw"` when `openapi` is missing or unsupported. Default `"fallback31"`.          |
 
 ## Custom keywords
 


### PR DESCRIPTION
## Summary

- Sweep user-facing docs (`README`, `INTEGRATION`, `COMPARISON`, `OVERLAYS`, `CONTRIBUTING`, `examples/`, `packages/*/README.md`) to fix API-surface gaps, broken anchors, dev-team voice, and label inconsistencies.
- Move inline example specs into `examples/specs/*.yaml` and rewrite each example to load via `loadSpec` + `createYamlFileReader` — matches the pattern a real consumer would use.
- Add `getOperation`, `validateFetchRequest`, `validateFetchResponse` to the validator methods table; add `ignoreUndocumented`, `ignorePaths`, `validateSecurity` to the options table in README and validator README (all were only documented in INTEGRATION before).

Closes #111.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (617 / 617 passing)
- [x] All 9 examples run clean (`tsx examples/<file>.ts`)
- [x] Cross-file anchors verified (no more broken `#why-this-exists`)