### PR TITLE
fix(build): conditional exports so CJS TypeScript consumers can resolve types

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,39 +38,74 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./schema": {
-      "types": "./dist/schema.d.ts",
-      "import": "./dist/schema.js",
-      "require": "./dist/schema.cjs"
+      "import": {
+        "types": "./dist/schema.d.ts",
+        "default": "./dist/schema.js"
+      },
+      "require": {
+        "types": "./dist/schema.d.cts",
+        "default": "./dist/schema.cjs"
+      }
     },
     "./schema/internals": {
-      "types": "./dist/schema-internals.d.ts",
-      "import": "./dist/schema-internals.js",
-      "require": "./dist/schema-internals.cjs"
+      "import": {
+        "types": "./dist/schema-internals.d.ts",
+        "default": "./dist/schema-internals.js"
+      },
+      "require": {
+        "types": "./dist/schema-internals.d.cts",
+        "default": "./dist/schema-internals.cjs"
+      }
     },
     "./spec": {
-      "types": "./dist/spec.d.ts",
-      "import": "./dist/spec.js",
-      "require": "./dist/spec.cjs"
+      "import": {
+        "types": "./dist/spec.d.ts",
+        "default": "./dist/spec.js"
+      },
+      "require": {
+        "types": "./dist/spec.d.cts",
+        "default": "./dist/spec.cjs"
+      }
     },
     "./formats": {
-      "types": "./dist/formats.d.ts",
-      "import": "./dist/formats.js",
-      "require": "./dist/formats.cjs"
+      "import": {
+        "types": "./dist/formats.d.ts",
+        "default": "./dist/formats.js"
+      },
+      "require": {
+        "types": "./dist/formats.d.cts",
+        "default": "./dist/formats.cjs"
+      }
     },
     "./core": {
-      "types": "./dist/core.d.ts",
-      "import": "./dist/core.js",
-      "require": "./dist/core.cjs"
+      "import": {
+        "types": "./dist/core.d.ts",
+        "default": "./dist/core.js"
+      },
+      "require": {
+        "types": "./dist/core.d.cts",
+        "default": "./dist/core.cjs"
+      }
     },
     "./validator/internals": {
-      "types": "./dist/validator-internals.d.ts",
-      "import": "./dist/validator-internals.js",
-      "require": "./dist/validator-internals.cjs"
+      "import": {
+        "types": "./dist/validator-internals.d.ts",
+        "default": "./dist/validator-internals.js"
+      },
+      "require": {
+        "types": "./dist/validator-internals.d.cts",
+        "default": "./dist/validator-internals.cjs"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/packages/oav/package.json
+++ b/packages/oav/package.json
@@ -42,39 +42,74 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./schema": {
-      "types": "./dist/schema.d.ts",
-      "import": "./dist/schema.js",
-      "require": "./dist/schema.cjs"
+      "import": {
+        "types": "./dist/schema.d.ts",
+        "default": "./dist/schema.js"
+      },
+      "require": {
+        "types": "./dist/schema.d.cts",
+        "default": "./dist/schema.cjs"
+      }
     },
     "./schema/internals": {
-      "types": "./dist/schema-internals.d.ts",
-      "import": "./dist/schema-internals.js",
-      "require": "./dist/schema-internals.cjs"
+      "import": {
+        "types": "./dist/schema-internals.d.ts",
+        "default": "./dist/schema-internals.js"
+      },
+      "require": {
+        "types": "./dist/schema-internals.d.cts",
+        "default": "./dist/schema-internals.cjs"
+      }
     },
     "./spec": {
-      "types": "./dist/spec.d.ts",
-      "import": "./dist/spec.js",
-      "require": "./dist/spec.cjs"
+      "import": {
+        "types": "./dist/spec.d.ts",
+        "default": "./dist/spec.js"
+      },
+      "require": {
+        "types": "./dist/spec.d.cts",
+        "default": "./dist/spec.cjs"
+      }
     },
     "./formats": {
-      "types": "./dist/formats.d.ts",
-      "import": "./dist/formats.js",
-      "require": "./dist/formats.cjs"
+      "import": {
+        "types": "./dist/formats.d.ts",
+        "default": "./dist/formats.js"
+      },
+      "require": {
+        "types": "./dist/formats.d.cts",
+        "default": "./dist/formats.cjs"
+      }
     },
     "./core": {
-      "types": "./dist/core.d.ts",
-      "import": "./dist/core.js",
-      "require": "./dist/core.cjs"
+      "import": {
+        "types": "./dist/core.d.ts",
+        "default": "./dist/core.js"
+      },
+      "require": {
+        "types": "./dist/core.d.cts",
+        "default": "./dist/core.cjs"
+      }
     },
     "./validator/internals": {
-      "types": "./dist/validator-internals.d.ts",
-      "import": "./dist/validator-internals.js",
-      "require": "./dist/validator-internals.cjs"
+      "import": {
+        "types": "./dist/validator-internals.d.ts",
+        "default": "./dist/validator-internals.js"
+      },
+      "require": {
+        "types": "./dist/validator-internals.d.cts",
+        "default": "./dist/validator-internals.cjs"
+      }
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
## Summary

- CJS TypeScript projects on `moduleResolution: Node16` / `NodeNext` hit TS1479 on every oav import, even though Node's runtime resolution worked fine.
- Root cause: the exports map used a flat `"types"` entry pointing at a `.d.ts` file. TypeScript infers module kind from extension (`.d.ts` → ESM, `.d.cts` → CJS), so the flat entry signalled "ESM-only types" to CJS consumers.
- Switched both `package.json` exports maps (root `@aahoughton/oav-core`, `packages/oav/@aahoughton/oav`) to the Node16 conditional-types shape so TypeScript resolves the right declaration per consumer module kind.

Closes #114.

## Test plan

- [x] `pnpm typecheck` passes in monorepo
- [x] `pnpm test` passes (631/631)
- [x] CJS TypeScript consumer (`/tmp/oav-integration-validation/cjs/`, `"type": "commonjs"` + `module: "Node16"`) — `tsc --noEmit` now clean; TS1479 gone
- [x] CJS Node.js runtime (no TS) still works — `require('@aahoughton/oav')` + subpaths load, validator runs
- [x] ESM TypeScript consumer (`/tmp/oav-integration-validation/express5/`) still type-checks — no regression