### PR TITLE
fix(validator): gate content-type check before schema validation

### DIFF
--- a/packages/validator/src/validate-step.ts
+++ b/packages/validator/src/validate-step.ts
@@ -156,10 +156,47 @@ export function validateParameter(
 }
 
 /**
+ * Content-type gate for the request body. Returns a single leaf when
+ * the request carries a body whose `Content-Type` isn't in the declared
+ * media-type set for the operation; otherwise `null`. Runs before
+ * {@link validateBody} (and before parameter validation) so a
+ * content-type mismatch short-circuits with an unambiguous single-leaf
+ * tree instead of being paired with unrelated parameter diagnostics.
+ *
+ * Returns `null` — deliberately not a content-type error — when:
+ * - the operation declares no `requestBody`,
+ * - the request carries no body (body-missing is a separate concern,
+ *   handled by {@link validateBody}),
+ * - the operation's `requestBody.content` map is empty (nothing to
+ *   match against).
+ *
+ * @internal
+ */
+export function checkBodyContentType(
+  req: HttpRequest,
+  cache: OperationCache,
+): ValidationError | null {
+  if (cache.requestBody === undefined) return null;
+  const hasBody = req.body !== undefined && req.body !== null;
+  if (!hasBody) return null;
+  if (cache.bodyValidators.size === 0) return null;
+  const mt = matchMediaType(req.contentType, cache.bodyValidators.keys());
+  if (mt !== undefined) return null;
+  return createLeafError(
+    "content-type",
+    ["body"],
+    `request Content-Type "${req.contentType ?? "<missing>"}" is not accepted`,
+    { contentType: req.contentType, accepted: [...cache.bodyValidators.keys()] },
+  );
+}
+
+/**
  * Validate the request body against the operation cache's pre-compiled
- * per-media-type validators. Returns a leaf error for required-missing
- * or content-type mismatch; delegates shape validation to the compiled
- * schema and returns its error subtree (or `null` on success).
+ * per-media-type validators. Returns a leaf error for required-missing;
+ * delegates shape validation to the compiled schema and returns its
+ * error subtree (or `null` on success). Content-type matching is the
+ * caller's responsibility via {@link checkBodyContentType}; when
+ * reached here, a matching media-type validator is assumed to exist.
  *
  * @internal
  */
@@ -175,14 +212,7 @@ export function validateBody(req: HttpRequest, cache: OperationCache): Validatio
   }
   if (cache.bodyValidators.size === 0) return null;
   const mt = matchMediaType(req.contentType, cache.bodyValidators.keys());
-  if (mt === undefined) {
-    return createLeafError(
-      "content-type",
-      ["body"],
-      `request Content-Type "${req.contentType ?? "<missing>"}" is not accepted`,
-      { contentType: req.contentType, accepted: [...cache.bodyValidators.keys()] },
-    );
-  }
+  if (mt === undefined) return null; // content-type gate ran upstream; defensive no-op.
   const validator = cache.bodyValidators.get(mt);
   if (validator === undefined) return null;
   const r = validator.validate(req.body, ["body"]);

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -43,7 +43,7 @@ import {
   type OperationCache,
 } from "./operation-cache.js";
 import { checkSecurity, compileOperationSecurity } from "./security.js";
-import { validateBody, validateParameter } from "./validate-step.js";
+import { checkBodyContentType, validateBody, validateParameter } from "./validate-step.js";
 
 /**
  * Pick the dialect for a given OpenAPI version. 3.1 and 3.2 share the
@@ -541,6 +541,21 @@ export function createValidator(
           { method: req.method, pathPattern: match.pathPattern },
         );
       }
+    }
+
+    // Content-type gate: if the request carries a body whose
+    // Content-Type doesn't match any declared media type, short-circuit
+    // with a single leaf. Parameter / body schema diagnostics against a
+    // request the server can't parse in the first place are noise.
+    const ctErr = checkBodyContentType(req, cache);
+    if (ctErr !== null) {
+      return createBranchError(
+        "request",
+        [],
+        `${req.method.toUpperCase()} ${match.pathPattern}: request validation failed`,
+        [ctErr],
+        { method: req.method, pathPattern: match.pathPattern },
+      );
     }
 
     for (const p of cache.parameters) {

--- a/packages/validator/test/request.test.ts
+++ b/packages/validator/test/request.test.ts
@@ -120,6 +120,24 @@ describe("validateRequest", () => {
     expect(leafCodes(err)).toContain("content-type");
   });
 
+  it("content-type gate short-circuits before parameter validation", () => {
+    // Wrong Content-Type AND missing required X-Tenant header. The gate
+    // fires first, so the tree is a single content-type leaf — no
+    // paired header-param diagnostic. Motivation: a client who fixes
+    // the content-type can't act on a header-param complaint anyway;
+    // surface the upstream problem unambiguously.
+    const err = v.validateRequest({
+      method: "POST",
+      path: "/pets",
+      contentType: "text/plain",
+      body: "raw",
+      // no X-Tenant header
+    });
+    const leaves = collectLeaves(err);
+    expect(leaves).toHaveLength(1);
+    expect(leaves[0]?.code).toBe("content-type");
+  });
+
   it("deserializes path parameters to their declared type", () => {
     expect(v.validateRequest({ method: "GET", path: "/pets/42" })).toBeNull();
     const err = v.validateRequest({ method: "GET", path: "/pets/abc" });


### PR DESCRIPTION
## Summary

- The content-type check lived inside `validateBody` and ran in parallel with parameter validation. A request that both declared the wrong `Content-Type` AND omitted a required parameter surfaced both errors together — noise, since a client can't act on the parameter diagnostic until the server can parse the body.
- Lifted content-type matching into a proper gate between `security` and parameter/body validation. New ordering: route → method → security → **content-type** → parameters + body + strictQueryParameters.
- Matches the HTTP response-code ladder (404 → 405 → 401 → 415 → 400). Also means `httpStatusFor`'s 415 branch fires on an unambiguous single-leaf tree.
- Factored the matching logic into a `checkBodyContentType` helper so the gate and `validateBody` share it. `validateBody` now assumes content-type is valid when reached (defensive no-op returns `null` if not). Response-side content-type handling is untouched — kept focused to the request side per issue scope.

Closes #113.

## Test plan

- [x] `pnpm test` passes (632/632 — new gate test added)
- [x] `pnpm typecheck` / `pnpm lint` clean
- [x] Empirical: POST with wrong `Content-Type` + missing required header now returns a single `content-type` leaf (previously returned a paired `content-type` + `header-param` tree)
- [x] HTTP 415 still resolves correctly via `httpStatusFor` (now unambiguous — single leaf at top level)