### PR TITLE
docs: sharpen performance framing in README + COMPARISON

### DIFF
--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -10,9 +10,27 @@ oav covers the same ground as Ajv + `express-openapi-validator`
 combined — schema validation plus HTTP-layer checks — and trades
 differently on a handful of specifics, catalogued below.
 
-This document is about behaviour and capabilities. For runtime
-performance, see [`performance/README.md`](./performance/README.md),
-which runs both libraries on the same benchmark fixtures.
+This document is about behaviour and capabilities. For raw numbers
+and methodology see [`performance/README.md`](./performance/README.md);
+the shape of the trade-off is sketched below.
+
+## Performance sketch
+
+Ajv and oav trade differently depending on the workload:
+
+| Workload                                               | Winner                                                             | Notes                                                            |
+| ------------------------------------------------------ | ------------------------------------------------------------------ | ---------------------------------------------------------------- |
+| Validate, simple schemas (tiny / tree)                 | tied                                                               | Within ~5% either way; predicate mode slightly ahead of ajv      |
+| Validate, complex shapes (oneOf / allOf, large arrays) | ajv 2–5× faster                                                    | ajv's codegen excels on deep applicators                         |
+| Validate, predicate mode                               | ≈ ajv                                                              | `compileSchema(..., { predicate: true })` closes most of the gap |
+| Compile, synthetic (per shape)                         | **oav 30–180× faster**                                             | The largest gap in either direction                              |
+| Compile, real-world OpenAPI spec                       | **oav 8× on Stripe** (886 schemas); **5.5× on Adyen** (44 schemas) | Matches the synthetic trend at spec scale                        |
+
+The takeaway: ajv wins steady-state validate throughput on a spec you
+compile once and reuse; oav wins anywhere validator construction is
+part of the hot path (per-request, per-tenant, per-test, edge
+cold-starts). Full methodology, raw numbers, and the benchmark
+harness live in [`performance/README.md`](./performance/README.md).
 
 ## Where Ajv (+ express-openapi-validator) does more
 
@@ -152,11 +170,13 @@ both support custom keywords and formats, both produce
 machine-readable errors. Differences are real but bounded.
 
 Pick Ajv + `express-openapi-validator` when you want the fastest
-validator, a large userbase, multi-draft support, or the one-line
-middleware integration that comes with it. Pick oav when you want a
-structured error tree, overlays over specs you don't own, a bundled
-OpenAPI 3.0 dialect, or explicit control over where validation runs
-in your HTTP stack.
+steady-state validate throughput on a schema you compile once, a
+large userbase, multi-draft support, or the one-line middleware
+integration. Pick oav when you want a structured error tree,
+overlays over specs you don't own, a bundled OpenAPI 3.0 dialect,
+explicit control over where validation runs in your HTTP stack — or
+when compile throughput matters (1–2 orders of magnitude above ajv,
+8× on Stripe's real-world spec; see the performance sketch above).
 
 For benchmark numbers rather than feature comparisons, see
 [`performance/README.md`](./performance/README.md).

--- a/README.md
+++ b/README.md
@@ -106,11 +106,18 @@ elsewhere in the JavaScript ecosystem:
   tree (`code` / `path` / `params` / `children`) so downstream code
   can narrow on fields rather than pattern-match on messages.
 
-Ajv is the fastest JSON Schema validator for JavaScript and underpins
-most of the OpenAPI ecosystem. For pure validate-per-second throughput
-on a spec you fully own, it's still the right pick. Where the two
-projects overlap and where each does more is written up in
-[`COMPARISON.md`](./COMPARISON.md).
+Ajv is the canonical JSON Schema validator for JavaScript and
+underpins most of the OpenAPI ecosystem. It has the edge on
+steady-state validate throughput — roughly 2–5× on complex shapes in
+`oav`'s default error-tree mode; `oav`'s predicate mode
+(`compileSchema(..., { predicate: true })`) closes most of that gap.
+On _compile_ throughput the ranking flips by 1–2 orders of
+magnitude: on a real-world OpenAPI doc (Stripe, 886 schemas), oav
+compiles **8× faster**; on synthetic schemas, 30–180× faster. If
+you construct validators per-request, per-tenant, or per-test, that
+usually dominates the overall picture. Full numbers in
+[`COMPARISON.md`](./COMPARISON.md) and
+[`performance/README.md`](./performance/README.md).
 
 ## Conformance
 


### PR DESCRIPTION
## Summary

- Previous wording ("Ajv is the fastest JSON Schema validator... still the right pick") was accurate for steady-state validate but erased oav's compile-side lead.
- README: replace the three-sentence ajv paragraph with one that names both sides and cites concrete numbers — steady-state validate 2–5× to ajv on complex shapes, compile 8× to oav on Stripe's real-world 886-schema spec, 30–180× on synthetic shapes, predicate mode closing most of the validate gap.
- COMPARISON: add a short `## Performance sketch` section with a workload/winner table after the intro, so readers get the shape in 5 seconds without bouncing to `performance/README.md`. Sharpen the Summary to qualify "fastest validator" as "fastest steady-state validate throughput" and name the compile-throughput flip as a reason to pick oav.

Numbers measured on `main` @ `8418a57` via `performance/run.ts` (synthetic and `--spec` modes). Raw results kept in `performance/results/`.

## Test plan

- [x] `pnpm lint` clean (oxfmt ran)
- [x] No code changes — docs-only
- [x] Cross-file references in the new COMPARISON.md table still link to `performance/README.md` (unchanged target)