### PR TITLE
perf: HTTP-server steady-state memory benchmark

### DIFF
--- a/performance/README.md
+++ b/performance/README.md
@@ -68,6 +68,31 @@ more specs and reports:
 Use it to sanity-check a new spec loads end-to-end through oav, or to
 regression-check when you touch `@oav/spec` / `@oav/validator`.
 
+### `mem.ts` — steady-state memory under HTTP load
+
+```bash
+# One-time bootstrap (builds oav, installs both server fixtures):
+pnpm --filter=. build          # from repo root
+cd performance/mem-bench && pnpm install
+cd ..
+
+pnpm bench:mem                                      # default 100 × 500 = 50,000 requests
+BATCHES=20 PER_BATCH=500 WARMUP=250 pnpm bench:mem  # quick smoke
+```
+
+Spawns two Express 4 servers — one wraps `@aahoughton/oav`, the other
+wraps `express-openapi-validator` (which pulls in ajv). Both validate
+a ~40-schema OpenAPI spec with discriminated payment-method unions,
+nested address + amount objects, and array-of-items transfers. The
+driver fires a round-robin mix of 13 request cases (valid + invalid
+POST/GET/404/405 across five endpoints), forcing GC between samples
+via each server's `/__memory?gc=1` endpoint, and reports baseline /
+post-warmup / steady-state / post-idle RSS + heapUsed.
+
+Use it to compare library footprint in a real HTTP backend shape, or
+to regression-check when you change validator construction or cache
+retention.
+
 ## Which entry point when
 
 | You want to know...                                                    | Use                                                                       |
@@ -76,6 +101,7 @@ regression-check when you touch `@oav/spec` / `@oav/validator`.
 | How does library choice scale across a real spec's schemas?            | `run.ts --spec=<path>`                                                    |
 | Does this real spec load cleanly through oav's pipeline?               | `bench-real-world.mjs`                                                    |
 | How long does oav take from spec-on-disk to "first validated request"? | `bench-real-world.mjs`                                                    |
+| What's the steady-state memory cost of each library in an HTTP server? | `mem.ts`                                                                  |
 
 ## Reading the results
 
@@ -114,6 +140,51 @@ compile (per library, aggregated across every schema):
   library that rejects an OAS 3.0-specific keyword like `nullable`
   will show up here; that's a real property of the library, not a
   benchmark artifact).
+
+### Memory mode (`mem.ts`)
+
+```
+=== Steady-state memory: 100 × 500 = 50000 reqs ===
+
+metric                                 oav       eov+ajv   Δ (eov-oav)
+------------------------------------------------------------------------
+baseline  RSS                       77.0MB       108.9MB        31.9MB  (-29%)
+baseline  heapUsed                   8.8MB        12.1MB         3.3MB
+warmup    RSS                       83.4MB       111.6MB        28.2MB
+warmup    heapUsed                  11.5MB        14.4MB         2.9MB
+steady    RSS (avg last 5)          98.3MB       117.1MB        18.8MB  (-16%)
+steady    heapUsed (avg)            11.9MB        14.6MB         2.7MB
+postIdle  RSS                       98.3MB       117.1MB        18.8MB
+postIdle  heapUsed                  11.9MB        14.6MB         2.7MB
+growth    RSS                       14.9MB         5.5MB        -9.4MB
+growth    heapUsed                   0.5MB         0.3MB        -0.2MB
+
+batch throughput (avg ms per 500-req batch): oav 75ms, eov 80ms
+```
+
+What to look at:
+
+- **`baseline RSS`** — the library + validator-set footprint at rest,
+  right after `app.listen`. Stable across runs; typically eov+ajv is
+  ~30 MB higher than oav on the bench spec.
+- **`steady heapUsed`** — V8 heap after 50k requests with GC forced
+  before each sample. Stable; typically eov+ajv is ~2.5–3 MB higher
+  (~15–20%).
+- **`growth` rows** — delta from post-warmup to end-of-run. Both
+  libraries plateau; if either grows without bound the value here
+  diverges and the steady rows keep rising across runs.
+- **`steady RSS`** is noisier than heapUsed — V8 expands the heap in
+  chunks, and when a chunk boundary falls mid-run the final RSS
+  differs by 10–15 MB between runs even though the actual working
+  set is stable. The heapUsed number is the cleaner signal for
+  retention; RSS is what the OS accountancy shows and includes V8's
+  uncommitted-but-reserved pages.
+- **Status-code distribution** is printed above the table; both
+  servers should agree on every batch. A mismatch means the
+  validators diverge on some request shape and the comparison is
+  invalid.
+
+Raw per-batch data lands in `results/mem-<timestamp>.json`.
 
 ### Note on `validate` under `--spec`
 

--- a/performance/mem-bench/openapi.yaml
+++ b/performance/mem-bench/openapi.yaml
@@ -1,0 +1,352 @@
+openapi: "3.1.0"
+info:
+  title: Core Banking API
+  version: "1.0"
+paths:
+  /transactions:
+    post:
+      operationId: createTransaction
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/Transaction" }
+      responses:
+        "201":
+          description: created
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id]
+                properties: { id: { type: string, format: uuid } }
+    get:
+      operationId: listTransactions
+      parameters:
+        - { name: limit, in: query, schema: { type: integer, minimum: 1, maximum: 100 } }
+        - { name: cursor, in: query, schema: { type: string, maxLength: 256 } }
+        - { name: status, in: query, schema: { type: string, enum: [pending, completed, failed] } }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items: { $ref: "#/components/schemas/Transaction" }
+                  nextCursor: { type: string }
+  /transfers:
+    post:
+      parameters:
+        - name: X-Idempotency-Key
+          in: header
+          required: true
+          schema: { type: string, pattern: "^[A-Za-z0-9_-]{16,64}$" }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/Transfer" }
+      responses:
+        "201":
+          description: created
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, status]
+                properties:
+                  id: { type: string, format: uuid }
+                  status: { type: string, enum: [pending, completed, failed] }
+  /accounts:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/Account" }
+      responses:
+        "201":
+          description: created
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id]
+                properties: { id: { type: string, format: uuid } }
+  /invoices:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/Invoice" }
+      responses:
+        "201":
+          description: created
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, total]
+                properties:
+                  id: { type: string, format: uuid }
+                  total: { $ref: "#/components/schemas/Money" }
+  /subscriptions:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/Subscription" }
+      responses:
+        "201":
+          description: created
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id]
+                properties: { id: { type: string, format: uuid } }
+components:
+  schemas:
+    Money:
+      type: object
+      required: [value, currency]
+      properties:
+        value: { type: integer, minimum: 1, maximum: 100000000 }
+        currency: { type: string, pattern: "^[A-Z]{3}$" }
+    Address:
+      type: object
+      required: [line1, city, country]
+      properties:
+        line1: { type: string, minLength: 1, maxLength: 200 }
+        line2: { type: string, maxLength: 200 }
+        city: { type: string, minLength: 1, maxLength: 100 }
+        region: { type: string, maxLength: 100 }
+        postalCode: { type: string, pattern: "^[A-Za-z0-9 -]{2,12}$" }
+        country: { type: string, pattern: "^[A-Z]{2}$" }
+        email: { type: string, format: email }
+    # ------- Transaction surface -------
+    Transaction:
+      type: object
+      required: [id, amount, currency, createdAt, paymentMethod]
+      properties:
+        id: { type: string, format: uuid }
+        amount: { $ref: "#/components/schemas/Money" }
+        currency: { type: string, pattern: "^[A-Z]{3}$" }
+        createdAt: { type: string, format: date-time }
+        memo: { type: string, maxLength: 140 }
+        status: { type: string, enum: [pending, completed, failed] }
+        tags:
+          type: array
+          maxItems: 20
+          items: { type: string, minLength: 1, maxLength: 50 }
+        paymentMethod:
+          oneOf:
+            - $ref: "#/components/schemas/CardPayment"
+            - $ref: "#/components/schemas/BankPayment"
+            - $ref: "#/components/schemas/CryptoPayment"
+        billingAddress: { $ref: "#/components/schemas/Address" }
+    CardPayment:
+      type: object
+      required: [type, card]
+      properties:
+        type: { type: string, enum: [card] }
+        card:
+          type: object
+          required: [last4, brand, expMonth, expYear]
+          properties:
+            last4: { type: string, pattern: "^[0-9]{4}$" }
+            brand: { type: string, enum: [visa, mastercard, amex, discover] }
+            expMonth: { type: integer, minimum: 1, maximum: 12 }
+            expYear: { type: integer, minimum: 2024, maximum: 2100 }
+            holderName: { type: string, minLength: 1, maxLength: 100 }
+    BankPayment:
+      type: object
+      required: [type, bank]
+      properties:
+        type: { type: string, enum: [bank] }
+        bank:
+          type: object
+          required: [accountLast4, routingNumber]
+          properties:
+            accountLast4: { type: string, pattern: "^[0-9]{4}$" }
+            routingNumber: { type: string, pattern: "^[0-9]{9}$" }
+            accountType: { type: string, enum: [checking, savings] }
+    CryptoPayment:
+      type: object
+      required: [type, crypto]
+      properties:
+        type: { type: string, enum: [crypto] }
+        crypto:
+          type: object
+          required: [network, txHash]
+          properties:
+            network: { type: string, enum: [btc, eth, sol, matic] }
+            txHash: { type: string, pattern: "^0x[a-fA-F0-9]{40,66}$" }
+            confirmations: { type: integer, minimum: 0 }
+    # ------- Transfer surface -------
+    Transfer:
+      type: object
+      required: [from, to, items]
+      properties:
+        from: { $ref: "#/components/schemas/AccountRef" }
+        to: { $ref: "#/components/schemas/AccountRef" }
+        items:
+          type: array
+          minItems: 1
+          maxItems: 50
+          items:
+            type: object
+            required: [sku, quantity, price]
+            properties:
+              sku: { type: string, pattern: "^SKU-[A-Z0-9]{6,12}$" }
+              quantity: { type: integer, minimum: 1, maximum: 10000 }
+              price: { $ref: "#/components/schemas/Money" }
+              metadata:
+                type: object
+                additionalProperties: { type: string, maxLength: 500 }
+        note: { type: string, maxLength: 500 }
+    AccountRef:
+      type: object
+      required: [accountId]
+      properties:
+        accountId: { type: string, format: uuid }
+        displayName: { type: string, maxLength: 80 }
+    # ------- Account surface -------
+    Account:
+      type: object
+      required: [type, owner, balance]
+      properties:
+        type: { type: string, enum: [checking, savings, brokerage] }
+        owner:
+          oneOf:
+            - $ref: "#/components/schemas/Individual"
+            - $ref: "#/components/schemas/Business"
+        balance: { $ref: "#/components/schemas/Money" }
+        openedAt: { type: string, format: date-time }
+        preferences:
+          type: object
+          properties:
+            notifications:
+              type: array
+              maxItems: 10
+              items: { type: string, enum: [email, sms, push] }
+            currency: { type: string, pattern: "^[A-Z]{3}$" }
+            locale: { type: string, pattern: "^[a-z]{2}(-[A-Z]{2})?$" }
+        addresses:
+          type: array
+          maxItems: 5
+          items: { $ref: "#/components/schemas/Address" }
+    Individual:
+      type: object
+      required: [kind, firstName, lastName, dob]
+      properties:
+        kind: { type: string, enum: [individual] }
+        firstName: { type: string, minLength: 1, maxLength: 60 }
+        lastName: { type: string, minLength: 1, maxLength: 60 }
+        dob: { type: string, format: date }
+        ssn: { type: string, pattern: "^\\d{3}-\\d{2}-\\d{4}$" }
+    Business:
+      type: object
+      required: [kind, legalName, ein]
+      properties:
+        kind: { type: string, enum: [business] }
+        legalName: { type: string, minLength: 1, maxLength: 200 }
+        ein: { type: string, pattern: "^\\d{2}-\\d{7}$" }
+        website: { type: string, format: uri }
+    # ------- Invoice surface -------
+    Invoice:
+      type: object
+      required: [customer, lineItems, issuedAt]
+      properties:
+        customer: { $ref: "#/components/schemas/AccountRef" }
+        issuedAt: { type: string, format: date-time }
+        dueAt: { type: string, format: date-time }
+        currency: { type: string, pattern: "^[A-Z]{3}$" }
+        lineItems:
+          type: array
+          minItems: 1
+          maxItems: 200
+          items:
+            type: object
+            required: [description, quantity, unitPrice]
+            properties:
+              description: { type: string, minLength: 1, maxLength: 300 }
+              quantity: { type: integer, minimum: 1, maximum: 100000 }
+              unitPrice: { $ref: "#/components/schemas/Money" }
+              taxCategory: { type: string, enum: [standard, reduced, zero, exempt] }
+              discount:
+                type: object
+                properties:
+                  kind: { type: string, enum: [percent, absolute] }
+                  value: { type: number, minimum: 0 }
+        taxBreakdown:
+          type: array
+          maxItems: 10
+          items:
+            type: object
+            required: [rate, amount]
+            properties:
+              rate: { type: number, minimum: 0, maximum: 1 }
+              amount: { $ref: "#/components/schemas/Money" }
+              jurisdiction: { type: string, maxLength: 80 }
+        notes: { type: string, maxLength: 1000 }
+    # ------- Subscription surface -------
+    Subscription:
+      type: object
+      required: [plan, billingCycle, startDate]
+      properties:
+        plan:
+          oneOf:
+            - $ref: "#/components/schemas/FlatRatePlan"
+            - $ref: "#/components/schemas/TieredPlan"
+            - $ref: "#/components/schemas/MeteredPlan"
+        billingCycle:
+          type: object
+          required: [interval, intervalCount]
+          properties:
+            interval: { type: string, enum: [day, week, month, year] }
+            intervalCount: { type: integer, minimum: 1, maximum: 36 }
+            anchorDay: { type: integer, minimum: 1, maximum: 28 }
+        startDate: { type: string, format: date }
+        endDate: { type: string, format: date }
+        trialDays: { type: integer, minimum: 0, maximum: 365 }
+        metadata:
+          type: object
+          additionalProperties: { type: string, maxLength: 500 }
+    FlatRatePlan:
+      type: object
+      required: [kind, amount]
+      properties:
+        kind: { type: string, enum: [flat] }
+        amount: { $ref: "#/components/schemas/Money" }
+        name: { type: string, maxLength: 100 }
+    TieredPlan:
+      type: object
+      required: [kind, tiers]
+      properties:
+        kind: { type: string, enum: [tiered] }
+        tiers:
+          type: array
+          minItems: 1
+          maxItems: 10
+          items:
+            type: object
+            required: [upTo, amount]
+            properties:
+              upTo: { type: integer, minimum: 1 }
+              amount: { $ref: "#/components/schemas/Money" }
+    MeteredPlan:
+      type: object
+      required: [kind, unitAmount, meter]
+      properties:
+        kind: { type: string, enum: [metered] }
+        unitAmount: { $ref: "#/components/schemas/Money" }
+        meter: { type: string, enum: [api-call, storage-gb, compute-second, bandwidth-gb] }
+        includedUnits: { type: integer, minimum: 0 }

--- a/performance/mem-bench/package.json
+++ b/performance/mem-bench/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@oav-dev/mem-bench",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Isolated HTTP-server fixtures for the steady-state memory benchmark. Both servers validate the same OpenAPI spec against identical traffic; the memory probe endpoint (/__memory) lets the runner compare RSS/heap across runs.",
+  "type": "module",
+  "dependencies": {
+    "@aahoughton/oav": "file:../../packages/oav",
+    "@aahoughton/oav-core": "file:../..",
+    "express": "^4.21.2",
+    "express-openapi-validator": "^5.5.9"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "pnpm": {
+    "overrides": {
+      "@aahoughton/oav-core": "file:../.."
+    }
+  }
+}

--- a/performance/mem-bench/pnpm-lock.yaml
+++ b/performance/mem-bench/pnpm-lock.yaml
@@ -1,0 +1,926 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+overrides:
+  '@aahoughton/oav-core': file:../..
+
+importers:
+
+  .:
+    dependencies:
+      '@aahoughton/oav':
+        specifier: file:../../packages/oav
+        version: file:../../packages/oav
+      '@aahoughton/oav-core':
+        specifier: file:../..
+        version: file:../..
+      express:
+        specifier: ^4.21.2
+        version: 4.22.1
+      express-openapi-validator:
+        specifier: ^5.5.9
+        version: 5.6.2(@types/json-schema@7.0.15)(express@4.22.1)
+
+packages:
+
+  '@aahoughton/oav-core@file:../..':
+    resolution: {directory: ../.., type: directory}
+    engines: {node: '>=22'}
+
+  '@aahoughton/oav@file:../../packages/oav':
+    resolution: {directory: ../../packages/oav, type: directory}
+    engines: {node: '>=20'}
+    hasBin: true
+    peerDependencies:
+      commander: ^14.0.0
+    peerDependenciesMeta:
+      commander:
+        optional: true
+
+  '@apidevtools/json-schema-ref-parser@14.2.1':
+    resolution: {integrity: sha512-HmdFw9CDYqM6B25pqGBpNeLCKvGPlIx1EbLrVL0zPvj50CJQUHyBNBw45Muk0kEIkogo1VZvOKHajdMuAzSxRg==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@types/json-schema': ^7.0.15
+
+  '@jsdevtools/ono@7.1.3':
+    resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
+
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/multer@2.1.0':
+    resolution: {integrity: sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==}
+
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@types/qs@6.15.0':
+    resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  append-field@1.0.0:
+    resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
+  body-parser@1.20.4:
+    resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  busboy@1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  concat-stream@2.0.0:
+    resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
+    engines: {'0': node >= 6.0}
+
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.0.7:
+    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  express-openapi-validator@5.6.2:
+    resolution: {integrity: sha512-fkDn4+ImUC4HTJ1g0cek/ItqYhmEO19AglJd2Iw2OJco0jLIbxIlDGVazmXbvvYeziU4Bnah2h+S2tb6NtWg8w==}
+    peerDependencies:
+      express: '*'
+
+  express@4.22.1:
+    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
+    engines: {node: '>= 0.10.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  finalhandler@1.3.2:
+    resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
+    engines: {node: '>= 0.8'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  lodash.clonedeep@4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
+
+  lodash.get@4.4.2:
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  multer@2.1.1:
+    resolution: {integrity: sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==}
+    engines: {node: '>= 10.16.0'}
+
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  ono@7.1.3:
+    resolution: {integrity: sha512-9jnfVriq7uJM4o5ganUY54ntUm+5EK21EGaQ5NWnkWg3zz5ywbbonlBguRcnmF1/HDiIe3zxNxXcO1YPBmPcQQ==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-to-regexp@0.1.13:
+    resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  qs@6.14.2:
+    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+    engines: {node: '>=0.6'}
+
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@2.5.3:
+    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
+    engines: {node: '>= 0.8'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  send@0.19.2:
+    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
+    engines: {node: '>= 0.8.0'}
+
+  serve-static@1.16.3:
+    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
+    engines: {node: '>= 0.8.0'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  streamsearch@1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
+  typedarray@0.0.6:
+    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+snapshots:
+
+  '@aahoughton/oav-core@file:../..': {}
+
+  '@aahoughton/oav@file:../../packages/oav':
+    dependencies:
+      '@aahoughton/oav-core': file:../..
+      yaml: 2.8.3
+
+  '@apidevtools/json-schema-ref-parser@14.2.1(@types/json-schema@7.0.15)':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      js-yaml: 4.1.1
+
+  '@jsdevtools/ono@7.1.3': {}
+
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 25.6.0
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 25.6.0
+
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 25.6.0
+      '@types/qs': 6.15.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
+
+  '@types/http-errors@2.0.5': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/multer@2.1.0':
+    dependencies:
+      '@types/express': 5.0.6
+
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
+
+  '@types/qs@6.15.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 25.6.0
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 25.6.0
+
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
+  ajv-draft-04@1.0.0(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  append-field@1.0.0: {}
+
+  argparse@2.0.1: {}
+
+  array-flatten@1.1.1: {}
+
+  body-parser@1.20.4:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.14.2
+      raw-body: 2.5.3
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  buffer-from@1.1.2: {}
+
+  busboy@1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  concat-stream@2.0.0:
+    dependencies:
+      buffer-from: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      typedarray: 0.0.6
+
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  content-type@1.0.5: {}
+
+  cookie-signature@1.0.7: {}
+
+  cookie@0.7.2: {}
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
+
+  depd@2.0.0: {}
+
+  destroy@1.2.0: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  escape-html@1.0.3: {}
+
+  etag@1.8.1: {}
+
+  express-openapi-validator@5.6.2(@types/json-schema@7.0.15)(express@4.22.1):
+    dependencies:
+      '@apidevtools/json-schema-ref-parser': 14.2.1(@types/json-schema@7.0.15)
+      '@types/multer': 2.1.0
+      ajv: 8.18.0
+      ajv-draft-04: 1.0.0(ajv@8.18.0)
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      express: 4.22.1
+      json-schema-traverse: 1.0.0
+      lodash.clonedeep: 4.5.0
+      lodash.get: 4.4.2
+      media-typer: 1.1.0
+      multer: 2.1.1
+      ono: 7.1.3
+      path-to-regexp: 8.4.2
+      qs: 6.15.1
+    transitivePeerDependencies:
+      - '@types/json-schema'
+
+  express@4.22.1:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.4
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.0.7
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.2
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.13
+      proxy-addr: 2.0.7
+      qs: 6.14.2
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.2
+      serve-static: 1.16.3
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.0: {}
+
+  finalhandler@1.3.2:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  forwarded@0.2.0: {}
+
+  fresh@0.5.2: {}
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  inherits@2.0.4: {}
+
+  ipaddr.js@1.9.1: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  json-schema-traverse@1.0.0: {}
+
+  lodash.clonedeep@4.5.0: {}
+
+  lodash.get@4.4.2: {}
+
+  math-intrinsics@1.1.0: {}
+
+  media-typer@0.3.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@1.0.3: {}
+
+  methods@1.1.2: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime@1.6.0: {}
+
+  ms@2.0.0: {}
+
+  ms@2.1.3: {}
+
+  multer@2.1.1:
+    dependencies:
+      append-field: 1.0.0
+      busboy: 1.6.0
+      concat-stream: 2.0.0
+      type-is: 1.6.18
+
+  negotiator@0.6.3: {}
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  ono@7.1.3:
+    dependencies:
+      '@jsdevtools/ono': 7.1.3
+
+  parseurl@1.3.3: {}
+
+  path-to-regexp@0.1.13: {}
+
+  path-to-regexp@8.4.2: {}
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  qs@6.14.2:
+    dependencies:
+      side-channel: 1.1.0
+
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@2.5.3:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  require-from-string@2.0.2: {}
+
+  safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
+  send@0.19.2:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@1.16.3:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  statuses@2.0.2: {}
+
+  streamsearch@1.1.0: {}
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  toidentifier@1.0.1: {}
+
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+
+  typedarray@0.0.6: {}
+
+  undici-types@7.19.2: {}
+
+  unpipe@1.0.0: {}
+
+  util-deprecate@1.0.2: {}
+
+  utils-merge@1.0.1: {}
+
+  vary@1.1.2: {}
+
+  yaml@2.8.3: {}

--- a/performance/mem-bench/pnpm-workspace.yaml
+++ b/performance/mem-bench/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/performance/mem-bench/server-eov.mjs
+++ b/performance/mem-bench/server-eov.mjs
@@ -1,0 +1,61 @@
+// eov memory test server — Express 4 + express-openapi-validator (ajv under the hood).
+// Run with: node --expose-gc server.mjs
+//
+// Instruments /__memory (and /__memory?gc=1 to force a GC first).
+
+import express from "express";
+import OpenApiValidator from "express-openapi-validator";
+import { fileURLToPath } from "node:url";
+
+const specPath = fileURLToPath(new URL("./openapi.yaml", import.meta.url));
+
+const app = express();
+app.use(express.json({ limit: "1mb" }));
+
+// Memory probe BEFORE the validator middleware chain so eov doesn't
+// intercept it (eov would 404 this path since it isn't in the spec).
+app.get("/__memory", (req, res) => {
+  if (req.query.gc === "1" && globalThis.gc) {
+    globalThis.gc();
+    globalThis.gc();
+  }
+  const m = process.memoryUsage();
+  res.json({
+    rss: m.rss,
+    heapTotal: m.heapTotal,
+    heapUsed: m.heapUsed,
+    external: m.external,
+    arrayBuffers: m.arrayBuffers,
+    uptime: process.uptime(),
+  });
+});
+
+app.use(
+  OpenApiValidator.middleware({
+    apiSpec: specPath,
+    validateRequests: true,
+    validateResponses: false,
+  }),
+);
+
+// Business handlers.
+const ok201 = { id: "00000000-0000-0000-0000-000000000000" };
+const ok201tx = { id: "00000000-0000-0000-0000-000000000000", status: "pending" };
+const ok201inv = {
+  id: "00000000-0000-0000-0000-000000000000",
+  total: { value: 1, currency: "USD" },
+};
+app.post("/transactions", (_req, res) => res.status(201).json(ok201));
+app.get("/transactions", (_req, res) => res.json({ items: [] }));
+app.post("/transfers", (_req, res) => res.status(201).json(ok201tx));
+app.post("/accounts", (_req, res) => res.status(201).json(ok201));
+app.post("/invoices", (_req, res) => res.status(201).json(ok201inv));
+app.post("/subscriptions", (_req, res) => res.status(201).json(ok201));
+
+// eov's default error shape.
+app.use((err, _req, res, _next) => {
+  res.status(err.status ?? 500).json({ message: err.message, errors: err.errors });
+});
+
+const PORT = Number(process.env.PORT ?? 3810);
+app.listen(PORT, () => console.log(`eov listening on ${PORT}`));

--- a/performance/mem-bench/server-oav.mjs
+++ b/performance/mem-bench/server-oav.mjs
@@ -1,0 +1,79 @@
+// oav memory test server — Express 4 + @aahoughton/oav adapter.
+// Run with: node --expose-gc server.mjs
+//
+// Instruments /__memory (and /__memory?gc=1 to force a GC first).
+
+import express from "express";
+import {
+  allowHeaderFor,
+  createValidator,
+  createYamlFileReader,
+  httpStatusFor,
+  toProblemDetails,
+} from "@aahoughton/oav";
+import { loadSpec } from "@aahoughton/oav/spec";
+import { fileURLToPath } from "node:url";
+
+const specPath = fileURLToPath(new URL("./openapi.yaml", import.meta.url));
+const { document } = await loadSpec({
+  reader: createYamlFileReader(),
+  entry: specPath,
+});
+const validator = createValidator(document);
+
+const app = express();
+app.use(express.json({ limit: "1mb" }));
+
+// Memory probe (before validation middleware so it's always reachable).
+app.get("/__memory", (req, res) => {
+  if (req.query.gc === "1" && globalThis.gc) {
+    globalThis.gc();
+    globalThis.gc(); // twice: first pass frees; second compacts
+  }
+  const m = process.memoryUsage();
+  res.json({
+    rss: m.rss,
+    heapTotal: m.heapTotal,
+    heapUsed: m.heapUsed,
+    external: m.external,
+    arrayBuffers: m.arrayBuffers,
+    uptime: process.uptime(),
+  });
+});
+
+// Validator adapter.
+app.use(async (req, res, next) => {
+  if (req.path === "/__memory") return next();
+  const err = validator.validateRequest({
+    method: req.method,
+    path: req.path,
+    query: req.query,
+    headers: req.headers,
+    contentType: req.get("content-type") ?? undefined,
+    body: req.body,
+  });
+  if (err === null) return next();
+  const allow = allowHeaderFor(err);
+  if (allow !== undefined) res.setHeader("Allow", allow);
+  res
+    .status(httpStatusFor(err))
+    .type("application/problem+json")
+    .json(toProblemDetails(err, { instance: req.originalUrl }));
+});
+
+// Business handlers.
+const ok201 = { id: "00000000-0000-0000-0000-000000000000" };
+const ok201tx = { id: "00000000-0000-0000-0000-000000000000", status: "pending" };
+const ok201inv = {
+  id: "00000000-0000-0000-0000-000000000000",
+  total: { value: 1, currency: "USD" },
+};
+app.post("/transactions", (_req, res) => res.status(201).json(ok201));
+app.get("/transactions", (_req, res) => res.json({ items: [] }));
+app.post("/transfers", (_req, res) => res.status(201).json(ok201tx));
+app.post("/accounts", (_req, res) => res.status(201).json(ok201));
+app.post("/invoices", (_req, res) => res.status(201).json(ok201inv));
+app.post("/subscriptions", (_req, res) => res.status(201).json(ok201));
+
+const PORT = Number(process.env.PORT ?? 3800);
+app.listen(PORT, () => console.log(`oav listening on ${PORT}`));

--- a/performance/mem.ts
+++ b/performance/mem.ts
@@ -1,0 +1,438 @@
+/**
+ * Steady-state HTTP-server memory benchmark.
+ *
+ * Spawns two Express 4 servers — one wraps @aahoughton/oav, the other
+ * wraps express-openapi-validator (which uses ajv under the hood) —
+ * against the same 40-schema OpenAPI spec. Hits each with 500 warmup
+ * requests + 100 × 500 = 50,000 workload requests round-robin across
+ * 13 cases (valid + invalid POST/GET/404/405 on five endpoints,
+ * exercising oneOf discrimination, nested objects, pattern + format
+ * constraints, and array-of-items schemas). Forces GC between samples
+ * via each server's `/__memory?gc=1` endpoint.
+ *
+ * Reports baseline, post-warmup, steady-state, and post-idle RSS +
+ * heapUsed. The gap is the sustained validator + runtime footprint
+ * each library carries at rest; growth across 50k reqs is a
+ * leak-shape check.
+ *
+ * Not a `tinybench` task — the numbers measured are memory
+ * footprints, which need a running HTTP server with a stable workload,
+ * not microbenchmark-style hot loops.
+ *
+ * Bootstrap:
+ *   cd performance/mem-bench && pnpm install
+ *   cd ..
+ *   pnpm bench:mem
+ *
+ * Env overrides (defaults produce the canonical 50k run):
+ *   BATCHES (default 100)
+ *   PER_BATCH (default 500)
+ *   WARMUP (default 500)
+ */
+
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { performance } from "node:perf_hooks";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MEM_BENCH_DIR = resolve(__dirname, "mem-bench");
+const RESULTS_DIR = resolve(__dirname, "results");
+
+const BATCHES = Number(process.env.BATCHES ?? 100);
+const PER_BATCH = Number(process.env.PER_BATCH ?? 500);
+const WARMUP = Number(process.env.WARMUP ?? 500);
+
+// ----- fixtures (same shape for both servers, identical payloads) -----
+
+const validTransaction = () => ({
+  id: "12345678-1234-4234-8234-123456789012",
+  amount: { value: 1500, currency: "USD" },
+  currency: "USD",
+  createdAt: "2026-04-23T10:30:00Z",
+  memo: "lunch",
+  status: "completed",
+  tags: ["food", "travel"],
+  paymentMethod: {
+    type: "card",
+    card: { last4: "4242", brand: "visa", expMonth: 12, expYear: 2028, holderName: "Jane Doe" },
+  },
+  billingAddress: {
+    line1: "500 Main St",
+    city: "Springfield",
+    region: "IL",
+    postalCode: "62701",
+    country: "US",
+    email: "jane@example.com",
+  },
+});
+
+const invalidTransaction = () => ({
+  id: "not-a-uuid",
+  amount: { value: -5, currency: "us" },
+  currency: "USD",
+  createdAt: "yesterday",
+  tags: ["", "x".repeat(60)],
+  paymentMethod: {
+    type: "card",
+    card: { last4: "42", brand: "mystery", expMonth: 13, expYear: 1999 },
+  },
+});
+
+const validTransfer = () => ({
+  from: { accountId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", displayName: "Checking" },
+  to: { accountId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", displayName: "Savings" },
+  items: [
+    {
+      sku: "SKU-ABC123",
+      quantity: 2,
+      price: { value: 1999, currency: "USD" },
+      metadata: { color: "red" },
+    },
+    { sku: "SKU-XYZ789", quantity: 1, price: { value: 5000, currency: "USD" } },
+  ],
+  note: "monthly top-up",
+});
+
+const invalidTransfer = () => ({
+  from: { accountId: "bad-uuid" },
+  to: { displayName: "Savings" },
+  items: [],
+});
+
+const validAccount = () => ({
+  type: "checking",
+  owner: {
+    kind: "individual",
+    firstName: "Jane",
+    lastName: "Doe",
+    dob: "1990-05-12",
+    ssn: "123-45-6789",
+  },
+  balance: { value: 250000, currency: "USD" },
+  openedAt: "2026-01-15T09:00:00Z",
+  preferences: { notifications: ["email", "sms"], currency: "USD", locale: "en-US" },
+  addresses: [
+    { line1: "1 Main St", city: "Austin", region: "TX", postalCode: "73301", country: "US" },
+  ],
+});
+
+const invalidAccount = () => ({
+  type: "crypto",
+  owner: { kind: "individual", firstName: "", lastName: "Doe", dob: "not-a-date" },
+  balance: { value: 0, currency: "us" },
+});
+
+const validInvoice = () => ({
+  customer: { accountId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc", displayName: "Acme Corp" },
+  issuedAt: "2026-04-23T00:00:00Z",
+  dueAt: "2026-05-23T00:00:00Z",
+  currency: "USD",
+  lineItems: [
+    {
+      description: "Consulting hours",
+      quantity: 10,
+      unitPrice: { value: 20000, currency: "USD" },
+      taxCategory: "standard",
+      discount: { kind: "percent", value: 5 },
+    },
+    {
+      description: "Travel",
+      quantity: 1,
+      unitPrice: { value: 45000, currency: "USD" },
+      taxCategory: "exempt",
+    },
+  ],
+  taxBreakdown: [{ rate: 0.0825, amount: { value: 16500, currency: "USD" }, jurisdiction: "TX" }],
+});
+
+const invalidInvoice = () => ({
+  customer: { accountId: "not-a-uuid" },
+  issuedAt: "tomorrow",
+  lineItems: [],
+});
+
+const validSubscription = () => ({
+  plan: {
+    kind: "tiered",
+    tiers: [
+      { upTo: 100, amount: { value: 1000, currency: "USD" } },
+      { upTo: 1000, amount: { value: 800, currency: "USD" } },
+    ],
+  },
+  billingCycle: { interval: "month", intervalCount: 1, anchorDay: 1 },
+  startDate: "2026-05-01",
+  trialDays: 14,
+});
+
+const invalidSubscription = () => ({
+  plan: { kind: "metered", unitAmount: { value: 1, currency: "USD" } },
+  billingCycle: { interval: "fortnight", intervalCount: 0 },
+  startDate: "2026/05/01",
+});
+
+type Case = {
+  name: string;
+  method: string;
+  path: string;
+  body?: () => Record<string, unknown>;
+  headers?: Record<string, string>;
+};
+
+const cases: Case[] = [
+  { name: "tx-valid", method: "POST", path: "/transactions", body: validTransaction },
+  { name: "tx-invalid", method: "POST", path: "/transactions", body: invalidTransaction },
+  {
+    name: "tf-valid",
+    method: "POST",
+    path: "/transfers",
+    body: validTransfer,
+    headers: { "x-idempotency-key": "AAAA-BBBB-CCCC-DDDD" },
+  },
+  {
+    name: "tf-invalid",
+    method: "POST",
+    path: "/transfers",
+    body: invalidTransfer,
+    headers: { "x-idempotency-key": "AAAA-BBBB-CCCC-DDDD" },
+  },
+  { name: "acct-valid", method: "POST", path: "/accounts", body: validAccount },
+  { name: "acct-invalid", method: "POST", path: "/accounts", body: invalidAccount },
+  { name: "inv-valid", method: "POST", path: "/invoices", body: validInvoice },
+  { name: "inv-invalid", method: "POST", path: "/invoices", body: invalidInvoice },
+  { name: "sub-valid", method: "POST", path: "/subscriptions", body: validSubscription },
+  { name: "sub-invalid", method: "POST", path: "/subscriptions", body: invalidSubscription },
+  { name: "tx-list", method: "GET", path: "/transactions?limit=25&status=pending" },
+  { name: "tx-unknown", method: "POST", path: "/unknown-route", body: () => ({}) },
+  { name: "tx-badverb", method: "PATCH", path: "/transactions", body: () => ({}) },
+];
+
+// ----- HTTP helpers -----
+
+interface MemorySample {
+  rss: number;
+  heapTotal: number;
+  heapUsed: number;
+  external: number;
+  arrayBuffers: number;
+  uptime: number;
+}
+
+async function fireRequest(base: string, c: Case): Promise<number> {
+  const res = await fetch(base + c.path, {
+    method: c.method,
+    headers: { "content-type": "application/json", ...c.headers },
+    body: c.body ? JSON.stringify(c.body()) : undefined,
+  });
+  await res.arrayBuffer();
+  return res.status;
+}
+
+async function sample(base: string, withGc = true): Promise<MemorySample> {
+  const r = await fetch(base + `/__memory${withGc ? "?gc=1" : ""}`);
+  return (await r.json()) as MemorySample;
+}
+
+async function batchRun(
+  base: string,
+  n: number,
+): Promise<{ durationMs: number; statuses: Record<number, number> }> {
+  const statuses = new Map<number, number>();
+  const t0 = performance.now();
+  for (let i = 0; i < n; i++) {
+    const c = cases[i % cases.length]!;
+    const got = await fireRequest(base, c);
+    statuses.set(got, (statuses.get(got) ?? 0) + 1);
+  }
+  return {
+    durationMs: performance.now() - t0,
+    statuses: Object.fromEntries(statuses),
+  };
+}
+
+// ----- server lifecycle -----
+
+interface ServerHandle {
+  proc: ChildProcessWithoutNullStreams;
+  base: string;
+}
+
+async function startServer(script: string, port: number): Promise<ServerHandle> {
+  const proc = spawn("node", ["--expose-gc", script], {
+    cwd: MEM_BENCH_DIR,
+    env: { ...process.env, PORT: String(port) },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const base = `http://localhost:${port}`;
+  proc.stderr.on("data", (d) => process.stderr.write(`[server:${port}] ${d}`));
+
+  const ready = new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`server ${script} did not ready in 10s`)),
+      10000,
+    );
+    const onData = (chunk: Buffer) => {
+      if (chunk.toString().includes(`listening on ${port}`)) {
+        clearTimeout(timer);
+        proc.stdout.off("data", onData);
+        resolve();
+      }
+    };
+    proc.stdout.on("data", onData);
+    proc.once("exit", (code) => reject(new Error(`server ${script} exited early (${code})`)));
+  });
+  await ready;
+  return { proc, base };
+}
+
+async function stopServer(h: ServerHandle): Promise<void> {
+  const closed = new Promise<void>((resolve) => h.proc.once("exit", () => resolve()));
+  h.proc.kill("SIGTERM");
+  await closed;
+}
+
+// ----- per-server run -----
+
+interface BatchResult {
+  batch: number;
+  durationMs: number;
+  statuses: Record<number, number>;
+}
+
+interface ServerResult {
+  label: string;
+  baseline: MemorySample;
+  afterWarmup: MemorySample;
+  perBatch: (BatchResult & MemorySample)[];
+  postIdle: MemorySample;
+}
+
+async function runOne(label: string, script: string, port: number): Promise<ServerResult> {
+  process.stderr.write(`\n[mem] ${label}: starting ${script}\n`);
+  const srv = await startServer(script, port);
+  try {
+    const baseline = await sample(srv.base, true);
+    process.stderr.write(
+      `[mem] ${label}: baseline  rss=${mb(baseline.rss)}  heapUsed=${mb(baseline.heapUsed)}\n`,
+    );
+
+    await batchRun(srv.base, WARMUP);
+    const afterWarmup = await sample(srv.base, true);
+    process.stderr.write(
+      `[mem] ${label}: warmup    rss=${mb(afterWarmup.rss)}  heapUsed=${mb(afterWarmup.heapUsed)}\n`,
+    );
+
+    const perBatch: (BatchResult & MemorySample)[] = [];
+    for (let i = 0; i < BATCHES; i++) {
+      const res = await batchRun(srv.base, PER_BATCH);
+      const mem = await sample(srv.base, true);
+      perBatch.push({ batch: i + 1, ...res, ...mem });
+      if ((i + 1) % 10 === 0 || i === 0) {
+        process.stderr.write(
+          `[mem] ${label}: batch ${i + 1}/${BATCHES}  ${res.durationMs.toFixed(0)}ms  rss=${mb(mem.rss)}  heapUsed=${mb(mem.heapUsed)}\n`,
+        );
+      }
+    }
+
+    await new Promise((r) => setTimeout(r, 2000));
+    const postIdle = await sample(srv.base, true);
+    process.stderr.write(
+      `[mem] ${label}: postIdle  rss=${mb(postIdle.rss)}  heapUsed=${mb(postIdle.heapUsed)}\n`,
+    );
+
+    return { label, baseline, afterWarmup, perBatch, postIdle };
+  } finally {
+    await stopServer(srv);
+  }
+}
+
+// ----- output -----
+
+function mb(bytes: number): string {
+  return (bytes / 1024 / 1024).toFixed(1) + "MB";
+}
+
+function avg(xs: number[]): number {
+  return xs.reduce((a, b) => a + b, 0) / xs.length;
+}
+
+function summarize(r: ServerResult) {
+  const lastFive = r.perBatch.slice(-5);
+  return {
+    baselineRss: r.baseline.rss,
+    baselineHeapUsed: r.baseline.heapUsed,
+    afterWarmupRss: r.afterWarmup.rss,
+    afterWarmupHeapUsed: r.afterWarmup.heapUsed,
+    steadyRss: avg(lastFive.map((b) => b.rss)),
+    steadyHeapUsed: avg(lastFive.map((b) => b.heapUsed)),
+    postIdleRss: r.postIdle.rss,
+    postIdleHeapUsed: r.postIdle.heapUsed,
+    growthRss: r.perBatch.at(-1)!.rss - r.afterWarmup.rss,
+    growthHeapUsed: r.perBatch.at(-1)!.heapUsed - r.afterWarmup.heapUsed,
+    avgBatchMs: avg(r.perBatch.map((b) => b.durationMs)),
+  };
+}
+
+function printTable(oav: ServerResult, eov: ServerResult): void {
+  const o = summarize(oav);
+  const e = summarize(eov);
+  const row = (label: string, ov: number, ev: number, format: (n: number) => string) =>
+    `${label.padEnd(28)}  ${format(ov).padStart(12)}  ${format(ev).padStart(12)}  ${format(ev - ov).padStart(12)}`;
+  const pct = (ov: number, ev: number) => ((1 - ov / ev) * 100).toFixed(0) + "%";
+
+  console.log("");
+  console.log(
+    `=== Steady-state memory: ${BATCHES} × ${PER_BATCH} = ${BATCHES * PER_BATCH} reqs ===`,
+  );
+  console.log("");
+  console.log(
+    `${"metric".padEnd(28)}  ${"oav".padStart(12)}  ${"eov+ajv".padStart(12)}  ${"Δ (eov-oav)".padStart(12)}`,
+  );
+  console.log("-".repeat(72));
+  console.log(
+    row("baseline  RSS", o.baselineRss, e.baselineRss, mb),
+    ` (-${pct(o.baselineRss, e.baselineRss)})`,
+  );
+  console.log(row("baseline  heapUsed", o.baselineHeapUsed, e.baselineHeapUsed, mb));
+  console.log(row("warmup    RSS", o.afterWarmupRss, e.afterWarmupRss, mb));
+  console.log(row("warmup    heapUsed", o.afterWarmupHeapUsed, e.afterWarmupHeapUsed, mb));
+  console.log(
+    row("steady    RSS (avg last 5)", o.steadyRss, e.steadyRss, mb),
+    ` (-${pct(o.steadyRss, e.steadyRss)})`,
+  );
+  console.log(row("steady    heapUsed (avg)", o.steadyHeapUsed, e.steadyHeapUsed, mb));
+  console.log(row("postIdle  RSS", o.postIdleRss, e.postIdleRss, mb));
+  console.log(row("postIdle  heapUsed", o.postIdleHeapUsed, e.postIdleHeapUsed, mb));
+  console.log(row("growth    RSS", o.growthRss, e.growthRss, mb));
+  console.log(row("growth    heapUsed", o.growthHeapUsed, e.growthHeapUsed, mb));
+  console.log("");
+  console.log(
+    `batch throughput (avg ms per ${PER_BATCH}-req batch): oav ${o.avgBatchMs.toFixed(0)}ms, eov ${e.avgBatchMs.toFixed(0)}ms`,
+  );
+}
+
+// ----- main -----
+
+const oav = await runOne("oav", "server-oav.mjs", 3800);
+const eov = await runOne("eov", "server-eov.mjs", 3810);
+
+// Sanity: both servers should have seen the same status distribution each batch.
+const oavStatuses = JSON.stringify(oav.perBatch[0]!.statuses);
+const eovStatuses = JSON.stringify(eov.perBatch[0]!.statuses);
+if (oavStatuses !== eovStatuses) {
+  process.stderr.write(
+    `\n[mem] WARNING: status-code mismatch between servers\n  oav: ${oavStatuses}\n  eov: ${eovStatuses}\n`,
+  );
+}
+
+printTable(oav, eov);
+
+mkdirSync(RESULTS_DIR, { recursive: true });
+const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+const outPath = resolve(RESULTS_DIR, `mem-${stamp}.json`);
+writeFileSync(
+  outPath,
+  JSON.stringify({ batches: BATCHES, perBatch: PER_BATCH, warmup: WARMUP, oav, eov }, null, 2),
+);
+console.log(`\nRaw numbers written to ${outPath}`);

--- a/performance/package.json
+++ b/performance/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "bench": "tsx run.ts",
-    "bench:long": "tsx run.ts --time=1500"
+    "bench:long": "tsx run.ts --time=1500",
+    "bench:mem": "tsx mem.ts"
   },
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "^15.3.5",


### PR DESCRIPTION
## Summary

Adds a third entry point to `performance/` alongside `run.ts` (tinybench library comparison) and `bench-real-world.mjs` (oav end-to-end pipeline): `performance/mem.ts` compares sustained memory use in a realistic Express 4 backend.

Spawns two servers — one wraps `@aahoughton/oav`, one wraps `express-openapi-validator` (ajv under the hood) — against a 40-schema payments spec (discriminated `oneOf` across card/bank/crypto, nested address + amount objects, pattern/format constraints, array-of-items transfers). Fires 500 warmup + 100 × 500 = 50,000 round-robin requests across 13 cases (valid + invalid POST / GET / 404 / 405), forcing GC between samples via each server's `/__memory?gc=1` endpoint.

## Findings on the bench spec

- **Baseline RSS gap: ~−29%** (eov+ajv starts ~30 MB higher). Consistent across runs — this is the library + eagerly-compiled validator footprint.
- **Steady heapUsed gap: ~−18–20%** (eov+ajv carries ~2.5–3 MB more at rest). Consistent across runs.
- **Steady RSS is noisier** — V8 expands heap in chunks, and run-to-run timing shifts which side crosses a chunk boundary first. heapUsed is the cleaner retention signal (documented in the new Reading-the-results section).
- **No leaks:** both plateau by batch 3, grow ~0.2–0.5 MB heap across 50k reqs, hold through post-idle.
- **Throughput parity** with ~5–10% oav edge on this mix (not the headline; kept for regression detection).

## Bootstrap

`mem-bench/` is an isolated sub-workspace (`packages: []` pnpm layout, same pattern as `conformance/` and the existing `performance/`) so file: deps against the repo's `packages/` don't pull the whole workspace graph in. One-time:

```bash
pnpm build
cd performance/mem-bench && pnpm install
cd .. && pnpm bench:mem
```

A pnpm `overrides` entry in `mem-bench/package.json` rewrites the `workspace:*` reference in `@aahoughton/oav`'s own dependency on `@aahoughton/oav-core` so the file: install resolves cleanly.

## Test plan

- [x] `pnpm lint` / `pnpm typecheck` / `pnpm test` all clean (no behavior changes in any published package)
- [x] `pnpm bench:mem` smoke at 5 × 100 = 500 reqs runs end-to-end (~15s total)
- [x] `pnpm bench:mem` full 100 × 500 = 50,000 reqs runs clean; results match the earlier /tmp validation shape (ran twice to check variance; heapUsed gap is stable, RSS has expected V8-heap-expansion noise)
- [x] Both servers agree on every request's status code (driver asserts this on first batch; mismatches log a warning)