### PR TITLE
feat(cli): oav compile --standalone — bundle runtime helpers via esbuild

### DIFF
--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -27,16 +27,18 @@ Capabilities that the Ajv stack covers and oav does not.
   strings to numbers, stripping undeclared properties, filling missing
   properties from `default`. oav treats validation as a yes/no
   question and does not mutate inputs.
-- **Ahead-of-time code generation.** Ajv ships a programmatic
-  `standaloneCode` API plus Node APIs that emit compiled validators
-  as module source. oav ships a CLI equivalent (`oav compile
-schema.json -o v.mjs`) that covers the edge-runtime / build-time-
-  bundling story for a single JSON Schema at a time. Ajv's
-  programmatic surface is richer — batch emission, multiple schemas
-  per file, CommonJS output — and Ajv's output can be made fully
-  self-contained; oav's emitted module imports runtime helpers from
-  `@aahoughton/oav/*`. For most "prepare a validator at build time"
-  use cases the CLI is enough.
+- **Ahead-of-time code generation — programmatic surface.** Ajv
+  ships a `standaloneCode` API plus Node APIs that emit compiled
+  validators as module source. oav's AOT story is CLI-only (`oav
+compile schema.json -o v.mjs`, with `--standalone` for a
+  zero-import bundle). Ajv's programmatic surface is richer: batch
+  emission across many schemas in one file, CommonJS output,
+  named-schema references resolved at emit time. If you're running
+  emit as a library call inside a build tool, Ajv is more ergonomic.
+  oav's CLI covers the "compile one schema at build time" case
+  directly (including self-contained output for Lambda / edge-runtime
+  deployments via `--standalone`, which uses esbuild to inline the
+  runtime helpers) but doesn't expose a batched programmatic API.
 - **Named schema registry.** `addSchema` / `getSchema` / `removeSchema`
   give Ajv a name-to-validator map that cross-schema `$ref`s resolve
   through. oav accepts an `external: Map<string, Schema>` on

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -792,8 +792,9 @@ app.use(async (req, res, next) => {
   counts by category.
 - **Overlays.** Extend externally-owned specs at load time —
   see [OVERLAYS.md](./OVERLAYS.md).
-- **Smaller install footprint.** Single runtime dep (`yaml`) plus an
-  optional peer (`commander`, CLI only).
+- **Smaller install footprint.** Single runtime dep (`yaml`) plus
+  two optional peers (`commander` for the CLI; `esbuild` only for
+  `oav compile --standalone`).
 - **No mutation of `req`.** `express-openapi-validator` attaches
   `req.openapi`, coerces types, and replaces `req.body` after
   deserialize. `oav` reads its inputs and returns an error tree;

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ skip what they don't use:
 
 | Package                | When to use                                                                                                                                                                                    |
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@aahoughton/oav`      | Default. Batteries-included: adds YAML readers and the `oav` CLI. Depends on `yaml`; `commander` is an optional peer for the CLI.                                                              |
+| `@aahoughton/oav`      | Default. Batteries-included: adds YAML readers and the `oav` CLI. Depends on `yaml`; `commander` and `esbuild` are optional peers (CLI; `esbuild` only for `oav compile --standalone`).        |
 | `@aahoughton/oav-core` | Lean alternative. Zero runtime dependencies. Same programmatic surface as `@aahoughton/oav`, minus the YAML readers and CLI. Feed it JSON specs (or pre-parsed objects via the memory reader). |
 
 ```bash
@@ -40,10 +40,14 @@ npm install @aahoughton/oav-core           # lean install, JSON-only
 subpaths. Samples below use `@aahoughton/oav`; on the lean package,
 substitute `@aahoughton/oav-core` in imports that don't touch the
 YAML readers (`createYamlFileReader`, `createSmartHttpReader`) or
-the CLI. If you plan to use the CLI, add `commander`:
+the CLI. If you plan to use the CLI, add `commander`; if you plan to
+use `oav compile --standalone` (self-contained validator bundles),
+also add `esbuild`:
 
 ```bash
 npm install @aahoughton/oav commander
+# or, if you also need --standalone:
+npm install @aahoughton/oav commander esbuild
 ```
 
 ## Quick start

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
   "devDependencies": {
     "@types/node": "25.6.0",
     "commander": "14.0.3",
+    "esbuild": "0.24.2",
     "oxfmt": "0.46.0",
     "oxlint": "1.61.0",
     "tsup": "8.5.1",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -16,11 +16,21 @@ npx @aahoughton/oav validate openapi.yaml --request req.http
 
 The CLI lives in the batteries-included `@aahoughton/oav` package,
 not the lean `@aahoughton/oav-core` — `oav-core` doesn't ship a `bin`
-or any CLI glue. `commander` is an **optional peer dependency** on
-`@aahoughton/oav`: the library itself doesn't pull it in, so consumers
-who only use the programmatic API stay on a single runtime dep
-(`yaml`). CLI users install `commander` alongside. Running `oav`
-without it prints an install hint and exits with status 2.
+or any CLI glue. Two packages are **optional peer dependencies** on
+`@aahoughton/oav`:
+
+- **`commander`** — required by every CLI invocation. Install it
+  alongside `@aahoughton/oav`. Running `oav` without it prints an
+  install hint and exits with status 2.
+- **`esbuild`** — only required by `oav compile --standalone` (see
+  [`compile` output](#compile-output) below). Not needed for any
+  other command. Install it alongside `@aahoughton/oav` if you use
+  `--standalone`, otherwise skip it. Missing-esbuild surfaces as an
+  install hint on stderr with exit code 3 at `compile --standalone`
+  time only.
+
+Neither is pulled in by the library itself, so consumers who only
+use the programmatic API stay on a single runtime dep (`yaml`).
 
 ## Commands
 
@@ -34,6 +44,7 @@ oav validate <spec> --path "GET /pets" --response --status 200 --body resp.json
 
 oav compile <schema.json> -o v.mjs                           # emit a validator module
 oav compile <schema.json> --dialect openapi-3.0              # pick a non-default dialect
+oav compile <schema.json> --standalone -o v.mjs              # inline runtime helpers (needs esbuild)
 ```
 
 Pass `-` as the file path to read from stdin (e.g. `--body -`).
@@ -47,14 +58,15 @@ below for the expected shape.
 
 ## Flags
 
-| Flag                                          | Command            | Meaning                                               |
-| --------------------------------------------- | ------------------ | ----------------------------------------------------- |
-| `--format text\|json\|flat`                   | validate           | Error rendering. Default `text`.                      |
-| `--depth <n>`                                 | validate           | Truncate error tree depth (text format).              |
-| `--overlay <file>`                            | resolve / validate | Repeatable; applies overlays in order.                |
-| `--dialect 2020-12\|openapi-3.1\|openapi-3.0` | compile            | Schema dialect to compile against. Default `2020-12`. |
-| `-o <file>`                                   | all                | Write output to a file instead of stdout.             |
-| `--quiet`                                     | resolve / validate | Exit code only, no stdout.                            |
+| Flag                                          | Command            | Meaning                                                                                   |
+| --------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------- |
+| `--format text\|json\|flat`                   | validate           | Error rendering. Default `text`.                                                          |
+| `--depth <n>`                                 | validate           | Truncate error tree depth (text format).                                                  |
+| `--overlay <file>`                            | resolve / validate | Repeatable; applies overlays in order.                                                    |
+| `--dialect 2020-12\|openapi-3.1\|openapi-3.0` | compile            | Schema dialect to compile against. Default `2020-12`.                                     |
+| `--standalone`                                | compile            | Bundle runtime helpers via esbuild — emit a module with zero `@aahoughton/oav/*` imports. |
+| `-o <file>`                                   | all                | Write output to a file instead of stdout.                                                 |
+| `--quiet`                                     | resolve / validate | Exit code only, no stdout.                                                                |
 
 ## `compile` output
 
@@ -63,10 +75,23 @@ below for the expected shape.
 `compileSchema(schema).validate(data)`, but with no `new Function()`
 call at load time. Useful for edge runtimes (Cloudflare Workers,
 Vercel Edge) where runtime code generation is forbidden or undesirable.
-The emitted module imports runtime helpers from `@aahoughton/oav/*`;
-it is not a fully self-contained bundle.
 
-Constraints on the input schema:
+Two output modes:
+
+- **Default** — the emitted module imports runtime helpers from
+  `@aahoughton/oav/core`, `@aahoughton/oav/schema/internals`, and
+  `@aahoughton/oav/formats`. Consumers install `@aahoughton/oav`
+  alongside the generated file. Smallest emit, shared runtime across
+  many validators.
+- **`--standalone`** — bundles the runtime helpers into the output via
+  esbuild. The resulting module has zero imports and runs without
+  `@aahoughton/oav` installed at all. Typical output is ~13 KB for a
+  small schema, ~20–40 KB for a schema that touches every built-in
+  format. Use for Lambda zips, edge-runtime bundles, or anywhere a
+  single-file drop-in matters. Requires `esbuild` as an optional peer
+  dependency.
+
+Constraints on the input schema (apply to both modes):
 
 - **Built-in formats only.** If the schema references `format: "..."`
   names not in `@aahoughton/oav/formats`'s built-in set, compile fails
@@ -76,11 +101,6 @@ Constraints on the input schema:
 - **External `$ref`s must be pre-inlined.** Run `oav resolve` over
   your spec first, or use `@aahoughton/oav/spec.resolveSpec`
   programmatically, before piping the schema into `compile`.
-
-The emitted module imports its runtime helpers from
-`@aahoughton/oav/core`, `@aahoughton/oav/schema/internals`, and
-`@aahoughton/oav/formats` — consumers install `@aahoughton/oav`
-alongside the generated file.
 
 ## Exit codes
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -127,7 +127,7 @@ export function buildProgram(options: BuildProgramOptions = {}): Command {
 
   program
     .command("compile <schema>")
-    .description("Compile a JSON Schema to a standalone ES module (no new Function at runtime).")
+    .description("Compile a JSON Schema to an ES module (no new Function at runtime).")
     .option(
       "--dialect <dialect>",
       STANDALONE_DIALECTS.join(" | "),
@@ -137,18 +137,28 @@ export function buildProgram(options: BuildProgramOptions = {}): Command {
       },
       "2020-12" as StandaloneDialect,
     )
+    .option(
+      "--standalone",
+      "bundle runtime helpers into the output via esbuild so it has no imports (requires 'esbuild' as an optional peer dep)",
+    )
     .option("-o, --output <file>", "write output to a file instead of stdout")
-    .action(async (schema: string, opts: { dialect: StandaloneDialect; output?: string }) => {
-      const res = await compileCommand(
-        {
-          schema,
-          output: opts.output,
-          dialect: opts.dialect,
-        },
-        io,
-      );
-      exit(res.exitCode);
-    });
+    .action(
+      async (
+        schema: string,
+        opts: { dialect: StandaloneDialect; output?: string; standalone?: boolean },
+      ) => {
+        const res = await compileCommand(
+          {
+            schema,
+            output: opts.output,
+            dialect: opts.dialect,
+            standalone: opts.standalone === true,
+          },
+          io,
+        );
+        exit(res.exitCode);
+      },
+    );
 
   return program;
 }

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -228,10 +228,19 @@ export type ValidateMode =
  * Implement the `oav compile <schema>` subcommand. Reads a JSON
  * Schema from disk (or stdin via `-`), emits an ES module whose
  * `validate(data)` mirrors `compileSchema(schema).validate(data)`.
- * The emitted module imports the runtime helpers from
+ *
+ * By default the emitted module imports runtime helpers from
  * `@aahoughton/oav/core`, `@aahoughton/oav/schema/internals`, and
  * `@aahoughton/oav/formats` — no `new Function()` at the consumer's
- * load time, suitable for edge runtimes that forbid it.
+ * load time, suitable for edge runtimes that forbid it. Consumers
+ * install `@aahoughton/oav` alongside the generated file.
+ *
+ * With `standalone: true` the emitted module is passed through
+ * `esbuild` to inline every runtime helper, producing a bundle with
+ * zero imports that runs without `@aahoughton/oav` installed at all
+ * — the Lambda / edge / single-file bundling case. `esbuild` is an
+ * optional peer dependency; a clear install hint is printed if it's
+ * not present.
  *
  * @public
  */
@@ -240,6 +249,22 @@ export async function compileCommand(
     schema: string;
     output?: string;
     dialect?: StandaloneDialect;
+    standalone?: boolean;
+    /**
+     * Override the `@aahoughton/oav` prefix used in the emitted
+     * module's imports. Tests pass `"@oav"` so the output resolves
+     * against the in-workspace package aliases rather than the
+     * published package name. Not exposed on the CLI.
+     */
+    importPrefix?: string;
+    /**
+     * Override esbuild's resolveDir for `--standalone`. Defaults to
+     * `process.cwd()`, which is where a real consumer's installed
+     * `@aahoughton/oav` sits. Tests point this at
+     * `packages/oav/` where the workspace's `@oav/*` symlinks are
+     * reachable. Not exposed on the CLI.
+     */
+    resolveDir?: string;
   },
   io: CommandIo = defaultCommandIo(),
 ): Promise<CommandResult> {
@@ -253,10 +278,21 @@ export async function compileCommand(
   }
   let source: string;
   try {
-    source = emitStandalone(parsed as SchemaOrBoolean, { dialect: args.dialect ?? "2020-12" });
+    source = emitStandalone(parsed as SchemaOrBoolean, {
+      dialect: args.dialect ?? "2020-12",
+      importPrefix: args.importPrefix,
+    });
   } catch (err) {
     io.stderr(`compile: ${(err as Error).message}\n`);
     return { exitCode: 3 };
+  }
+  if (args.standalone === true) {
+    try {
+      source = await bundleStandalone(source, args.resolveDir ?? process.cwd());
+    } catch (err) {
+      io.stderr(`compile: ${(err as Error).message}\n`);
+      return { exitCode: 3 };
+    }
   }
   if (args.output !== undefined) {
     await io.writeText(args.output, source);
@@ -264,4 +300,38 @@ export async function compileCommand(
   }
   io.stdout(source);
   return { exitCode: 0 };
+}
+
+/**
+ * Bundle an emitted validator with esbuild so it has no external
+ * imports. Lazy-imports esbuild so consumers who don't use
+ * `--standalone` don't pay the dependency cost. Throws with an
+ * install-hint message when esbuild isn't resolvable.
+ */
+async function bundleStandalone(source: string, resolveDir: string): Promise<string> {
+  let esbuild: typeof import("esbuild");
+  try {
+    esbuild = await import("esbuild");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ERR_MODULE_NOT_FOUND") {
+      throw new Error(
+        "--standalone requires 'esbuild' as a peer dependency.\n" +
+          "  Install it alongside @aahoughton/oav, e.g.:\n" +
+          "    npm install esbuild\n" +
+          "    pnpm add esbuild",
+      );
+    }
+    throw err;
+  }
+  const result = await esbuild.build({
+    stdin: { contents: source, resolveDir, loader: "js" },
+    bundle: true,
+    format: "esm",
+    platform: "neutral",
+    write: false,
+    logLevel: "silent",
+  });
+  const out = result.outputFiles[0];
+  if (out === undefined) throw new Error("esbuild produced no output");
+  return out.text;
 }

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -171,3 +171,50 @@ describe("buildProgram — argv-level", () => {
     expect(out.stderr).toContain("built-in");
   });
 });
+
+// A separate describe for the --standalone flow because it invokes
+// esbuild to bundle the emit output, which needs to resolve the
+// `@aahoughton/oav/*` imports. In production the consumer's cwd has
+// `@aahoughton/oav` installed; here we override the emit prefix to
+// `@oav` so esbuild resolves against the in-workspace packages.
+describe("compile --standalone", () => {
+  it("inlines runtime helpers and produces an import-free bundle that runs", async () => {
+    const { compileCommand } = await import("../src/commands.js");
+    const { resolve } = await import("node:path");
+    const { fileURLToPath } = await import("node:url");
+    const schema = { type: "object", required: ["name"], properties: { name: { type: "string" } } };
+    const mem = memoryIo([], [["schema.json", JSON.stringify(schema)]]);
+    // Point esbuild at packages/oav/ so the workspace-alias `@oav/*`
+    // resolves via its local node_modules. (In production the
+    // consumer's cwd has `@aahoughton/oav` installed and the default
+    // resolveDir is correct.)
+    const resolveDir = resolve(fileURLToPath(new URL("../../oav", import.meta.url)));
+    const res = await compileCommand(
+      {
+        schema: "schema.json",
+        output: "v.mjs",
+        dialect: "2020-12",
+        standalone: true,
+        importPrefix: "@oav",
+        resolveDir,
+      },
+      mem.io,
+    );
+    if (res.exitCode !== 0) console.error("stderr:", mem.stderr.value);
+    expect(res.exitCode).toBe(0);
+
+    const bundled = mem.writes[0]?.[1] ?? "";
+    // No `@oav/*` or `@aahoughton/oav/*` imports survive the bundle.
+    expect(bundled).not.toMatch(/from\s+["']@aahoughton\/oav/);
+    expect(bundled).not.toMatch(/from\s+["']@oav/);
+    expect(bundled).toMatch(/\bvalidate\b/);
+
+    // Load + run the bundled module via a data URL so the test stays
+    // in-process, no filesystem side-effects.
+    const mod = (await import(
+      `data:text/javascript;base64,${Buffer.from(bundled).toString("base64")}`
+    )) as { validate: (d: unknown) => { valid: boolean } };
+    expect(mod.validate({ name: "Fido" })).toEqual({ valid: true });
+    expect(mod.validate({}).valid).toBe(false);
+  });
+});

--- a/packages/oav/package.json
+++ b/packages/oav/package.json
@@ -134,15 +134,20 @@
     "@oav/spec": "workspace:*",
     "@oav/validator": "workspace:*",
     "commander": "^14.0.0",
+    "esbuild": "^0.24.0",
     "tsup": "8.5.1",
     "typescript": "5.9.3",
     "vitest": "4.1.5"
   },
   "peerDependencies": {
-    "commander": "^14.0.0"
+    "commander": "^14.0.0",
+    "esbuild": ">=0.20.0"
   },
   "peerDependenciesMeta": {
     "commander": {
+      "optional": true
+    },
+    "esbuild": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       commander:
         specifier: 14.0.3
         version: 14.0.3
+      esbuild:
+        specifier: 0.24.2
+        version: 0.24.2
       oxfmt:
         specifier: 0.46.0
         version: 0.46.0
@@ -28,7 +31,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.24.2)(yaml@2.8.3))
       yaml:
         specifier: 2.8.3
         version: 2.8.3
@@ -92,6 +95,9 @@ importers:
       commander:
         specifier: ^14.0.0
         version: 14.0.3
+      esbuild:
+        specifier: ^0.24.0
+        version: 0.24.2
       tsup:
         specifier: 8.5.1
         version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)(yaml@2.8.3)
@@ -100,7 +106,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.5
-        version: 4.1.5(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.24.2)(yaml@2.8.3))
 
   packages/router:
     dependencies:
@@ -149,16 +155,34 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@esbuild/aix-ppc64@0.24.2':
+    resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.24.2':
+    resolution: {integrity: sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.24.2':
+    resolution: {integrity: sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.7':
@@ -167,16 +191,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.24.2':
+    resolution: {integrity: sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.24.2':
+    resolution: {integrity: sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.24.2':
+    resolution: {integrity: sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.7':
@@ -185,10 +227,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.24.2':
+    resolution: {integrity: sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.7':
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.24.2':
+    resolution: {integrity: sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -197,10 +251,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.24.2':
+    resolution: {integrity: sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.24.2':
+    resolution: {integrity: sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.7':
@@ -209,10 +275,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.24.2':
+    resolution: {integrity: sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.7':
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.24.2':
+    resolution: {integrity: sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.7':
@@ -221,10 +299,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.24.2':
+    resolution: {integrity: sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.7':
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.24.2':
+    resolution: {integrity: sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -233,10 +323,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.24.2':
+    resolution: {integrity: sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.7':
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.24.2':
+    resolution: {integrity: sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.7':
@@ -245,16 +347,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.24.2':
+    resolution: {integrity: sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.7':
     resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.24.2':
+    resolution: {integrity: sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.24.2':
+    resolution: {integrity: sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.7':
@@ -263,10 +383,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.24.2':
+    resolution: {integrity: sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.24.2':
+    resolution: {integrity: sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -281,11 +413,23 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.24.2':
+    resolution: {integrity: sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.27.7':
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.24.2':
+    resolution: {integrity: sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
@@ -293,10 +437,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.24.2':
+    resolution: {integrity: sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.7':
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.24.2':
+    resolution: {integrity: sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.7':
@@ -918,6 +1074,11 @@ packages:
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
+  esbuild@0.24.2:
+    resolution: {integrity: sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
@@ -1335,64 +1496,127 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.24.2':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.24.2':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.24.2':
+    optional: true
+
   '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.24.2':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.24.2':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.24.2':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.24.2':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.24.2':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.24.2':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.24.2':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.24.2':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.24.2':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.24.2':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.24.2':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.24.2':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.24.2':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.24.2':
+    optional: true
+
   '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.24.2':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.24.2':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-arm64@0.24.2':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.24.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -1401,13 +1625,25 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.24.2':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.24.2':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.24.2':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.24.2':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
@@ -1705,13 +1941,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.5(vite@8.0.8(@types/node@25.6.0)(esbuild@0.24.2)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.24.2)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -1773,6 +2009,34 @@ snapshots:
   detect-libc@2.1.2: {}
 
   es-module-lexer@2.0.0: {}
+
+  esbuild@0.24.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.24.2
+      '@esbuild/android-arm': 0.24.2
+      '@esbuild/android-arm64': 0.24.2
+      '@esbuild/android-x64': 0.24.2
+      '@esbuild/darwin-arm64': 0.24.2
+      '@esbuild/darwin-x64': 0.24.2
+      '@esbuild/freebsd-arm64': 0.24.2
+      '@esbuild/freebsd-x64': 0.24.2
+      '@esbuild/linux-arm': 0.24.2
+      '@esbuild/linux-arm64': 0.24.2
+      '@esbuild/linux-ia32': 0.24.2
+      '@esbuild/linux-loong64': 0.24.2
+      '@esbuild/linux-mips64el': 0.24.2
+      '@esbuild/linux-ppc64': 0.24.2
+      '@esbuild/linux-riscv64': 0.24.2
+      '@esbuild/linux-s390x': 0.24.2
+      '@esbuild/linux-x64': 0.24.2
+      '@esbuild/netbsd-arm64': 0.24.2
+      '@esbuild/netbsd-x64': 0.24.2
+      '@esbuild/openbsd-arm64': 0.24.2
+      '@esbuild/openbsd-x64': 0.24.2
+      '@esbuild/sunos-x64': 0.24.2
+      '@esbuild/win32-arm64': 0.24.2
+      '@esbuild/win32-ia32': 0.24.2
+      '@esbuild/win32-x64': 0.24.2
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -2117,7 +2381,7 @@ snapshots:
 
   undici-types@7.19.2: {}
 
-  vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3):
+  vite@8.0.8(@types/node@25.6.0)(esbuild@0.24.2)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -2126,14 +2390,14 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.6.0
-      esbuild: 0.27.7
+      esbuild: 0.24.2
       fsevents: 2.3.3
       yaml: 2.8.3
 
-  vitest@4.1.5(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)):
+  vitest@4.1.5(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.24.2)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.5(vite@8.0.8(@types/node@25.6.0)(esbuild@0.24.2)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -2150,7 +2414,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.24.2)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0


### PR DESCRIPTION
## Summary

- `oav compile` currently emits an ESM module that imports runtime helpers from `@aahoughton/oav/*`. Fine server-side; a footprint problem for Lambda zips, Cloudflare Workers, or anywhere a single-file drop-in matters.
- Add `--standalone` to `oav compile`. Runs the emitted module through `esbuild` to inline every runtime helper; the result has zero imports and runs without `@aahoughton/oav` installed at all. Typical output is ~13 KB for a small schema.
- `esbuild` declared as an optional peer dependency on `@aahoughton/oav` (same pattern as `commander`): lazy-imported only when `--standalone` is set, with a clear install-hint on exit 3 when missing.

Closes the "not fully self-contained" gap that `COMPARISON.md` called out. The remaining AOT gap vs ajv is now the programmatic surface (batch emission, CommonJS output, named-schema refs at emit time) — documented as such.

## Test plan

- [x] New test: `compile --standalone` produces a bundle with no `@aahoughton/oav` / `@oav` imports, loads via data URL, validates valid + invalid inputs (`packages/cli/test/cli.test.ts`)
- [x] `pnpm test` (633 / 633 passing — +1 new)
- [x] `pnpm lint` / `pnpm typecheck` clean
- [x] `pnpm build` succeeds — tsup bundles fine with esbuild as an optional peer
- [x] Empirical: 13.4 KB output on a small schema; output runs standalone in a directory with zero `node_modules`