### PR TITLE
ci: allow all-caps acronyms at the start of a PR subject

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -32,7 +32,10 @@ jobs:
             style
             test
           requireScope: false
-          subjectPattern: ^[a-z].+[^.]$
+          # Lowercase start OR an all-caps acronym run of 2+ letters
+          # (HTTP, API, CLI, JSON, YAML, RFC, …). Still rejects
+          # sentence-case ("Do something") and trailing periods.
+          subjectPattern: ^([a-z]|[A-Z]{2,}).+[^.]$
           subjectPatternError: |
-            Subject must start lowercase and not end with a period.
+            Subject must start with a lowercase letter or an all-caps acronym (e.g. HTTP, API, CLI), and must not end with a period.
             Got: "{subject}"


### PR DESCRIPTION
## Summary

- Existing regex `^[a-z].+[^.]$` rejects titles that start with all-caps acronyms (HTTP, API, CLI, JSON, YAML, RFC, …) — common enough in this repo's domain that it's become recurring friction. #118's title was blocked for starting with a capital \`H\`.
- Relaxed to `^([a-z]|[A-Z]{2,}).+[^.]$`: lowercase first letter (existing sentence rule) OR an all-caps run of 2+ letters at the start. Still rejects sentence-case (\`Do something …\`) and trailing periods. The 2+-letter requirement keeps accidental title-case out — \`A simple fix\` still fails.
- Updated the error message to explain the new rule.

## After this merges

Editing / re-titling #118 retriggers the workflow; the existing title (\`perf: HTTP-server steady-state memory benchmark\`) will pass without change.