### PR TITLE
fix(validator): reject non-3.x specs at construction; narrow onUnknownVersion

### DIFF
--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -64,6 +64,53 @@ function dialectFor(version: OpenAPIVersion): Dialect {
 }
 
 /**
+ * Why did {@link detectOpenAPIVersion} return `undefined`? Distinguishes
+ * category errors (missing or non-string `openapi` field, wrong major)
+ * from a valid-shaped 3.x spec with an unknown minor (forward-compat).
+ *
+ * @internal
+ */
+type UnknownVersionReason =
+  | { kind: "missing-openapi"; message: string }
+  | { kind: "wrong-major"; message: string }
+  | { kind: "ok-unknown-minor"; raw: string };
+
+function classifyUnknownVersion(rawOpenapi: unknown): UnknownVersionReason {
+  if (typeof rawOpenapi !== "string") {
+    return {
+      kind: "missing-openapi",
+      message:
+        "expected an OpenAPI 3.x document — the `openapi` field must be a string " +
+        `like "3.1.0" (got ${typeof rawOpenapi}). ` +
+        'Swagger 2.0 documents use `swagger: "2.0"` instead and need to be converted ' +
+        "first (e.g. `npx swagger2openapi input.json -o output.json`). " +
+        "AsyncAPI / OpenRPC / other formats are different domains and oav doesn't handle them.",
+    };
+  }
+  const match = /^(\d+)\.(\d+)/.exec(rawOpenapi);
+  if (match === null) {
+    return {
+      kind: "missing-openapi",
+      message: `the \`openapi\` field \`"${rawOpenapi}"\` doesn't look like a semver version`,
+    };
+  }
+  const major = match[1]!;
+  if (major !== "3") {
+    const hint =
+      major === "2"
+        ? " Convert to 3.x first, e.g. `npx swagger2openapi input.json -o output.json`."
+        : "";
+    return {
+      kind: "wrong-major",
+      message: `oav supports OpenAPI 3.x; got openapi: "${rawOpenapi}".${hint}`,
+    };
+  }
+  // Valid 3.x major but unknown minor — forward-compat, not a category
+  // error.
+  return { kind: "ok-unknown-minor", raw: rawOpenapi };
+}
+
+/**
  * The HTTP validator: after being built from a (resolved) OpenAPI document,
  * `validateRequest` / `validateResponse` each return a full
  * {@link ValidationError} tree (or `null`).
@@ -241,6 +288,15 @@ export interface ValidatorOptions {
    * picks a matching built-in dialect (`openapi31Dialect` for 3.1/3.2,
    * `oas30Dialect` for 3.0). Pass this option to plug in a custom
    * {@link Dialect} or force a specific built-in.
+   *
+   * Setting `dialect` is also the universal escape hatch for the
+   * category-error checks that normally throw at construction: a
+   * missing/non-string `openapi` field or a wrong major version
+   * would reject the spec by default, but an explicit `dialect`
+   * signals "I know what I'm doing" and compilation proceeds. A
+   * single warning is emitted via {@link ValidatorOptions.warn}
+   * when the override suppresses a would-be category error, so
+   * accidental misuse is still visible.
    */
   dialect?: Dialect;
 
@@ -339,12 +395,15 @@ export interface ValidatorOptions {
    */
   ignorePaths?: (path: string) => boolean;
   /**
-   * How to handle a spec whose `openapi` field is missing, malformed,
-   * or not one of the supported versions (3.0, 3.1, 3.2).
+   * How to handle a spec with an unknown **minor** version inside the
+   * OpenAPI 3.x line — e.g. `openapi: "3.7.0"` if a future minor ships
+   * before oav is updated. Pure forward-compat control; does not govern
+   * category errors (missing `openapi` field, wrong major), which
+   * always throw unless `dialect` is set.
    *
    * - `"fallback31"` (default) — silently use the 3.1 dialect.
-   * - `"warn"` — emit a warning via {@link ValidatorOptions.warn} (defaults
-   *   to `process.stderr.write`) and use the 3.1 dialect.
+   * - `"warn"` — emit a warning via {@link ValidatorOptions.warn}
+   *   (defaults to `process.stderr.write`) and use the 3.1 dialect.
    * - `"throw"` — throw an `Error`.
    *
    * Regardless of the choice, `OavValidator.detectedVersion` is set to
@@ -386,25 +445,48 @@ export function createValidator(
   // Version detection is pure compile-time: we bake the right
   // dialect into the compiled validator and never branch on version
   // per request.
+  //
+  // Three categories of input:
+  //   (1) valid 3.x spec (3.0 / 3.1 / 3.2)  — pick dialect, compile
+  //   (2) missing openapi field / wrong major — category error, throw
+  //       (unless `dialect` is set, which is the universal override)
+  //   (3) valid 3.x major but unknown minor (e.g. "3.7.0") — forward
+  //       compat, governed by `onUnknownVersion`
   const detectedVersion = detectOpenAPIVersion(spec);
   const dialect: Dialect = (() => {
-    if (options.dialect !== undefined) return options.dialect;
-    if (detectedVersion === undefined) {
+    if (detectedVersion !== undefined) return dialectFor(detectedVersion);
+
+    // Classify the reason detection failed so we can distinguish
+    // category errors from unknown-minor forward-compat.
+    const rawOpenapi = (spec as { openapi?: unknown }).openapi;
+    const reason = classifyUnknownVersion(rawOpenapi);
+    const warn = options.warn ?? ((m: string) => void process.stderr.write(m));
+
+    if (reason.kind === "ok-unknown-minor") {
+      if (options.dialect !== undefined) return options.dialect;
       const policy = options.onUnknownVersion ?? "fallback31";
       if (policy === "throw") {
         throw new Error(
-          "createValidator: spec has a missing or unsupported `openapi` field; set onUnknownVersion to 'warn' or 'fallback31' to accept it",
+          `createValidator: openapi: "${reason.raw}" is an unknown 3.x minor version; ` +
+            "set onUnknownVersion to 'warn' or 'fallback31' to accept it, or pass `dialect` to force a specific compiler",
         );
       }
       if (policy === "warn") {
-        const warn = options.warn ?? ((m: string) => void process.stderr.write(m));
         warn(
-          "createValidator: spec has a missing or unsupported `openapi` field; falling back to the 3.1 dialect\n",
+          `createValidator: openapi: "${reason.raw}" is an unknown 3.x minor version; falling back to the 3.1 dialect\n`,
         );
       }
       return openapi31Dialect;
     }
-    return dialectFor(detectedVersion);
+
+    // Category error: missing field, wrong major, or non-string.
+    // `dialect` is the universal override; emit a warning so the
+    // override is still visible but don't block compilation.
+    if (options.dialect !== undefined) {
+      warn(`createValidator: ${reason.message}; compiling anyway because \`dialect\` was set\n`);
+      return options.dialect;
+    }
+    throw new Error(`createValidator: ${reason.message}`);
   })();
 
   const graph = resolve(spec as unknown as SchemaOrBoolean);

--- a/packages/validator/test/versioning.test.ts
+++ b/packages/validator/test/versioning.test.ts
@@ -11,6 +11,7 @@
 
 import { describe, expect, it } from "vitest";
 import type { OpenAPIDocument } from "@oav/core";
+import { jsonSchemaDialect } from "@oav/schema";
 import { createValidator } from "../src/validator.js";
 
 function spec32(): OpenAPIDocument {
@@ -343,10 +344,9 @@ describe("3.0 support", () => {
     ).toThrow(/OpenAPI 3\.0 'type' must be a single string/);
   });
 
-  it("an explicit `dialect` option overrides the version dispatch", async () => {
+  it("an explicit `dialect` option overrides the version dispatch", () => {
     // The override path skips version detection entirely and uses the
     // caller's dialect even if the spec declares a different version.
-    const { jsonSchemaDialect } = await import("@oav/schema");
     const spec: OpenAPIDocument = {
       openapi: "3.0.3",
       info: { title: "Old", version: "1" },
@@ -356,41 +356,155 @@ describe("3.0 support", () => {
   });
 });
 
-describe("unknown version", () => {
-  function bareSpec(): OpenAPIDocument {
+describe("category errors", () => {
+  // Missing / non-string `openapi` field and non-3.x major versions
+  // are category errors: "this doesn't look like an OpenAPI 3.x
+  // document at all". Always throw unless `dialect` is set as the
+  // universal escape hatch.
+
+  function specWith(openapi: unknown): OpenAPIDocument {
     return {
-      openapi: "" as unknown as string,
-      info: { title: "bare", version: "1" },
+      openapi: openapi as string,
+      info: { title: "t", version: "1" },
       paths: {},
     };
   }
 
-  it("falls through to the 3.1 dialect for missing `openapi` fields", () => {
-    expect(() => createValidator(bareSpec())).not.toThrow();
+  it("throws when the openapi field is missing", () => {
+    expect(() => createValidator(specWith(undefined))).toThrow(/openapi.*must be a string/);
   });
 
-  it("exposes detectedVersion=undefined when the field is missing", () => {
-    const v = createValidator(bareSpec());
+  it("throws when the openapi field is null", () => {
+    expect(() => createValidator(specWith(null))).toThrow(/openapi.*must be a string/);
+  });
+
+  it("throws when the openapi field isn't semver-shaped", () => {
+    expect(() => createValidator(specWith("yes"))).toThrow(/doesn't look like a semver version/);
+  });
+
+  it("throws on a Swagger 2.0 document (wrong major), hint points at swagger2openapi", () => {
+    const err = (() => {
+      try {
+        createValidator(specWith("2.0.0"));
+      } catch (e) {
+        return e as Error;
+      }
+      return null;
+    })();
+    expect(err?.message).toMatch(/supports OpenAPI 3.x/);
+    expect(err?.message).toMatch(/swagger2openapi/);
+  });
+
+  it("throws on a future major (4.0.0) without the swagger2openapi hint", () => {
+    const err = (() => {
+      try {
+        createValidator(specWith("4.0.0"));
+      } catch (e) {
+        return e as Error;
+      }
+      return null;
+    })();
+    expect(err?.message).toMatch(/supports OpenAPI 3.x/);
+    expect(err?.message).not.toMatch(/swagger2openapi/);
+  });
+
+  it("message for missing openapi mentions the `swagger` sibling-field convention as a hint", () => {
+    // We don't *sniff* the `swagger` field — the check is just
+    // "openapi must be a string." But the error text points the user
+    // at the common sibling-format convention so they know where to
+    // go next.
+    const err = (() => {
+      try {
+        createValidator(specWith(undefined));
+      } catch (e) {
+        return e as Error;
+      }
+      return null;
+    })();
+    expect(err?.message).toMatch(/swagger2openapi/);
+  });
+
+  it("dialect option is the universal override: compiles a bare spec + emits a single warn", () => {
+    const chunks: string[] = [];
+    const v = createValidator(specWith(undefined), {
+      dialect: jsonSchemaDialect,
+      warn: (msg) => chunks.push(msg),
+    });
+    expect(v.detectedVersion).toBeUndefined();
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toMatch(/compiling anyway because `dialect` was set/);
+  });
+
+  it("dialect override also suppresses the wrong-major throw", () => {
+    const chunks: string[] = [];
+    expect(() =>
+      createValidator(specWith("2.0.0"), {
+        dialect: jsonSchemaDialect,
+        warn: (msg) => chunks.push(msg),
+      }),
+    ).not.toThrow();
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toMatch(/supports OpenAPI 3.x/);
+  });
+});
+
+describe("unknown minor version (forward-compat within 3.x)", () => {
+  // Valid 3.x major with an unknown minor — e.g. 3.7.0. Not a
+  // category error; this is the one case `onUnknownVersion` governs.
+
+  function specWith(openapi: string): OpenAPIDocument {
+    return {
+      openapi,
+      info: { title: "t", version: "1" },
+      paths: {},
+    };
+  }
+
+  it("default onUnknownVersion='fallback31' silently accepts 3.7.0", () => {
+    const v = createValidator(specWith("3.7.0"));
     expect(v.detectedVersion).toBeUndefined();
   });
 
-  it("exposes detectedVersion when the field is present", () => {
-    const v = createValidator({ ...bareSpec(), openapi: "3.1.0" });
-    expect(v.detectedVersion).toBe("3.1");
-  });
-
-  it("throws when onUnknownVersion is 'throw'", () => {
-    expect(() => createValidator(bareSpec(), { onUnknownVersion: "throw" })).toThrow(
-      /missing or unsupported `openapi`/,
+  it("onUnknownVersion='throw' rejects 3.7.0 with a message that mentions `dialect`", () => {
+    expect(() => createValidator(specWith("3.7.0"), { onUnknownVersion: "throw" })).toThrow(
+      /unknown 3.x minor/,
+    );
+    expect(() => createValidator(specWith("3.7.0"), { onUnknownVersion: "throw" })).toThrow(
+      /dialect/,
     );
   });
 
-  it("routes the warning through options.warn when onUnknownVersion is 'warn'", () => {
+  it("onUnknownVersion='warn' routes through options.warn and falls back to 3.1", () => {
     const chunks: string[] = [];
-    createValidator(bareSpec(), {
+    createValidator(specWith("3.7.0"), {
       onUnknownVersion: "warn",
       warn: (msg) => chunks.push(msg),
     });
+    expect(chunks.join("")).toMatch(/unknown 3.x minor/);
     expect(chunks.join("")).toMatch(/falling back to the 3.1 dialect/);
+  });
+
+  it("dialect override skips onUnknownVersion entirely", () => {
+    const chunks: string[] = [];
+    const v = createValidator(specWith("3.7.0"), {
+      dialect: jsonSchemaDialect,
+      onUnknownVersion: "throw", // should be ignored
+      warn: (msg) => chunks.push(msg),
+    });
+    expect(v.detectedVersion).toBeUndefined();
+    // No warn here — `dialect` on a valid-shaped 3.x spec is just a
+    // normal override, not a category-error suppression.
+    expect(chunks).toHaveLength(0);
+  });
+});
+
+describe("detectedVersion", () => {
+  it("exposes the detected bucket when the field is a known 3.x version", () => {
+    const spec: OpenAPIDocument = {
+      openapi: "3.1.0",
+      info: { title: "t", version: "1" },
+      paths: {},
+    };
+    expect(createValidator(spec).detectedVersion).toBe("3.1");
   });
 });


### PR DESCRIPTION
## Summary

Before, `createValidator` silently fell back to 3.1 for anything whose openapi-detection returned `undefined` — Swagger 2.0 specs, AsyncAPI descriptors, arbitrary `{foo: 1}` — and then `validateRequest` returned `null` for everything. Category errors were being swallowed as forward-compat.

Split the two concerns:

- **Category errors (always throw unless `dialect` is set)**: missing or non-string `openapi`, non-semver string, major ≠ 3. Error text hints at sibling-format conventions (`swagger` / `asyncapi` / `openrpc`) without sniffing — the check is a simple `typeof` + `parseInt(major)`, no branch per format.
- **`onUnknownVersion`** narrows to forward-compat within 3.x. Governs `3.7.0`-style unknown minors, not category errors. Default stays `fallback31`.
- **`dialect`** is the universal escape hatch. Set it and all category checks are skipped; single warn goes to `options.warn` (default stderr) so misuse is still visible.

Closes #108.

## Behavior table

| Input                          | No `dialect`                   | With `dialect`    |
| ------------------------------ | ------------------------------ | ----------------- |
| `openapi: "3.1.0"`             | compile                        | compile           |
| `openapi: "3.7.0"` unknown minor | `onUnknownVersion` (fallback31)| compile, skipped  |
| `openapi: "4.0.0"` wrong major | **throw**                      | compile + warn    |
| `openapi: "2.0.0"`             | **throw** + swagger2openapi hint | compile + warn  |
| `{swagger: "2.0", ...}`        | **throw** via missing-openapi  | compile + warn    |
| `{openapi: null, ...}`         | **throw** via missing-openapi  | compile + warn    |
| `{foo: 1}`                     | **throw**                      | compile + warn    |

## Test plan

- [x] `pnpm test` — 641 passing (26 versioning including 17 new)
- [x] `pnpm lint` / `pnpm typecheck` / `pnpm fmt` clean
- [x] New tests cover: missing openapi, null openapi, non-semver, 2.0 wrong major + swagger2openapi hint, 4.0 wrong major without hint, each with and without `dialect` override, unknown minor with all three `onUnknownVersion` values, and `dialect` override skipping `onUnknownVersion` silently for a valid-shaped 3.x spec.