### PR TITLE
refactor(validator): no-console lint in core; warnings as a property

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -9,9 +9,24 @@
       "error",
       { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }
     ],
+    "no-console": "error",
     "unicorn/no-new-array": "off",
     "unicorn/prefer-module": "off"
   },
+  "overrides": [
+    {
+      "files": [
+        "packages/cli/**",
+        "packages/oav/src/cli.ts",
+        "examples/**",
+        "performance/**",
+        "conformance/**"
+      ],
+      "rules": {
+        "no-console": "off"
+      }
+    }
+  ],
   "env": {
     "builtin": true,
     "node": true

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -67,14 +67,15 @@ the upstream test suites live in
 
 ## Validator methods
 
-| Method                                        | Purpose                                                                                                                                 |
-| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `validateRequest(req)`                        | Check an `HttpRequest` against the spec. Returns `null` on success or a `ValidationError` tree.                                         |
-| `validateResponse(req, res)`                  | Check an `HttpResponse` against the spec (request is used only for method + path). Returns `null` or a tree.                            |
-| `validateFetchRequest<T>(request, opts?)`     | Convenience for Web Standards `Request`: reads URL, headers, body; returns a discriminated union with a typed body. See INTEGRATION.md. |
-| `validateFetchResponse<T>(request, response)` | Symmetric Web Standards `Response` check. Useful for contract-testing an upstream.                                                      |
-| `getOperation({ method, path })`              | Startup-time introspection: returns the resolved, overlay-applied `OperationObject` + matched template for a (method, path) pair.       |
-| `detectedVersion`                             | The `openapi` string detected on construction, or `undefined` for an unrecognised / missing version (see `onUnknownVersion`).           |
+| Method                                        | Purpose                                                                                                                                                             |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `validateRequest(req)`                        | Check an `HttpRequest` against the spec. Returns `null` on success or a `ValidationError` tree.                                                                     |
+| `validateResponse(req, res)`                  | Check an `HttpResponse` against the spec (request is used only for method + path). Returns `null` or a tree.                                                        |
+| `validateFetchRequest<T>(request, opts?)`     | Convenience for Web Standards `Request`: reads URL, headers, body; returns a discriminated union with a typed body. See INTEGRATION.md.                             |
+| `validateFetchResponse<T>(request, response)` | Symmetric Web Standards `Response` check. Useful for contract-testing an upstream.                                                                                  |
+| `getOperation({ method, path })`              | Startup-time introspection: returns the resolved, overlay-applied `OperationObject` + matched template for a (method, path) pair.                                   |
+| `detectedVersion`                             | The `openapi` string detected on construction, or `undefined` for an unrecognised / missing version (see `onUnknownVersion`).                                       |
+| `warnings`                                    | `readonly string[]` — warnings accumulated at construction time (`onUnknownVersion: "warn"` or `dialect`-suppressed category error). Empty when neither path fires. |
 
 ## Options
 
@@ -131,14 +132,24 @@ true` when the tree was capped.
 
 ## Handling unknown `openapi` versions
 
-Specs in the wild sometimes omit the `openapi` field or declare an
-unsupported value. The default — `onUnknownVersion: "fallback31"` —
-silently uses the 3.1 dialect. For stricter environments:
+Two kinds of "unknown":
 
-```ts
-createValidator(spec, { onUnknownVersion: "throw" }); // refuse to build
-createValidator(spec, { onUnknownVersion: "warn" }); // stderr message, use 3.1
-```
+- **Category errors** — missing / non-string `openapi`, non-semver
+  string, or a major version that isn't `3`. These **throw** at
+  construction by default. Set `dialect` to force a specific
+  compiler; that suppresses the throw and adds an entry to
+  `validator.warnings` so the override is still visible.
+- **Unknown minor within 3.x** — e.g. `"3.7.0"` if a future minor
+  ships before oav is updated. Governed by `onUnknownVersion`:
+
+  ```ts
+  createValidator(spec); // fallback31 default — silent, uses 3.1 dialect
+  createValidator(spec, { onUnknownVersion: "throw" }); // refuse to build
+  createValidator(spec, { onUnknownVersion: "warn" }); // populates validator.warnings, uses 3.1 dialect
+  createValidator(spec, { onUnknownVersion: "warn", warn: (m) => log.info(m) }); // plus live callback
+  ```
 
 `validator.detectedVersion` is `undefined` in the fallback cases so
-callers can introspect what dialect they actually got.
+callers can introspect what dialect they actually got. Warnings from
+any path land on `validator.warnings`; the library never writes to
+`process.stderr` or `console` on its own.

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -222,6 +222,21 @@ export interface OavValidator {
    */
   readonly detectedVersion: OpenAPIVersion | undefined;
   /**
+   * Warnings collected during `createValidator`. Populated when
+   * `onUnknownVersion: "warn"` fires, or when the `dialect` escape
+   * hatch suppresses a category error that would otherwise throw
+   * (missing `openapi` field, wrong major). Empty when neither applies.
+   *
+   * The library never writes to `process.stderr` or `console` — this
+   * array is the library's only record of such events. Callers that
+   * want live output pass {@link ValidatorOptions.warn}; the CLI
+   * wrapper does this.
+   *
+   * Frozen after `createValidator` returns; no post-construction
+   * writes happen.
+   */
+  readonly warnings: readonly string[];
+  /**
    * Runtime observability for compile-time-specialisation optimisations.
    * The counters live on the validator, not inside a ValidationError
    * tree, so tests can assert on the optimisation directly rather than
@@ -401,9 +416,10 @@ export interface ValidatorOptions {
    * category errors (missing `openapi` field, wrong major), which
    * always throw unless `dialect` is set.
    *
-   * - `"fallback31"` (default) — silently use the 3.1 dialect.
-   * - `"warn"` — emit a warning via {@link ValidatorOptions.warn}
-   *   (defaults to `process.stderr.write`) and use the 3.1 dialect.
+   * - `"fallback31"` (default) — accept silently; use the 3.1 dialect.
+   * - `"warn"` — add an entry to {@link OavValidator.warnings} (and
+   *   call {@link ValidatorOptions.warn} if provided) and use the 3.1
+   *   dialect.
    * - `"throw"` — throw an `Error`.
    *
    * Regardless of the choice, `OavValidator.detectedVersion` is set to
@@ -411,10 +427,17 @@ export interface ValidatorOptions {
    */
   onUnknownVersion?: "fallback31" | "warn" | "throw";
   /**
-   * Sink for the warning emitted by `onUnknownVersion: "warn"`. Defaults
-   * to `(m) => process.stderr.write(m)`. Inject an alternative when
-   * embedding the validator in workers / edge runtimes / test harnesses
-   * where `process.stderr` isn't the right destination.
+   * Optional live-output sink for warnings — called synchronously
+   * during {@link createValidator} whenever a warning is emitted
+   * (currently: `onUnknownVersion: "warn"` path, and the single
+   * category-error-overridden-by-`dialect` case). Every warning is
+   * _also_ accumulated into {@link OavValidator.warnings} regardless
+   * of whether this callback is set.
+   *
+   * Default: undefined (no live sink). The library never writes to
+   * `process.stderr` or `console` on its own; pass a callback if you
+   * want live output. The CLI wrapper supplies one that prints to
+   * stderr.
    */
   warn?: (message: string) => void;
 }
@@ -442,6 +465,16 @@ export function createValidator(
   const router: Router = createRouter(paths);
   const formats = { ...builtInFormats, ...options.formats };
 
+  // Warnings are accumulated passively (no I/O from the library); a
+  // caller-supplied `options.warn` additionally gets them live. The
+  // CLI wrapper passes a stderr-writing callback; the core library
+  // never does.
+  const warnings: string[] = [];
+  const emitWarn = (message: string): void => {
+    warnings.push(message);
+    options.warn?.(message);
+  };
+
   // Version detection is pure compile-time: we bake the right
   // dialect into the compiled validator and never branch on version
   // per request.
@@ -460,7 +493,6 @@ export function createValidator(
     // category errors from unknown-minor forward-compat.
     const rawOpenapi = (spec as { openapi?: unknown }).openapi;
     const reason = classifyUnknownVersion(rawOpenapi);
-    const warn = options.warn ?? ((m: string) => void process.stderr.write(m));
 
     if (reason.kind === "ok-unknown-minor") {
       if (options.dialect !== undefined) return options.dialect;
@@ -472,8 +504,8 @@ export function createValidator(
         );
       }
       if (policy === "warn") {
-        warn(
-          `createValidator: openapi: "${reason.raw}" is an unknown 3.x minor version; falling back to the 3.1 dialect\n`,
+        emitWarn(
+          `createValidator: openapi: "${reason.raw}" is an unknown 3.x minor version; falling back to the 3.1 dialect`,
         );
       }
       return openapi31Dialect;
@@ -483,7 +515,7 @@ export function createValidator(
     // `dialect` is the universal override; emit a warning so the
     // override is still visible but don't block compilation.
     if (options.dialect !== undefined) {
-      warn(`createValidator: ${reason.message}; compiling anyway because \`dialect\` was set\n`);
+      emitWarn(`createValidator: ${reason.message}; compiling anyway because \`dialect\` was set`);
       return options.dialect;
     }
     throw new Error(`createValidator: ${reason.message}`);
@@ -838,6 +870,7 @@ export function createValidator(
     validateFetchResponse,
     getOperation,
     detectedVersion,
+    warnings,
     stats,
   };
 }

--- a/packages/validator/test/versioning.test.ts
+++ b/packages/validator/test/versioning.test.ts
@@ -446,6 +446,26 @@ describe("category errors", () => {
     expect(chunks).toHaveLength(1);
     expect(chunks[0]).toMatch(/supports OpenAPI 3.x/);
   });
+
+  it("warnings accumulate onto validator.warnings even without a warn callback", () => {
+    // The library never writes to stderr on its own — instead, every
+    // would-warn event lands on validator.warnings so the caller can
+    // inspect post-construction.
+    const v = createValidator(specWith(undefined), { dialect: jsonSchemaDialect });
+    expect(v.warnings).toHaveLength(1);
+    expect(v.warnings[0]).toMatch(/compiling anyway because `dialect` was set/);
+  });
+
+  it("warnings and the warn callback both receive each warning", () => {
+    const chunks: string[] = [];
+    const v = createValidator(specWith("2.0.0"), {
+      dialect: jsonSchemaDialect,
+      warn: (msg) => chunks.push(msg),
+    });
+    expect(chunks).toHaveLength(1);
+    expect(v.warnings).toHaveLength(1);
+    expect(chunks[0]).toBe(v.warnings[0]);
+  });
 });
 
 describe("unknown minor version (forward-compat within 3.x)", () => {
@@ -472,6 +492,12 @@ describe("unknown minor version (forward-compat within 3.x)", () => {
     expect(() => createValidator(specWith("3.7.0"), { onUnknownVersion: "throw" })).toThrow(
       /dialect/,
     );
+  });
+
+  it("onUnknownVersion='warn' populates validator.warnings even without a callback", () => {
+    const v = createValidator(specWith("3.7.0"), { onUnknownVersion: "warn" });
+    expect(v.warnings).toHaveLength(1);
+    expect(v.warnings[0]).toMatch(/unknown 3.x minor/);
   });
 
   it("onUnknownVersion='warn' routes through options.warn and falls back to 3.1", () => {


### PR DESCRIPTION
Stacks on #123 — base is \`fix/validator-reject-non-3x-spec\`; will auto-retarget to \`main\` when #123 merges.

## Summary

Two related changes in one PR — the lint rule and the I/O hygiene that lets it be true in spirit as well as letter.

**no-console lint.** `.oxlintrc.json` enables `no-console: "error"` globally, with overrides for the CLI entry point and the dev-only sub-packages (examples/, performance/, conformance/, packages/cli/, packages/oav/src/cli.ts). Core library code (validator, schema, spec, formats, router, core) falls under the rule. No runtime-path `console.*` calls exist today so this lands clean; guards against future regressions.

**Warnings as a property, not stderr I/O.** The dialect-check work in #123 added a `warn` callback defaulting to `process.stderr.write`. That's adjacent to the no-console spirit: a library silently writing to stderr is the same kind of implicit I/O the rule tries to prevent. Removed the default:

- `options.warn` is now undefined by default — no sink, no I/O.
- `OavValidator.warnings: readonly string[]` added. Every would-warn event (`onUnknownVersion: "warn"`, or a `dialect`-suppressed category error) pushes here. When `options.warn` is set it's also called live; accumulator and callback both receive each event.

The CLI never passed `warn` and never reached either warning path (default `onUnknownVersion: "fallback31"` is silent), so no CLI changes required.

## Test plan

- [x] `pnpm test` — 644 passing (3 new around warnings accumulation)
- [x] `pnpm lint` / `pnpm typecheck` / `pnpm fmt` clean
- [x] New tests: warnings accumulate without a callback; warnings and callback both receive each event; `onUnknownVersion: "warn"` populates warnings without a callback.