### PR TITLE
feat(schema): recognise xml, externalDocs, and the JSON Schema content vocabulary as annotation keywords

### DIFF
--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -52,14 +52,17 @@ export type {
 // Vocabulary URIs + built-in vocabularies + dialects.
 export {
   APPLICATOR_VOCAB,
+  CONTENT_VOCAB,
   CORE_VALIDATION_VOCAB,
   CORE_VOCAB,
   FORMAT_ASSERTION_VOCAB,
   FORMAT_VOCAB,
   META_DATA_VOCAB,
   OAS30_VOCAB,
+  OPENAPI_META_DATA_VOCAB,
   UNEVALUATED_VOCAB,
   applicatorVocabulary,
+  contentVocabulary,
   coreVocabulary,
   defaultVocabularies,
   formatAssertionVocabulary,
@@ -93,14 +96,19 @@ export {
 export { constKeyword, enumKeyword } from "./keywords/equality.js";
 export { containsKeyword, itemsKeyword, prefixItemsKeyword } from "./keywords/items.js";
 export {
+  contentEncodingKeyword,
+  contentMediaTypeKeyword,
+  contentSchemaKeyword,
   defaultKeyword,
   deprecatedKeyword,
   descriptionKeyword,
   exampleKeyword,
   examplesKeyword,
+  externalDocsKeyword,
   readOnlyKeyword,
   titleKeyword,
   writeOnlyKeyword,
+  xmlKeyword,
 } from "./keywords/meta-data.js";
 export {
   exclusiveMaximumKeyword,

--- a/packages/schema/src/keywords/index.ts
+++ b/packages/schema/src/keywords/index.ts
@@ -67,14 +67,17 @@ export {
 export { typeKeyword } from "./type.js";
 export {
   APPLICATOR_VOCAB,
+  CONTENT_VOCAB,
   CORE_VALIDATION_VOCAB,
   CORE_VOCAB,
   FORMAT_ASSERTION_VOCAB,
   FORMAT_VOCAB,
   META_DATA_VOCAB,
   OAS30_VOCAB,
+  OPENAPI_META_DATA_VOCAB,
   UNEVALUATED_VOCAB,
   applicatorVocabulary,
+  contentVocabulary,
   coreVocabulary,
   defaultVocabularies,
   formatAssertionVocabulary,
@@ -89,14 +92,19 @@ export {
   validationVocabulary,
 } from "./vocabulary.js";
 export {
+  contentEncodingKeyword,
+  contentMediaTypeKeyword,
+  contentSchemaKeyword,
   defaultKeyword,
   deprecatedKeyword,
   descriptionKeyword,
   exampleKeyword,
   examplesKeyword,
+  externalDocsKeyword,
   readOnlyKeyword,
   titleKeyword,
   writeOnlyKeyword,
+  xmlKeyword,
 } from "./meta-data.js";
 export {
   oas30ExclusiveMaximumKeyword,

--- a/packages/schema/src/keywords/meta-data.ts
+++ b/packages/schema/src/keywords/meta-data.ts
@@ -8,13 +8,13 @@
  * `annotation: true` flag.
  */
 
-import { META_DATA_VOCAB } from "./vocabulary-uris.js";
+import { CONTENT_VOCAB, META_DATA_VOCAB, OPENAPI_META_DATA_VOCAB } from "./vocabulary-uris.js";
 import type { KeywordDefinition } from "./types.js";
 
-function annotationKeyword(name: string): KeywordDefinition {
+function annotationKeyword(name: string, vocabulary: string = META_DATA_VOCAB): KeywordDefinition {
   return {
     keyword: name,
-    vocabulary: META_DATA_VOCAB,
+    vocabulary,
     annotation: true,
     compile(): void {
       // intentionally empty — pure annotation
@@ -97,4 +97,51 @@ export const examplesKeyword = annotationKeyword("examples");
  *
  * @public
  */
-export const exampleKeyword = annotationKeyword("example");
+export const exampleKeyword = annotationKeyword("example", OPENAPI_META_DATA_VOCAB);
+
+/**
+ * OpenAPI Schema Object's `xml` annotation. Describes how a property
+ * serialises to XML (element name, namespace, attribute placement).
+ * Annotation-only for JSON validation; oav doesn't emit XML.
+ * Spec-defined on the OpenAPI Schema Object across 3.0 / 3.1 / 3.2.
+ *
+ * @public
+ */
+export const xmlKeyword = annotationKeyword("xml", OPENAPI_META_DATA_VOCAB);
+
+/**
+ * OpenAPI Schema Object's `externalDocs` annotation — pointer to
+ * additional external documentation for this schema. Annotation-only.
+ * Spec-defined fixed field on the Schema Object across 3.0 / 3.1 / 3.2.
+ *
+ * @public
+ */
+export const externalDocsKeyword = annotationKeyword("externalDocs", OPENAPI_META_DATA_VOCAB);
+
+/**
+ * JSON Schema 2020-12 `contentEncoding` — declares the encoding (e.g.
+ * `base64`) used for a string value. The spec marks the content
+ * vocabulary as not required to validate; oav treats it as
+ * annotation-only.
+ *
+ * @public
+ */
+export const contentEncodingKeyword = annotationKeyword("contentEncoding", CONTENT_VOCAB);
+
+/**
+ * JSON Schema 2020-12 `contentMediaType` — declares the media type
+ * (e.g. `application/jwt`) of a string value's content. Annotation-only
+ * companion to {@link contentEncodingKeyword}.
+ *
+ * @public
+ */
+export const contentMediaTypeKeyword = annotationKeyword("contentMediaType", CONTENT_VOCAB);
+
+/**
+ * JSON Schema 2020-12 `contentSchema` — schema describing the structure
+ * of decoded content (after applying `contentEncoding` and parsing
+ * `contentMediaType`). Annotation-only — oav doesn't decode + re-validate.
+ *
+ * @public
+ */
+export const contentSchemaKeyword = annotationKeyword("contentSchema", CONTENT_VOCAB);

--- a/packages/schema/src/keywords/vocabulary-uris.ts
+++ b/packages/schema/src/keywords/vocabulary-uris.ts
@@ -11,6 +11,11 @@ export const FORMAT_VOCAB = "https://json-schema.org/draft/2020-12/vocab/format-
 export const FORMAT_ASSERTION_VOCAB =
   "https://json-schema.org/draft/2020-12/vocab/format-assertion";
 export const META_DATA_VOCAB = "https://json-schema.org/draft/2020-12/vocab/meta-data";
+export const CONTENT_VOCAB = "https://json-schema.org/draft/2020-12/vocab/content";
 
 // Not a JSON-Schema-spec URI; used only to group the OpenAPI 3.0 keyword set.
 export const OAS30_VOCAB = "https://spec.openapis.org/oas/3.0/vocab/schema";
+
+// Not a JSON-Schema-spec URI; groups OpenAPI 3.x annotation keywords
+// (`example`, `xml`, `externalDocs`) shared across 3.0 / 3.1 / 3.2.
+export const OPENAPI_META_DATA_VOCAB = "https://spec.openapis.org/oas/vocab/meta-data";

--- a/packages/schema/src/keywords/vocabulary.ts
+++ b/packages/schema/src/keywords/vocabulary.ts
@@ -30,14 +30,19 @@ import {
   propertyNamesKeyword,
 } from "./properties.js";
 import {
+  contentEncodingKeyword,
+  contentMediaTypeKeyword,
+  contentSchemaKeyword,
   defaultKeyword,
   deprecatedKeyword,
   descriptionKeyword,
   exampleKeyword,
   examplesKeyword,
+  externalDocsKeyword,
   readOnlyKeyword,
   titleKeyword,
   writeOnlyKeyword,
+  xmlKeyword,
 } from "./meta-data.js";
 import {
   anchorKeyword,
@@ -71,22 +76,26 @@ import type { Dialect, Vocabulary } from "./types.js";
 export type { Dialect, DialectRules } from "./types.js";
 export {
   APPLICATOR_VOCAB,
+  CONTENT_VOCAB,
   CORE_VALIDATION_VOCAB,
   CORE_VOCAB,
   FORMAT_ASSERTION_VOCAB,
   FORMAT_VOCAB,
   META_DATA_VOCAB,
   OAS30_VOCAB,
+  OPENAPI_META_DATA_VOCAB,
   UNEVALUATED_VOCAB,
 } from "./vocabulary-uris.js";
 import {
   APPLICATOR_VOCAB,
+  CONTENT_VOCAB,
   CORE_VALIDATION_VOCAB,
   CORE_VOCAB,
   FORMAT_ASSERTION_VOCAB,
   FORMAT_VOCAB,
   META_DATA_VOCAB,
   OAS30_VOCAB,
+  OPENAPI_META_DATA_VOCAB,
   UNEVALUATED_VOCAB,
 } from "./vocabulary-uris.js";
 
@@ -226,14 +235,29 @@ export const metaDataVocabulary: Vocabulary = {
 
 /**
  * OpenAPI-specific annotations layered on top of
- * {@link metaDataVocabulary}. Currently carries only `example` (single),
- * which OpenAPI permits but JSON Schema 2020-12 does not.
+ * {@link metaDataVocabulary}. Carries the singular `example`
+ * (deprecated in 3.1 but widely used), `xml` (XML serialisation hints
+ * on Schema Objects), and `externalDocs` (pointer to external docs).
+ * All annotation-only.
  *
  * @public
  */
 export const openapiMetaDataVocabulary: Vocabulary = {
-  uri: "https://spec.openapis.org/oas/vocab/meta-data",
-  keywords: [exampleKeyword],
+  uri: OPENAPI_META_DATA_VOCAB,
+  keywords: [exampleKeyword, xmlKeyword, externalDocsKeyword],
+};
+
+/**
+ * The JSON Schema 2020-12 Content vocabulary: `contentEncoding`,
+ * `contentMediaType`, `contentSchema`. The spec marks the content
+ * vocabulary as not required to validate; oav treats all three as
+ * pure annotations so schemas using them lint clean in strict mode.
+ *
+ * @public
+ */
+export const contentVocabulary: Vocabulary = {
+  uri: CONTENT_VOCAB,
+  keywords: [contentEncodingKeyword, contentMediaTypeKeyword, contentSchemaKeyword],
 };
 
 /**
@@ -252,6 +276,7 @@ export const defaultVocabularies: Vocabulary[] = [
   unevaluatedVocabulary,
   formatVocabulary,
   metaDataVocabulary,
+  contentVocabulary,
 ];
 
 /**
@@ -305,6 +330,7 @@ export const openapi31Dialect: Dialect = {
     formatVocabulary,
     metaDataVocabulary,
     openapiMetaDataVocabulary,
+    contentVocabulary,
   ],
   rules: { refSuppressesSiblings: false },
 };
@@ -329,6 +355,7 @@ export const oas30Dialect: Dialect = {
     formatVocabulary,
     metaDataVocabulary,
     openapiMetaDataVocabulary,
+    contentVocabulary,
   ],
   rules: { refSuppressesSiblings: true },
 };

--- a/packages/schema/test/keyword-meta-data.test.ts
+++ b/packages/schema/test/keyword-meta-data.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from "vitest";
 import {
+  contentEncodingKeyword,
+  contentMediaTypeKeyword,
+  contentSchemaKeyword,
+  contentVocabulary,
   descriptionKeyword,
   exampleKeyword,
+  externalDocsKeyword,
   jsonSchemaDialect,
   metaDataVocabulary,
   oas30Dialect,
   openapi31Dialect,
   openapiMetaDataVocabulary,
+  xmlKeyword,
 } from "../src/keywords/index.js";
 import { compile } from "./helpers.js";
 
@@ -31,21 +37,32 @@ describe("meta-data vocabulary", () => {
     expect(metaDataVocabulary.uri).toBe("https://json-schema.org/draft/2020-12/vocab/meta-data");
   });
 
-  it("OpenAPI dialects extend the meta-data set with `example`", () => {
-    expect(openapiMetaDataVocabulary.keywords.map((k) => k.keyword)).toEqual(["example"]);
+  it("OpenAPI dialects extend the meta-data set with `example`, `xml`, `externalDocs`", () => {
+    expect(openapiMetaDataVocabulary.keywords.map((k) => k.keyword).sort()).toEqual([
+      "example",
+      "externalDocs",
+      "xml",
+    ]);
+    for (const kw of openapiMetaDataVocabulary.keywords) {
+      expect(kw.annotation).toBe(true);
+    }
     expect(exampleKeyword.annotation).toBe(true);
     for (const d of [openapi31Dialect, oas30Dialect]) {
       const has = (name: string) =>
         d.vocabularies.some((v) => v.keywords.some((k) => k.keyword === name));
       expect(has("description")).toBe(true);
       expect(has("example")).toBe(true);
+      expect(has("xml")).toBe(true);
+      expect(has("externalDocs")).toBe(true);
     }
     // jsonSchemaDialect gets the Meta-Data vocab, but NOT the OpenAPI
-    // `example` extension.
+    // extensions (`example`, `xml`, `externalDocs`).
     const jsHas = (name: string) =>
       jsonSchemaDialect.vocabularies.some((v) => v.keywords.some((k) => k.keyword === name));
     expect(jsHas("description")).toBe(true);
     expect(jsHas("example")).toBe(false);
+    expect(jsHas("xml")).toBe(false);
+    expect(jsHas("externalDocs")).toBe(false);
   });
 
   it("is a no-op at runtime — annotation-only schemas accept any input", () => {
@@ -68,5 +85,60 @@ describe("meta-data vocabulary", () => {
     // don't count as "real" validation keywords. Lock it in explicitly
     // so a refactor can't silently drop the flag.
     expect(descriptionKeyword.annotation).toBe(true);
+  });
+
+  it("registers `xml` and `externalDocs` as OpenAPI annotations", () => {
+    expect(xmlKeyword.annotation).toBe(true);
+    expect(externalDocsKeyword.annotation).toBe(true);
+    const v = compile({
+      type: "object",
+      properties: {
+        msg: { type: "string", xml: { name: "Message", attribute: true } },
+        ref: { type: "string", externalDocs: { url: "https://example.com/docs" } },
+      },
+    } as Record<string, unknown>);
+    expect(v.validate({ msg: "hi", ref: "x" }).valid).toBe(true);
+  });
+});
+
+describe("content vocabulary", () => {
+  it("registers contentEncoding / contentMediaType / contentSchema as annotation: true", () => {
+    expect(contentVocabulary.keywords.map((k) => k.keyword).sort()).toEqual([
+      "contentEncoding",
+      "contentMediaType",
+      "contentSchema",
+    ]);
+    for (const kw of contentVocabulary.keywords) {
+      expect(kw.annotation).toBe(true);
+    }
+    expect(contentEncodingKeyword.annotation).toBe(true);
+    expect(contentMediaTypeKeyword.annotation).toBe(true);
+    expect(contentSchemaKeyword.annotation).toBe(true);
+  });
+
+  it("carries the spec's content vocabulary URI", () => {
+    expect(contentVocabulary.uri).toBe("https://json-schema.org/draft/2020-12/vocab/content");
+  });
+
+  it("appears in every built-in dialect", () => {
+    for (const d of [jsonSchemaDialect, openapi31Dialect, oas30Dialect]) {
+      const has = (name: string) =>
+        d.vocabularies.some((v) => v.keywords.some((k) => k.keyword === name));
+      expect(has("contentEncoding")).toBe(true);
+      expect(has("contentMediaType")).toBe(true);
+      expect(has("contentSchema")).toBe(true);
+    }
+  });
+
+  it("is a no-op at runtime — content keywords accept any string", () => {
+    const v = compile({
+      type: "string",
+      contentEncoding: "base64",
+      contentMediaType: "application/jwt",
+      contentSchema: { type: "object", properties: { iss: { type: "string" } } },
+    } as Record<string, unknown>);
+    // Not actually base64-encoded JWT; oav doesn't decode + re-validate.
+    expect(v.validate("anything").valid).toBe(true);
+    expect(v.validate(123).valid).toBe(false); // type:string still enforced
   });
 });

--- a/packages/schema/test/strict-mode.test.ts
+++ b/packages/schema/test/strict-mode.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it } from "vitest";
 import type { SchemaOrBoolean } from "@oav/core";
 import { compileSchema } from "../src/compiler/compiler.js";
-import { jsonSchemaDialect } from "../src/keywords/vocabulary.js";
+import { jsonSchemaDialect, oas30Dialect, openapi31Dialect } from "../src/keywords/vocabulary.js";
 
 describe("strict mode", () => {
   const lint = (schema: SchemaOrBoolean, mode?: "off" | "warn-partial" | "strict") =>
@@ -46,6 +46,39 @@ describe("strict mode", () => {
       "strict",
     );
     expect(issues).toEqual([]);
+  });
+
+  it('"strict" tolerates the JSON Schema 2020-12 content vocabulary', () => {
+    const issues = lint(
+      {
+        type: "string",
+        contentEncoding: "base64",
+        contentMediaType: "application/jwt",
+        contentSchema: { type: "object" },
+      } as unknown as SchemaOrBoolean,
+      "strict",
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('"strict" tolerates `xml` and `externalDocs` under the OpenAPI dialects', () => {
+    const schema = {
+      type: "string",
+      xml: { name: "Msg" },
+      externalDocs: { url: "https://example.com/docs" },
+    } as unknown as SchemaOrBoolean;
+    // Base JSON Schema dialect does NOT recognise `xml` / `externalDocs`
+    // — they're OpenAPI extensions, not core JSON Schema keywords.
+    const baseIssues = compileSchema(schema, {
+      dialect: jsonSchemaDialect,
+      strict: "strict",
+    }).stats.strictIssues;
+    expect(baseIssues.map((i) => i.keyword).sort()).toEqual(["externalDocs", "xml"]);
+    // Both OpenAPI dialects DO recognise them.
+    for (const dialect of [openapi31Dialect, oas30Dialect]) {
+      const issues = compileSchema(schema, { dialect, strict: "strict" }).stats.strictIssues;
+      expect(issues).toEqual([]);
+    }
   });
 
   it('"strict" tolerates the standard $-prefixed metadata keys', () => {


### PR DESCRIPTION
## Summary

Closes #127.

Adds five spec-defined annotation-only keywords that strict mode was previously flagging as `unknown-keyword`:

- **`xml`** and **`externalDocs`** — OpenAPI Schema Object fixed fields, present in 3.0 / 3.1 / 3.2.
- **`contentEncoding`**, **`contentMediaType`**, **`contentSchema`** — JSON Schema 2020-12 content vocabulary. The spec marks the content vocab as not required to validate; oav treats the triple as pure annotations.

Wired through:

- New `contentVocabulary` carrying the spec's content vocab URI; appears in every built-in dialect via `defaultVocabularies`.
- `xml` and `externalDocs` join the existing `openapiMetaDataVocabulary` (3.0 and 3.1+ dialects only — they're OpenAPI extensions, not core JSON Schema).
- New URI constants `CONTENT_VOCAB`, `OPENAPI_META_DATA_VOCAB` in `vocabulary-uris.ts`.
- Five exports surfaced through both barrels (`packages/schema/src/keywords/index.ts` and `packages/schema/src/index.ts`).

## Validation

Re-ran the strict-mode compile sweep over 73 real-world openapi specs (AWS / Discord / Walmart / GitHub / Stripe / Adyen / Twilio / Atlassian / Google / etc.). Total strict-mode findings dropped from **1,753 to 0** — the `xml` keyword on AWS EC2 alone accounted for 1,541 spurious warnings before.

## Test plan

- [x] `pnpm test` — 656 tests pass
- [x] `pnpm lint` — clean
- [x] `pnpm fmt --check` — clean
- [x] `pnpm typecheck` — clean
- [x] Re-run the corpus sweep — strict findings 1,753 → 0
- [x] New regression in `strict-mode.test.ts`: base JSON Schema dialect still flags `xml` / `externalDocs` as unknown (they're OpenAPI extensions); both OpenAPI dialects accept them
- [x] New regression in `strict-mode.test.ts`: content triple tolerated under strict mode
- [x] Updated `keyword-meta-data.test.ts`: openapiMetaDataVocabulary now carries 3 keywords; new `contentVocabulary` describe block with URI / dialect-presence / runtime no-op assertions