### PR TITLE
docs: accuracy pass — eov mechanisms, deps, AOT framing, swagger 2.0, cross-field example

### DIFF
--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -71,7 +71,13 @@ Capabilities that the Ajv stack covers and oav does not.
   against the meta-schema.
 - **`$data` references.** Ajv's non-standard extension where one
   keyword's value comes from the data being validated
-  (`{ minimum: { $data: "1/min" } }`). oav doesn't implement it.
+  (`{ minimum: { $data: "1/min" } }`). oav doesn't implement it. The
+  common use case — cross-field constraints like `max >= min` —
+  works in oav via an object-level custom keyword that sees the
+  whole object and reaches siblings directly; see
+  [`examples/cross-field-validation.ts`](./examples/cross-field-validation.ts).
+  Trade-off: the constraint sits on the parent object in the schema
+  rather than inside the constrained field's own subschema.
 - **Async validation.** Ajv supports async formats and keywords (e.g.
   a format that hits a database). oav's formats and custom keywords
   are synchronous.

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -45,13 +45,14 @@ Capabilities that the Ajv stack covers and oav does not.
   strings to numbers, stripping undeclared properties, filling missing
   properties from `default`. oav treats validation as a yes/no
   question and does not mutate inputs.
-- **Schema-level AOT — programmatic surface.** Ajv ships a
-  `standaloneCode` API plus Node APIs that emit one or many compiled
-  schemas as module source, with CommonJS output and named-reference
-  resolution at emit time. oav's schema-level AOT is CLI-only (`oav
-compile-schema <schema> -o v.mjs`); for build tools that want to
-  emit many schemas in a loop, Ajv's API is more ergonomic. oav has
-  no batched programmatic API equivalent.
+- **Schema-level AOT — programmatic surface.** Ajv's `standaloneCode`
+  is a library API that takes a map of named schemas and emits one
+  module with interlinked validators — cross-schema `$ref`s resolve
+  at emit time, CommonJS or ESM output. `oav compile-schema` is
+  CLI-only and single-schema: multi-schema projects need to run it
+  per schema, with a preceding `oav resolve` step to inline any
+  cross-references. For build tools scripting many emits, Ajv's API
+  is more ergonomic; oav has no batched programmatic equivalent.
 - **Named schema registry.** `addSchema` / `getSchema` / `removeSchema`
   give Ajv a name-to-validator map that cross-schema `$ref`s resolve
   through. oav accepts an `external: Map<string, Schema>` on

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -115,11 +115,15 @@ Capabilities oav has that Ajv (alone or with
   them.
 - **Built-in OpenAPI 3.0 dialect.** `nullable`, boolean
   `exclusiveMaximum` / `exclusiveMinimum`, and
-  `$ref`-suppresses-siblings are compiled by a dedicated 3.0 dialect
-  selected once at `createValidator` time. Ajv reaches the same
-  semantics via `ajv-draft-04` plus a custom `nullable` keyword — the
-  functionality is equivalent; oav's version is one dependency with
-  no setup step.
+  `$ref`-suppresses-siblings are keyword definitions in the 3.0
+  vocabulary stack, selected once at `createValidator` time. eov
+  reaches the same semantics by a different route: switching to
+  `ajv-draft-04` (draft-04 handles boolean `exclusiveMaximum` and
+  `$ref`-suppresses-siblings natively) and preprocessing `nullable`
+  out of the schema before compile (rewriting `{ nullable: true,
+type: "string" }` to `{ type: ["string", "number", "boolean",
+"object", "array"] }` with an `x-eov-type` side channel to narrow
+  back). Different mechanism, equivalent behaviour.
 - **First-class overlays.** `applyOverlays` rewrites an
   externally-owned base spec at load time — add a required header to
   every operation, extend a component schema, swap a response shape —
@@ -148,8 +152,10 @@ Capabilities oav has that Ajv (alone or with
 - **Discriminator.** First-class OpenAPI discriminator support — a
   single-dispatch alternative to `oneOf` whose error message names the
   offending property and value rather than listing per-branch
-  failures. `express-openapi-validator` supports discriminator via a
-  custom Ajv keyword; the functionality is equivalent.
+  failures. eov supports discriminator by preprocessing the schema
+  (walking `oneOf` / `anyOf` at load time and rewriting the branches
+  into a form ajv can validate). Functionally equivalent, different
+  implementation shape.
 - **Compile-time observability.** `CompiledSchema.stats` exposes
   `functionCount`, `unevaluatedTrackingEmitted`, and
   `emittedTreeRuntime` so tests can assert on compiler optimisations

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ shape per code is documented in `BuiltInErrorParams`.
 
 ## Why (yet another) OpenAPI validator?
 
-Three things `oav` brings together that aren't jointly available
-elsewhere in the JavaScript ecosystem:
+Things `oav` brings together that aren't jointly available elsewhere
+in the JavaScript ecosystem:
 
 - **An HTTP-aware validator.** One call checks method + path +
   parameters + body + content type + status + headers against the
@@ -108,6 +108,14 @@ elsewhere in the JavaScript ecosystem:
   dispatch. Errors come back as a typed
   tree (`code` / `path` / `params` / `children`) so downstream code
   can narrow on fields rather than pattern-match on messages.
+- **AOT compilation for edge runtimes.** `oav compile-spec
+<openapi.yaml>` emits a single ES module — zero imports — exposing
+  the full `validateRequest` / `validateResponse` / `getOperation`
+  surface with every operation's schemas pre-compiled. Runs on
+  Cloudflare Workers / Vercel Edge / Lambda@Edge / Deno Deploy —
+  anywhere runtime code generation is forbidden or dependency
+  footprint matters. Full details in
+  [`packages/cli/README.md`](./packages/cli/README.md#compile-spec-output).
 
 Ajv is the canonical JSON Schema validator for JavaScript and
 underpins most of the OpenAPI ecosystem. It has the edge on

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ walk programmatically.
 `oav` ships in two packages so consumers on constrained runtimes can
 skip what they don't use:
 
-| Package                | When to use                                                                                                                                                                                    |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@aahoughton/oav`      | Default. Batteries-included: adds YAML readers and the `oav` CLI. Depends on `yaml`, `commander`, and `esbuild` (the latter two for CLI + AOT compile).                                        |
-| `@aahoughton/oav-core` | Lean alternative. Zero runtime dependencies. Same programmatic surface as `@aahoughton/oav`, minus the YAML readers and CLI. Feed it JSON specs (or pre-parsed objects via the memory reader). |
+| Package                | When to use                                                                                                                                                                                                                                                                                               |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@aahoughton/oav`      | Default. Batteries-included: YAML readers + the `oav` CLI. Depends on `yaml`; pulls in `commander` + `esbuild` for the CLI only (never imported from the library entry points, so bundlers tree-shake them out of application bundles; Node server runs load them only when the `oav` binary is invoked). |
+| `@aahoughton/oav-core` | Lean alternative. Zero runtime dependencies. Same programmatic surface as `@aahoughton/oav`, minus the YAML readers and CLI. Feed it JSON specs (or pre-parsed objects via the memory reader).                                                                                                            |
 
 ```bash
 npm install @aahoughton/oav
@@ -42,8 +42,15 @@ npm install @aahoughton/oav-core           # lean install, JSON-only
 subpaths. Samples below use `@aahoughton/oav`; on the lean package,
 substitute `@aahoughton/oav-core` in imports that don't touch the
 YAML readers (`createYamlFileReader`, `createSmartHttpReader`) or
-the CLI. `@aahoughton/oav` pulls in the CLI's deps (`commander`,
-`esbuild`) so `oav <command>` runs after a single install.
+the CLI.
+
+The `commander` + `esbuild` deps `@aahoughton/oav` pulls in are
+reachable only from the `oav` CLI binary (`dist/cli.js`). Application
+code importing from `@aahoughton/oav` hits `dist/index.js`, which
+doesn't reference them — bundlers tree-shake them out of the output,
+and Node servers load them only when the CLI is invoked. Consumers
+who want to skip the ~10 MB of esbuild's native binary on disk can
+install `@aahoughton/oav-core` instead (zero runtime deps, no CLI).
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,15 @@ one of the built-in dialects (`jsonSchemaDialect`, `openapi31Dialect`,
 3.1 dialect by default; configure with
 `onUnknownVersion: "throw" | "warn" | "fallback31"`.
 
+**Swagger 2.0 specs** aren't supported directly — `createValidator`
+throws on `swagger: "2.0"` documents. Convert to OpenAPI 3.0 first with
+[`swagger2openapi`](https://github.com/Mermade/oas-kit/tree/main/packages/swagger2openapi)
+and pass the 3.0 output to `createValidator`:
+
+```bash
+npx swagger2openapi swagger.json -o openapi.json
+```
+
 ## Configuring the validator
 
 | Option                  | Effect                                                                                                 |

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ walk programmatically.
 - Structured error trees (not flat arrays), so downstream code can
   distinguish a missing `required` property from a `oneOf` branch
   failure from an unsupported `Content-Type`.
-- Real 3.0 support (`nullable`, boolean `exclusiveMaximum`,
-  `$ref`-suppresses-siblings), not "3.1 and hope".
+- OpenAPI 3.0 compiles through its own dialect: `nullable`, boolean
+  `exclusiveMaximum`, and `$ref`-suppresses-siblings are keyword
+  definitions in the 3.0 vocabulary stack. Single compiler pass, no
+  schema preprocessing.
 - Codegen-compiled at construction, cached by schema identity, zero
   per-request version branching. Handles recursive `$ref`, multi-file
   specs, overlays, and custom keywords / formats.

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,6 +28,7 @@ for `@aahoughton/oav` in import specifiers that don't touch
 | `basic-validation.ts`          | `petstore.yaml`       | Load a spec → `createValidator` → request + response checks                         |
 | `custom-formats.ts`            | `contacts.yaml`       | Register a user format (E.164 phone) via the `formats` option                       |
 | `custom-keywords.ts`           | `widgets.yaml`        | Register a schema keyword (`activeTenant`) via the `keywords` option                |
+| `cross-field-validation.ts`    | `ranges.yaml`         | Cross-field constraint (`max >= min`) via an object-level custom keyword            |
 | `max-errors.ts`                | `items.yaml`          | Fast-fail and bounded error collection on a bulk-invalid payload                    |
 | `versions.ts`                  | `pets-3.{0,1,2}.yaml` | 3.0, 3.1, and 3.2 side by side: `nullable`, QUERY method, etc.                      |
 | `overlay.ts`                   | `petstore.yaml`       | Minimal overlay: merge a gateway header requirement into one op                     |

--- a/examples/cross-field-validation.ts
+++ b/examples/cross-field-validation.ts
@@ -1,0 +1,74 @@
+/**
+ * Cross-field validation via an object-level custom keyword.
+ *
+ * JSON Schema keywords see only their own data, so a field-level
+ * check like "max >= min" can't reach sibling fields. The pattern:
+ * declare a custom keyword on the OBJECT that names the cross-field
+ * rule, register a validator that sees the whole object, and let
+ * the validator reach siblings directly.
+ *
+ * This is the oav equivalent of Ajv's `$data` references
+ * (`{ minimum: { $data: "1/min" } }`), which aren't part of standard
+ * JSON Schema. Trade-off: the constraint sits on the parent object
+ * in the schema rather than inside the constrained field's own
+ * subschema.
+ *
+ * Run from the repo root:
+ *   pnpm tsx examples/cross-field-validation.ts
+ */
+
+import { fileURLToPath } from "node:url";
+import { formatText } from "../packages/core/src/index.ts";
+import { createYamlFileReader } from "../packages/oav/src/yaml.ts";
+import { loadSpec } from "../packages/spec/src/index.ts";
+import { createValidator } from "../packages/validator/src/index.ts";
+import type { CustomKeywordValidator } from "../packages/validator/src/index.ts";
+
+/**
+ * `x-cross-field: { <field>: { atLeast: <other-field> } }` — the
+ * named field must be `>=` the named other field. Walks the rules
+ * map, reaches each named sibling directly on the object data.
+ */
+const crossField: CustomKeywordValidator = (data, schemaValue) => {
+  if (typeof data !== "object" || data === null) return true;
+  const obj = data as Record<string, unknown>;
+  const rules = schemaValue as Record<string, { atLeast?: string }>;
+  for (const [field, rule] of Object.entries(rules)) {
+    if (rule.atLeast === undefined) continue;
+    const a = obj[field];
+    const b = obj[rule.atLeast];
+    if (typeof a !== "number" || typeof b !== "number") continue;
+    if (a < b) {
+      return {
+        message: `${field} (${a}) must be at least ${rule.atLeast} (${b})`,
+        params: { field, atLeast: rule.atLeast, got: a, expected: b },
+      };
+    }
+  }
+  return true;
+};
+
+const specPath = fileURLToPath(new URL("./specs/ranges.yaml", import.meta.url));
+const { document } = await loadSpec({ reader: createYamlFileReader(), entry: specPath });
+
+const v = createValidator(document, {
+  keywords: { "x-cross-field": crossField },
+});
+
+const ok = v.validateRequest({
+  method: "POST",
+  path: "/search",
+  contentType: "application/json",
+  body: { min: 3, max: 10 },
+});
+console.log("min=3 max=10  →", ok === null ? "ok" : "FAIL");
+
+const bad = v.validateRequest({
+  method: "POST",
+  path: "/search",
+  contentType: "application/json",
+  body: { min: 10, max: 3 },
+});
+if (bad !== null) {
+  console.log("\nmin=10 max=3:\n" + formatText(bad));
+}

--- a/examples/specs/ranges.yaml
+++ b/examples/specs/ranges.yaml
@@ -1,0 +1,31 @@
+openapi: "3.1.0"
+info:
+  title: Search
+  version: "1"
+paths:
+  /search:
+    post:
+      summary: Search with a numeric range
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [min, max]
+              properties:
+                min:
+                  type: integer
+                  minimum: 0
+                max:
+                  type: integer
+                  minimum: 0
+              # Custom cross-field rule: max must be >= min.
+              # See examples/cross-field-validation.ts for the
+              # keyword registration + validator.
+              x-cross-field:
+                max:
+                  atLeast: min
+      responses:
+        "200":
+          description: ok


### PR DESCRIPTION
## Summary

Six small documentation accuracy fixes accumulated after the recent compile-spec / CLI-consistency / tone-pass PRs landed. Each commit is independently reviewable.

- `docs: correct eov mechanism characterisations; drop "3.1 and hope"` — README's 3.0-support bullet implied eov approximates 3.0 by treating it as 3.1; eov actually swaps to `ajv-draft-04` and runs a `nullable` schema preprocessor. Verified by reading the installed eov source. COMPARISON.md updated alongside (eov uses preprocessors for both `nullable` and discriminator, not custom ajv keywords).
- `docs: clarify CLI-only reach of commander/esbuild deps` — readers scanning the install table thought these were always loaded; they're tree-shaken out of every non-CLI entry point. Added a short prose paragraph after the table.
- `docs: add compile-spec bullet to the "Why" section` — the recent AOT compile-spec work deserved a call-out alongside the structured-error-tree / overlays / 3.0-dialect bullets.
- `docs: tighten schema-level AOT bullet in COMPARISON` — leads with the substantive difference (cross-schema `$ref` resolution at emit time) rather than burying it.
- `docs(examples): cross-field-validation example; reference from COMPARISON` — adds `examples/cross-field-validation.ts` (object-level custom keyword pattern for `max >= min` style constraints) and references it from the `$data` discussion in COMPARISON.md.
- `docs: mention swagger2openapi for swagger 2.0 input specs` — short note in the README's Versions section pointing to `npx swagger2openapi` for users with swagger 2.0 specs. Validated against 16 real swagger 2.0 specs from the corpus: 15 convert and compile cleanly through `createValidator`; the 1 failure is a separate router bug (issue #129).

## Test plan

- [x] All examples (including new `cross-field-validation.ts`) run from the repo root via `pnpm tsx examples/<file>.ts`
- [x] Markdown links resolve
- [x] No code changes — no new tests required