### PR TITLE
fix(router): per-method ambiguity check, not per-structure

### DIFF
--- a/packages/router/src/matcher.ts
+++ b/packages/router/src/matcher.ts
@@ -82,6 +82,23 @@ interface Route {
 }
 
 /**
+ * Methods a `PathItem` declares, including HEAD when only GET is
+ * declared (RFC 9110 §9.3.2: GET implicitly answers HEAD via the
+ * runtime fallback below). Used by the per-(method, structure)
+ * ambiguity check so a pattern declaring GET reserves the HEAD slot
+ * too — a structurally-identical sibling declaring explicit HEAD would
+ * otherwise slip past the check and silently win at match time.
+ */
+function methodsDeclaredOn(item: PathItem): Set<HttpMethod> {
+  const declared = new Set<HttpMethod>();
+  for (const m of ALL_METHODS) {
+    if (item[m] !== undefined) declared.add(m);
+  }
+  if (declared.has("get")) declared.add("head");
+  return declared;
+}
+
+/**
  * Parse an OpenAPI path template into segments.
  *
  * @param template - The path template (e.g. `"/pets/{petId}"`).
@@ -130,22 +147,26 @@ export function parseTemplate(template: string): Segment[] {
  */
 export function createRouter(paths: Record<string, PathItem>): Router {
   const routes: Route[] = [];
-  const bySignature = new Map<string, string>();
+  // Per-(method, structure) ambiguity index. Two patterns that differ
+  // only in parameter names are an ill-formed document only when they
+  // also overlap on at least one HTTP method — disjoint-method siblings
+  // (e.g. `/items/{id}` GET and `/items/{slug}` POST) describe disjoint
+  // routing cells and would never collide at match time. Real-world
+  // specs (GitHub, Jira, Gmail, several AWS APIs) declare such pairs.
+  const byMethodSignature = new Map<string, string>();
   for (const [pattern, item] of Object.entries(paths)) {
     const segments = parseTemplate(pattern);
-    // Detect routes that are structurally identical except for template
-    // parameter names — e.g. `/items/{id}` vs `/items/{slug}`. These are
-    // an ill-formed document per OAS (two paths that would always match
-    // the same request), so surface that at construction rather than
-    // silently dropping every request into whichever sort order wins.
     const signature = segments.map((s) => (s.kind === "literal" ? s.value : "\0{}")).join("/");
-    const existing = bySignature.get(signature);
-    if (existing !== undefined) {
-      throw new Error(
-        `createRouter: path templates "${existing}" and "${pattern}" are ambiguous — they differ only in parameter names. Rename one or merge them.`,
-      );
+    for (const method of methodsDeclaredOn(item)) {
+      const key = `${method}\t${signature}`;
+      const existing = byMethodSignature.get(key);
+      if (existing !== undefined) {
+        throw new Error(
+          `createRouter: path templates "${existing}" and "${pattern}" both declare ${method.toUpperCase()} on the same path structure (parameter names differ but every ${method.toUpperCase()} request would match both). Rename one or merge them.`,
+        );
+      }
+      byMethodSignature.set(key, pattern);
     }
-    bySignature.set(signature, pattern);
     routes.push({ segments, pathPattern: pattern, pathItem: item });
   }
   // Sort by specificity: more literal segments win, longer paths win on ties.

--- a/packages/router/test/router.test.ts
+++ b/packages/router/test/router.test.ts
@@ -115,13 +115,54 @@ describe("router", () => {
     expect(rc.match("get", "/users/me%3Afollow")?.operation.operationId).toBe("follow");
   });
 
-  it("rejects two path templates that differ only in parameter names", () => {
+  it("rejects two path templates that differ only in parameter names when methods overlap", () => {
     expect(() =>
       createRouter({
         "/items/{id}": { get: op("byId") },
         "/items/{slug}": { get: op("bySlug") },
       }),
-    ).toThrow(/ambiguous/);
+    ).toThrow(/both declare GET/);
+  });
+
+  it("allows structurally-identical templates with disjoint methods", () => {
+    // Real-world pattern from GitHub / Jira / Gmail / several AWS specs:
+    // two paths describing the same URL shape but disjoint HTTP methods
+    // (e.g. one declares only DELETE, the other only GET). They never
+    // collide at match time, so construction must not throw.
+    const rc = createRouter({
+      "/orgs/{org}/attestations/{attestation_id}": { delete: op("deleteById") },
+      "/orgs/{org}/attestations/{subject_digest}": { get: op("listByDigest") },
+    });
+    const del = rc.match("delete", "/orgs/acme/attestations/42");
+    expect(del?.operation.operationId).toBe("deleteById");
+    expect(del?.pathParams).toEqual({ org: "acme", attestation_id: "42" });
+    const get = rc.match("get", "/orgs/acme/attestations/sha256:abc");
+    expect(get?.operation.operationId).toBe("listByDigest");
+    expect(get?.pathParams).toEqual({ org: "acme", subject_digest: "sha256:abc" });
+  });
+
+  it("flags GET-vs-explicit-HEAD as ambiguous on identical structure", () => {
+    // GET implicitly answers HEAD via the runtime fallback (RFC 9110).
+    // A sibling pattern declaring explicit HEAD on the same structure
+    // would silently win at match time depending on sort order — surface
+    // it at construction.
+    expect(() =>
+      createRouter({
+        "/things/{id}": { get: op("get") },
+        "/things/{slug}": { head: op("head") },
+      }),
+    ).toThrow(/both declare HEAD/);
+  });
+
+  it("ignores path items declaring no methods when checking ambiguity", () => {
+    // A PathItem with only `parameters` and no methods can never match
+    // a request, so it shouldn't conflict with a sibling that does.
+    expect(() =>
+      createRouter({
+        "/things/{id}": { get: op("get") },
+        "/things/{slug}": { parameters: [] } as PathItem,
+      }),
+    ).not.toThrow();
   });
 
   it("returns method-not-allowed with an allowed set (405 shape)", () => {


### PR DESCRIPTION
## Summary

Closes #128.

Relaxes the construction-time path-template ambiguity check from per-structure to per-(method, structure). Two paths that differ only in parameter names but declare disjoint HTTP methods describe disjoint routing cells and would never collide at match time — real-world specs (GitHub, Jira, Gmail, several AWS APIs) ship pairs like this and were previously rejected.

### What stays caught

- Two patterns of the same structure that overlap on at least one HTTP method (Google Logging's DELETE-on-DELETE; Google Pub/Sub's GET-on-`{subscription}`/`{topic}`).
- A pattern declaring GET vs a structurally-identical sibling declaring explicit HEAD — GET implicitly answers HEAD per RFC 9110 §9.3.2, so the GET reserves the HEAD slot too.

### What stops being a false positive

| Spec | Construction before | Construction after |
|---|---|---|
| AWS CloudFront | throws | ok |
| AWS Lambda | throws | ok |
| AWS Route53 | throws | ok |
| Atlassian Confluence | throws | ok |
| Atlassian Jira | throws | ok |
| GitHub REST | throws | ok |
| Gmail | throws | ok |
| Google Logging | throws | **still throws (real DELETE collision)** |
| Google Pub/Sub | throws | **still throws (real GET / DELETE collision)** |

Across the 83-spec real-world corpus the number of `createValidator` construction failures drops from 9 to 2.

### Error message

Now names the conflicting method, since structure alone no longer tells the user what the actual collision is:

> `createRouter: path templates "/items/{id}" and "/items/{slug}" both declare GET on the same path structure (parameter names differ but every GET request would match both). Rename one or merge them.`

## Test plan

- [x] `pnpm test` — 659 tests pass
- [x] `pnpm lint` / `pnpm fmt --check` / `pnpm typecheck` — clean
- [x] New regression: structurally-identical templates with disjoint methods compile and route correctly
- [x] New regression: GET-vs-explicit-HEAD sibling still throws (HEAD-fallback case)
- [x] New regression: a PathItem declaring no methods never participates in the ambiguity check
- [x] Updated existing regression: error message now mentions the conflicting method name
- [x] Re-ran corpus sweep — 73 ok → 80 ok; only Google Logging + Pub/Sub keep their (real) collisions