### PR TITLE
fix(router): support compound path segments (e.g. {sha}.{diffType})

### DIFF
--- a/packages/router/src/matcher.ts
+++ b/packages/router/src/matcher.ts
@@ -1,11 +1,29 @@
 import type { HttpMethod, OperationObject, PathItem } from "@oav/core";
 
 /**
- * Segments of a parsed OpenAPI path template.
+ * Segments of a parsed OpenAPI path template. Three kinds:
+ *
+ * - `literal` — a fixed substring (`pets`).
+ * - `template` — a single `{name}` parameter occupying the whole
+ *   segment (`{petId}`).
+ * - `compound` — multiple `{name}` parameters interleaved with literal
+ *   text inside one segment (`{sha}.{diffType}`,
+ *   `{year}-{month}.json`). Carries a pre-compiled regex with one
+ *   non-greedy capture group per template part so the matcher stays a
+ *   single `.exec` per segment in the hot path.
+ *
+ * Spec basis: OpenAPI 3.0 / 3.1 / 3.2 path templating only requires
+ * that template expressions be delimited by `{}`; multiple per segment
+ * with literal separators are spec-legal (cf. RFC 6570). Mainstream
+ * routers (path-to-regexp, hono, find-my-way, gorilla/mux, werkzeug)
+ * all use the non-greedy left-to-right rule modelled here.
  *
  * @public
  */
-export type Segment = { kind: "literal"; value: string } | { kind: "template"; name: string };
+export type Segment =
+  | { kind: "literal"; value: string }
+  | { kind: "template"; name: string }
+  | { kind: "compound"; regex: RegExp; names: string[]; raw: string };
 
 /**
  * Result of a successful route match: the path template matched *and*
@@ -102,11 +120,13 @@ function methodsDeclaredOn(item: PathItem): Set<HttpMethod> {
  * Parse an OpenAPI path template into segments.
  *
  * @param template - The path template (e.g. `"/pets/{petId}"`).
- * @returns An array of literal/template segments.
+ * @returns An array of literal / template / compound segments.
  *
  * @example
  * ```ts
  * parseTemplate("/pets/{id}"); // [{literal "pets"}, {template "id"}]
+ * parseTemplate("/commits/{sha}.{ext}");
+ * // [{literal "commits"}, {compound regex /^([^/]+?)\.([^/]+?)$/ names ["sha","ext"]}]
  * ```
  *
  * @public
@@ -114,12 +134,80 @@ function methodsDeclaredOn(item: PathItem): Set<HttpMethod> {
 export function parseTemplate(template: string): Segment[] {
   const trimmed = template.replace(/^\/+/, "").replace(/\/+$/, "");
   if (trimmed === "") return [];
-  return trimmed.split("/").map((seg): Segment => {
-    if (seg.startsWith("{") && seg.endsWith("}")) {
-      return { kind: "template", name: seg.slice(1, -1) };
-    }
+  return trimmed.split("/").map((seg) => parseSegment(seg));
+}
+
+function parseSegment(seg: string): Segment {
+  // Pure literal — no template syntax at all. Common case; skip parsing.
+  if (!seg.includes("{")) {
     return { kind: "literal", value: decodeURIComponent(seg) };
-  });
+  }
+  // Pure template — the whole segment is one `{name}`.
+  const pure = /^\{([^{}]+)\}$/.exec(seg);
+  if (pure !== null) {
+    return { kind: "template", name: pure[1]! };
+  }
+  // Compound — alternating literal and `{name}` parts. Build a regex
+  // with one non-greedy `[^/]+?` capture per template part; the trailing
+  // `$` anchor + lazy capture resolves multi-param ambiguity left-to-right
+  // (e.g. `{x}.{y}` against `a.b.c` captures `x="a"`, `y="b.c"`), matching
+  // path-to-regexp / hono / find-my-way / werkzeug behaviour.
+  const names: string[] = [];
+  let regexSrc = "^";
+  let i = 0;
+  let pendingLiteral = "";
+  while (i < seg.length) {
+    const ch = seg[i];
+    if (ch === "{") {
+      const end = seg.indexOf("}", i);
+      if (end === -1) {
+        // Unterminated `{` — treat the rest as literal so we don't throw
+        // on a malformed template; match `path-to-regexp`'s tolerance.
+        pendingLiteral += seg.slice(i);
+        break;
+      }
+      if (pendingLiteral !== "") {
+        regexSrc += escapeRegex(pendingLiteral);
+        pendingLiteral = "";
+      }
+      const name = seg.slice(i + 1, end);
+      names.push(name);
+      regexSrc += "([^/]+?)";
+      i = end + 1;
+    } else {
+      pendingLiteral += ch;
+      i += 1;
+    }
+  }
+  if (pendingLiteral !== "") {
+    regexSrc += escapeRegex(pendingLiteral);
+  }
+  regexSrc += "$";
+  // No template parts ended up in the segment despite a `{` — degenerate.
+  // Fall back to literal so behaviour matches the !includes("{") branch.
+  if (names.length === 0) {
+    return { kind: "literal", value: decodeURIComponent(seg) };
+  }
+  return { kind: "compound", regex: new RegExp(regexSrc), names, raw: seg };
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Stable signature of a segment for the per-(method, structure)
+ * ambiguity index. Two segments share a signature iff they would match
+ * the same set of tokens for any choice of parameter names. Compound
+ * segments emit their literal skeleton with `\0{}` markers replacing
+ * each `{name}`, so `{a}.{b}` and `{x}.{y}` both produce `\0{}.\0{}`
+ * (correctly flagged as ambiguous on overlapping methods); `{a}.{b}`
+ * vs `{a}-{b}` produce different signatures (correctly distinct).
+ */
+function segmentSignature(s: Segment): string {
+  if (s.kind === "literal") return s.value;
+  if (s.kind === "template") return "\0{}";
+  return s.raw.replaceAll(/\{[^{}]+\}/g, "\0{}");
 }
 
 /**
@@ -156,7 +244,7 @@ export function createRouter(paths: Record<string, PathItem>): Router {
   const byMethodSignature = new Map<string, string>();
   for (const [pattern, item] of Object.entries(paths)) {
     const segments = parseTemplate(pattern);
-    const signature = segments.map((s) => (s.kind === "literal" ? s.value : "\0{}")).join("/");
+    const signature = segments.map(segmentSignature).join("/");
     for (const method of methodsDeclaredOn(item)) {
       const key = `${method}\t${signature}`;
       const existing = byMethodSignature.get(key);
@@ -169,11 +257,19 @@ export function createRouter(paths: Record<string, PathItem>): Router {
     }
     routes.push({ segments, pathPattern: pattern, pathItem: item });
   }
-  // Sort by specificity: more literal segments win, longer paths win on ties.
+  // Sort by specificity:
+  //   1. more pure-literal segments win
+  //   2. more compound segments win (compounds carry literal anchors,
+  //      so they're stricter than a bare `{name}` at the same position)
+  //   3. longer paths win
+  //   4. alphabetical tie-break for stability
   routes.sort((a, b) => {
     const aLit = a.segments.filter((s) => s.kind === "literal").length;
     const bLit = b.segments.filter((s) => s.kind === "literal").length;
     if (aLit !== bLit) return bLit - aLit;
+    const aComp = a.segments.filter((s) => s.kind === "compound").length;
+    const bComp = b.segments.filter((s) => s.kind === "compound").length;
+    if (aComp !== bComp) return bComp - aComp;
     if (a.segments.length !== b.segments.length) return b.segments.length - a.segments.length;
     return a.pathPattern.localeCompare(b.pathPattern);
   });
@@ -209,8 +305,17 @@ export function createRouter(paths: Record<string, PathItem>): Router {
               matched = false;
               break;
             }
-          } else {
+          } else if (seg.kind === "template") {
             params[seg.name] = tok;
+          } else {
+            const m = seg.regex.exec(tok);
+            if (m === null) {
+              matched = false;
+              break;
+            }
+            for (let j = 0; j < seg.names.length; j += 1) {
+              params[seg.names[j]!] = m[j + 1]!;
+            }
           }
         }
         if (!matched) continue;

--- a/packages/router/test/router.test.ts
+++ b/packages/router/test/router.test.ts
@@ -17,6 +17,23 @@ describe("parseTemplate", () => {
   it("returns [] for root path", () => {
     expect(parseTemplate("/")).toEqual([]);
   });
+
+  it("recognises compound segments with multiple {name} parts and a literal separator", () => {
+    const segs = parseTemplate("/commits/{sha}.{ext}");
+    expect(segs).toHaveLength(2);
+    expect(segs[0]).toEqual({ kind: "literal", value: "commits" });
+    expect(segs[1]?.kind).toBe("compound");
+    if (segs[1]?.kind === "compound") {
+      expect(segs[1].names).toEqual(["sha", "ext"]);
+      expect(segs[1].raw).toBe("{sha}.{ext}");
+    }
+  });
+
+  it("treats unterminated `{` in a segment as a literal rather than throwing", () => {
+    // path-to-regexp tolerates malformed templates; mirror that.
+    const segs = parseTemplate("/files/{name");
+    expect(segs[1]).toEqual({ kind: "literal", value: "{name" });
+  });
 });
 
 describe("router", () => {
@@ -152,6 +169,65 @@ describe("router", () => {
         "/things/{slug}": { head: op("head") },
       }),
     ).toThrow(/both declare HEAD/);
+  });
+
+  it("routes compound segments and captures both parameters", () => {
+    // Real-world Gitea-style spec: `{sha}` and `{sha}.{diffType}` are
+    // distinct structures and must coexist; both have to route.
+    const rc = createRouter({
+      "/repos/{owner}/{repo}/git/commits/{sha}": { get: op("commit") },
+      "/repos/{owner}/{repo}/git/commits/{sha}.{diffType}": { get: op("commitDiff") },
+    });
+    const plain = rc.match("get", "/repos/foo/bar/git/commits/abc123");
+    expect(plain?.operation.operationId).toBe("commit");
+    expect(plain?.pathParams).toEqual({ owner: "foo", repo: "bar", sha: "abc123" });
+    const diff = rc.match("get", "/repos/foo/bar/git/commits/abc123.diff");
+    expect(diff?.operation.operationId).toBe("commitDiff");
+    expect(diff?.pathParams).toEqual({
+      owner: "foo",
+      repo: "bar",
+      sha: "abc123",
+      diffType: "diff",
+    });
+  });
+
+  it("compound segment captures resolve left-to-right (lazy) when params could span the separator", () => {
+    // `{x}.{y}` against `a.b.c` → x="a", y="b.c" (path-to-regexp /
+    // hono / find-my-way / werkzeug all share this rule).
+    const rc = createRouter({ "/x/{x}.{y}": { get: op("xy") } });
+    const m = rc.match("get", "/x/a.b.c");
+    expect(m?.pathParams).toEqual({ x: "a", y: "b.c" });
+  });
+
+  it("compound segment with three params resolves to one capture per part", () => {
+    const rc = createRouter({ "/v/{a}.{b}.{c}": { get: op("abc") } });
+    const m = rc.match("get", "/v/x.y.z");
+    expect(m?.pathParams).toEqual({ a: "x", b: "y", c: "z" });
+  });
+
+  it("compound segment with non-matching literal separator returns 404", () => {
+    const rc = createRouter({ "/v/{a}.{b}": { get: op("ab") } });
+    expect(rc.match("get", "/v/xy")).toBeUndefined();
+  });
+
+  it("two compound siblings differing only in parameter names flag as ambiguous on overlapping methods", () => {
+    expect(() =>
+      createRouter({
+        "/x/{a}.{b}": { get: op("ab") },
+        "/x/{p}.{q}": { get: op("pq") },
+      }),
+    ).toThrow(/both declare GET/);
+  });
+
+  it("compound and pure-template siblings are distinct structures (signatures differ)", () => {
+    // `{sha}` and `{sha}.{ext}` are different shapes. Both must compile
+    // even when they declare overlapping methods.
+    expect(() =>
+      createRouter({
+        "/c/{sha}": { get: op("plain") },
+        "/c/{sha}.{ext}": { get: op("withExt") },
+      }),
+    ).not.toThrow();
   });
 
   it("ignores path items declaring no methods when checking ambiguity", () => {


### PR DESCRIPTION
## Summary

Closes #129.

`parseTemplate` previously recognised only pure-literal or pure-`{name}` segments. A segment mixing literal text with template parts — spec-legal per OpenAPI 3.x and RFC 6570; appears in real-world specs like Gitea's `/repos/{owner}/{repo}/git/commits/{sha}.{diffType}` — slipped through the `startsWith("{") && endsWith("}")` check and became a template segment with the inner braces in its name. Both the runtime matcher and the ambiguity check were silently broken.

Adds a third segment kind `compound` carrying a pre-compiled regex (one non-greedy `[^/]+?` capture per template part, anchored at both ends) and a names array. Built once at construction; the matcher does one `RegExp.exec` per compound segment per match attempt, no per-request allocation.

Lazy left-to-right matching matches `path-to-regexp` / hono / find-my-way / werkzeug / gorilla-mux behaviour: `{x}.{y}` against `a.b.c` yields `x="a"`, `y="b.c"`.

### Routing-semantics changes

- **Specificity sort** gains a new tier between literal-count and length: at equal literal-count, the route with more compound segments wins. Compound segments carry literal anchors, so they're stricter than a bare `{name}` at the same position. So `/c/{sha}` and `/c/{sha}.{ext}` route correctly when both exist (a request for `/c/abc.diff` hits the compound).
- **Ambiguity signature** emits the literal skeleton with `\0{}` markers for each `{name}` inside compound segments. `{a}.{b}` and `{x}.{y}` are correctly flagged as ambiguous on overlapping methods; `{a}.{b}` vs `{a}-{b}` are correctly distinct.
- **Unterminated `{`** in a segment is now treated as a literal rather than producing a garbage template name (matches path-to-regexp tolerance).

### Performance impact

Specs without compound segments: one extra V8-inlinable branch per segment in the match loop. The third dispatch arm is statically unreachable, sub-nanosecond cost.

Specs with compound segments: one cached `RegExp.exec` per compound segment per matching attempt. Strictly better than the prior behaviour, which was either silently wrong or refused to compile.

### Corpus impact

Of the 99 valid openapi-dialect specs across both `specs/` and `specs-converted/`, **96 compile cleanly**. The 3 remaining are real spec issues:
- Google Logging — real DELETE-on-DELETE collision (kept by #128).
- Google Pub/Sub — real GET-on-GET collision (kept by #128).
- matrix-client — unresolved external `$ref` (user must run `resolveSpec`).

Gitea (the spec that surfaced this issue) now compiles.

## Test plan

- [x] `pnpm test` — 667 tests pass
- [x] `pnpm lint` / `pnpm fmt --check` / `pnpm typecheck` — clean
- [x] New regressions cover: parseTemplate compound recognition; lazy left-to-right capture across 2- and 3-param compounds; failed-literal-separator → 404; specificity sort prefers compound over pure-template at equal literal-count; ambiguity check across two compound siblings; compound-vs-pure-template coexist when structurally distinct; unterminated `{` tolerated as literal
- [x] Re-ran corpus sweep — Gitea now compiles; no regression for any previously-passing spec