### PR TITLE
fix(schema,validator): reject maxErrors <= 0 and non-integers

### DIFF
--- a/packages/schema/src/compiler/compiler.ts
+++ b/packages/schema/src/compiler/compiler.ts
@@ -264,6 +264,13 @@ export interface CompileOptions {
    *   the CPU and memory cost of validating a huge payload is bounded.
    *
    * `maxErrors: 1` is the classic fast-fail mode.
+   *
+   * Must be a positive integer (>= 1) when supplied. A cap of 0 is
+   * effectively predicate mode (no errors collected, validation
+   * collapses to yes/no) — for that, prefer
+   * {@link CompileOptions.predicate} which compiles a fully
+   * specialised function with no error infrastructure at all.
+   * `compileSchema` throws on `maxErrors <= 0`.
    */
   maxErrors?: number;
   /**
@@ -448,6 +455,22 @@ export function compileSchema(
   }
 
   const maxErrors = options.maxErrors ?? Number.POSITIVE_INFINITY;
+  if (
+    options.maxErrors !== undefined &&
+    Number.isFinite(maxErrors) &&
+    (!Number.isInteger(maxErrors) || maxErrors < 1)
+  ) {
+    // Reject values that would silently neutralise validation. A cap
+    // of 0 collects nothing and would return `valid: true` for invalid
+    // data; non-integers are likely a typo. Predicate mode is the
+    // explicit way to skip error collection entirely. `Infinity` is
+    // degenerate (equivalent to omitting the option) but harmless,
+    // and existing callers may pass it explicitly — accept it.
+    throw new Error(
+      `compileSchema: \`maxErrors\` must be a positive integer (got ${String(options.maxErrors)}). ` +
+        "Use `predicate: true` if you want a yes/no validator with no error tree.",
+    );
+  }
   const predicate = options.predicate === true;
   if (predicate && Number.isFinite(maxErrors)) {
     // Predicate mode short-circuits at the first failure by design;

--- a/packages/schema/test/max-errors.test.ts
+++ b/packages/schema/test/max-errors.test.ts
@@ -93,11 +93,17 @@ describe("maxErrors option", () => {
     expect(v.validate(42).truncated).toBeUndefined();
   });
 
-  it("maxErrors: 0 drops every error but still reports invalid", () => {
-    const v = compile({ type: "number" }, 0);
-    const r = v.validate("x");
-    expect(r.valid).toBe(true); // no errors collected; wrap returns null
-    // A cap of 0 effectively disables error reporting.
-    // (Users who want fast-fail should pass 1.)
+  it("rejects maxErrors: 0 at compile time", () => {
+    // A cap of 0 collects no errors and would silently return
+    // `valid: true` for invalid data — a correctness trap. Predicate
+    // mode is the explicit way to skip error collection entirely.
+    expect(() => compile({ type: "number" }, 0)).toThrow(
+      /must be a positive integer.*Use `predicate: true`/,
+    );
+  });
+
+  it("rejects negative and non-integer maxErrors", () => {
+    expect(() => compile({ type: "number" }, -1)).toThrow(/must be a positive integer/);
+    expect(() => compile({ type: "number" }, 1.5)).toThrow(/must be a positive integer/);
   });
 });

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -349,6 +349,10 @@ export interface ValidatorOptions {
    * error). When the cap is hit, the returned error tree is marked
    * with a `truncated: true` param on the root so consumers can tell
    * the report was shortened.
+   *
+   * Must be a positive integer (>= 1). `createValidator` throws on
+   * non-integer or zero/negative values; the compiler surfaces the
+   * error eagerly at construction time.
    */
   maxErrors?: number;
   /**
@@ -461,6 +465,19 @@ export function createValidator(
   spec: OpenAPIDocument,
   options: ValidatorOptions = {},
 ): OavValidator {
+  if (
+    options.maxErrors !== undefined &&
+    Number.isFinite(options.maxErrors) &&
+    (!Number.isInteger(options.maxErrors) || options.maxErrors < 1)
+  ) {
+    // `Infinity` is degenerate (equivalent to omitting) but harmless;
+    // existing callers may pass it explicitly. Reject the values that
+    // would silently break validation: 0, negatives, non-integers.
+    throw new Error(
+      `createValidator: \`maxErrors\` must be a positive integer (got ${String(options.maxErrors)}). ` +
+        "Use `maxErrors: 1` for fast-fail, or omit the option for uncapped error collection.",
+    );
+  }
   const paths = spec.paths ?? {};
   const router: Router = createRouter(paths);
   const formats = { ...builtInFormats, ...options.formats };

--- a/packages/validator/test/request.test.ts
+++ b/packages/validator/test/request.test.ts
@@ -972,3 +972,28 @@ describe("validateRequest", () => {
     expect(leafCodes(err)).toContain("minLength");
   });
 });
+
+describe("createValidator option validation", () => {
+  it("rejects maxErrors: 0 eagerly at construction", () => {
+    // Lazy compile would otherwise defer this until the first
+    // request and surface as a per-op compile error. Surface it at
+    // construction so misconfiguration fails loudly.
+    expect(() => createValidator(petSpec(), { maxErrors: 0 })).toThrow(
+      /must be a positive integer/,
+    );
+  });
+
+  it("rejects negative and non-integer maxErrors", () => {
+    expect(() => createValidator(petSpec(), { maxErrors: -1 })).toThrow(
+      /must be a positive integer/,
+    );
+    expect(() => createValidator(petSpec(), { maxErrors: 1.5 })).toThrow(
+      /must be a positive integer/,
+    );
+  });
+
+  it("accepts maxErrors: 1 (fast-fail) and finite positive integers", () => {
+    expect(() => createValidator(petSpec(), { maxErrors: 1 })).not.toThrow();
+    expect(() => createValidator(petSpec(), { maxErrors: 100 })).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Surfaced by the test-review pass (#135). `maxErrors: 0` previously compiled cleanly and produced a validator that silently returned `valid: true` for invalid data — a real correctness trap for callers that check only `result.valid`. Reject the value at both `compileSchema` and `createValidator` entry, with an error message pointing to \`predicate: true\` as the explicit way to skip error collection.

Also rejected: negative values and non-integer finite numbers (likely typos). \`Infinity\` is degenerate (equivalent to omitting the option) but harmless and accepted, since an existing predicate-mode test pins it as a documented no-op.

\`createValidator\`'s check is eager — bad option fails at construction rather than deferring to the first lazy compile.

## Test plan

- [x] Updated `max-errors.test.ts` regression that previously pinned the silent-pass-through behaviour
- [x] New `createValidator` regression in `request.test.ts` covers eager rejection at construction
- [x] All existing tests still pass (671 total)
- [x] Existing predicate-mode test asserting `maxErrors: Infinity` is accepted alongside `predicate: true` still passes