### PR TITLE
test: fill verified coverage gaps across cli, spec, router, core

### DIFF
--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -141,6 +141,114 @@ describe("buildProgram — argv-level", () => {
       runCli(["compile-schema", "schema.json", "--dialect", "draft-07"], mem),
     ).rejects.toThrow(/unknown dialect: draft-07/);
   });
+
+  it("validate --request reads an .http file and exits 0 on success", async () => {
+    const httpFile = "POST /pets HTTP/1.1\nContent-Type: application/json\n\n" + '{"name":"Fido"}';
+    const mem = memoryIo([["spec.json", spec]], [["req.http", httpFile]]);
+    const out = await runCli(["validate", "spec.json", "--request", "req.http"], mem);
+    expect(out.exitCode).toBe(0);
+    expect(out.stderr).toBe("");
+  });
+
+  it("validate --request surfaces validation errors with exit 1", async () => {
+    const httpFile =
+      "POST /pets HTTP/1.1\nContent-Type: application/json\n\n" + '{"wrong":"field"}';
+    const mem = memoryIo([["spec.json", spec]], [["req.http", httpFile]]);
+    const out = await runCli(["validate", "spec.json", "--request", "req.http"], mem);
+    expect(out.exitCode).toBe(1);
+    expect(out.stdout).toContain("required");
+  });
+
+  it("validate --response --status validates a response body", async () => {
+    // Spec with a typed 200 response so the validator has something to
+    // check. The base `spec` only has `description: ok` on responses.
+    const respSpec = {
+      ...spec,
+      paths: {
+        "/pets/{id}": {
+          get: {
+            parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+            responses: {
+              "200": {
+                description: "ok",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      required: ["name"],
+                      properties: { name: { type: "string" } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const okMem = memoryIo(
+      [["spec.json", respSpec]],
+      [["body.json", JSON.stringify({ name: "Fido" })]],
+    );
+    const ok = await runCli(
+      [
+        "validate",
+        "spec.json",
+        "--path",
+        "GET /pets/42",
+        "--body",
+        "body.json",
+        "--response",
+        "--status",
+        "200",
+      ],
+      okMem,
+    );
+    expect(ok.exitCode).toBe(0);
+
+    const failMem = memoryIo([["spec.json", respSpec]], [["body.json", JSON.stringify({})]]);
+    const fail = await runCli(
+      [
+        "validate",
+        "spec.json",
+        "--path",
+        "GET /pets/42",
+        "--body",
+        "body.json",
+        "--response",
+        "--status",
+        "200",
+      ],
+      failMem,
+    );
+    expect(fail.exitCode).toBe(1);
+    expect(failMem.stdout.value).toContain("required");
+  });
+
+  it("validate --format json on the error path emits parseable JSON", async () => {
+    const mem = memoryIo([["spec.json", spec]], [["body.json", JSON.stringify({})]]);
+    const out = await runCli(
+      ["validate", "spec.json", "--path", "POST /pets", "--body", "body.json", "--format", "json"],
+      mem,
+    );
+    expect(out.exitCode).toBe(1);
+    // stdout for the error tree (exit code is what flags failure).
+    const parsed = JSON.parse(out.stdout);
+    expect(parsed.code).toBeDefined();
+  });
+
+  it("validate --format flat on the error path emits one error per line", async () => {
+    const mem = memoryIo([["spec.json", spec]], [["body.json", JSON.stringify({})]]);
+    const out = await runCli(
+      ["validate", "spec.json", "--path", "POST /pets", "--body", "body.json", "--format", "flat"],
+      mem,
+    );
+    expect(out.exitCode).toBe(1);
+    const lines = out.stdout.split("\n").filter((l) => l.length > 0);
+    expect(lines.length).toBeGreaterThan(0);
+    // Flat format puts each leaf on its own line — no nested indentation.
+    for (const line of lines) expect(line.startsWith(" ")).toBe(false);
+  });
 });
 
 // The compile-schema command always bundles via esbuild. These tests

--- a/packages/cli/test/compile-spec.test.ts
+++ b/packages/cli/test/compile-spec.test.ts
@@ -236,6 +236,25 @@ describe("compile-spec --requests-only", () => {
 });
 
 describe("compile-spec --only", () => {
+  it("returns exit code 2 when the spec file can't be loaded", async () => {
+    // No `spec.json` in the memory reader → loadSpec throws → exit 2.
+    // (Exit 3 is reserved for compile/bundle failures after a successful
+    // load.) Pin the distinction so a future refactor can't collapse them.
+    const mem = memoryIo([]);
+    const res = await compileSpecCommand(
+      {
+        spec: "spec.json",
+        overlays: [],
+        output: "out.mjs",
+        importPrefix: "@oav",
+        resolveDir: RESOLVE_DIR,
+      },
+      mem.io,
+    );
+    expect(res.exitCode).toBe(2);
+    expect(mem.stderr.value).toContain("compile-spec:");
+  });
+
   it("drops unincluded ops from the router (→ route error on call)", async () => {
     // Include only POST /pets; GET /pets is dropped.
     const aot = await buildAot(petstore, {

--- a/packages/core/test/errors.test.ts
+++ b/packages/core/test/errors.test.ts
@@ -33,6 +33,17 @@ describe("createError", () => {
     expect(err.children[0]).toBe(child);
     expect(err.params).toEqual({ matchCount: 0 });
   });
+
+  it("snapshots `path` so later caller-side mutation can't corrupt the error", () => {
+    // Generated validators reuse one mutable path array across traversal
+    // (push/pop per depth). Without a snapshot the error would silently
+    // point at whatever path the validator landed on next.
+    const livePath: (string | number)[] = ["body", "items", 0, "name"];
+    const err = createError({ code: "type", path: livePath, message: "x" });
+    livePath.push("mutation");
+    livePath[3] = "zzz";
+    expect(err.path).toEqual(["body", "items", 0, "name"]);
+  });
 });
 
 describe("createLeafError", () => {

--- a/packages/core/test/format.test.ts
+++ b/packages/core/test/format.test.ts
@@ -49,6 +49,11 @@ describe("formatText", () => {
     for (const line of lines) {
       expect(line).not.toContain("must be boolean");
     }
+    // Boundary: depth==maxDepth must still render (the rule is `depth >
+    // maxDepth`, not `>=`). Pin it so an off-by-one regression here would
+    // be caught.
+    expect(lines).toContain("    body — branch 0 (Cat) failed [branch]");
+    expect(lines).toContain("    body — branch 1 (Dog) failed [branch]");
   });
 
   it("allows overriding the indent string", () => {

--- a/packages/core/test/http-status.test.ts
+++ b/packages/core/test/http-status.test.ts
@@ -83,6 +83,17 @@ describe("httpStatusFor", () => {
     expect(httpStatusFor(err)).toBe(401);
   });
 
+  it("prefers 401 (security) over 500 (status) when both leaves are present", () => {
+    // Same gate ladder: auth runs before any response-status check, so
+    // 401 must win even when a status mismatch is also present in the
+    // tree (e.g. composed validations bubbled up together).
+    const err = createBranchError("response", [], "response validation failed", [
+      createLeafError("status", ["status"], "no matching status", { status: 200 }),
+      createLeafError("security", ["security"], "missing credential", {}),
+    ]);
+    expect(httpStatusFor(err)).toBe(401);
+  });
+
   it("applies overrides for individual slots", () => {
     const err = createBranchError("request", [], "request validation failed", [
       createLeafError("required", ["body"], "missing name", { missing: "name" }),

--- a/packages/router/test/router.test.ts
+++ b/packages/router/test/router.test.ts
@@ -278,6 +278,9 @@ describe("router", () => {
     if (m?.kind === "match") {
       expect(m.operation.operationId).toBe("byId");
       expect(m.pathPattern).toBe("/items/{id}");
+      // Falling through must still capture the matched template's params,
+      // otherwise the operation would receive an empty / stale param map.
+      expect(m.pathParams).toEqual({ id: "42" });
     }
   });
 });

--- a/packages/spec/test/load.test.ts
+++ b/packages/spec/test/load.test.ts
@@ -50,4 +50,58 @@ describe("loadSpec", () => {
     });
     expect(Object.keys(document.paths ?? {})).toEqual(["/pets"]);
   });
+
+  it("inlines external $refs first, then applies overlays to the resolved document", async () => {
+    // Integration: confirms `loadSpec` runs `resolveSpec` before
+    // `applyOverlays`, so an overlay extending `components.schemas.Pet`
+    // sees the inlined definition from the sibling file. If overlays
+    // ran first, `Pet` would still be the bare `$ref` and extendSchemas
+    // would silently insert the extension verbatim instead of wrapping.
+    const reader = createMemoryReader(
+      new Map<string, unknown>([
+        [
+          "main.json",
+          {
+            openapi: "3.1.0",
+            info: { title: "X", version: "1" },
+            paths: {
+              "/pets": {
+                post: {
+                  requestBody: {
+                    content: {
+                      "application/json": { schema: { $ref: "#/components/schemas/Pet" } },
+                    },
+                  },
+                  responses: { "201": { description: "created" } },
+                },
+              },
+            },
+            components: {
+              schemas: {
+                Pet: { $ref: "schemas.json#/Pet" },
+              },
+            },
+          },
+        ],
+        [
+          "schemas.json",
+          {
+            Pet: { type: "object", properties: { name: { type: "string" } } },
+          },
+        ],
+      ]),
+    );
+
+    const { document, sources } = await loadSpec({
+      reader,
+      entry: "main.json",
+      overlays: [{ extendSchemas: { Pet: { required: ["name"] } } }],
+    });
+
+    expect(sources.sort()).toEqual(["main.json", "schemas.json"]);
+    // External ref inlined into components.schemas.Pet, then wrapped in
+    // allOf by extendSchemas — proves resolveSpec ran first.
+    const pet = document.components?.schemas?.["Pet"];
+    expect(pet).toMatchObject({ allOf: expect.any(Array) });
+  });
 });

--- a/packages/spec/test/overlay.test.ts
+++ b/packages/spec/test/overlay.test.ts
@@ -91,6 +91,30 @@ describe("applyOverlays", () => {
     expect(pet).toMatchObject({ allOf: expect.any(Array) });
   });
 
+  it("extendSchemas inserts the extension verbatim when the target schema doesn't exist", () => {
+    // Pin the silent-create behaviour explicitly so a future "throw on
+    // missing target" change is a deliberate decision, not an accident.
+    const patched = applyOverlays(base(), [
+      { extendSchemas: { NewType: { type: "string", minLength: 1 } } },
+    ]);
+    expect(patched.components?.schemas?.["NewType"]).toEqual({
+      type: "string",
+      minLength: 1,
+    });
+  });
+
+  it("overrides targeting an unknown (non-wildcard) path throws", () => {
+    expect(() =>
+      applyOverlays(base(), [
+        {
+          overrides: {
+            "/missing": { operations: { get: { upsertParameters: [] } } },
+          },
+        },
+      ]),
+    ).toThrow(/overlay override targets unknown path/);
+  });
+
   it("replaceSchemas fully replaces the entry", () => {
     const patched = applyOverlays(base(), [{ replaceSchemas: { Pet: { type: "string" } } }]);
     expect(patched.components?.schemas?.["Pet"]).toEqual({ type: "string" });

--- a/packages/spec/test/reader.test.ts
+++ b/packages/spec/test/reader.test.ts
@@ -146,4 +146,16 @@ describe("composeReaders", () => {
     const composed = composeReaders([createMemoryReader(new Map())]);
     await expect(composed.read("nope")).rejects.toThrow(/no reader/);
   });
+
+  it("first reader to claim a URI wins (later readers are shadowed)", async () => {
+    // Documented composition contract: composeReaders walks the array and
+    // returns the first reader where canRead() is true. A second reader
+    // that also claims the same URI must be shadowed — this is the
+    // mechanism for layering (e.g. a project-specific reader in front of
+    // a generic file reader).
+    const front = createMemoryReader(new Map([["shared.json", '{"from":"front"}']]));
+    const back = createMemoryReader(new Map([["shared.json", '{"from":"back"}']]));
+    const composed = composeReaders([front, back]);
+    expect(await composed.read("shared.json")).toEqual({ from: "front" });
+  });
 });


### PR DESCRIPTION
## Summary

Targeted additions for gaps confirmed in the post-review audit per #135. The earlier multi-agent review over-claimed several packages (formats, from-fetch, OAS 3.0 quirks, schema keyword files, validator deserialize/strictQueryParameters/cookie — all already covered). Only the items below were genuinely missing coverage.

12 new tests across 4 packages, 683 total.

### What's covered

**cli (7 tests in 2 files)**
- `validate --request <file>` happy + failure paths
- `validate --response --status` happy + failure with a typed 200 response
- `validate --format json` and `--format flat` on the error path (only `text` was tested before)
- `compile-spec` exit code 2 (bad-spec load failure) — pins the distinction from exit 3 (compile/bundle failure)

**spec (4 tests across 3 files)**
- `extendSchemas` inserting the extension verbatim when the target schema doesn't exist (silent-create behaviour)
- `overrides` throwing on a non-wildcard missing path (`removePaths` and `removeSchemas` had this; `overrides` didn't)
- `composeReaders` shadow-ordering: first reader to claim a URI wins
- `loadSpec` integration test combining external `$ref` resolution + overlays applied to the resolved document

**router (extends 1 test)**
- Fall-through test now also asserts `pathParams` (was only checking `operationId` + `pathPattern`)

**core (3 tests across 3 files)**
- `createError` snapshots the path array (mutation-isolation; the implementation already does it but no test pinned it)
- `formatText` depth boundary at `maxDepth` (`>` vs `>=` off-by-one)
- `httpStatusFor` prefers 401 (security) over 500 (status) when both leaves coexist

## Test plan

- [x] `pnpm test` — 683 pass (was 671)
- [x] `pnpm lint` / `pnpm fmt --check` / `pnpm typecheck` — clean