### PR TITLE
docs: drop @aahoughton scope from narrative prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 # Changelog
 
-Release notes for `@aahoughton/oav-core` and `@aahoughton/oav` land here,
+Release notes for `oav-core` and `oav` land here,
 appended by release-please on every merged release PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ external dev-dependencies (benchmark runners, competing validators,
   The public barrel holds what keyword authors need; codegen mechanics
   (`NAMES`, `pathJoinExpr`, `rawExpr`, `quoteString`, runtime helpers,
   `SchemaRegistry`, `SUBSCHEMA_*_POSITIONS`, `createKeywordContext`)
-  live behind the `@aahoughton/oav/schema/internals` subpath — reach
+  live behind the `oav/schema/internals` subpath — reach
   for them only when a plugin genuinely needs them (not covered by
   semver).
 - **`@oav/formats`** — pure string validators; exported as a `Record<string,

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -60,7 +60,7 @@ Capabilities that the Ajv stack covers and oav does not.
   that build up a schema collection incrementally.
 - **Full RFC 3986 URI resolution.** Ajv handles absolute-URI `$ref`s
   and `$id` base-URI rewrites natively. oav requires external /
-  multi-file refs to be pre-inlined by `@aahoughton/oav/spec.resolveSpec()`
+  multi-file refs to be pre-inlined by `oav/spec.resolveSpec()`
   before compile, and accepts fragment-only refs thereafter.
 - **Full meta-schema validation.** Ajv can validate your schema
   against the draft's meta-schema at compile time, catching both
@@ -180,8 +180,8 @@ Ajv 8 has four runtime dependencies:
 | `require-from-string`  | Load compiled-validator source as a module (standalone codegen) |
 
 oav's compiler and validator have zero runtime dependencies. The lean
-`@aahoughton/oav-core` package ships exactly that — no runtime deps —
-and accepts JSON specs. The batteries-included `@aahoughton/oav`
+`oav-core` package ships exactly that — no runtime deps —
+and accepts JSON specs. The batteries-included `oav`
 package layers `yaml` on top for `.yaml` spec files and adds the `oav`
 CLI (with `commander` as an optional peer). The two efficiency
 libraries Ajv pulls in (`fast-deep-equal`, `json-schema-traverse`)

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -74,7 +74,7 @@ children hang off `body`, `query.<name>`, `headers.<name>`, etc.
 
 ## Supporting helpers used below
 
-Both shipped from `@aahoughton/oav`:
+Both shipped from `oav`:
 
 - **`httpStatusFor(err, overrides?)`** — maps a `ValidationError`
   tree to an HTTP status: `route` → 404, `method` → 405, `security`
@@ -365,7 +365,7 @@ updating the document.
 
 ### Status-code mapping
 
-Use `httpStatusFor` from `@aahoughton/oav`:
+Use `httpStatusFor` from `oav`:
 
 ```ts
 import { httpStatusFor, toProblemDetails } from "@aahoughton/oav";
@@ -792,9 +792,9 @@ app.use(async (req, res, next) => {
   counts by category.
 - **Overlays.** Extend externally-owned specs at load time —
   see [OVERLAYS.md](./OVERLAYS.md).
-- **Smaller install footprint.** `@aahoughton/oav` depends on `yaml`,
+- **Smaller install footprint.** `oav` depends on `yaml`,
   `commander`, and `esbuild` (the latter two for CLI + AOT compile
-  output); `@aahoughton/oav-core` is the lean alternative with zero
+  output); `oav-core` is the lean alternative with zero
   runtime deps for programmatic-only consumers who don't need the
   CLI or YAML readers.
 - **No mutation of `req`.** `express-openapi-validator` attaches
@@ -826,7 +826,7 @@ formats: {
 ```
 
 When migrating a map of ajv-shaped definitions without rewriting each
-one, `@aahoughton/oav/formats` exports `fromAjvFormats` for the
+one, `oav/formats` exports `fromAjvFormats` for the
 conversion:
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -38,19 +38,19 @@ npm install @aahoughton/oav
 npm install @aahoughton/oav-core           # lean install, JSON-only
 ```
 
-`@aahoughton/oav` re-exports `@aahoughton/oav-core` at matching
-subpaths. Samples below use `@aahoughton/oav`; on the lean package,
-substitute `@aahoughton/oav-core` in imports that don't touch the
+`oav` re-exports `oav-core` at matching
+subpaths. Samples below use `oav`; on the lean package,
+substitute `oav-core` in imports that don't touch the
 YAML readers (`createYamlFileReader`, `createSmartHttpReader`) or
 the CLI.
 
-The `commander` + `esbuild` deps `@aahoughton/oav` pulls in are
+The `commander` + `esbuild` deps `oav` pulls in are
 reachable only from the `oav` CLI binary (`dist/cli.js`). Application
-code importing from `@aahoughton/oav` hits `dist/index.js`, which
+code importing from `oav` hits `dist/index.js`, which
 doesn't reference them — bundlers tree-shake them out of the output,
 and Node servers load them only when the CLI is invoked. Consumers
 who want to skip the ~10 MB of esbuild's native binary on disk can
-install `@aahoughton/oav-core` instead (zero runtime deps, no CLI).
+install `oav-core` instead (zero runtime deps, no CLI).
 
 ## Quick start
 
@@ -305,8 +305,8 @@ no monkey-patching of `req` or `res`.
 ## Modules
 
 The package publishes a small root and four subpath entrypoints.
-`@aahoughton/oav-core` exposes the same five entrypoints; substitute
-`@aahoughton/oav-core/...` to import from the lean package.
+`oav-core` exposes the same five entrypoints; substitute
+`oav-core/...` to import from the lean package.
 
 | Import                    | Surface                                                  |
 | ------------------------- | -------------------------------------------------------- |
@@ -316,7 +316,7 @@ The package publishes a small root and four subpath entrypoints.
 | `@aahoughton/oav/formats` | Built-in string format validators                        |
 | `@aahoughton/oav/core`    | Error tree model, shared OpenAPI / HTTP types            |
 
-`@aahoughton/oav` also exports `createYamlFileReader`,
+`oav` also exports `createYamlFileReader`,
 `createSmartHttpReader` (HTTP reader that handles both JSON and YAML
 by inspecting `Content-Type`), and `parseYamlString` at the root entry,
 and ships the `oav` CLI as a `bin`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ Please include:
 
 - A description of the issue and its impact.
 - Steps to reproduce, or a minimal proof of concept.
-- The affected version(s) of `@aahoughton/oav`.
+- The affected version(s) of `oav`.
 - Any mitigations or workarounds you're aware of.
 
 You should receive an acknowledgement within a few business days.

--- a/examples/custom-formats.ts
+++ b/examples/custom-formats.ts
@@ -2,7 +2,7 @@
  * Custom formats: register a string format (here, E.164 phone numbers)
  * and have it enforced alongside the built-ins. A format is any
  * `(value: string) => boolean`; merged on top of
- * `@aahoughton/oav/formats`' defaults at validator-construction time.
+ * `oav/formats`' defaults at validator-construction time.
  *
  * Run from the repo root:
  *   pnpm tsx examples/custom-formats.ts

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # oav (CLI)
 
-The `oav` binary — a thin wrapper around `@aahoughton/oav` for shell
+The `oav` binary — a thin wrapper around the oav library for shell
 scripts, Makefiles, and CI.
 
 ## Install
@@ -14,13 +14,13 @@ oav --help
 npx @aahoughton/oav validate openapi.yaml --request req.http
 ```
 
-The CLI lives in the batteries-included `@aahoughton/oav` package, not
-the lean `@aahoughton/oav-core` — `oav-core` doesn't ship a `bin` or
-any CLI glue. `@aahoughton/oav` pulls in `commander` (argv parsing)
+The CLI lives in the batteries-included `oav` package, not
+the lean `oav-core` — `oav-core` doesn't ship a `bin` or
+any CLI glue. `oav` pulls in `commander` (argv parsing)
 and `esbuild` (AOT bundling for `compile-schema` / `compile-spec`) as
 regular dependencies, so the CLI runs out of the box after one
 install. Users who only need the programmatic API and want a smaller
-footprint install `@aahoughton/oav-core` instead.
+footprint install `oav-core` instead.
 
 ## Commands
 
@@ -77,13 +77,13 @@ library footprint is unwanted.
 Constraints on the input schema:
 
 - **Built-in formats only.** If the schema references `format: "..."`
-  names outside `@aahoughton/oav/formats`, compile fails with exit
+  names outside `oav/formats`, compile fails with exit
   code 3 and a listing of the unknown names. Custom formats aren't
   serialisable to standalone source.
 - **No custom keywords.** Same reason — the keyword's validator
   function can't be serialised.
 - **External `$ref`s must be pre-inlined.** Run `oav resolve` over
-  a multi-file input first, or use `@aahoughton/oav/spec.resolveSpec`
+  a multi-file input first, or use `oav/spec.resolveSpec`
   programmatically, before piping the schema into `compile-schema`.
 
 ## `compile-spec` output

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -78,7 +78,7 @@ export function defaultCommandIo(): CommandIo {
     // stat against the HTTP reader (which would reject it via
     // canRead anyway, but clearer ordering). HTTP reader accepts
     // `http:` / `https:` URIs; the YAML-over-HTTP story rides on
-    // top of this chain in `@aahoughton/oav`'s CLI wrapper, which
+    // top of this chain in `oav`'s CLI wrapper, which
     // composes YAML readers in front of whatever we return here.
     reader: composeReaders([createFileReader(), createHttpReader()]),
     async readText(pathOrDash: string) {
@@ -232,7 +232,7 @@ export type ValidateMode =
  * `validate(data)` mirrors `compileSchema(schema).validate(data)`, then
  * bundles it via esbuild into a single file with zero imports.
  *
- * The output runs without `@aahoughton/oav` installed at all — the
+ * The output runs without `oav` installed at all — the
  * Lambda / edge / single-file deployment case. `esbuild` is a required
  * peer dependency for this subcommand; a clear install hint prints on
  * stderr with exit code 3 if it's not resolvable.
@@ -245,7 +245,7 @@ export async function compileSchemaCommand(
     output?: string;
     dialect?: StandaloneDialect;
     /**
-     * Override the `@aahoughton/oav` prefix used in the intermediate
+     * Override the `oav` prefix used in the intermediate
      * pre-bundle module's imports. Tests pass `"@oav"` so esbuild
      * resolves against the in-workspace package aliases rather than
      * the published package name. Not exposed on the CLI.
@@ -253,7 +253,7 @@ export async function compileSchemaCommand(
     importPrefix?: string;
     /**
      * Override esbuild's resolveDir. Defaults to `process.cwd()`,
-     * which is where a real consumer's installed `@aahoughton/oav`
+     * which is where a real consumer's installed `oav`
      * sits. Tests point this at `packages/oav/` where the workspace's
      * `@oav/*` symlinks are reachable. Not exposed on the CLI.
      */

--- a/packages/cli/src/emit-spec.ts
+++ b/packages/cli/src/emit-spec.ts
@@ -62,7 +62,7 @@ export interface EmitSpecOptions {
   only?: Array<{ method: string; path: string }>;
   /**
    * Import-path prefix for runtime deps. Defaults to
-   * `"@aahoughton/oav"`. Tests override to `"@oav"` so the output
+   * `"oav"`. Tests override to `"@oav"` so the output
    * resolves against the workspace aliases.
    */
   importPrefix?: string;

--- a/packages/cli/src/emit-standalone.ts
+++ b/packages/cli/src/emit-standalone.ts
@@ -32,7 +32,7 @@ export interface EmitStandaloneOptions {
   dialect: StandaloneDialect;
   /**
    * Import-path prefix for runtime deps in the emitted module.
-   * Defaults to `"@aahoughton/oav"` — the published name. Tests
+   * Defaults to `"oav"` — the published name. Tests
    * override to `"@oav"` so the output resolves against the
    * workspace aliases instead of a published tarball.
    */

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -255,7 +255,7 @@ describe("buildProgram — argv-level", () => {
 // invoke the command directly (not through runCli) so they can override
 // the esbuild resolveDir to point at packages/oav/, which has the
 // workspace-alias `@oav/*` symlinks. In production the consumer's cwd
-// has `@aahoughton/oav` installed and the default resolveDir is
+// has `oav` installed and the default resolveDir is
 // correct.
 describe("compile-schema output", () => {
   it("produces an import-free bundle that runs", async () => {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,4 +1,4 @@
-# @aahoughton/oav/core
+# oav/core
 
 Error tree model, shared OpenAPI / HTTP types, and output formatters.
 Imported by every other module in the package and — because the error

--- a/packages/formats/README.md
+++ b/packages/formats/README.md
@@ -1,4 +1,4 @@
-# @aahoughton/oav/formats
+# oav/formats
 
 Built-in string format validators for the `format` keyword. Each is a
 pure `(value: string) => boolean`; `builtInFormats` is the keyed map
@@ -63,6 +63,6 @@ In JSON Schema 2020-12, `format` is advisory by default: a validator
 recognises the name but doesn't reject malformed values. OpenAPI 3.0 /
 3.1 / 3.2 treat `format` as assertive; the validator wires up the
 corresponding vocabulary so `format: email` rejects non-emails.
-When compiling directly via `@aahoughton/oav/schema`, use
+When compiling directly via `oav/schema`, use
 `openapi31Dialect` (or the assertive vocabulary explicitly) to get
 assertive semantics.

--- a/packages/oav/src/cli.ts
+++ b/packages/oav/src/cli.ts
@@ -2,7 +2,7 @@
 export {};
 
 // `commander` and `esbuild` are regular dependencies of
-// `@aahoughton/oav`, so a normal install puts them in node_modules.
+// `oav`, so a normal install puts them in node_modules.
 // If they're missing, the install is corrupted — catch the dynamic
 // import up front and print a clearer message than the default
 // ERR_MODULE_NOT_FOUND trace.

--- a/packages/oav/src/core.ts
+++ b/packages/oav/src/core.ts
@@ -1,2 +1,2 @@
-// Re-export of `@aahoughton/oav-core/core` (types + error helpers).
+// Re-export of `oav-core/core` (types + error helpers).
 export * from "@oav/core";

--- a/packages/oav/src/formats.ts
+++ b/packages/oav/src/formats.ts
@@ -1,2 +1,2 @@
-// Re-export of `@aahoughton/oav-core/formats`.
+// Re-export of `oav-core/formats`.
 export * from "@oav/formats";

--- a/packages/oav/src/index.ts
+++ b/packages/oav/src/index.ts
@@ -1,11 +1,11 @@
 /**
- * `@aahoughton/oav` — batteries-included distribution. Re-exports the
- * full surface of `@aahoughton/oav-core` and adds YAML readers so
+ * `oav` — batteries-included distribution. Re-exports the
+ * full surface of `oav-core` and adds YAML readers so
  * `loadSpec` works against hand-authored `.yaml` specs out of the
  * box. Also ships the `oav` CLI binary.
  *
  * Consumers who want the zero-runtime-dep version (edge runtimes,
- * JSON-only workloads, minimal bundles) install `@aahoughton/oav-core`
+ * JSON-only workloads, minimal bundles) install `oav-core`
  * directly; the surface is the same minus the YAML readers and the
  * CLI.
  *

--- a/packages/oav/src/schema-internals.ts
+++ b/packages/oav/src/schema-internals.ts
@@ -1,2 +1,2 @@
-// Re-export of `@aahoughton/oav-core/schema/internals`. See schema.ts.
+// Re-export of `oav-core/schema/internals`. See schema.ts.
 export * from "@oav/schema/internals";

--- a/packages/oav/src/schema.ts
+++ b/packages/oav/src/schema.ts
@@ -1,5 +1,5 @@
-// Re-export of `@aahoughton/oav-core/schema`. Build-time alias in
-// `tsup.config.ts` rewrites `@oav/schema` → `@aahoughton/oav-core/schema`
+// Re-export of `oav-core/schema`. Build-time alias in
+// `tsup.config.ts` rewrites `@oav/schema` → `oav-core/schema`
 // and marks it external so the emitted bundle imports at load time
 // rather than bundling the schema compiler.
 export * from "@oav/schema";

--- a/packages/oav/src/spec.ts
+++ b/packages/oav/src/spec.ts
@@ -1,7 +1,7 @@
-// Re-export of `@aahoughton/oav-core/spec`. JSON-only readers; the
+// Re-export of `oav-core/spec`. JSON-only readers; the
 // batteries-included readers (`createYamlFileReader`,
 // `createSmartHttpReader`, `parseYamlString`) live at the root of
-// `@aahoughton/oav` — compose them ahead of the readers in this
+// `oav` — compose them ahead of the readers in this
 // subpath when loading YAML specs or fetching over HTTP with
 // Content-Type dispatch.
 export * from "@oav/spec";

--- a/packages/oav/src/validator-internals.ts
+++ b/packages/oav/src/validator-internals.ts
@@ -1,2 +1,2 @@
-// Re-export of `@aahoughton/oav-core/validator/internals`.
+// Re-export of `oav-core/validator/internals`.
 export * from "@oav/validator/internals";

--- a/packages/oav/src/yaml.ts
+++ b/packages/oav/src/yaml.ts
@@ -1,15 +1,15 @@
 /**
  * YAML + HTTP readers shipped by the batteries-included
- * `@aahoughton/oav` distribution. Each implements
+ * `oav` distribution. Each implements
  * {@link @aahoughton/oav/spec!DocumentReader} and is designed to be
  * composed via
  * {@link @aahoughton/oav/spec!composeReaders} — order YAML readers
- * first so the JSON-only readers in `@aahoughton/oav-core/spec` act
+ * first so the JSON-only readers in `oav-core/spec` act
  * as the fallback for `.json` paths.
  *
- * The lean `@aahoughton/oav-core` package intentionally doesn't carry
+ * The lean `oav-core` package intentionally doesn't carry
  * YAML parsing so it can advertise zero runtime dependencies; this
- * module lives in `@aahoughton/oav` (which depends on oav-core plus
+ * module lives in `oav` (which depends on oav-core plus
  * `yaml`).
  *
  * @example

--- a/packages/oav/tsup.config.ts
+++ b/packages/oav/tsup.config.ts
@@ -3,19 +3,19 @@ import type { Plugin } from "esbuild";
 import { defineConfig } from "tsup";
 
 /**
- * Build config for `@aahoughton/oav` — the batteries-included tarball.
- * Emits subpath shims that re-export `@aahoughton/oav-core/*`, adds
+ * Build config for `oav` — the batteries-included tarball.
+ * Emits subpath shims that re-export `oav-core/*`, adds
  * the YAML readers at the root entry, and bundles the `oav` CLI.
  *
  * Dependency shape:
- * - `@aahoughton/oav-core` and `yaml` are external runtime deps the
+ * - `oav-core` and `yaml` are external runtime deps the
  *   consumer's install already provides.
  * - `commander` is an external optional-peer — resolved at CLI run
  *   time with a clear error when missing.
  * - `@oav/cli` (the workspace package that owns the CLI logic) is
  *   bundled in, along with everything it transitively imports from
  *   `@oav/*`. Those transitive imports are rewritten to the
- *   corresponding `@aahoughton/oav-core/*` subpaths AND marked
+ *   corresponding `oav-core/*` subpaths AND marked
  *   external by the plugin below, so the final bundles still import
  *   the compiler / validator from oav-core at run time rather than
  *   inlining a second copy.
@@ -28,7 +28,7 @@ import { defineConfig } from "tsup";
  */
 const repoRoot = resolve(__dirname, "..", "..");
 
-// `@oav/*` → `@aahoughton/oav-core[/*]`: kept external (resolved at
+// `@oav/*` → `oav-core[/*]`: kept external (resolved at
 // run time from the consumer's install of oav-core).
 const oavCoreRewrite: Record<string, string> = {
   "@oav/core": "@aahoughton/oav-core/core",
@@ -51,7 +51,7 @@ const bundledWorkspace: Record<string, string> = {
 // the originally-imported specifier. Doing the rewrite+external in a
 // single onResolve hook is the reliable way to get imports like
 // `@oav/schema` emitted into the bundle as
-// `import ... from "@aahoughton/oav-core/schema"`.
+// `import ... from "oav-core/schema"`.
 function rewriteOavCore(): Plugin {
   return {
     name: "oav-core-rewrite",

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -1,7 +1,7 @@
 # @oav/router
 
 > **Internal package — not published.** `@oav/router` is a workspace-private
-> dependency of `@aahoughton/oav`; it does not appear on npm and has no
+> dependency of `oav`; it does not appear on npm and has no
 > published subpath. This README documents the internal surface for
 > contributors navigating the monorepo. Third-party consumers get the
 > router's functionality transparently via `createValidator`.

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -1,4 +1,4 @@
-# @aahoughton/oav/schema
+# oav/schema
 
 JSON Schema 2020-12 compiler. Walks the schema once at construction
 time and emits a JavaScript function via code generation — no

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * The public `@aahoughton/oav/schema` surface. Two audiences:
+ * The public `oav/schema` surface. Two audiences:
  *
  *   1. Compiler consumers — `compileSchema`, `CompiledSchema`,
  *      `CompileOptions`, dialects. The minimum needed to turn a schema
@@ -11,7 +11,7 @@
  *
  * Codegen mechanics, runtime helpers, resolve internals, and the
  * subschema-position constants live behind
- * `@aahoughton/oav/schema/internals`. Reach for them when a custom
+ * `oav/schema/internals`. Reach for them when a custom
  * plugin genuinely needs them, accepting that they're not covered by
  * semver.
  *

--- a/packages/schema/src/internals.ts
+++ b/packages/schema/src/internals.ts
@@ -1,10 +1,10 @@
 /**
- * Internal re-exports for `@aahoughton/oav/schema/internals`. Exposes
+ * Internal re-exports for `oav/schema/internals`. Exposes
  * the codegen mechanics, runtime helpers, resolve internals, and
  * subschema-position constants that sit below the public extension
  * recipe. Reachable when you really need them — tests, advanced
  * plugins, tooling that walks or rewrites schemas — but deliberately
- * separated from the main `@aahoughton/oav/schema` barrel so the
+ * separated from the main `oav/schema` barrel so the
  * public surface matches what keyword authors actually need.
  *
  * Nothing here is covered by semver guarantees. Compare against the

--- a/packages/schema/src/keywords/meta-data.ts
+++ b/packages/schema/src/keywords/meta-data.ts
@@ -26,7 +26,7 @@ function annotationKeyword(name: string, vocabulary: string = META_DATA_VOCAB): 
  * `title` — a short human-readable label for the schema. Annotation-
  * only; emits no validation code. Bundled into
  * {@link metaDataVocabulary} and reachable alongside it from
- * `@aahoughton/oav/schema`.
+ * `oav/schema`.
  *
  * @public
  */

--- a/packages/schema/src/subschema-positions.ts
+++ b/packages/schema/src/subschema-positions.ts
@@ -66,7 +66,7 @@ export type SubschemaVisitor = (schema: SchemaOrBoolean, path: string) => void |
  * drifting from the vocabulary. Callers that need to *rewrite* schemas
  * in place can instead reach for the underlying
  * `SUBSCHEMA_*_POSITIONS` constants exported from
- * `@aahoughton/oav/schema/internals`.
+ * `oav/schema/internals`.
  *
  * @public
  */

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -1,4 +1,4 @@
-# @aahoughton/oav/spec
+# oav/spec
 
 Multi-file OpenAPI loader, `$ref` resolver, and overlay merger. Use
 this when you want to stitch a spec together before handing it to
@@ -9,10 +9,11 @@ This module is available at matching subpaths in both
 below import from `@aahoughton/oav`; substitute `@aahoughton/oav-core`
 if you're on the lean package.
 
-> **oav-core ships JSON readers only.** Calling `createFileReader()` or
-> `createHttpReader()` on a `.yaml` / `.yml` path throws an install-hint
-> error. For YAML support, install `@aahoughton/oav` (for the bundled
-> `createYamlFileReader`) or register your own YAML reader.
+> **`@aahoughton/oav-core` ships JSON readers only.** Calling
+> `createFileReader()` or `createHttpReader()` on a `.yaml` / `.yml`
+> path throws an install-hint error. For YAML support, install
+> `@aahoughton/oav` (for the bundled `createYamlFileReader`) or
+> register your own YAML reader.
 
 ## Loading a spec
 
@@ -49,16 +50,16 @@ interface DocumentReader {
 }
 ```
 
-Built-ins (JSON only — YAML support lives in `@aahoughton/oav`):
+Built-ins (JSON only — YAML support lives in `oav`):
 
 - `createFileReader(cwd?)` — filesystem JSON. `.yaml` / `.yml` paths
   throw an install-hint error; compose with `createYamlFileReader` from
-  `@aahoughton/oav` to cover YAML.
+  `oav` to cover YAML.
 - `createHttpReader()` — HTTP / HTTPS JSON. Same YAML policy.
 - `createMemoryReader(entries)` — in-memory JSON or pre-parsed objects.
 - `composeReaders([...])` — layers readers, dispatching by `canRead`.
 
-`@aahoughton/oav` additionally exports `createYamlFileReader`,
+`oav` additionally exports `createYamlFileReader`,
 `createSmartHttpReader`, and `parseYamlString` for YAML-backed specs.
 `createSmartHttpReader` supersedes the JSON-only `createHttpReader`
 when composed — it claims every `http(s)` URI and dispatches by

--- a/packages/spec/src/reader.ts
+++ b/packages/spec/src/reader.ts
@@ -27,7 +27,7 @@ const YAML_HINT =
 /**
  * Read files from the local filesystem. JSON only — `.yaml` / `.yml`
  * paths throw with a clear install hint. Pair with
- * `@aahoughton/oav`' `createYamlFileReader` via
+ * `oav`' `createYamlFileReader` via
  * {@link composeReaders} for YAML support.
  *
  * @param cwd - Optional base directory. Defaults to `process.cwd()`.
@@ -68,7 +68,7 @@ export function createFileReader(cwd: string = process.cwd()): DocumentReader {
 
 /**
  * Read documents over HTTP/HTTPS. JSON only; pair with
- * `@aahoughton/oav`'s `createSmartHttpReader` for YAML (it claims all
+ * `oav`'s `createSmartHttpReader` for YAML (it claims all
  * `http(s)` URIs and dispatches by `Content-Type`, so it shadows this
  * reader in a compose chain — that's fine; JSON endpoints still parse
  * as JSON there).
@@ -102,7 +102,7 @@ export function createHttpReader(): DocumentReader {
  * In-memory reader, keyed by string URI. Primarily used in tests.
  * String sources are parsed as JSON; pre-parsed object sources pass
  * through. YAML strings need pre-parsing via
- * `@aahoughton/oav`' `parseYamlString` before they're added to
+ * `oav`' `parseYamlString` before they're added to
  * the map.
  *
  * @param sources - Map of URI → JSON string (or already-parsed value).
@@ -135,7 +135,7 @@ export function createMemoryReader(sources: Map<string, string | unknown>): Docu
 /**
  * Try each reader in order until one accepts the URI. Useful for mixing
  * file / HTTP / memory sources in a single resolver, and for layering
- * the YAML readers from `@aahoughton/oav` ahead of the
+ * the YAML readers from `oav` ahead of the
  * JSON-only ones here.
  *
  * @param readers - Ordered list of readers.

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -1,4 +1,4 @@
-# @aahoughton/oav (validator)
+# oav (validator)
 
 HTTP request/response validator for OpenAPI 3.0, 3.1, and 3.2. This is
 the headline surface of the package — `createValidator` is re-exported
@@ -39,7 +39,7 @@ unsupported and a fallback was used — see `onUnknownVersion` below).
 Native OpenAPI 3.0 dialect alongside 3.1 / 3.2, so `nullable`,
 boolean `exclusiveMaximum`, and `$ref`-suppresses-siblings work by
 3.0 rules rather than via a 2020-12 translation shim. Pairs with
-[`@aahoughton/oav/spec`](../spec/README.md)'s `applyOverlays` for
+[`oav/spec`](../spec/README.md)'s `applyOverlays` for
 patching externally-owned base specs at load time. Pass counts against
 the upstream test suites live in
 [`conformance/REPORT.md`](../../conformance/REPORT.md). The
@@ -62,7 +62,7 @@ the upstream test suites live in
 - **Content-type negotiation**: against the request / response
   `Content-Type`, including wildcards (`application/*`, `*/*`).
 - **Response status matching**: exact → `NXX` class → `default`.
-- **Format validators**: the `@aahoughton/oav/formats` built-ins merged
+- **Format validators**: the `oav/formats` built-ins merged
   with any extras passed via `options.formats`.
 
 ## Validator methods
@@ -82,7 +82,7 @@ the upstream test suites live in
 | Option                  | Effect                                                                                                             |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------ |
 | `dialect`               | Force a specific {@link Dialect}, bypassing version detection.                                                     |
-| `formats`               | Extra string format validators merged with `@aahoughton/oav/formats`.                                              |
+| `formats`               | Extra string format validators merged with `oav/formats`.                                                          |
 | `keywords`              | User-registered schema keywords (see below).                                                                       |
 | `maxErrors`             | Cap on leaf errors; `1` is fast-fail. Default: uncapped.                                                           |
 | `strictQueryParameters` | Reject undeclared query parameters. Default `false`.                                                               |

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * The public `@aahoughton/oav/validator` surface. One audience: callers
+ * The public `oav/validator` surface. One audience: callers
  * building a request/response validator from a resolved OpenAPI
  * document — `createValidator`, the `OavValidator` instance it returns,
  * the options, and the Fetch-API adapters for consumers plugging the
@@ -7,7 +7,7 @@
  *
  * Parameter deserialisation primitives, query-assembly helpers, and
  * the operation-level `$ref` resolver live behind
- * `@aahoughton/oav/validator/internals`. Reach for them only when a
+ * `oav/validator/internals`. Reach for them only when a
  * tool needs the same style/explode or `$ref` rules outside the normal
  * validator flow; nothing there is covered by semver.
  *

--- a/packages/validator/src/internals.ts
+++ b/packages/validator/src/internals.ts
@@ -1,11 +1,11 @@
 /**
- * Internal re-exports for `@aahoughton/oav/validator/internals`. Exposes
+ * Internal re-exports for `oav/validator/internals`. Exposes
  * the parameter-deserialisation and query-assembly primitives that the
  * validator uses to prepare values before schema compilation, plus the
  * operation-level `$ref` resolver. Reachable when you need them —
  * tests, advanced plugins, tooling that reuses the same style /
  * explode rules outside the normal validator flow — but deliberately
- * separated from the main `@aahoughton/oav/validator` barrel so the
+ * separated from the main `oav/validator` barrel so the
  * public surface matches what request/response-validation consumers
  * actually need.
  *
@@ -56,6 +56,6 @@ export { checkSecurity, compileOperationSecurity } from "./security.js";
 // isn't published on its own. `oav compile-spec`'s emitted output
 // needs `createRouter` at module load to build its dispatch table;
 // re-exporting it here keeps all emit-side imports funnelled through
-// `@aahoughton/oav/validator/internals` so the emitted module only
+// `oav/validator/internals` so the emitted module only
 // has to reach into one subpath.
 export { createRouter, type RouteMatch, type Router } from "@oav/router";

--- a/performance/README.md
+++ b/performance/README.md
@@ -80,7 +80,7 @@ pnpm bench:mem                                      # default 100 × 500 = 50,00
 BATCHES=20 PER_BATCH=500 WARMUP=250 pnpm bench:mem  # quick smoke
 ```
 
-Spawns two Express 4 servers — one wraps `@aahoughton/oav`, the other
+Spawns two Express 4 servers — one wraps `oav`, the other
 wraps `express-openapi-validator` (which pulls in ajv). Both validate
 a ~40-schema OpenAPI spec with discriminated payment-method unions,
 nested address + amount objects, and array-of-items transfers. The

--- a/performance/mem-bench/server-oav.mjs
+++ b/performance/mem-bench/server-oav.mjs
@@ -1,4 +1,4 @@
-// oav memory test server — Express 4 + @aahoughton/oav adapter.
+// oav memory test server — Express 4 + oav adapter.
 // Run with: node --expose-gc server.mjs
 //
 // Instruments /__memory (and /__memory?gc=1 to force a GC first).

--- a/performance/mem.ts
+++ b/performance/mem.ts
@@ -1,7 +1,7 @@
 /**
  * Steady-state HTTP-server memory benchmark.
  *
- * Spawns two Express 4 servers — one wraps @aahoughton/oav, the other
+ * Spawns two Express 4 servers — one wraps oav, the other
  * wraps express-openapi-validator (which uses ajv under the hood) —
  * against the same 40-schema OpenAPI spec. Hits each with 500 warmup
  * requests + 100 × 500 = 50,000 workload requests round-robin across

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,14 @@
 /**
- * Default entry for `@aahoughton/oav`. Re-exports the HTTP validator
+ * Default entry for `oav`. Re-exports the HTTP validator
  * (`createValidator` and friends) plus the entirety of
- * `@aahoughton/oav/core`: error-tree helpers, formatters, shared
+ * `oav/core`: error-tree helpers, formatters, shared
  * OpenAPI / HTTP types, and version detection.
  *
  * Lower-level pieces live on per-subsystem entrypoints:
- *   - `@aahoughton/oav/schema`  — JSON Schema 2020-12 compiler + dialects
- *   - `@aahoughton/oav/spec`    — multi-file loader, resolver, overlays
- *   - `@aahoughton/oav/formats` — built-in string format validators
- *   - `@aahoughton/oav/core`    — the surface re-exported here, imported on its own
+ *   - `oav/schema`  — JSON Schema 2020-12 compiler + dialects
+ *   - `oav/spec`    — multi-file loader, resolver, overlays
+ *   - `oav/formats` — built-in string format validators
+ *   - `oav/core`    — the surface re-exported here, imported on its own
  */
 
 export * from "../packages/validator/src/index.js";

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 import { workspaceAliases } from "./workspace-aliases.js";
 
 /**
- * Build config for the publishable `@aahoughton/oav-core` — the lean
+ * Build config for the publishable `oav-core` — the lean
  * validator tarball with zero runtime dependencies. Each entry
  * becomes a subpath:
  *
@@ -18,7 +18,7 @@ import { workspaceAliases } from "./workspace-aliases.js";
  * source via the esbuild `alias` option, then bundled in as normal
  * modules so consumers never see them.
  *
- * The companion `@aahoughton/oav` package (`packages/oav/`) builds
+ * The companion `oav` package (`packages/oav/`) builds
  * separately and carries the YAML readers + CLI — the batteries-
  * included experience that depends on this package. Keeping the CLI
  * and YAML parsing out of this tarball is what delivers the zero-


### PR DESCRIPTION
## Summary

Use the short form \`oav\` (and \`oav-core\`) in JSDoc and Markdown prose where the scope is just noise. Mirrors the convention major scoped projects use in their docs (\`@octokit/rest\` → "Octokit", \`@nestjs/core\` → "Nest", \`@aws-sdk/*\` → "AWS SDK").

The fully-qualified \`@aahoughton/oav\` and \`@aahoughton/oav-core\` are preserved in places that document identifiers users actually type or copy:

- Import statements (everywhere, including JSDoc \`@example\` blocks)
- Install commands (\`npm install\`, \`pnpm add\`)
- \`package.json\` names and dependencies
- Error message strings the user sees and may search for
- TypeDoc \`{@link @aahoughton/oav!X}\` package-link references (dropping the scope can break link resolution)
- README "Install" and "Modules" tables that list real package identifiers
- Prose paragraphs that sit directly next to a real import and would otherwise mismatch (the substitute-X-for-Y / available-from-both cases in \`core/\`, \`spec/\`, \`examples/\` READMEs)

## Numbers

- 122 mechanical replacements across 43 files
- Manual review identified ~12 reverts where the abbreviated form was ambiguous next to actual import statements
- Net result: ~95 narrative references switched to the short form, full names retained where they matter

## Test plan

- [x] All 10 examples still execute (\`tsx examples/*.ts\`)
- [x] \`pnpm test\` — 683 pass
- [x] \`pnpm lint\` / \`pnpm fmt --check\` / \`pnpm typecheck\` — clean
- [x] Manual audit of high-volume files (README, INTEGRATION, COMPARISON, every package README, key source files like \`oav/src/yaml.ts\`, \`spec/src/reader.ts\`, \`cli/src/commands.ts\`)

You mentioned a close pass afterwards — this PR's diff is mechanical enough that anything still off is straightforward to revert per-line.