### PR TITLE
chore: bump hyperjump in performance, add dependabot for isolated roots

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,36 @@ updates:
           - minor
           - patch
 
+  - package-ecosystem: npm
+    directory: "/performance"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      prefix-development: chore
+      include: scope
+    groups:
+      dev-minor-and-patch:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: "/conformance"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      prefix-development: chore
+      include: scope
+    groups:
+      dev-minor-and-patch:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/performance/package.json
+++ b/performance/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "^15.3.5",
-    "@hyperjump/json-schema": "^1.17.5",
+    "@hyperjump/json-schema": "^1.17.6",
     "ajv": "^8.18.0",
     "tinybench": "^6.0.0",
     "tsx": "^4.21.0",

--- a/performance/pnpm-lock.yaml
+++ b/performance/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^15.3.5
         version: 15.3.5(@types/json-schema@7.0.15)
       '@hyperjump/json-schema':
-        specifier: ^1.17.5
-        version: 1.17.5(@hyperjump/browser@1.3.1)
+        specifier: ^1.17.6
+        version: 1.17.6(@hyperjump/browser@1.3.1)
       ajv:
         specifier: ^8.18.0
         version: 8.18.0
@@ -201,8 +201,8 @@ packages:
   '@hyperjump/json-schema-formats@1.0.1':
     resolution: {integrity: sha512-qvcIxysnMfcPxyPSFFzzo28o2BN1CNT5b0tQXNUP0kaFpvptQNDg8SCLvlnMg2sYxuiuqna8+azGBaBthiskAw==}
 
-  '@hyperjump/json-schema@1.17.5':
-    resolution: {integrity: sha512-f/yM4hQsBQYNEDu8zxmAZNfa/GxquWoC1FzUY0ADbSjsN8B3ICagdCPg4F2rrRET+/MJp/qKecgIF7GtdjX0sg==}
+  '@hyperjump/json-schema@1.17.6':
+    resolution: {integrity: sha512-m0QggWCn58IACqLi3fqI9cuUrFju79DVAxjkDENo+xgE26963rudPMwKwwlkZkB+JqAgu+OGvJAMfE1toevfGw==}
     peerDependencies:
       '@hyperjump/browser': ^1.1.0
 
@@ -286,8 +286,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
 snapshots:
@@ -389,7 +389,7 @@ snapshots:
       '@hyperjump/uri': 1.3.3
       idn-hostname: 15.1.8
 
-  '@hyperjump/json-schema@1.17.5(@hyperjump/browser@1.3.1)':
+  '@hyperjump/json-schema@1.17.6(@hyperjump/browser@1.3.1)':
     dependencies:
       '@hyperjump/browser': 1.3.1
       '@hyperjump/json-pointer': 1.1.2
@@ -399,7 +399,7 @@ snapshots:
       content-type: 1.0.5
       json-stringify-deterministic: 1.0.13
       just-curry-it: 5.3.0
-      uuid: 9.0.1
+      uuid: 14.0.0
 
   '@hyperjump/pact@1.4.0': {}
 
@@ -489,4 +489,4 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  uuid@9.0.1: {}
+  uuid@14.0.0: {}


### PR DESCRIPTION
## Summary

- Bumps `@hyperjump/json-schema` 1.17.5 → 1.17.6 in `performance/`, which pulls `uuid` 9.0.1 → 14.0.0 transitively. Resolves Dependabot alert [#3](https://github.com/aahoughton/oav/security/dependabot/3) (GHSA-w5hq-g745-h8pq — out-of-bounds write on caller-provided `buf` in `uuid` v3/v5/v6). Dev-only, isolated sub-package; no shipped `oav` package or main-workspace dev install touched this uuid.
- Adds weekly Dependabot npm updaters for `/performance` and `/conformance`. Those sub-packages are isolated pnpm roots (own `pnpm-workspace.yaml`), so the existing `/` updater never sees their lockfiles — which is how we ended up doing this manually in the first place. The new entries mirror the root's `dev-minor-and-patch` grouping.

## Test plan

- [x] `pnpm update @hyperjump/json-schema` in `performance/` runs clean; lockfile diff limited to hyperjump + uuid.
- [x] Smoke-imported `@hyperjump/json-schema/draft-2020-12` after the bump — loads, public surface unchanged.
- [x] `yq` parses `.github/dependabot.yml`; 4 updater entries (npm /, npm /performance, npm /conformance, github-actions /).
- [ ] CI passes.