### PR TITLE
docs: document deepObject single-level nesting limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,10 @@ Ajv (draft versions, `$data`, async validation, etc.) see
 
 - `$dynamicRef` behaves like `$ref` with anchor lookup — no runtime
   dynamic-scope traversal.
+- `style: deepObject` query parameters support only single-level
+  nesting (`obj[key]=value`). OpenAPI 3.0–3.2 do not define nested
+  semantics; specs that rely on `obj[a][b]=value` should model the
+  flattened shape explicitly or use a different parameter style.
 - `pattern` keywords and `format: "regex"` compile to the JavaScript
   built-in `RegExp`, which has no execution timeout. If your OpenAPI
   spec is attacker-controlled (e.g. multi-tenant upload), a

--- a/packages/validator/src/query-assembly.ts
+++ b/packages/validator/src/query-assembly.ts
@@ -71,7 +71,9 @@ export function coerceQueryScalar(value: string | undefined, schema: SchemaOrBoo
 
 /**
  * Gather `name[key]=value` pairs from the top-level query into an
- * object — the `style: deepObject` assembly.
+ * object — the `style: deepObject` assembly. Single-level only:
+ * OpenAPI 3.0–3.2 do not define nested semantics, so `obj[a][b]=v`
+ * yields a property literally named `a][b`.
  *
  * @internal
  */


### PR DESCRIPTION
## Summary

- Adds a bullet to README "Known limitations" noting that `style: deepObject` supports only single-level nesting, per spec ambiguity in OpenAPI 3.0–3.2.
- Clarifies the JSDoc on `assembleDeepObject` (`packages/validator/src/query-assembly.ts`) so the limitation is visible at the source too.

Closes #144.

## Test plan

- [x] `pnpm lint` clean.
- [ ] CI passes.