### PR TITLE
fix(cli): emit full pathItem/operation for AOT getOperation

### DIFF
--- a/packages/cli/src/emit-spec.ts
+++ b/packages/cli/src/emit-spec.ts
@@ -185,6 +185,10 @@ export function emitSpec(document: OpenAPIDocument, options: EmitSpecOptions = {
     (o) => `  ${JSON.stringify(`${o.pathPattern}::${o.method}`)}: ${o.stateLiteral},`,
   );
 
+  const metaTableEntries = opsEmitted.map(
+    (o) => `  ${JSON.stringify(`${o.pathPattern}::${o.method}`)}: ${o.introspectionLiteral},`,
+  );
+
   const pathsTableEntries = [...pathMethods.entries()].map(
     ([pattern, methods]) =>
       `  ${JSON.stringify(pattern)}: { ${[...methods].map((m) => `${m.toLowerCase()}: {}`).join(", ")} },`,
@@ -236,6 +240,15 @@ export function emitSpec(document: OpenAPIDocument, options: EmitSpecOptions = {
     ...pathsTableEntries,
     "});",
     "",
+    "// ---- introspection (getOperation) ----",
+    "// Resolved OpenAPI objects for each emitted operation, mirroring the",
+    "// runtime's match.pathItem / match.operation references. Kept out of",
+    "// the `ops` table so the __REF:Sn__ placeholder rewrite never touches",
+    "// raw spec content.",
+    "const __meta = {",
+    ...metaTableEntries,
+    "};",
+    "",
     "// ---- detected version + warnings ----",
     `export const detectedVersion = ${JSON.stringify(detectVersionBucket(document))};`,
     "export const warnings = Object.freeze([]);",
@@ -260,6 +273,12 @@ interface EmittedOp {
   method: string;
   /** The JSON-stringified state object for `ops[key]`. */
   stateLiteral: string;
+  /**
+   * JSON blob of `{ pathItem, operation }` for the module's `__meta`
+   * table. Kept separate from `stateLiteral` so the raw OpenAPI objects
+   * never pass through the `__REF:Sn__` placeholder rewrite.
+   */
+  introspectionLiteral: string;
 }
 
 interface BuildEmittedOpArgs {
@@ -370,8 +389,15 @@ function buildEmittedOp(args: BuildEmittedOpArgs): EmittedOp {
     ),
   );
 
+  // Introspection payload for `getOperation`. Matches the runtime's
+  // `match.pathItem` / `match.operation` references — the resolved
+  // top-level objects from the document. Nested `$ref`s (e.g. inside a
+  // `requestBody` or `responses[status]`) are left intact, same as
+  // runtime.
+  const introspectionLiteral = JSON.stringify({ pathItem, operation }, null, 2);
+
   void document; // currently unused; keep in signature for future overlay resolution
-  return { pathPattern, method, stateLiteral };
+  return { pathPattern, method, stateLiteral, introspectionLiteral };
 }
 
 function paramValidatorName(
@@ -713,17 +739,14 @@ function renderGetOperation(): string {
   const m = (method ?? "GET").toUpperCase();
   const match = router.match(m, path);
   if (match === undefined || match.kind === "method-not-allowed") return null;
-  const op = ops[\`\${match.pathPattern}::\${m}\`];
+  const key = \`\${match.pathPattern}::\${m}\`;
+  const op = ops[key];
   if (op === undefined) return null;
+  const meta = __meta[key];
   return {
     pathPattern: match.pathPattern,
-    pathItem: {},
-    operation: {
-      // The AOT output doesn't retain the full OperationObject
-      // literal; we preserve enough for the common introspection
-      // uses (operationId, requestBody content-types, required
-      // headers, security). Extend the emit if you need more.
-    },
+    pathItem: meta?.pathItem ?? {},
+    operation: meta?.operation ?? {},
   };
 }
 `;

--- a/packages/cli/test/compile-spec.test.ts
+++ b/packages/cli/test/compile-spec.test.ts
@@ -68,7 +68,10 @@ const petstore: OpenAPIDocument = {
 interface AotValidator {
   validateRequest: (req: unknown) => ValidationError | null;
   validateResponse: (req: unknown, res: unknown) => ValidationError | null;
-  getOperation: (req: { method: string; path: string }) => { pathPattern: string } | null;
+  getOperation: (req: {
+    method: string;
+    path: string;
+  }) => { pathPattern: string; pathItem: unknown; operation: unknown } | null;
   detectedVersion: string | undefined;
   warnings: readonly string[];
 }
@@ -209,6 +212,30 @@ describe("compile-spec — equivalence vs createValidator", () => {
     const aot = await buildAot(petstore);
     expect(aot.getOperation({ method: "POST", path: "/pets" })?.pathPattern).toBe("/pets");
     expect(aot.getOperation({ method: "GET", path: "/unknown" })).toBe(null);
+  });
+
+  it("getOperation returns the full pathItem and operation objects", async () => {
+    const aot = await buildAot(petstore);
+    const info = aot.getOperation({ method: "POST", path: "/pets" });
+    expect(info).not.toBe(null);
+    const op = info?.operation as { operationId?: string; requestBody?: { required?: boolean } };
+    expect(op.operationId).toBe("createPet");
+    expect(op.requestBody?.required).toBe(true);
+    const pathItem = info?.pathItem as { post?: { operationId?: string }; get?: unknown };
+    expect(pathItem.post?.operationId).toBe("createPet");
+    expect(pathItem.get).toBeDefined();
+  });
+
+  it("getOperation shape matches createValidator().getOperation", async () => {
+    const runtime = createValidator(petstore);
+    const aot = await buildAot(petstore);
+    const target = { method: "POST", path: "/pets" };
+    const rt = runtime.getOperation(target);
+    const at = aot.getOperation(target);
+    expect(at?.pathPattern).toBe(rt?.pathPattern);
+    const rtOp = rt?.operation as { operationId?: string } | undefined;
+    const atOp = at?.operation as { operationId?: string } | undefined;
+    expect(atOp?.operationId).toBe(rtOp?.operationId);
   });
 });
 


### PR DESCRIPTION
## Summary

AOT `getOperation` returned empty stubs for `pathItem` and `operation`, silently breaking any consumer that reads `operation.operationId` or `operation.requestBody.content` from a `compile-spec` module. The runtime validator returns the raw resolved OpenAPI objects; AOT now does too.

The raw spec objects go in a separate `__meta` table rather than the `ops` table, so the `__REF:Sn__` placeholder rewrite never touches user-supplied spec content.

Closes #140.

## Test plan

- [x] New CLI test asserts `getOperation(...).operation.operationId` and `.requestBody.required` round-trip through the AOT output.
- [x] New CLI test asserts AOT `operation.operationId` matches `createValidator(...).getOperation(...).operation.operationId` on the same spec.
- [x] Existing CLI `compile-spec` equivalence tests pass unchanged.
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` (685/685) all clean.
- [ ] CI passes.