### PR TITLE
fix(cli): carry AOT dialect-fallback warnings into the emitted module

### DIFF
--- a/packages/cli/src/emit-spec.ts
+++ b/packages/cli/src/emit-spec.ts
@@ -29,6 +29,7 @@ import {
   type Dialect,
   type RefResolver,
 } from "@oav/schema";
+import { classifyUnknownVersion } from "@oav/core";
 import type {
   HeaderObject,
   OpenAPIDocument,
@@ -82,7 +83,8 @@ const DIALECT_MAP: Record<StandaloneDialect, Dialect> = {
  */
 export function emitSpec(document: OpenAPIDocument, options: EmitSpecOptions = {}): string {
   const importPrefix = options.importPrefix ?? "@aahoughton/oav";
-  const dialect = resolveDialect(document, options.dialect);
+  const warnings: string[] = [];
+  const dialect = resolveDialect(document, options.dialect, warnings);
   const graph = resolve(document as unknown as SchemaOrBoolean);
   const refResolver: RefResolver = createRefResolver(graph);
 
@@ -251,7 +253,7 @@ export function emitSpec(document: OpenAPIDocument, options: EmitSpecOptions = {
     "",
     "// ---- detected version + warnings ----",
     `export const detectedVersion = ${JSON.stringify(detectVersionBucket(document))};`,
-    "export const warnings = Object.freeze([]);",
+    `export const warnings = Object.freeze(${JSON.stringify(warnings)});`,
     "",
     renderValidateRequest(),
     "",
@@ -496,11 +498,44 @@ function detectVersionBucket(document: OpenAPIDocument): "3.0" | "3.1" | "3.2" |
 function resolveDialect(
   document: OpenAPIDocument,
   override: StandaloneDialect | undefined,
+  warnings: string[],
 ): Dialect {
-  if (override !== undefined) return DIALECT_MAP[override];
   const bucket = detectVersionBucket(document);
+
+  // Explicit override short-circuits detection. Mirror the runtime's
+  // behaviour of surfacing a warning when the override is hiding a
+  // category error.
+  if (override !== undefined) {
+    if (bucket === undefined) {
+      const rawOpenapi = (document as { openapi?: unknown }).openapi;
+      const reason = classifyUnknownVersion(rawOpenapi);
+      if (reason.kind !== "ok-unknown-minor") {
+        warnings.push(
+          `compile-spec: ${reason.message}; compiling anyway because \`dialect\` was set`,
+        );
+      }
+    }
+    return DIALECT_MAP[override];
+  }
+
   if (bucket === "3.0") return oas30Dialect;
-  return openapi31Dialect; // 3.1, 3.2, or unknown
+  if (bucket === "3.1" || bucket === "3.2") return openapi31Dialect;
+
+  // bucket === undefined: classify and warn. We still fall back to the
+  // 3.1 dialect rather than throwing — AOT is a build-time pipeline and
+  // the consumer's `warnings` export is the appropriate signal.
+  const rawOpenapi = (document as { openapi?: unknown }).openapi;
+  const reason = classifyUnknownVersion(rawOpenapi);
+  if (reason.kind === "ok-unknown-minor") {
+    warnings.push(
+      `compile-spec: openapi: "${reason.raw}" is an unknown 3.x minor version; falling back to the 3.1 dialect`,
+    );
+  } else {
+    warnings.push(
+      `compile-spec: ${reason.message}; falling back to the 3.1 dialect (pass \`dialect\` to override)`,
+    );
+  }
+  return openapi31Dialect;
 }
 
 // ----- orchestration templates -----

--- a/packages/cli/test/compile-spec.test.ts
+++ b/packages/cli/test/compile-spec.test.ts
@@ -208,6 +208,23 @@ describe("compile-spec — equivalence vs createValidator", () => {
     expect(aot.warnings).toEqual([]);
   });
 
+  it("warnings carries an unknown-minor fallback into the emitted module", async () => {
+    const weird = { ...petstore, openapi: "3.7.0" };
+    const aot = await buildAot(weird);
+    expect(aot.detectedVersion).toBe(undefined);
+    expect(aot.warnings.length).toBe(1);
+    expect(aot.warnings[0]).toMatch(/3\.7\.0.*unknown 3\.x minor.*3\.1/);
+    expect(Object.isFrozen(aot.warnings)).toBe(true);
+  });
+
+  it("warnings carries a missing-openapi fallback into the emitted module", async () => {
+    const noVersion = { ...petstore } as Partial<OpenAPIDocument> as OpenAPIDocument;
+    delete (noVersion as { openapi?: unknown }).openapi;
+    const aot = await buildAot(noVersion);
+    expect(aot.warnings.length).toBe(1);
+    expect(aot.warnings[0]).toMatch(/openapi.*field.*must be a string/);
+  });
+
   it("getOperation resolves a known (method, path)", async () => {
     const aot = await buildAot(petstore);
     expect(aot.getOperation({ method: "POST", path: "/pets" })?.pathPattern).toBe("/pets");

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,7 +42,12 @@ export {
 
 export { resolveJsonPointer } from "./json-pointer.js";
 
-export { detectOpenAPIVersion, type OpenAPIVersion } from "./version.js";
+export {
+  detectOpenAPIVersion,
+  classifyUnknownVersion,
+  type OpenAPIVersion,
+  type UnknownVersionReason,
+} from "./version.js";
 
 export type {
   ComponentsObject,

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -59,3 +59,55 @@ export function detectOpenAPIVersion(spec: unknown): OpenAPIVersion | undefined 
   if (minor === "2") return "3.2";
   return undefined;
 }
+
+/**
+ * Why did {@link detectOpenAPIVersion} return `undefined`? Distinguishes
+ * category errors (missing or non-string `openapi` field, wrong major)
+ * from a valid-shaped 3.x spec with an unknown minor (forward-compat).
+ *
+ * @public
+ */
+export type UnknownVersionReason =
+  | { kind: "missing-openapi"; message: string }
+  | { kind: "wrong-major"; message: string }
+  | { kind: "ok-unknown-minor"; raw: string };
+
+/**
+ * Classify a spec's `openapi` field when {@link detectOpenAPIVersion}
+ * returned `undefined`. Shared by `createValidator` (runtime) and
+ * `compile-spec` (AOT) so both emit the same warning / error messages.
+ *
+ * @public
+ */
+export function classifyUnknownVersion(rawOpenapi: unknown): UnknownVersionReason {
+  if (typeof rawOpenapi !== "string") {
+    return {
+      kind: "missing-openapi",
+      message:
+        "expected an OpenAPI 3.x document — the `openapi` field must be a string " +
+        `like "3.1.0" (got ${typeof rawOpenapi}). ` +
+        'Swagger 2.0 documents use `swagger: "2.0"` instead and need to be converted ' +
+        "first (e.g. `npx swagger2openapi input.json -o output.json`). " +
+        "AsyncAPI / OpenRPC / other formats are different domains and oav doesn't handle them.",
+    };
+  }
+  const match = /^(\d+)\.(\d+)/.exec(rawOpenapi);
+  if (match === null) {
+    return {
+      kind: "missing-openapi",
+      message: `the \`openapi\` field \`"${rawOpenapi}"\` doesn't look like a semver version`,
+    };
+  }
+  const major = match[1]!;
+  if (major !== "3") {
+    const hint =
+      major === "2"
+        ? " Convert to 3.x first, e.g. `npx swagger2openapi input.json -o output.json`."
+        : "";
+    return {
+      kind: "wrong-major",
+      message: `oav supports OpenAPI 3.x; got openapi: "${rawOpenapi}".${hint}`,
+    };
+  }
+  return { kind: "ok-unknown-minor", raw: rawOpenapi };
+}

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -1,4 +1,5 @@
 import {
+  classifyUnknownVersion,
   createBranchError,
   createLeafError,
   detectOpenAPIVersion,
@@ -61,53 +62,6 @@ function dialectFor(version: OpenAPIVersion): Dialect {
     case "3.0":
       return oas30Dialect;
   }
-}
-
-/**
- * Why did {@link detectOpenAPIVersion} return `undefined`? Distinguishes
- * category errors (missing or non-string `openapi` field, wrong major)
- * from a valid-shaped 3.x spec with an unknown minor (forward-compat).
- *
- * @internal
- */
-type UnknownVersionReason =
-  | { kind: "missing-openapi"; message: string }
-  | { kind: "wrong-major"; message: string }
-  | { kind: "ok-unknown-minor"; raw: string };
-
-function classifyUnknownVersion(rawOpenapi: unknown): UnknownVersionReason {
-  if (typeof rawOpenapi !== "string") {
-    return {
-      kind: "missing-openapi",
-      message:
-        "expected an OpenAPI 3.x document — the `openapi` field must be a string " +
-        `like "3.1.0" (got ${typeof rawOpenapi}). ` +
-        'Swagger 2.0 documents use `swagger: "2.0"` instead and need to be converted ' +
-        "first (e.g. `npx swagger2openapi input.json -o output.json`). " +
-        "AsyncAPI / OpenRPC / other formats are different domains and oav doesn't handle them.",
-    };
-  }
-  const match = /^(\d+)\.(\d+)/.exec(rawOpenapi);
-  if (match === null) {
-    return {
-      kind: "missing-openapi",
-      message: `the \`openapi\` field \`"${rawOpenapi}"\` doesn't look like a semver version`,
-    };
-  }
-  const major = match[1]!;
-  if (major !== "3") {
-    const hint =
-      major === "2"
-        ? " Convert to 3.x first, e.g. `npx swagger2openapi input.json -o output.json`."
-        : "";
-    return {
-      kind: "wrong-major",
-      message: `oav supports OpenAPI 3.x; got openapi: "${rawOpenapi}".${hint}`,
-    };
-  }
-  // Valid 3.x major but unknown minor — forward-compat, not a category
-  // error.
-  return { kind: "ok-unknown-minor", raw: rawOpenapi };
 }
 
 /**


### PR DESCRIPTION
## Summary

The AOT output's `warnings` export was hardcoded as `Object.freeze([])`, discarding every signal the emitter had about version-detection fallbacks. Now `resolveDialect` collects warnings during emit and bakes them into the exported constant, matching the runtime validator's behaviour.

Covered emit-time fallbacks:
- `openapi: "3.7.0"` and similar unknown 3.x minors → fall back to the 3.1 dialect with a warning.
- Missing / non-string / wrong-major `openapi` field → fall back with a warning (runtime throws unless `dialect` is set; AOT stays permissive but surfaces the issue).
- `dialect` override hiding a category error → surfaces the same "compiling anyway because \`dialect\` was set" message the runtime would.

Also lifts `classifyUnknownVersion` / `UnknownVersionReason` out of `validator.ts` into `@oav/core`, so the runtime and AOT emit identical messages from one source. No runtime behaviour change — validator.ts now imports what it used to define inline.

Closes #141.

## Test plan

- [x] New compile-spec tests cover unknown-minor and missing-openapi fallbacks — asserts the frozen `warnings` array carries the expected message.
- [x] Existing "clean spec" test still asserts `warnings === []`.
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` (687/687) all clean.
- [ ] CI passes.