### PR TITLE
perf(schema): uniqueItems primitive fast path via findDuplicate helper

### DIFF
--- a/packages/schema/src/compiler/runtime.ts
+++ b/packages/schema/src/compiler/runtime.ts
@@ -40,6 +40,19 @@ export interface ValidatorDeps {
    * string's iterator and counts — O(1) memory.
    */
   countCodePoints: (s: string) => number;
+  /**
+   * Find the first duplicate in an array. Returns `{ a, b }` where
+   * `arr[a]` and `arr[b]` are structurally equal (JSON deep equality)
+   * and `a < b`, or `null` when every item is unique. Backs `uniqueItems`.
+   *
+   * Primitives use a `Map<value, firstIndex>` (O(N) total); objects and
+   * arrays fall back to pairwise `deepEqual` against the running list
+   * of seen non-primitive items (O(k²) in the object-count tail, which
+   * is unavoidable without canonicalisation). Mixed inputs get the
+   * primitive fast path for every primitive and the object fallback
+   * only for the object subset.
+   */
+  findDuplicate: (arr: readonly unknown[]) => { a: number; b: number } | null;
   formats: Map<string, (value: string) => boolean>;
   refs: Map<string, Validator>;
   /** User-registered keyword validators, keyed by keyword name. */
@@ -117,6 +130,38 @@ export function typeOf(value: unknown): string {
  *
  * @public
  */
+/**
+ * Find the first pair of structurally-equal elements in `arr`. Backs
+ * the `uniqueItems` keyword: primitives hit a `Map` fast path (O(N)),
+ * while objects/arrays fall back to pairwise `deepEqual` against the
+ * running list of seen non-primitives (O(k²) in the object-count
+ * tail, unavoidable without hashing).
+ *
+ * @param arr - The array to scan.
+ * @returns `{ a, b }` with `a < b` for the first duplicate pair, or
+ *          `null` when every element is unique.
+ *
+ * @public
+ */
+export function findDuplicate(arr: readonly unknown[]): { a: number; b: number } | null {
+  const primitives = new Map<unknown, number>();
+  const objects: Array<{ val: unknown; idx: number }> = [];
+  for (let i = 0; i < arr.length; i += 1) {
+    const v = arr[i];
+    if (v !== null && typeof v === "object") {
+      for (const o of objects) {
+        if (deepEqual(v, o.val)) return { a: o.idx, b: i };
+      }
+      objects.push({ val: v, idx: i });
+    } else {
+      const first = primitives.get(v);
+      if (first !== undefined) return { a: first, b: i };
+      primitives.set(v, i);
+    }
+  }
+  return null;
+}
+
 /**
  * Count the Unicode code points in `s` without allocating. Replaces
  * `[...s].length`, whose intermediate array blows up on large strings
@@ -213,6 +258,7 @@ export function createDeps(maxErrors: number = Number.POSITIVE_INFINITY): Valida
     typeOf,
     deepEqual,
     countCodePoints,
+    findDuplicate,
     wrapErrors,
     patterns,
     compilePattern(pattern: string): RegExp {

--- a/packages/schema/src/keywords/array-validation.ts
+++ b/packages/schema/src/keywords/array-validation.ts
@@ -59,23 +59,13 @@ export const uniqueItemsKeyword: KeywordDefinition = {
   vocabulary: CORE_VALIDATION_VOCAB,
   compile(ctx: KeywordCompileContext): void {
     if (ctx.schema !== true) return;
-    const i = ctx.gen.scope.name("i");
-    const j = ctx.gen.scope.name("j");
     const dup = ctx.gen.scope.name("dup");
     ctx.gen.if(`Array.isArray(${ctx.data})`, (g) => {
-      g.let(dup, "null");
-      g.line(`outer_${dup}: for (let ${i} = 0; ${i} < ${ctx.data}.length; ${i} += 1) {`);
-      g.indent();
-      g.line(`for (let ${j} = ${i} + 1; ${j} < ${ctx.data}.length; ${j} += 1) {`);
-      g.indent();
-      g.if(`${NAMES.DEPS}.deepEqual(${ctx.data}[${i}], ${ctx.data}[${j}])`, (gi) => {
-        gi.line(`${dup} = { a: ${i}, b: ${j} };`);
-        gi.line(`break outer_${dup};`);
-      });
-      g.dedent();
-      g.line(`}`);
-      g.dedent();
-      g.line(`}`);
+      // Runtime helper does one Map-backed scan for primitives plus a
+      // pairwise deepEqual sweep of object/array items. Replaces the
+      // previous inline O(N^2) nested loop; generated code stays tiny
+      // and V8 gets to monomorphise the hot helper.
+      g.const(dup, `${NAMES.DEPS}.findDuplicate(${ctx.data})`);
       g.if(`${dup} !== null`, () => {
         // Duplicate indices live in params.duplicates; keep the
         // message as a baked literal to avoid per-error template

--- a/packages/schema/test/keyword-array.test.ts
+++ b/packages/schema/test/keyword-array.test.ts
@@ -27,6 +27,25 @@ describe("array validation keywords", () => {
     expect(v.validate([1, 1, 1]).valid).toBe(true);
   });
 
+  it("uniqueItems spots mixed-type collisions via the primitive fast path", () => {
+    // Regression for #142 — the Map-backed lookup must treat each
+    // primitive identity (number, string, boolean, null) correctly.
+    const v = compile({ uniqueItems: true });
+    expect(v.validate([1, "1"]).valid).toBe(true); // different types, not equal
+    expect(v.validate([null, null]).valid).toBe(false);
+    expect(v.validate([true, false, true]).error?.params).toMatchObject({ duplicates: [0, 2] });
+  });
+
+  it("uniqueItems mixes primitives and objects without false matches", () => {
+    const v = compile({ uniqueItems: true });
+    // Primitives go through the Map; objects fall back to deepEqual.
+    // This shape stresses both paths in one call.
+    expect(v.validate([1, { a: 1 }, 2, { a: 2 }, "x"]).valid).toBe(true);
+    expect(v.validate([1, { a: 1 }, 2, { a: 1 }]).error?.params).toMatchObject({
+      duplicates: [1, 3],
+    });
+  });
+
   it("leaves non-arrays alone", () => {
     const v = compile({ maxItems: 1, minItems: 1, uniqueItems: true });
     expect(v.validate({ length: 5 }).valid).toBe(true);

--- a/performance/schemas.ts
+++ b/performance/schemas.ts
@@ -135,6 +135,36 @@ const composition: PerfSchema = {
   ],
 };
 
+// 6. Unique-primitives — pure `uniqueItems` pressure on a large array.
+// Picks up any regression to the primitive-fast-path fix; a naïve
+// O(N^2) implementation would show a sharp compile/validate split.
+const uniquePrimitives: PerfSchema = {
+  name: "unique-primitives",
+  description: "array of 500 unique strings with uniqueItems; O(N) primitive fast path",
+  schema: {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    type: "array",
+    uniqueItems: true,
+    items: { type: "string" },
+  },
+  validInputs: [makeUniqueStrings(500)],
+  invalidInputs: [makeDuplicateStrings(500)],
+};
+
+function makeUniqueStrings(n: number): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < n; i += 1) out.push(`item-${i}`);
+  return out;
+}
+
+function makeDuplicateStrings(n: number): string[] {
+  const out = makeUniqueStrings(n);
+  // Put the duplicate in the middle so the scan can't trivially
+  // short-circuit on the first pair.
+  out[Math.floor(n / 2)] = out[0]!;
+  return out;
+}
+
 // 5. Array-heavy — exercises the hot per-item validation loop.
 const arrayHeavy: PerfSchema = {
   name: "array-heavy",
@@ -170,4 +200,11 @@ function makeInvalidArray(n: number): Array<Record<string, unknown>> {
   return out;
 }
 
-export const perfSchemas: PerfSchema[] = [tiny, petstore, tree, composition, arrayHeavy];
+export const perfSchemas: PerfSchema[] = [
+  tiny,
+  petstore,
+  tree,
+  composition,
+  arrayHeavy,
+  uniquePrimitives,
+];


### PR DESCRIPTION
## Summary

The emitted `uniqueItems` loop was O(N²) pairwise `deepEqual`, which is catastrophic for long arrays of unique primitives. Replaces it with a `findDuplicate(arr)` runtime helper: primitives hit a `Map<value, firstIndex>` lookup (O(N) total), objects/arrays keep the pairwise `deepEqual` fallback (O(k²) in the object count, unavoidable without hashing).

## Results

Added a `unique-primitives` case to the performance corpus (500 unique strings, `uniqueItems: true`) to measure this directly:

| metric | before | after | vs ajv before | vs ajv after |
| --- | --- | --- | --- | --- |
| validate (valid) | 2.5K ops/s | **88.6K ops/s** (~35×) | 0.04× | **1.50×** |
| validate (invalid, dup @ N/2) | 1.07M ops/s | 158.9K ops/s | 18× | 2.72× |

Caveat on the invalid case: the bench's duplicate sits at index 250 of 500, which is the sweet spot for the old nested loop (short-circuits after ~250 pairs). Still sub-10µs absolute and dramatically faster against a duplicate near the end of a long array — the actual DoS case.

Other schemas in the corpus (`tiny`, `petstore`, `tree`, `composition`, `array-heavy`) are unchanged within noise.

Closes #142.

## Test plan

- [x] Existing `keyword-array.test.ts` coverage (uniqueItems duplicates, `uniqueItems: false` no-op, non-array passthrough) still passes.
- [x] New tests exercise the primitive fast path (mixed-type collisions, null/null, true/false/true) and the mixed primitive + object case (ensures the two code paths interoperate correctly).
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` (688/688) all clean.
- [x] Full `performance/` bench run confirms no regression on unrelated schemas.
- [ ] CI passes.