### PR TITLE
chore(dependabot): ignore typescript major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
       prefix: chore
       prefix-development: chore
       include: scope
+    ignore:
+      # TypeScript majors cross every file in the tree at once and
+      # routinely land breaking type-narrowing changes. Opt out of
+      # auto-PRs; bump it deliberately when the time is right.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       types:
         patterns:
@@ -27,6 +33,12 @@ updates:
       prefix: chore
       prefix-development: chore
       include: scope
+    ignore:
+      # TypeScript majors cross every file in the tree at once and
+      # routinely land breaking type-narrowing changes. Opt out of
+      # auto-PRs; bump it deliberately when the time is right.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       dev-minor-and-patch:
         dependency-type: development
@@ -42,6 +54,12 @@ updates:
       prefix: chore
       prefix-development: chore
       include: scope
+    ignore:
+      # TypeScript majors cross every file in the tree at once and
+      # routinely land breaking type-narrowing changes. Opt out of
+      # auto-PRs; bump it deliberately when the time is right.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       dev-minor-and-patch:
         dependency-type: development


### PR DESCRIPTION
## Summary

Adding `/performance` and `/conformance` to the Dependabot watchers (PR #147) immediately produced TS 5.9.3 → 6.0.3 PRs (#149, #152). The existing root config didn't actually block TS majors either — it was just timing; the next scheduled root scan would have produced the same PR.

Adds an explicit `ignore` rule for `typescript` `version-update:semver-major` to all three npm updaters (root, `/performance`, `/conformance`). Minor/patch TS bumps still flow through `dev-minor-and-patch` as before.

Once this merges, I'll close #149 and #152.

## Test plan

- [x] `yq` parses the updated file; each npm updater now has an `ignore` entry with the typescript/semver-major rule.
- [x] github-actions updater untouched.
- [ ] CI passes.