### PR TITLE
fix(examples): typecheck examples and narrow requestBody refs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,8 @@ testing.
 Both have their own `package.json` + `pnpm-workspace.yaml` (with empty
 `packages:` list so pnpm treats them as isolated roots). Their
 external dev-dependencies (benchmark runners, competing validators,
-`tsx`) are NOT in the main workspace install.
+`tsx`) are NOT in the main workspace install. Neither is type-checked
+in CI — they're tsx-run dev tooling, breakage shows up when you run them.
 
 ## Architecture, package by package
 

--- a/examples/spec-digest.ts
+++ b/examples/spec-digest.ts
@@ -20,6 +20,7 @@
 
 import { fileURLToPath } from "node:url";
 import type {
+  MediaTypeObject,
   OperationObject,
   ParameterObject,
   SchemaObject,
@@ -49,11 +50,17 @@ export interface OperationDigest {
   security: string[][];
 }
 
+function getMediaTypes(op: OperationObject): Record<string, MediaTypeObject> {
+  const body = op.requestBody;
+  if (body === undefined || "$ref" in body) return {};
+  return body.content;
+}
+
 export function digestOperation(op: OperationObject): OperationDigest {
   return {
     operationId: op.operationId,
     deprecated: op.deprecated === true,
-    requestContentTypes: Object.keys(op.requestBody?.content ?? {}),
+    requestContentTypes: Object.keys(getMediaTypes(op)),
     bodyLimits: bodyLimitsByMediaType(op),
     requiredHeaders: (op.parameters ?? [])
       .filter((p): p is ParameterObject => "name" in p && p.in === "header" && p.required === true)
@@ -72,7 +79,7 @@ export function digestOperation(op: OperationObject): OperationDigest {
  */
 function bodyLimitsByMediaType(op: OperationObject): Record<string, { maxBytes?: number }> {
   const out: Record<string, { maxBytes?: number }> = {};
-  for (const [mediaType, mto] of Object.entries(op.requestBody?.content ?? {})) {
+  for (const [mediaType, mto] of Object.entries(getMediaTypes(op))) {
     out[mediaType] = { maxBytes: declaredMaxBytes(mto.schema) };
   }
   return out;

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "allowImportingTsExtensions": true,
+    "baseUrl": "..",
+    "paths": {
+      "@oav/core": ["./packages/core/src/index.ts"],
+      "@oav/schema": ["./packages/schema/src/index.ts"],
+      "@oav/schema/internals": ["./packages/schema/src/internals.ts"],
+      "@oav/formats": ["./packages/formats/src/index.ts"],
+      "@oav/spec": ["./packages/spec/src/index.ts"],
+      "@oav/router": ["./packages/router/src/index.ts"],
+      "@oav/validator": ["./packages/validator/src/index.ts"],
+      "@oav/validator/internals": ["./packages/validator/src/internals.ts"],
+      "@oav/cli": ["./packages/cli/src/index.ts"],
+      "@oav/oav": ["./packages/oav/src/index.ts"]
+    }
+  },
+  "include": ["**/*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "test:watch": "vitest",
     "lint": "oxlint && oxfmt --check .",
     "fmt": "oxfmt --write .",
-    "typecheck": "tsc -b",
+    "typecheck": "tsc -b && tsc -p examples",
     "prepublishOnly": "pnpm build && pnpm test"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #160

  - Add `examples/tsconfig.json` with `allowImportingTsExtensions` so the LS stops emitting TS5097 on relative `.ts` imports.
  - Wire `tsc -p examples` into `pnpm typecheck`.
  - Narrow `op.requestBody` past the `ReferenceObject` branch in `spec-digest.ts` via a `getMediaTypes` helper.
  - Note in CLAUDE.md that `conformance/` and `performance/` are intentionally not type-checked.
 
