### PR TITLE
refactor(validator): rename OavValidator interface to Validator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ external dev-dependencies (benchmark runners, competing validators,
   at construction (more-literal segments first); `match` is a linear scan,
   O(routes × segments). Cheap for typical OpenAPI spec sizes.
 - **`@oav/validator`** — the HTTP orchestrator. `createValidator(spec,
-options)` returns an `OavValidator` exposing `validateRequest(req)`,
+options)` returns a `Validator` exposing `validateRequest(req)`,
   `validateResponse(req, res)`, and `getOperation({ method, path })`.
   Per-operation parameter / body / response schemas are pre-compiled
   on first access; the validator handles route matching, content-type

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * The public `oav/validator` surface. One audience: callers
  * building a request/response validator from a resolved OpenAPI
- * document — `createValidator`, the `OavValidator` instance it returns,
+ * document — `createValidator`, the `Validator` instance it returns,
  * the options, and the Fetch-API adapters for consumers plugging the
  * validator into Next.js / Hono / Bun / Deno handlers.
  *
@@ -16,7 +16,7 @@
 
 export {
   createValidator,
-  type OavValidator,
+  type Validator,
   type ValidatorOptions,
   type ValidatorStats,
 } from "./validator.js";

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -71,7 +71,7 @@ function dialectFor(version: OpenAPIVersion): Dialect {
  *
  * @public
  */
-export interface OavValidator {
+export interface Validator {
   validateRequest(req: HttpRequest): ValidationError | null;
   validateResponse(req: HttpRequest, res: HttpResponse): ValidationError | null;
   /**
@@ -200,7 +200,7 @@ export interface OavValidator {
 }
 
 /**
- * Live counters attached to an {@link OavValidator}.
+ * Live counters attached to an {@link Validator}.
  *
  * @public
  */
@@ -375,12 +375,12 @@ export interface ValidatorOptions {
    * always throw unless `dialect` is set.
    *
    * - `"fallback31"` (default) — accept silently; use the 3.1 dialect.
-   * - `"warn"` — add an entry to {@link OavValidator.warnings} (and
+   * - `"warn"` — add an entry to {@link Validator.warnings} (and
    *   call {@link ValidatorOptions.warn} if provided) and use the 3.1
    *   dialect.
    * - `"throw"` — throw an `Error`.
    *
-   * Regardless of the choice, `OavValidator.detectedVersion` is set to
+   * Regardless of the choice, `Validator.detectedVersion` is set to
    * `undefined` so callers can introspect after the fact.
    */
   onUnknownVersion?: "fallback31" | "warn" | "throw";
@@ -389,7 +389,7 @@ export interface ValidatorOptions {
    * during {@link createValidator} whenever a warning is emitted
    * (currently: `onUnknownVersion: "warn"` path, and the single
    * category-error-overridden-by-`dialect` case). Every warning is
-   * _also_ accumulated into {@link OavValidator.warnings} regardless
+   * _also_ accumulated into {@link Validator.warnings} regardless
    * of whether this callback is set.
    *
    * Default: undefined (no live sink). The library never writes to
@@ -401,7 +401,7 @@ export interface ValidatorOptions {
 }
 
 /**
- * Build an {@link OavValidator} from a resolved OpenAPI 3.1 document.
+ * Build a {@link Validator} from a resolved OpenAPI 3.1 document.
  *
  * @param spec - The fully-resolved OpenAPI document (no external `$ref`s).
  * @param options - Optional formats / strict-mode settings.
@@ -415,10 +415,7 @@ export interface ValidatorOptions {
  *
  * @public
  */
-export function createValidator(
-  spec: OpenAPIDocument,
-  options: ValidatorOptions = {},
-): OavValidator {
+export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions = {}): Validator {
   if (
     options.maxErrors !== undefined &&
     Number.isFinite(options.maxErrors) &&

--- a/packages/validator/test/get-operation.test.ts
+++ b/packages/validator/test/get-operation.test.ts
@@ -46,7 +46,7 @@ function uploadSpec(): OpenAPIDocument {
   };
 }
 
-describe("OavValidator.getOperation", () => {
+describe("Validator.getOperation", () => {
   it("returns the operation + path metadata for a matching request", () => {
     const v = createValidator(uploadSpec());
     const info = v.getOperation({ method: "POST", path: "/uploads" });

--- a/performance/bench-real-world.mjs
+++ b/performance/bench-real-world.mjs
@@ -1,7 +1,7 @@
 /**
  * Real-world OpenAPI benchmark driver. Takes one or more spec entry
  * paths (YAML / JSON), loads each through @oav/spec's `loadSpec`,
- * constructs an `OavValidator`, and reports:
+ * constructs a `Validator`, and reports:
  *
  *   - raw file size on disk
  *   - `loadSpec` duration (read + resolve external $refs)


### PR DESCRIPTION
## Summary
- Drops the `Oav` prefix on the `createValidator` return-type interface so it pairs symmetrically with `ValidatorOptions` / `ValidatorStats`.
- The `@oav/schema` `Validator` (compiled-validator function type) only re-exports through the `oav/schema` subpath, so the two never collide in the same barrel.
- Updates JSDoc `@link` references, the test `describe` label, and stray prose in `CLAUDE.md` and the bench driver.

Closes #172

## Test plan
- [x] `pnpm test` (60 files, 690 tests pass)
- [x] `pnpm lint` (oxlint + oxfmt --check clean)
- [x] `pnpm typecheck` (composite project tsc -b clean)