### PR TITLE
docs(validator): make ValidatorOptions the canonical option reference

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -655,7 +655,8 @@ a single leaf error with `code: "security"` and `path: ["security"]`,
 mapping to HTTP 401 in the default status recipe.
 
 Disable with `createValidator(spec, { validateSecurity: false })` if
-you want schema checks only.
+you want schema checks only. See `ValidatorOptions.validateSecurity`
+for the option contract; this section is the recipe.
 
 `express-openapi-validator`'s `securityHandlers` is a _credential-
 verifying_ dispatch table — you supply an auth function per scheme and
@@ -699,7 +700,9 @@ createValidator(spec, {
 
 `ignorePaths` runs before the router; `ignoreUndocumented` only
 applies to paths the router couldn't match. Both leave `method`
-errors (405 — path exists, verb doesn't) alone.
+errors (405 — path exists, verb doesn't) alone. See
+`ValidatorOptions.ignorePaths` / `ValidatorOptions.ignoreUndocumented`
+for the option contracts.
 
 If you need branching based on the error rather than the path, fall
 back to the manual pattern:

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -228,7 +228,22 @@ export interface ValidatorStats {
 }
 
 /**
- * Options for {@link createValidator}.
+ * The full set of {@link createValidator} tunables. Every knob you
+ * might reach for lives on this type; the per-field TSDoc below is
+ * the canonical contract for each one. The integration guide carries
+ * worked examples; this type carries the API.
+ *
+ * - **Dialect override** — {@link ValidatorOptions.dialect}.
+ * - **Schema extension** — {@link ValidatorOptions.formats},
+ *   {@link ValidatorOptions.keywords}.
+ * - **Error budget** — {@link ValidatorOptions.maxErrors}.
+ * - **Strict-mode linting** — {@link ValidatorOptions.strict}.
+ * - **Security gating** — {@link ValidatorOptions.validateSecurity}.
+ * - **Path filtering** — {@link ValidatorOptions.ignoreUndocumented},
+ *   {@link ValidatorOptions.ignorePaths}.
+ * - **Query strictness** — {@link ValidatorOptions.strictQueryParameters}.
+ * - **Version mismatch** — {@link ValidatorOptions.onUnknownVersion}.
+ * - **Warn sink** — {@link ValidatorOptions.warn}.
  *
  * @remarks
  * Ordering convention (shared with
@@ -404,7 +419,10 @@ export interface ValidatorOptions {
  * Build a {@link Validator} from a resolved OpenAPI 3.1 document.
  *
  * @param spec - The fully-resolved OpenAPI document (no external `$ref`s).
- * @param options - Optional formats / strict-mode settings.
+ * @param options - Tunables for the validator. See {@link ValidatorOptions}
+ *   for the full set: security gating, path filtering, dialect override,
+ *   error budget, custom formats and keywords, strict-mode linting,
+ *   version-mismatch handling, and a warn-output sink.
  * @returns A validator that can check individual requests and responses.
  *
  * @example
@@ -413,6 +431,7 @@ export interface ValidatorOptions {
  * const err = v.validateRequest({ method: "POST", path: "/pets", body: {...} });
  * ```
  *
+ * @see {@link ValidatorOptions}
  * @public
  */
 export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions = {}): Validator {


### PR DESCRIPTION
## Summary
- Lead `ValidatorOptions`'s TSDoc with a roadmap of the option groups (dialect, extension points, error budget, strict, security, path filtering, query strictness, version mismatch, warn sink) so a reader of the type sees the full surface immediately.
- Update `createValidator`'s `@param options` to point at `ValidatorOptions` explicitly instead of the misleading "Optional formats / strict-mode settings" summary; add an `@see` cross-link.
- Add short backreferences in `INTEGRATION.md`'s security and path-filter recipes so the prose routes API-contract questions to the type and reads as recipe rather than reference.

Doc-only change. No runtime / API behaviour changes.

Closes #173

## Test plan
- [x] `pnpm test` (60 files, 690 tests pass)
- [x] `pnpm lint` (oxlint + oxfmt --check clean)
- [x] `pnpm typecheck` (composite tsc -b clean)