### PR TITLE
fix(validator): surface 415 when body absent but Content-Type unmatched

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -134,20 +134,17 @@ app.use(async (req, res, next) => {
 Requires `express.json()` registered before this middleware (and
 `cookie-parser` if you use the `cookies` field).
 
-**Two known sharp edges with stock `express.json()`:**
+**One known sharp edge with stock `express.json()`:**
 
-1. **`express.json()` only parses JSON content-types.** If a client
-   sends `Content-Type: text/plain` (or anything else your spec
-   doesn't declare), `req.body` is left empty and oav reports
-   "missing required request body" rather than a 415. To get
-   accurate 415 responses, register `express.raw({ type: '*/*' })`
-   on the non-JSON content types you want oav to gate, or parse
-   the body yourself in middleware and hand it to `validateRequest`.
-2. **Malformed JSON throws before oav runs.** `express.json()`
-   throws a `SyntaxError` on bad JSON, and Express's default error
-   handler emits an HTML page. Install an Express error middleware
-   to convert it to `application/problem+json` upstream of the
-   validator.
+**Malformed JSON throws before oav runs.** `express.json()` throws a
+`SyntaxError` on bad JSON, and Express's default error handler emits
+an HTML page. Install an Express error middleware to convert it to
+`application/problem+json` upstream of the validator.
+
+(Unmatched `Content-Type` is handled correctly without extra wiring:
+even when `express.json()` leaves `req.body` empty for a non-JSON
+request, oav sees the declared header, finds no matching media type
+in the spec, and returns a `content-type` leaf that maps to 415.)
 
 ### Express 4
 
@@ -172,7 +169,7 @@ app.use((req, res, next) => {
 });
 ```
 
-The same two body-parser caveats apply as for Express 5.
+The same body-parser caveat applies as for Express 5.
 
 ### Fastify
 

--- a/packages/validator/src/validate-step.ts
+++ b/packages/validator/src/validate-step.ts
@@ -157,18 +157,21 @@ export function validateParameter(
 
 /**
  * Content-type gate for the request body. Returns a single leaf when
- * the request carries a body whose `Content-Type` isn't in the declared
- * media-type set for the operation; otherwise `null`. Runs before
- * {@link validateBody} (and before parameter validation) so a
- * content-type mismatch short-circuits with an unambiguous single-leaf
- * tree instead of being paired with unrelated parameter diagnostics.
+ * the client's `Content-Type` doesn't match the operation's declared
+ * media types; otherwise `null`. Runs before {@link validateBody} (and
+ * before parameter validation) so a content-type mismatch short-circuits
+ * with an unambiguous single-leaf tree instead of being paired with
+ * unrelated parameter diagnostics.
  *
+ * Fires whenever the client declared a `Content-Type` that doesn't
+ * match — including the body-absent case, where the wrong header is
+ * the more actionable signal than the downstream "body required" leaf.
  * Returns `null` — deliberately not a content-type error — when:
  * - the operation declares no `requestBody`,
- * - the request carries no body (body-missing is a separate concern,
- *   handled by {@link validateBody}),
  * - the operation's `requestBody.content` map is empty (nothing to
- *   match against).
+ *   match against),
+ * - the request has no body AND no `Content-Type` (body-missing is a
+ *   separate concern, handled by {@link validateBody}).
  *
  * @internal
  */
@@ -177,9 +180,12 @@ export function checkBodyContentType(
   cache: OperationCache,
 ): ValidationError | null {
   if (cache.requestBody === undefined) return null;
-  const hasBody = req.body !== undefined && req.body !== null;
-  if (!hasBody) return null;
   if (cache.bodyValidators.size === 0) return null;
+  const hasBody = req.body !== undefined && req.body !== null;
+  // No body and no Content-Type: the client said nothing about the
+  // payload, so the actionable signal is the missing body, not a 415
+  // for an unsent header. Defer to validateBody.
+  if (!hasBody && req.contentType === undefined) return null;
   const mt = matchMediaType(req.contentType, cache.bodyValidators.keys());
   if (mt !== undefined) return null;
   return createLeafError(

--- a/packages/validator/test/request.test.ts
+++ b/packages/validator/test/request.test.ts
@@ -1,4 +1,4 @@
-import { collectLeaves, type OpenAPIDocument } from "@oav/core";
+import { collectLeaves, httpStatusFor, type OpenAPIDocument } from "@oav/core";
 import { describe, expect, it } from "vitest";
 import { createValidator } from "../src/validator.js";
 import { leafAt, leafCodes, petSpec } from "./fixtures.js";
@@ -118,6 +118,69 @@ describe("validateRequest", () => {
       body: "raw",
     });
     expect(leafCodes(err)).toContain("content-type");
+  });
+
+  it("absent body + unmatched Content-Type → content-type leaf (415), not body-required (400)", () => {
+    // Spec accepts only multipart/form-data. Client says text/plain and
+    // sends no body. Today's bug: the gate skipped body-absent requests
+    // entirely, so validateBody fired "missing required request body"
+    // (400) — true but downstream of the actual cause. Now the gate
+    // sees the unmatched header and surfaces a content-type leaf (415),
+    // which is the actionable signal.
+    const spec: OpenAPIDocument = {
+      openapi: "3.1.0",
+      info: { title: "t", version: "1" },
+      paths: {
+        "/upload": {
+          post: {
+            requestBody: {
+              required: true,
+              content: { "multipart/form-data": { schema: { type: "object" } } },
+            },
+            responses: { "200": { description: "ok" } },
+          },
+        },
+      },
+    };
+    const sv = createValidator(spec);
+    const err = sv.validateRequest({
+      method: "POST",
+      path: "/upload",
+      contentType: "text/plain",
+    });
+    const leaves = collectLeaves(err);
+    expect(leaves).toHaveLength(1);
+    expect(leaves[0]?.code).toBe("content-type");
+    expect(httpStatusFor(err)).toBe(415);
+  });
+
+  it("absent body + no Content-Type → body-required leaf (400), not content-type", () => {
+    // Regression guard for the body-absent fix: with no header, the
+    // client said nothing about the payload, so the actionable signal
+    // is the missing required body (400). The naive "swap the gate
+    // unconditionally" fix would regress this to a less-helpful 415
+    // for a header the client never sent.
+    const spec: OpenAPIDocument = {
+      openapi: "3.1.0",
+      info: { title: "t", version: "1" },
+      paths: {
+        "/x": {
+          post: {
+            requestBody: {
+              required: true,
+              content: { "application/json": { schema: { type: "object" } } },
+            },
+            responses: { "200": { description: "ok" } },
+          },
+        },
+      },
+    };
+    const sv = createValidator(spec);
+    const err = sv.validateRequest({ method: "POST", path: "/x" });
+    const leaves = collectLeaves(err);
+    expect(leaves).toHaveLength(1);
+    expect(leaves[0]?.code).toBe("body");
+    expect(httpStatusFor(err)).toBe(400);
   });
 
   it("content-type gate short-circuits before parameter validation", () => {


### PR DESCRIPTION
## Summary
- Restructure the body content-type gate so it fires whenever the client's declared `Content-Type` doesn't match an operation's accepted media types — including the body-absent case. Previously the gate skipped body-absent requests entirely, so an unmatched header fell through to `validateBody` and emitted "missing required request body" (400) instead of the actionable 415.
- Skip the gate only when the client sent neither body nor `Content-Type` — that case stays a body-required leaf, which is more actionable than a 415 for a header the client never sent.
- Drop the `express.raw({ type: '*/*' })` workaround from `INTEGRATION.md`: with the gate fixed, an unmatched Content-Type produces the correct 415 even when `express.json()` leaves `req.body` empty.

## Behaviour matrix

| body    | Content-Type    | before                    | after                       |
| ------- | --------------- | ------------------------- | --------------------------- |
| absent  | absent          | `body` / 400              | `body` / 400 (unchanged)    |
| absent  | matches spec    | `body` / 400              | `body` / 400 (unchanged)    |
| absent  | set, unmatched  | `body` / 400 (wrong)      | `content-type` / 415        |
| present | unmatched       | `content-type` / 415      | `content-type` / 415 (unchanged) |

Closes #163

## Test plan
- [x] New test: spec accepts only `multipart/form-data`, client sends `text/plain` and no body → expect single `content-type` leaf, `httpStatusFor` → 415.
- [x] New regression-guard test: spec requires JSON, client sends no body and no `Content-Type` → expect single `body` leaf, 400 (catches the naive "swap the gate unconditionally" fix).
- [x] `pnpm test` (60 files, 692 tests pass — 2 new)
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean