### PR TITLE
fix(publish): tighten pack/install scripts (closes #165 #166 #167)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    # engines.node is ">=20"; exercise every supported major so we
+    # engines.node is ">=22"; exercise every supported major so we
     # catch version-specific regressions before consumers do.
     strategy:
       fail-fast: false

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "provenance": true
   },
   "scripts": {
-    "preinstall": "npx -y only-allow pnpm",
+    "preinstall": "node -e \"require('fs').existsSync('pnpm-workspace.yaml')&&require('child_process').execSync('npx -y only-allow pnpm',{stdio:'inherit'})\"",
     "build": "tsup && pnpm --filter @aahoughton/oav build",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,8 @@
     "lint": "oxlint && oxfmt --check .",
     "fmt": "oxfmt --write .",
     "typecheck": "tsc -b && tsc -p examples",
-    "prepublishOnly": "pnpm build && pnpm test"
+    "prepack": "pnpm build",
+    "prepublishOnly": "pnpm test"
   },
   "devDependencies": {
     "@types/node": "25.6.0",

--- a/packages/oav/package.json
+++ b/packages/oav/package.json
@@ -120,7 +120,8 @@
   "scripts": {
     "build": "tsup",
     "test": "vitest run",
-    "typecheck": "tsc -b"
+    "typecheck": "tsc -b",
+    "prepack": "tsup"
   },
   "dependencies": {
     "@aahoughton/oav-core": "workspace:*",

--- a/packages/oav/package.json
+++ b/packages/oav/package.json
@@ -121,7 +121,7 @@
     "build": "tsup",
     "test": "vitest run",
     "typecheck": "tsc -b",
-    "prepack": "tsup"
+    "prepack": "node -e \"if((process.env.npm_config_user_agent||'').startsWith('npm/'))throw Error('Use pnpm pack: npm pack does not rewrite workspace:* deps.')\" && tsup"
   },
   "dependencies": {
     "@aahoughton/oav-core": "workspace:*",


### PR DESCRIPTION
## Summary

Three independent publish-tooling bugs, plus a stale-comment drive-by. Each fix is a separate commit so it bisects cleanly. All three issues are closed by this PR.

### #167 — `prepack: pnpm build` on root, `prepack: tsup` on packages/oav
\`prepublishOnly\` fires on \`npm publish\` but not on \`npm pack\` / \`pnpm pack\`, so a stale or absent \`dist/\` could ship a tarball whose runtime exports drift from source. Add \`prepack\` so packing always rebuilds, regardless of who runs the pack command. Drop the now-redundant \`pnpm build\` from \`prepublishOnly\`.

### #165 — guard root \`preinstall\` so it no-ops in consumer installs
\`package.json#scripts\` ships in every tarball regardless of \`files\`, so the workspace-only \`preinstall: npx -y only-allow pnpm\` script also runs whenever a downstream consumer installs \`@aahoughton/oav-core\`. Modern \`only-allow\` self-detects the transitive case and silently no-ops, but relying on a third party's heuristic is fragile. Wrap the call in a CWD check that only fires when \`pnpm-workspace.yaml\` is present (true only in the source repo).

### #166 — reject \`npm pack\` on packages/oav
\`pnpm pack\` rewrites \`workspace:*\` dependency specs to real versions; \`npm pack\` does not — so an \`npm pack\` of packages/oav produces a tarball whose dependency on \`@aahoughton/oav-core\` is the literal string \`"workspace:*"\`, which fails on consumer install. Add a \`prepack\` guard that rejects the npm user agent. Production publish path uses pnpm and is unaffected.

### Drive-by

Stale comment in \`ci.yml:49\` said \`engines.node is ">=20"\`; corrected to \`>=22\` to match \`package.json\`. Unrelated to the three issues but adjacent and one line.

## Adjacent rough edges (filed as #177)

While auditing the publish surface I found two cleanups that don't belong in this PR:
- Redundant \`pnpm build\` steps in \`ci.yml\` and \`release.yml\` after prepack lands.
- \`packages/oav\` has no \`prepublishOnly\` (defense-in-depth gap, not a current bug).

Filed as a single \`polish\`-labelled issue (#177) for "fix when convenient" treatment.

## Verification (local)

- **#167**: \`rm -rf dist && pnpm pack\` → tarball contains a fresh \`dist/\` (was empty before the fix).
- **#166**: \`cd packages/oav && npm pack\` fails with the guard message; \`pnpm pack\` still succeeds and rewrites \`workspace:*\` → \`0.0.0\`.
- **#165**: \`npm install\` of root tarball into a clean tmp dir succeeds; the guarded preinstall ships in the tarball but is structurally inert there. Source-repo \`npm install\` still rejected with the only-allow box.
- \`pnpm test\` — 60 files, 692 tests pass
- \`pnpm lint\` clean
- \`pnpm typecheck\` clean

## Test plan
- [x] Pack-smoke job covers pnpm pack + npm install end-to-end.
- [x] Local repro confirms each fix.
- [ ] Watch pack-smoke + lint/typecheck/test/build/conformance turn green in CI.

Closes #165
Closes #166
Closes #167