### PR TITLE
feat(core): add summarize() helper and use it for toProblemDetails.detail

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -93,7 +93,16 @@ Both shipped from `oav`:
   [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html)
   `application/problem+json` body with the failing leaves carried in
   an `issues` field (a non-standard field alongside the required
-  ones).
+  ones). The `detail` field defaults to `summarize(err)` (a one-line
+  description of the first failing leaf); pass `detail` explicitly
+  for an override.
+
+- **`summarize(err, opts?)`** — single-line summary of the first
+  failing leaf as `<dotted-path> <message>`. Use it directly for log
+  lines, error-monitoring titles (Sentry/New Relic group by message),
+  or as the top-level `message` field in custom response envelopes.
+  See `SummarizeOptions.select` for the leaf-picking policy
+  (`"first"` / `"deepest"` / `{ byCode }`).
 
 ```ts
 import { allowHeaderFor, httpStatusFor, toProblemDetails } from "@aahoughton/oav";

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -63,11 +63,27 @@ declaration merging.
 
 ## Formatters
 
-All three produce strings suitable for stdout / logs.
+Tree formatters — produce strings suitable for stdout / logs.
 
 - `formatText(err, { maxDepth?, indent? })` — indented human-readable.
 - `formatJson(err)` — deep copy that round-trips through `JSON.stringify`.
 - `formatFlat(err)` — one line per leaf.
+
+Single-line summary — for response-body `message` fields, log lines,
+error-monitoring titles, and `Error.message`:
+
+- `summarize(err, { select? })` — picks one leaf and renders it as
+  `<dotted-path> <message>` (e.g. `"body.users[0].email must match
+format \"email\""`).
+  - `select: "first"` (default) — first leaf in tree-traversal
+    order. Matches `express-openapi-validator`'s top-level message.
+  - `select: "deepest"` — leaf with the longest path; more
+    informative on `oneOf` / composition trees.
+  - `select: { byCode: ["content-type", "required", ...] }` —
+    priority list. Returns the first leaf matching the
+    highest-priority listed code; falls back to `"first"` if no
+    match. Useful when the wire format wants to surface specific
+    failure categories first.
 
 `countErrors(err)` returns the total number of nodes in the tree.
 
@@ -83,10 +99,13 @@ For rendering validation failures as an HTTP response:
   `err.code`). Pass `{ default: 422 }` etc. to override a slot.
 - `allowHeaderFor(err)` — returns the comma-joined `Allow` header
   value for a 405, or `undefined` otherwise (RFC 9110 §15.5.6).
-- `toProblemDetails(err, { type?, title?, status?, instance? })` — RFC
-  9457 `application/problem+json` envelope with a typed `issues` array
-  as an extension member. Defaults: `about:blank` type,
-  `"Validation failed"` title, status `400`.
+- `toProblemDetails(err, { type?, title?, status?, detail?, instance? })` —
+  RFC 9457 `application/problem+json` envelope with a typed `issues`
+  array as an extension member. Defaults: `about:blank` type,
+  `"Validation failed"` title, status `400`, and `detail` = `summarize(err)`
+  (first failing leaf). Pass `detail` explicitly for a structural
+  summary like `` `${pd.issues.length} validation errors` `` or any
+  other override.
 - `collectIssues(err)` — just the flat leaf list (with
   `path` segments + RFC 6901 `pointer` strings), if you're rolling
   your own response shape.

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -104,6 +104,80 @@ export function formatFlat(error: ValidationError): string {
 }
 
 /**
+ * Leaf-selection policy for {@link summarize}.
+ *
+ * - `"first"` — the first leaf in tree-traversal order. Matches
+ *   `express-openapi-validator`'s top-level `message`. The default.
+ * - `"deepest"` — the leaf with the longest path. More informative
+ *   on `oneOf` / composition trees where the structural cause sits
+ *   one or two levels in. Tiebreak: first encountered.
+ * - `{ byCode }` — priority list of error codes. Returns the first
+ *   leaf whose `code` matches the highest-priority entry; if no leaf
+ *   matches any listed code, falls back to the `"first"` policy.
+ *
+ * @public
+ */
+export type SummarizeSelect = "first" | "deepest" | { byCode: readonly string[] };
+
+/**
+ * Options for {@link summarize}.
+ *
+ * @public
+ */
+export interface SummarizeOptions {
+  /** How to pick the leaf to summarise. Defaults to `"first"`. */
+  select?: SummarizeSelect;
+}
+
+/**
+ * Render a {@link ValidationError} tree as a single human-readable line —
+ * the kind of string every HTTP adapter needs for response-body
+ * `message` fields, log lines, error-monitoring titles, and
+ * `Error.message`.
+ *
+ * Picks one leaf per the {@link SummarizeOptions.select} policy and
+ * renders it as `<dotted-path> <message>` (or just `<message>` when
+ * the path is empty). Use {@link formatFlat} or {@link formatText}
+ * when you need the full tree.
+ *
+ * @example
+ * ```ts
+ * summarize(rootError);
+ * // "body.users[0].email must match format \"email\""
+ *
+ * summarize(rootError, { select: { byCode: ["content-type", "required"] } });
+ * // returns the content-type leaf if any, else the first required leaf,
+ * // else the first leaf overall.
+ * ```
+ *
+ * @public
+ */
+export function summarize(error: ValidationError, options: SummarizeOptions = {}): string {
+  const select = options.select ?? "first";
+  // collectLeaves defines a leaf as any node with no children, so even
+  // a single-leaf root yields one entry — leaves[0] is always present.
+  const leaves = collectLeaves(error);
+
+  let chosen: ValidationError = leaves[0]!;
+  if (select === "deepest") {
+    for (const leaf of leaves) {
+      if (leaf.path.length > chosen.path.length) chosen = leaf;
+    }
+  } else if (select !== "first") {
+    for (const code of select.byCode) {
+      const match = leaves.find((l) => l.code === code);
+      if (match !== undefined) {
+        chosen = match;
+        break;
+      }
+    }
+  }
+
+  const location = joinPath(chosen.path);
+  return location.length > 0 ? `${location} ${chosen.message}` : chosen.message;
+}
+
+/**
  * Count the nodes in a {@link ValidationError} tree (branches + leaves).
  *
  * @param error - Root of the error tree.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,7 +15,16 @@ export {
   type ValidationError,
 } from "./errors.js";
 
-export { countErrors, formatFlat, formatJson, formatText, type FormatOptions } from "./format.js";
+export {
+  countErrors,
+  formatFlat,
+  formatJson,
+  formatText,
+  summarize,
+  type FormatOptions,
+  type SummarizeOptions,
+  type SummarizeSelect,
+} from "./format.js";
 
 export {
   formatError,

--- a/packages/core/src/problem-details.ts
+++ b/packages/core/src/problem-details.ts
@@ -1,4 +1,5 @@
 import { collectLeaves, type PathSegment, type ValidationError } from "./errors.js";
+import { summarize } from "./format.js";
 
 /**
  * A single validation issue flattened for client consumption. Produced
@@ -64,6 +65,15 @@ export interface ProblemDetailsOptions {
   status?: number;
   /** URI reference identifying this specific occurrence (e.g. the request URL). */
   instance?: string;
+  /**
+   * Override the human-readable `detail`. Defaults to
+   * {@link summarize}(error) — a single line describing the first
+   * failing leaf (e.g. `"body.users[0].email must match format \"email\""`).
+   * Pass an explicit string for a structural summary like
+   * `` `${issues.length} validation error(s)` `` if you'd rather
+   * not surface a leaf in `detail`.
+   */
+  detail?: string;
 }
 
 /**
@@ -114,7 +124,7 @@ export function toProblemDetails(
     type: options.type ?? "about:blank",
     title: options.title ?? "Validation failed",
     status: options.status ?? 400,
-    detail: `${issues.length} validation error${issues.length === 1 ? "" : "s"}`,
+    detail: options.detail ?? summarize(error),
     issues,
   };
   if (options.instance !== undefined) result.instance = options.instance;

--- a/packages/core/test/format.test.ts
+++ b/packages/core/test/format.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createBranchError, createLeafError, type ValidationError } from "../src/errors.js";
-import { countErrors, formatFlat, formatJson, formatText } from "../src/format.js";
+import { countErrors, formatFlat, formatJson, formatText, summarize } from "../src/format.js";
 
 /** A realistic 4-level oneOf failure used by several formatter assertions. */
 function sampleTree(): ValidationError {
@@ -107,5 +107,59 @@ describe("formatFlat", () => {
 describe("countErrors", () => {
   it("counts branches and leaves", () => {
     expect(countErrors(sampleTree())).toBe(6);
+  });
+});
+
+describe("summarize", () => {
+  it('defaults to "first" — picks the first leaf in tree-traversal order', () => {
+    expect(summarize(sampleTree())).toBe("body.purr must be boolean");
+  });
+
+  it('"deepest" picks the leaf with the longest path', () => {
+    // sampleTree's two leaves: body.purr (depth 2) vs body (depth 1).
+    // "deepest" prefers body.purr; "first" would also land here, so add
+    // a more discriminating fixture.
+    const tree = createBranchError("body", ["body"], "bad", [
+      createLeafError("required", ["body"], "missing name"),
+      createLeafError("type", ["body", "items", 3, "name"], "must be string"),
+    ]);
+    expect(summarize(tree, { select: "first" })).toBe("body missing name");
+    expect(summarize(tree, { select: "deepest" })).toBe("body.items[3].name must be string");
+  });
+
+  it('"deepest" tiebreaks on first-encountered when path lengths match', () => {
+    const tree = createBranchError("body", ["body"], "bad", [
+      createLeafError("required", ["body", "a"], "missing a"),
+      createLeafError("required", ["body", "b"], "missing b"),
+    ]);
+    expect(summarize(tree, { select: "deepest" })).toBe("body.a missing a");
+  });
+
+  it("byCode returns the first leaf matching the highest-priority listed code", () => {
+    const tree = createBranchError("request", [], "request invalid", [
+      createLeafError("type", ["body", "age"], "must be number"),
+      createLeafError("content-type", ["body"], 'Content-Type "text/plain" not accepted'),
+      createLeafError("required", ["body"], "missing name"),
+    ]);
+    // content-type wins over required even though required appears later.
+    expect(summarize(tree, { select: { byCode: ["content-type", "required"] } })).toBe(
+      'body Content-Type "text/plain" not accepted',
+    );
+    // Priority order matters: required first picks the required leaf.
+    expect(summarize(tree, { select: { byCode: ["required", "content-type"] } })).toBe(
+      "body missing name",
+    );
+  });
+
+  it('byCode falls back to "first" when no leaf matches any listed code', () => {
+    const tree = createLeafError("type", ["body", "age"], "must be number");
+    expect(summarize(tree, { select: { byCode: ["content-type", "security"] } })).toBe(
+      "body.age must be number",
+    );
+  });
+
+  it("renders a path-less leaf as just the message", () => {
+    const tree = createLeafError("route", [], "no matching route");
+    expect(summarize(tree)).toBe("no matching route");
   });
 });

--- a/packages/core/test/problem-details.test.ts
+++ b/packages/core/test/problem-details.test.ts
@@ -68,14 +68,21 @@ describe("toProblemDetails", () => {
     expect(pd.type).toBe("about:blank");
     expect(pd.title).toBe("Validation failed");
     expect(pd.status).toBe(400);
-    expect(pd.detail).toBe("2 validation errors");
+    // detail summarises the first leaf via summarize(); the structural
+    // count is still in `issues.length` for callers that need it.
+    expect(pd.detail).toBe("body missing name");
     expect(pd.instance).toBeUndefined();
     expect(pd.issues).toHaveLength(2);
   });
 
-  it("singularises `detail` for a single issue", () => {
+  it("uses the leaf's own message when the path is empty", () => {
     const pd = toProblemDetails(createLeafError("type", [], "x"));
-    expect(pd.detail).toBe("1 validation error");
+    expect(pd.detail).toBe("x");
+  });
+
+  it("honours a caller-supplied `detail` override", () => {
+    const pd = toProblemDetails(err, { detail: "2 validation errors" });
+    expect(pd.detail).toBe("2 validation errors");
   });
 
   it("honours caller-supplied type / title / status / instance", () => {


### PR DESCRIPTION
## Summary

Adds \`summarize(error, opts?)\` to \`@oav/core\` — a one-line human-readable summary of a \`ValidationError\` tree, the kind of string every HTTP adapter needs for response-body \`message\` fields, log lines, error-monitoring titles, and \`Error.message\`.

\`\`\`ts
summarize(rootError);
// "body.users[0].email must match format \"email\""
\`\`\`

## Why

The root \`ValidationError.message\` is operation-scoped (\`"GET /pets: request validation failed"\`); the useful text lives on the leaves. Existing formatters are CLI-shaped (\`formatText\`/\`Flat\`/\`Json\` dump the tree, \`collectIssues\` returns a list, \`toProblemDetails.detail\` was just \`"N validation error(s)"\` — structural noise that \`issues.length\` already conveys). Every adapter ends up writing the same 3-line "pick a leaf, render path + message" loop with subtly different policy.

\`summarize\` puts the policy on the API surface, documented, with sensible defaults.

## API

\`\`\`ts
type SummarizeSelect = "first" | "deepest" | { byCode: readonly string[] };

interface SummarizeOptions {
  select?: SummarizeSelect;
}

function summarize(error: ValidationError, options?: SummarizeOptions): string;
\`\`\`

- \`"first"\` (default) — first leaf in tree-traversal order. Matches \`express-openapi-validator\`'s top-level \`message\`.
- \`"deepest"\` — leaf with the longest path; more informative on \`oneOf\` / composition trees.
- \`{ byCode }\` — priority list. Returns the first leaf matching the highest-priority listed code, falling back to \`"first"\` if no match.

Path rendering uses \`joinPath\` (dotted, e.g. \`body.users[3].email\`) — matches \`formatText\` / \`formatFlat\`. RFC 6901 \`/\`-style pointers stay on \`ValidationIssue.pointer\`.

## Companion change to toProblemDetails

\`toProblemDetails.detail\` previously emitted \`"\${issues.length} validation error(s)"\`. That's structural metadata that \`issues.length\` already conveys, and an under-use of the \`detail\` field per RFC 9457 (which is meant for human-readable per-occurrence explanation). Switch the default to \`summarize(error)\` so \`toProblemDetails\` is a one-call response builder; add a new \`detail?: string\` option for callers that want to keep the count or supply their own.

This is a default-behaviour shift for \`toProblemDetails\` — visible to anyone asserting on \`pd.detail\`. We've never published, so no real breakage.

## Test plan
- [x] \`summarize\` tests for all three select modes (\`first\`, \`deepest\`, \`byCode\`), plus tiebreak, byCode-fallback, and path-less leaf cases.
- [x] Updated \`toProblemDetails\` tests to assert on the new \`detail\` shape and the override path.
- [x] \`pnpm test\` — 60 files, 699 tests pass (7 new).
- [x] \`pnpm lint\` clean.
- [x] \`pnpm typecheck\` clean.

Closes #164