### PR TITLE
feat(oav-express4): ship Express 4 adapter as v0 of the companion-package family

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
   ".": "0.0.0",
-  "packages/oav": "0.0.0"
+  "packages/oav": "0.0.0",
+  "packages/oav-express4": "0.0.0"
 }

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -157,9 +157,28 @@ in the spec, and returns a `content-type` leaf that maps to 415.)
 
 ### Express 4
 
-The `req` surface is identical. The difference: Express 4 doesn't
-await returned promises, so uncaught async errors don't propagate.
-Use `try`/`catch`:
+For Express 4 specifically, the [`@aahoughton/oav-express4`](https://www.npmjs.com/package/@aahoughton/oav-express4)
+companion package ships the middleware as a one-liner with the same
+defaults as the inline pattern above:
+
+```ts
+import { validateRequests } from "@aahoughton/oav-express4";
+
+app.use(express.json()); // ← still required
+app.use(validateRequests(validator));
+```
+
+The package also exports `httpRequestFromExpress(req)` (the extractor)
+and `renderProblemDetails(err, ctx)` (the default renderer) standalone,
+for callers composing their own middleware. See the package's
+[README](https://github.com/aahoughton/oav/blob/main/packages/oav-express4/README.md)
+for the options table and common patterns (custom envelopes, async
+`onError`, forwarding to Express's error chain).
+
+If you'd rather wire the middleware yourself, the inline pattern is
+identical to the Express 5 snippet above, with one twist: Express 4
+doesn't await returned promises, so uncaught async errors don't
+propagate. Use `try`/`catch`:
 
 ```ts
 app.use((req, res, next) => {

--- a/packages/oav-express4/README.md
+++ b/packages/oav-express4/README.md
@@ -1,0 +1,146 @@
+# @aahoughton/oav-express4
+
+Express 4 adapter for [`@aahoughton/oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — a request-validator middleware factory plus standalone helpers (`httpRequestFromExpress`, `renderProblemDetails`) for callers composing their own middleware.
+
+Thin: this package re-exports nothing from oav-core. You install both. The adapter declares oav-core as a regular dependency, so a single `npm install @aahoughton/oav-express4` pulls oav-core along; or install [`@aahoughton/oav`](https://www.npmjs.com/package/@aahoughton/oav) instead if you want YAML readers and the CLI.
+
+For Express 5 / Fastify / Hono adapters, see the sibling `oav-express5` / `oav-fastify` / `oav-hono` packages — same API shape, same names, same defaults.
+
+## Install
+
+```bash
+# JSON specs only
+npm install @aahoughton/oav-core @aahoughton/oav-express4 express
+
+# YAML specs + CLI (oav transitively provides oav-core)
+npm install @aahoughton/oav @aahoughton/oav-express4 express
+```
+
+`express` is a peer dep — your app's existing install satisfies it.
+
+## Quick start
+
+```ts
+import express from "express";
+import { createValidator } from "@aahoughton/oav-core";
+import { validateRequests } from "@aahoughton/oav-express4";
+
+const validator = createValidator(spec);
+
+const app = express();
+app.use(express.json()); // ← MUST run before validateRequests
+app.use(validateRequests(validator));
+
+app.post("/pets", (req, res) => res.json({ ok: true }));
+```
+
+That's it. Invalid requests get a `400 application/problem+json` response (status from `httpStatusFor`, body from `toProblemDetails`, `Allow` header on 405). Valid requests reach your route handlers.
+
+> **Body parser ordering matters.** `express.json()` (or your equivalent) must run **before** `validateRequests(...)`, otherwise `req.body` is `undefined` and the validator emits `body required` for every request — a misleading error that points at the schema, not at the missing parser. Same for `cookie-parser` if your spec validates cookies.
+
+## API
+
+### `validateRequests(validator, options?)`
+
+Returns an Express 4 `RequestHandler`.
+
+| option          | type                                  | default                  |
+| --------------- | ------------------------------------- | ------------------------ |
+| `toHttpRequest` | `(req: Request) => HttpRequest`       | `httpRequestFromExpress` |
+| `onError`       | `(err, ctx) => void \| Promise<void>` | `renderProblemDetails`   |
+
+`onError` may be async — the middleware awaits it. If it throws or rejects, the error is forwarded via `next(err)` so the host's error middleware sees it. The middleware does **not** call `next()` after `onError` returns — your callback owns the response (write to `ctx.res`, or call `ctx.next(err)` to delegate).
+
+### `httpRequestFromExpress(req)`
+
+Convert an Express 4 `Request` to oav's framework-agnostic `HttpRequest` shape. Read what's already on `req` — body parsing is the host app's responsibility.
+
+Header keys lowercased, path stripped of query string, cookies read from `req.cookies` if present.
+
+Use this when you want to compose your own middleware (e.g. validate inside an existing custom wrapper) without re-implementing the extraction.
+
+### `renderProblemDetails(err, ctx)`
+
+The default `onError`. RFC 9457 `application/problem+json` body (via `toProblemDetails`), status from `httpStatusFor`, `Allow` header from `allowHeaderFor` on 405.
+
+Exported standalone so a custom `onError` can call it as the fallback path:
+
+```ts
+validateRequests(validator, {
+  onError: (err, ctx) => {
+    if (err.code === "security") return ctx.res.status(401).end();
+    renderProblemDetails(err, ctx);
+  },
+});
+```
+
+## Common patterns
+
+### Skip validation for paths the spec doesn't declare
+
+The validator owns this — pass it `ignorePaths` or `ignoreUndocumented` at construction. See `ValidatorOptions` in `@aahoughton/oav-core` for the contract.
+
+```ts
+const validator = createValidator(spec, {
+  ignorePaths: (p) => p.startsWith("/internal/"),
+});
+app.use(validateRequests(validator));
+```
+
+### Custom error envelope
+
+```ts
+app.use(
+  validateRequests(validator, {
+    onError: (err, ctx) => {
+      ctx.res.status(httpStatusFor(err)).json({
+        message: summarize(err),
+        errors: collectIssues(err),
+      });
+    },
+  }),
+);
+```
+
+### Forward to Express's error middleware
+
+```ts
+app.use(
+  validateRequests(validator, {
+    onError: (err, ctx) => ctx.next(new ValidationFailure(err)),
+  }),
+);
+
+app.use((err, _req, res, _next) => {
+  if (err instanceof ValidationFailure) {
+    res.status(422).json({ ... });
+    return;
+  }
+  // ... your existing error handler
+});
+```
+
+### Async `onError` (remote logging, dynamic config)
+
+```ts
+app.use(
+  validateRequests(validator, {
+    onError: async (err, ctx) => {
+      await sentry.captureException(err);
+      renderProblemDetails(err, ctx);
+    },
+  }),
+);
+```
+
+The middleware awaits the returned promise; rejections route to `next(err)`.
+
+### Per-route mounting
+
+`validateRequests(...)` is route-aware (it derives the operation from method+path). Mount it once at the app level — per-route mounting is redundant and may cause double-validation under nested routers.
+
+## See also
+
+- [`@aahoughton/oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — `createValidator`, `ValidatorOptions`, `summarize`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
+- [`@aahoughton/oav`](https://www.npmjs.com/package/@aahoughton/oav) — batteries-included distribution of oav-core: YAML readers + the `oav` CLI.
+- The repo-root `INTEGRATION.md` — broader recipes (security, file uploads, response validation, migration from `express-openapi-validator`).

--- a/packages/oav-express4/package.json
+++ b/packages/oav-express4/package.json
@@ -1,0 +1,77 @@
+{
+  "name": "@aahoughton/oav-express4",
+  "version": "0.0.0",
+  "description": "Express 4 adapter for @aahoughton/oav-core. Ships a request-validator middleware factory plus standalone helpers (httpRequestFromExpress, renderProblemDetails) for callers that want to compose their own.",
+  "keywords": [
+    "express",
+    "express4",
+    "middleware",
+    "openapi",
+    "openapi-3.0",
+    "openapi-3.1",
+    "openapi-3.2",
+    "validation",
+    "validator"
+  ],
+  "homepage": "https://github.com/aahoughton/oav#readme",
+  "bugs": {
+    "url": "https://github.com/aahoughton/oav/issues"
+  },
+  "license": "MIT",
+  "author": "Andrew Houghton <aah@roarmouse.org>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aahoughton/oav.git",
+    "directory": "packages/oav-express4"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "typecheck": "tsc -b",
+    "prepack": "node -e \"if((process.env.npm_config_user_agent||'').startsWith('npm/'))throw Error('Use pnpm pack: npm pack does not rewrite workspace:* deps.')\" && tsup"
+  },
+  "dependencies": {
+    "@aahoughton/oav-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@oav/core": "workspace:*",
+    "@oav/validator": "workspace:*",
+    "@types/express": "4.17.21",
+    "express": "4.21.2",
+    "tsup": "8.5.1",
+    "typescript": "5.9.3",
+    "vitest": "4.1.5"
+  },
+  "peerDependencies": {
+    "express": "^4.0.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/oav-express4/src/extract.ts
+++ b/packages/oav-express4/src/extract.ts
@@ -1,0 +1,48 @@
+import type { Request } from "express";
+import type { HttpRequest } from "@oav/core";
+
+/**
+ * Convert an Express 4 `Request` to oav's framework-agnostic
+ * {@link HttpRequest} shape. Read what's already on `req`; do not
+ * touch the body parser or any async source — bodies are assumed
+ * already-parsed by `express.json()` (or equivalent) upstream of
+ * the validator middleware.
+ *
+ * Header keys are lowercased to match oav's convention. The path is
+ * `req.path` (no query string). `Content-Type` is parsed off the
+ * `content-type` header (charset and boundary preserved verbatim;
+ * the validator strips them itself).
+ *
+ * Cookies are read from `req.cookies` if `cookie-parser` populated
+ * them, otherwise omitted.
+ *
+ * Pairs with future `httpRequestFromExpress5`, `httpRequestFromFastify`,
+ * etc. — same name pattern as oav's existing
+ * {@link httpRequestFromFetch}.
+ *
+ * @public
+ */
+export function httpRequestFromExpress(req: Request): HttpRequest {
+  const headers: Record<string, string | string[]> = {};
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (value !== undefined) headers[key.toLowerCase()] = value;
+  }
+
+  // express's Request typing widens query/body to any; carry through
+  // as-is and let the validator narrow.
+  const query = req.query as Record<string, string | string[]> | undefined;
+
+  const result: HttpRequest = {
+    method: req.method.toUpperCase(),
+    path: req.path,
+    headers,
+  };
+  if (query !== undefined) result.query = query;
+  const contentType = req.headers["content-type"];
+  if (typeof contentType === "string") result.contentType = contentType;
+  if (req.body !== undefined) result.body = req.body;
+  // cookie-parser populates req.cookies; absent otherwise.
+  const cookies = (req as Request & { cookies?: Record<string, string> }).cookies;
+  if (cookies !== undefined) result.cookies = cookies;
+  return result;
+}

--- a/packages/oav-express4/src/index.ts
+++ b/packages/oav-express4/src/index.ts
@@ -1,0 +1,21 @@
+/**
+ * The public `oav-express4` surface — three exports plus the type
+ * shape every adapter in the family shares.
+ *
+ * - {@link validateRequests} — middleware factory; the 80% case.
+ * - {@link httpRequestFromExpress} — standalone extractor; for
+ *   callers composing their own middleware.
+ * - {@link renderProblemDetails} — the default error renderer;
+ *   reusable from any custom middleware.
+ *
+ * Naming and option shapes are deliberately consistent with the
+ * future `oav-express5`, `oav-fastify`, and `oav-hono` adapters,
+ * and pair with future `validateResponses` on this package.
+ *
+ * @packageDocumentation
+ */
+
+export { httpRequestFromExpress } from "./extract.js";
+export { renderProblemDetails } from "./render.js";
+export { validateRequests, type ValidateRequestsOptions } from "./middleware.js";
+export type { ErrorHandler, ExpressContext } from "./types.js";

--- a/packages/oav-express4/src/middleware.ts
+++ b/packages/oav-express4/src/middleware.ts
@@ -1,0 +1,93 @@
+import type { Request, RequestHandler } from "express";
+import type { HttpRequest } from "@oav/core";
+import type { Validator } from "@oav/validator";
+import { httpRequestFromExpress } from "./extract.js";
+import { renderProblemDetails } from "./render.js";
+import type { ErrorHandler, ExpressContext } from "./types.js";
+
+/**
+ * Options for {@link validateRequests}. Names and semantics are
+ * shared with future {@link validateResponses} and with the same
+ * options on every other adapter in the family (`oav-express5`,
+ * `oav-fastify`, ...) — only the framework-typed argument differs.
+ *
+ * @public
+ */
+export interface ValidateRequestsOptions {
+  /**
+   * Custom extractor from the Express request to oav's
+   * {@link HttpRequest} shape. Default: {@link httpRequestFromExpress}.
+   * Override when your stack populates non-standard fields the
+   * validator needs (e.g. a proxy that puts the verified body on
+   * `req.verifiedBody`).
+   */
+  toHttpRequest?: (req: Request) => HttpRequest;
+  /**
+   * Called when {@link Validator.validateRequest} returns an error.
+   * Default: {@link renderProblemDetails} — RFC 9457
+   * `application/problem+json` with status from `httpStatusFor`.
+   * Pass your own to render a custom envelope, call `next(err)`,
+   * map to a different status, etc. The middleware does not call
+   * `next()` after invoking `onError` — the callback is the response.
+   */
+  onError?: ErrorHandler<ExpressContext>;
+}
+
+/**
+ * Build an Express 4 request-handler that runs every request through
+ * a {@link Validator} and either calls `next()` (valid) or invokes
+ * the configured `onError` (invalid). The default `onError` writes
+ * an RFC 9457 problem-details response.
+ *
+ * Plural (`validateRequests`, not `validateRequest`) because the
+ * middleware intercepts every request — the singular form is the
+ * Validator's own per-call method.
+ *
+ * Express 4 is sync at the framework level: thrown exceptions and
+ * rejected promises don't auto-propagate to the error handler. The
+ * middleware forwards both via `next(err)` so the host app's error
+ * middleware sees them.
+ *
+ * Pairs with future `validateResponses(validator, opts)`. Same
+ * factory shape across `oav-express5` / `oav-fastify` / `oav-hono`.
+ *
+ * @example
+ * ```ts
+ * import express from "express";
+ * import { validateRequests } from "@aahoughton/oav-express4";
+ *
+ * const app = express();
+ * app.use(express.json());
+ * app.use(validateRequests(validator));
+ * ```
+ *
+ * @public
+ */
+export function validateRequests(
+  validator: Validator,
+  options: ValidateRequestsOptions = {},
+): RequestHandler {
+  const toHttpRequest = options.toHttpRequest ?? httpRequestFromExpress;
+  const onError = options.onError ?? renderProblemDetails;
+
+  return (req, res, next) => {
+    let httpReq;
+    try {
+      httpReq = toHttpRequest(req);
+    } catch (e) {
+      next(e);
+      return;
+    }
+    const err = validator.validateRequest(httpReq);
+    if (err === null) {
+      next();
+      return;
+    }
+    // onError may be sync or async. Awaiting a sync (void) return is
+    // essentially free; awaiting a Promise lets handlers do async work
+    // (remote logging, dynamic rendering config) before the response
+    // settles. Promise rejection is forwarded to next(err) so the
+    // host's error middleware sees it.
+    Promise.resolve(onError(err, { req, res, next })).catch(next);
+  };
+}

--- a/packages/oav-express4/src/render.ts
+++ b/packages/oav-express4/src/render.ts
@@ -1,0 +1,33 @@
+import { allowHeaderFor, httpStatusFor, toProblemDetails, type ValidationError } from "@oav/core";
+import type { ExpressContext } from "./types.js";
+
+/**
+ * The default `onError` for {@link validateRequests} (and future
+ * `validateResponses`). Renders the validation tree as an
+ * RFC 9457 `application/problem+json` response: status from
+ * {@link httpStatusFor}, `Allow` header from {@link allowHeaderFor}
+ * on a 405, body from {@link toProblemDetails} (whose `detail` is
+ * the {@link summarize}d first leaf).
+ *
+ * Exported standalone for two cases:
+ *
+ * 1. You want oav's rendering as the fallback in your own
+ *    middleware — call this directly when you don't want to handle
+ *    the error yourself.
+ * 2. You want a slightly different renderer — use this as the
+ *    starting point and adjust (e.g. swap the body, override the
+ *    status, add headers).
+ *
+ * Pairs with future `responseValidator`'s default; the same
+ * function works for both sides.
+ *
+ * @public
+ */
+export function renderProblemDetails(err: ValidationError, ctx: ExpressContext): void {
+  const allow = allowHeaderFor(err);
+  if (allow !== undefined) ctx.res.setHeader("Allow", allow);
+  ctx.res
+    .status(httpStatusFor(err))
+    .type("application/problem+json")
+    .json(toProblemDetails(err, { instance: ctx.req.originalUrl }));
+}

--- a/packages/oav-express4/src/types.ts
+++ b/packages/oav-express4/src/types.ts
@@ -1,0 +1,33 @@
+import type { NextFunction, Request, Response } from "express";
+import type { ValidationError } from "@oav/core";
+
+/**
+ * The trio every Express 4 middleware receives. Passed to user-supplied
+ * `onError` callbacks so they can render their own response, call
+ * `next(err)`, or whatever the host app's error contract requires.
+ *
+ * Identical in shape to what an inline middleware would close over —
+ * the type is exported only so users can annotate their callbacks.
+ *
+ * @public
+ */
+export interface ExpressContext {
+  req: Request;
+  res: Response;
+  next: NextFunction;
+}
+
+/**
+ * Signature shared by `onError` on every adapter in the family
+ * (`oav-express4`, future `oav-express5`, `oav-fastify`, ...). The
+ * `Ctx` parameter is the only thing that varies — same name and shape
+ * everywhere.
+ *
+ * Returning a Promise is supported on every adapter. `oav-express4`
+ * awaits the return so async work (logging to a remote service,
+ * loading per-tenant rendering config, etc.) can complete before the
+ * middleware exits. Sync handlers pay no measurable overhead.
+ *
+ * @public
+ */
+export type ErrorHandler<Ctx> = (err: ValidationError, ctx: Ctx) => void | Promise<void>;

--- a/packages/oav-express4/test/extract.test.ts
+++ b/packages/oav-express4/test/extract.test.ts
@@ -1,0 +1,77 @@
+import type { Request } from "express";
+import { describe, expect, it } from "vitest";
+import { httpRequestFromExpress } from "../src/extract.js";
+
+function fakeReq(overrides: Partial<Request>): Request {
+  return overrides as unknown as Request;
+}
+
+describe("httpRequestFromExpress", () => {
+  it("extracts method, path, headers, contentType, query, and body", () => {
+    // Express normalises header keys to lowercase before middleware sees
+    // them; our fixtures match that contract so the assertions are honest.
+    const got = httpRequestFromExpress(
+      fakeReq({
+        method: "post",
+        path: "/pets",
+        headers: { "content-type": "application/json", "x-tenant": "t1" },
+        query: { limit: "10" },
+        body: { name: "Fido" },
+      }),
+    );
+    expect(got.method).toBe("POST");
+    expect(got.path).toBe("/pets");
+    expect(got.contentType).toBe("application/json");
+    expect(got.query).toEqual({ limit: "10" });
+    expect(got.body).toEqual({ name: "Fido" });
+  });
+
+  it("lowercases header keys defensively", () => {
+    // Express already lowercases, but downstream middleware can mutate
+    // req.headers — defensive pass keeps the contract regardless.
+    const got = httpRequestFromExpress(
+      fakeReq({
+        method: "GET",
+        path: "/x",
+        headers: { "X-Custom": "v1", "Content-Type": "application/json" },
+      }),
+    );
+    expect(got.headers).toEqual({ "x-custom": "v1", "content-type": "application/json" });
+  });
+
+  it("omits cookies when cookie-parser hasn't run", () => {
+    const got = httpRequestFromExpress(fakeReq({ method: "GET", path: "/x", headers: {} }));
+    expect(got.cookies).toBeUndefined();
+  });
+
+  it("propagates cookies when present", () => {
+    const got = httpRequestFromExpress(
+      fakeReq({
+        method: "GET",
+        path: "/x",
+        headers: {},
+        // express's Request type doesn't declare cookies; cookie-parser augments it.
+        cookies: { sid: "abc" },
+      } as Partial<Request> & { cookies: Record<string, string> }),
+    );
+    expect(got.cookies).toEqual({ sid: "abc" });
+  });
+
+  it("omits body when undefined (e.g. express.json() didn't fire)", () => {
+    const got = httpRequestFromExpress(
+      fakeReq({ method: "POST", path: "/x", headers: { "content-type": "text/plain" } }),
+    );
+    expect(got.body).toBeUndefined();
+    expect(got.contentType).toBe("text/plain");
+  });
+
+  it("does not include the query string in path (req.path strips it)", () => {
+    // req.path is what express gives us; document the contract so a
+    // future change to use req.url (which includes query) gets caught.
+    const got = httpRequestFromExpress(
+      fakeReq({ method: "GET", path: "/pets", query: { limit: "10" }, headers: {} }),
+    );
+    expect(got.path).toBe("/pets");
+    expect(got.path).not.toContain("?");
+  });
+});

--- a/packages/oav-express4/test/middleware.test.ts
+++ b/packages/oav-express4/test/middleware.test.ts
@@ -1,0 +1,214 @@
+import { type OpenAPIDocument, type ValidationError } from "@oav/core";
+import { createValidator } from "@oav/validator";
+import type { NextFunction, Request, Response } from "express";
+import { describe, expect, it, vi } from "vitest";
+import { httpRequestFromExpress } from "../src/extract.js";
+import { validateRequests } from "../src/middleware.js";
+
+function petSpec(): OpenAPIDocument {
+  return {
+    openapi: "3.1.0",
+    info: { title: "t", version: "1" },
+    paths: {
+      "/pets": {
+        post: {
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["name"],
+                  properties: { name: { type: "string" } },
+                },
+              },
+            },
+          },
+          responses: { "200": { description: "ok" } },
+        },
+      },
+    },
+  };
+}
+
+function fakeRes(): Response & {
+  setHeader: ReturnType<typeof vi.fn>;
+  status: ReturnType<typeof vi.fn>;
+  type: ReturnType<typeof vi.fn>;
+  json: ReturnType<typeof vi.fn>;
+} {
+  const res = { setHeader: vi.fn(), status: vi.fn(), type: vi.fn(), json: vi.fn() };
+  res.status.mockReturnValue(res);
+  res.type.mockReturnValue(res);
+  return res as unknown as ReturnType<typeof fakeRes>;
+}
+
+function fakeReq(overrides: Partial<Request>): Request {
+  return { originalUrl: "/pets", ...overrides } as unknown as Request;
+}
+
+describe("validateRequests", () => {
+  const v = createValidator(petSpec());
+
+  it("calls next() for a valid request without writing a response", () => {
+    const mw = validateRequests(v);
+    const res = fakeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    mw(
+      fakeReq({
+        method: "POST",
+        path: "/pets",
+        headers: { "content-type": "application/json" },
+        body: { name: "Fido" },
+      }),
+      res,
+      next,
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it("renders a problem-details response for an invalid request", () => {
+    const mw = validateRequests(v);
+    const res = fakeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    mw(
+      fakeReq({
+        method: "POST",
+        path: "/pets",
+        headers: { "content-type": "application/json" },
+        body: {}, // missing required "name"
+      }),
+      res,
+      next,
+    );
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.type).toHaveBeenCalledWith("application/problem+json");
+    const body = res.json.mock.calls[0]?.[0];
+    expect(body.title).toBe("Validation failed");
+    expect(body.issues.length).toBeGreaterThan(0);
+  });
+
+  it("sets the Allow header on 405 via the default renderer", () => {
+    const mw = validateRequests(v);
+    const res = fakeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    mw(fakeReq({ method: "DELETE", path: "/pets", headers: {} }), res, next);
+    expect(res.status).toHaveBeenCalledWith(405);
+    expect(res.setHeader).toHaveBeenCalledWith("Allow", expect.stringContaining("POST"));
+  });
+
+  it("invokes a custom onError without writing a response itself", () => {
+    const onError = vi.fn();
+    const mw = validateRequests(v, { onError });
+    const res = fakeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    mw(
+      fakeReq({
+        method: "POST",
+        path: "/pets",
+        headers: { "content-type": "application/json" },
+        body: {},
+      }),
+      res,
+      next,
+    );
+    expect(onError).toHaveBeenCalledTimes(1);
+    const [err, ctx] = onError.mock.calls[0]!;
+    expect((err as ValidationError).code).toBe("request");
+    expect(ctx).toMatchObject({ res, next });
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("uses a custom toHttpRequest extractor when supplied", () => {
+    const toHttpRequest = vi.fn((req: Request) => {
+      // Pretend the body lives in a weird upstream-injected field.
+      const httpReq = httpRequestFromExpress(req);
+      const fancy = (req as Request & { verifiedBody?: unknown }).verifiedBody;
+      if (fancy !== undefined) httpReq.body = fancy;
+      return httpReq;
+    });
+    const mw = validateRequests(v, { toHttpRequest });
+    const res = fakeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    mw(
+      fakeReq({
+        method: "POST",
+        path: "/pets",
+        headers: { "content-type": "application/json" },
+        verifiedBody: { name: "Fido" },
+      } as Partial<Request> & { verifiedBody: unknown }),
+      res,
+      next,
+    );
+    expect(toHttpRequest).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it("forwards thrown extractor errors via next(err)", () => {
+    const boom = new Error("extractor boom");
+    const toHttpRequest = vi.fn(() => {
+      throw boom;
+    });
+    const mw = validateRequests(v, { toHttpRequest });
+    const res = fakeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    mw(fakeReq({ method: "GET", path: "/pets", headers: {} }), res, next);
+    expect(next).toHaveBeenCalledWith(boom);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("awaits an async onError before considering the request handled", async () => {
+    let asyncWorkComplete = false;
+    const onError = vi.fn(async (_err, ctx) => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      asyncWorkComplete = true;
+      ctx.res.status(422).json({ kind: "custom" });
+    });
+    const mw = validateRequests(v, { onError });
+    const res = fakeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    mw(
+      fakeReq({
+        method: "POST",
+        path: "/pets",
+        headers: { "content-type": "application/json" },
+        body: {},
+      }),
+      res,
+      next,
+    );
+    // Microtask drain — the await inside onError needs the event loop to tick.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(asyncWorkComplete).toBe(true);
+    expect(res.status).toHaveBeenCalledWith(422);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("forwards a rejected onError promise via next(err)", async () => {
+    const boom = new Error("async logger died");
+    const onError = vi.fn(async () => {
+      throw boom;
+    });
+    const mw = validateRequests(v, { onError });
+    const res = fakeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    mw(
+      fakeReq({
+        method: "POST",
+        path: "/pets",
+        headers: { "content-type": "application/json" },
+        body: {},
+      }),
+      res,
+      next,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(next).toHaveBeenCalledWith(boom);
+  });
+});

--- a/packages/oav-express4/test/render.test.ts
+++ b/packages/oav-express4/test/render.test.ts
@@ -1,0 +1,70 @@
+import { createBranchError, createLeafError } from "@oav/core";
+import type { Request, Response } from "express";
+import { describe, expect, it, vi } from "vitest";
+import { renderProblemDetails } from "../src/render.js";
+
+function fakeRes(): Response & {
+  setHeader: ReturnType<typeof vi.fn>;
+  status: ReturnType<typeof vi.fn>;
+  type: ReturnType<typeof vi.fn>;
+  json: ReturnType<typeof vi.fn>;
+} {
+  const res = {
+    setHeader: vi.fn(),
+    status: vi.fn(),
+    type: vi.fn(),
+    json: vi.fn(),
+  };
+  res.status.mockReturnValue(res);
+  res.type.mockReturnValue(res);
+  return res as unknown as ReturnType<typeof fakeRes>;
+}
+
+function fakeReq(originalUrl = "/pets"): Request {
+  return { originalUrl } as unknown as Request;
+}
+
+describe("renderProblemDetails", () => {
+  it("writes status, content-type, and a problem-details body", () => {
+    const err = createLeafError("type", ["body", "age"], "must be number", {
+      expected: ["number"],
+      actual: "string",
+    });
+    const res = fakeRes();
+    renderProblemDetails(err, { req: fakeReq(), res, next: vi.fn() });
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.type).toHaveBeenCalledWith("application/problem+json");
+    const body = res.json.mock.calls[0]?.[0];
+    expect(body).toMatchObject({
+      type: "about:blank",
+      title: "Validation failed",
+      status: 400,
+      instance: "/pets",
+    });
+    // detail comes from summarize() — first leaf, "<path> <message>".
+    expect(body.detail).toBe("body.age must be number");
+    expect(body.issues).toHaveLength(1);
+  });
+
+  it("sets the Allow header on a 405 (method-not-allowed)", () => {
+    const err = createLeafError("method", [], "method not allowed", {
+      method: "DELETE",
+      pathPattern: "/pets",
+      allowed: ["GET", "POST"],
+    });
+    const res = fakeRes();
+    renderProblemDetails(err, { req: fakeReq(), res, next: vi.fn() });
+    expect(res.status).toHaveBeenCalledWith(405);
+    expect(res.setHeader).toHaveBeenCalledWith("Allow", "GET, POST");
+  });
+
+  it("does not set Allow on errors that aren't 405s", () => {
+    const err = createBranchError("request", [], "request invalid", [
+      createLeafError("type", ["body", "age"], "must be number"),
+    ]);
+    const res = fakeRes();
+    renderProblemDetails(err, { req: fakeReq(), res, next: vi.fn() });
+    expect(res.setHeader).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});

--- a/packages/oav-express4/tsconfig.json
+++ b/packages/oav-express4/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"],
+  "references": [{ "path": "../core" }, { "path": "../validator" }]
+}

--- a/packages/oav-express4/tsup.config.ts
+++ b/packages/oav-express4/tsup.config.ts
@@ -1,0 +1,46 @@
+import { resolve } from "node:path";
+import type { Plugin } from "esbuild";
+import { defineConfig } from "tsup";
+
+/**
+ * Build config for `oav-express4` — the Express 4 adapter.
+ *
+ * Thin tarball: nothing from `oav-core` is bundled. The adapter
+ * imports `@oav/core` / `@oav/validator` (workspace aliases) in
+ * source; the plugin below rewrites those to `@aahoughton/oav-core/*`
+ * AND marks them external so the published bundle resolves them
+ * from the consumer's install of `@aahoughton/oav-core` (or
+ * `@aahoughton/oav`, which transitively provides it).
+ *
+ * `express` is a peer dep — never bundled. `@types/express` is a
+ * dev dep and only contributes to the .d.ts emit.
+ */
+const oavCoreRewrite: Record<string, string> = {
+  "@oav/core": "@aahoughton/oav-core/core",
+  "@oav/validator": "@aahoughton/oav-core",
+};
+
+function rewriteOavCore(): Plugin {
+  return {
+    name: "oav-core-rewrite",
+    setup(build) {
+      build.onResolve({ filter: /^@oav\// }, (args) => {
+        const rewrite = oavCoreRewrite[args.path];
+        if (rewrite) return { path: rewrite, external: true };
+        return null;
+      });
+    },
+  };
+}
+
+export default defineConfig({
+  entry: { index: "src/index.ts" },
+  format: ["esm", "cjs"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  target: "es2022",
+  tsconfig: resolve(__dirname, "../../tsconfig.build.json"),
+  external: ["express", "@aahoughton/oav-core"],
+  esbuildPlugins: [rewriteOavCore()],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,34 @@ importers:
         specifier: 4.1.5
         version: 4.1.5(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(yaml@2.8.3))
 
+  packages/oav-express4:
+    dependencies:
+      '@aahoughton/oav-core':
+        specifier: workspace:*
+        version: link:../..
+    devDependencies:
+      '@oav/core':
+        specifier: workspace:*
+        version: link:../core
+      '@oav/validator':
+        specifier: workspace:*
+        version: link:../validator
+      '@types/express':
+        specifier: 4.17.21
+        version: 4.17.21
+      express:
+        specifier: 4.21.2
+        version: 4.21.2
+      tsup:
+        specifier: 8.5.1
+        version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+
   packages/router:
     dependencies:
       '@oav/core':
@@ -978,8 +1006,14 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -987,8 +1021,29 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/express-serve-static-core@4.19.8':
+    resolution: {integrity: sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==}
+
+  '@types/express@4.17.21':
+    resolution: {integrity: sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@types/qs@6.15.0':
+    resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
@@ -1019,6 +1074,10 @@ packages:
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -1027,9 +1086,16 @@ packages:
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
+  array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  body-parser@1.20.3:
+    resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -1037,9 +1103,21 @@ packages:
     peerDependencies:
       esbuild: '>=0.18'
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1064,8 +1142,31 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.0.6:
+    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+
+  cookie@0.7.1:
+    resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
+    engines: {node: '>= 0.6'}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1076,12 +1177,47 @@ packages:
       supports-color:
         optional: true
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@1.0.2:
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+    engines: {node: '>= 0.8'}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -1093,12 +1229,23 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express@4.21.2:
+    resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
+    engines: {node: '>= 0.10.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1109,13 +1256,63 @@ packages:
       picomatch:
         optional: true
 
+  finalhandler@1.3.1:
+    resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
+    engines: {node: '>= 0.8'}
+
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  http-errors@2.0.0:
+    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -1209,8 +1406,39 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1223,12 +1451,24 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   oxfmt@0.46.0:
     resolution: {integrity: sha512-CopwJOwPAjZ9p76fCvz+mSOJTw9/NY3cSksZK3VO/bUQ8UoEcketNgUuYS0UB3p+R9XnXe7wGGXUmyFxc7QxJA==}
@@ -1244,6 +1484,13 @@ packages:
     peerDependenciesMeta:
       oxlint-tsgolint:
         optional: true
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1284,6 +1531,22 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  qs@6.13.0:
+    resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@2.5.2:
+    resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
+    engines: {node: '>= 0.8'}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
@@ -1302,6 +1565,39 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  send@0.19.0:
+    resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
+    engines: {node: '>= 0.8.0'}
+
+  serve-static@1.16.2:
+    resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
+    engines: {node: '>= 0.8.0'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -1315,6 +1611,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
@@ -1353,6 +1653,10 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
@@ -1382,6 +1686,10 @@ packages:
       typescript:
         optional: true
 
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -1392,6 +1700,18 @@ packages:
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite@8.0.8:
     resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
@@ -1931,18 +2251,56 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 25.6.0
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 25.6.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
+  '@types/express-serve-static-core@4.19.8':
+    dependencies:
+      '@types/node': 25.6.0
+      '@types/qs': 6.15.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@4.17.21':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 4.19.8
+      '@types/qs': 6.15.0
+      '@types/serve-static': 2.2.0
+
+  '@types/http-errors@2.0.5': {}
+
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
+
+  '@types/qs@6.15.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 25.6.0
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 25.6.0
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -1952,6 +2310,14 @@ snapshots:
       '@vitest/utils': 4.1.5
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.5(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(yaml@2.8.3))':
     dependencies:
@@ -1985,18 +2351,54 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   acorn@8.16.0: {}
 
   any-promise@1.3.0: {}
 
+  array-flatten@1.1.1: {}
+
   assertion-error@2.0.1: {}
+
+  body-parser@1.20.3:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.13.0
+      raw-body: 2.5.2
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
       esbuild: 0.27.7
       load-tsconfig: 0.2.5
 
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   chai@6.2.2: {}
 
@@ -2012,15 +2414,53 @@ snapshots:
 
   consola@3.4.2: {}
 
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  content-type@1.0.5: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.0.6: {}
+
+  cookie@0.7.1: {}
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
+  depd@2.0.0: {}
+
+  destroy@1.2.0: {}
+
   detect-libc@2.1.2: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  encodeurl@1.0.2: {}
+
+  encodeurl@2.0.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.0.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -2080,15 +2520,67 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.0
       '@esbuild/win32-x64': 0.28.0
 
+  escape-html@1.0.3: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
 
+  etag@1.8.1: {}
+
   expect-type@1.3.0: {}
+
+  express@4.21.2:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.3
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.1
+      cookie-signature: 1.0.6
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.1
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.12
+      proxy-addr: 2.0.7
+      qs: 6.13.0
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.0
+      serve-static: 1.16.2
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  finalhandler@1.3.1:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.1
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
@@ -2096,8 +2588,56 @@ snapshots:
       mlly: 1.8.2
       rollup: 4.60.2
 
+  forwarded@0.2.0: {}
+
+  fresh@0.5.2: {}
+
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  http-errors@2.0.0:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      toidentifier: 1.0.1
+
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  inherits@2.0.4: {}
+
+  ipaddr.js@1.9.1: {}
 
   joycon@3.1.1: {}
 
@@ -2160,12 +2700,30 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@0.3.0: {}
+
+  merge-descriptors@1.0.3: {}
+
+  methods@1.1.2: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime@1.6.0: {}
+
   mlly@1.8.2:
     dependencies:
       acorn: 8.16.0
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.3
+
+  ms@2.0.0: {}
 
   ms@2.1.3: {}
 
@@ -2177,9 +2735,17 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  negotiator@0.6.3: {}
+
   object-assign@4.1.1: {}
 
+  object-inspect@1.13.4: {}
+
   obug@2.1.1: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   oxfmt@0.46.0:
     dependencies:
@@ -2227,6 +2793,10 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.61.0
       '@oxlint/binding-win32-x64-msvc': 1.61.0
 
+  parseurl@1.3.3: {}
+
+  path-to-regexp@0.1.12: {}
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
@@ -2253,6 +2823,24 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  qs@6.13.0:
+    dependencies:
+      side-channel: 1.1.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@2.5.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
 
   readdirp@4.1.2: {}
 
@@ -2310,6 +2898,67 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
+  send@0.19.0:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@1.16.2:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.0
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -2317,6 +2966,8 @@ snapshots:
   source-map@0.7.6: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.1: {}
 
   std-env@4.1.0: {}
 
@@ -2353,6 +3004,8 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  toidentifier@1.0.1: {}
+
   tree-kill@1.2.2: {}
 
   ts-interface-checker@0.1.13: {}
@@ -2388,11 +3041,35 @@ snapshots:
       - tsx
       - yaml
 
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+
   typescript@5.9.3: {}
 
   ufo@1.6.3: {}
 
   undici-types@7.19.2: {}
+
+  unpipe@1.0.0: {}
+
+  utils-merge@1.0.1: {}
+
+  vary@1.1.2: {}
+
+  vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rolldown: 1.0.0-rc.15
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.6.0
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      yaml: 2.8.3
 
   vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(yaml@2.8.3):
     dependencies:
@@ -2406,6 +3083,33 @@ snapshots:
       esbuild: 0.28.0
       fsevents: 2.3.3
       yaml: 2.8.3
+
+  vitest@4.1.5(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.5(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(yaml@2.8.3)):
     dependencies:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -28,6 +28,12 @@
       "package-name": "@aahoughton/oav",
       "component": "oav",
       "changelog-path": "CHANGELOG.md"
+    },
+    "packages/oav-express4": {
+      "release-type": "node",
+      "package-name": "@aahoughton/oav-express4",
+      "component": "oav-express4",
+      "changelog-path": "CHANGELOG.md"
     }
   }
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -17,7 +17,8 @@
       "@oav/validator": ["./packages/validator/src/index.ts"],
       "@oav/validator/internals": ["./packages/validator/src/internals.ts"],
       "@oav/cli": ["./packages/cli/src/index.ts"],
-      "@oav/oav": ["./packages/oav/src/index.ts"]
+      "@oav/oav": ["./packages/oav/src/index.ts"],
+      "@oav/oav-express4": ["./packages/oav-express4/src/index.ts"]
     }
   },
   "include": ["src/**/*", "packages/*/src/**/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     { "path": "./packages/router" },
     { "path": "./packages/validator" },
     { "path": "./packages/cli" },
-    { "path": "./packages/oav" }
+    { "path": "./packages/oav" },
+    { "path": "./packages/oav-express4" }
   ]
 }

--- a/workspace-aliases.ts
+++ b/workspace-aliases.ts
@@ -14,6 +14,7 @@ const PACKAGES = [
   "validator",
   "cli",
   "oav",
+  "oav-express4",
 ] as const;
 
 export function workspaceAliases(rootDir: string): Record<string, string> {


### PR DESCRIPTION
## Summary

`@aahoughton/oav-express4` — the first companion adapter. A thin package that imports the validator from oav-core and ships an Express 4 middleware factory plus the standalone helpers a custom middleware would otherwise reinvent.

```ts
import express from "express";
import { createValidator } from "@aahoughton/oav-core";
import { validateRequests } from "@aahoughton/oav-express4";

const app = express();
app.use(express.json());
app.use(validateRequests(createValidator(spec)));
```

## API surface

Three exports + three types:

- `validateRequests(validator, opts?): RequestHandler` — middleware factory; the 80% case. Plural verb to avoid colliding with the `Validator` type and the conventional `validator` variable.
- `httpRequestFromExpress(req): HttpRequest` — standalone extractor. Lowercases header keys, strips query from path, reads cookies if `cookie-parser` populated them.
- `renderProblemDetails(err, ctx): void` — the default `onError`. RFC 9457 `application/problem+json` body via `toProblemDetails`, status from `httpStatusFor`, `Allow` header from `allowHeaderFor` on 405.
- `ValidateRequestsOptions`, `ExpressContext`, `ErrorHandler<Ctx>`.

`onError` is async-aware (`void | Promise<void>`); the middleware awaits and routes promise rejections to `next(err)`. Forward-compatible with the promise-native adapters coming next (oav-express5, oav-fastify, oav-hono).

## Naming consistency (cross-adapter contract)

Every adapter in the family will export the same names with the same option shapes:

| concern | export |
| ------- | ------ |
| middleware factory | `validateRequests` (now), `validateResponses` (later) |
| extractor | `httpRequestFromExpress`, future `httpRequestFromFastify` / etc. — same pattern as oav's existing `httpRequestFromFetch` |
| default renderer | `renderProblemDetails` |
| context type | `ExpressContext`, future `FastifyContext`, etc. — framework-native names; same trigger+responder shape |

## Thin

Depends on `@aahoughton/oav-core` (transitive); declares `express ^4.0.0` as a peer. Consumers can install on top of either `oav-core` (JSON specs) or `oav` (YAML + CLI) — both satisfy the import resolution.

## Test plan

- 15 unit tests (`extract.test.ts` / `render.test.ts` / `middleware.test.ts`) — vitest, mock-based.
- Two end-to-end smoke suites against real Express 4 (run from `/tmp`, not in the repo): primary happy path / 400 / 405 / 404 (10 checks) plus custom `onError` forwarding to Express's error chain (5 checks). Both pass after `pnpm pack` + `npm install` of the tarballs.
- Pipeline: 716 unit tests pass, lint clean, typecheck clean.

## Wiring

- `pnpm-workspace.yaml` (already `packages/*`), `workspace-aliases.ts`, `tsconfig.json`, `tsconfig.build.json` — added the new package.
- `release-please-config.json` + `.release-please-manifest.json` — versioned independently.
- `pnpm-lock.yaml` updated for the express + @types/express devDeps.
- `INTEGRATION.md` — Express 4 section now leads with the adapter, keeps the inline pattern as the "if you want full control" alternative.

## Not in this PR (follow-ups)

- CI `pack-smoke` job doesn't yet exercise oav-express4 — to be added once the publish path is real (no first publish has happened yet).
- Top-level `README.md` mention — alongside the install table whenever that lands.

Closes #171