### PR TITLE
docs: cover the adapter family + add missing packages/oav/README.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,17 +72,30 @@ options)` returns a `Validator` exposing `validateRequest(req)`,
   `readBodyFromFetch`) for Next.js / Hono / Bun / Deno consumers.
 - **`@oav/cli`** — thin commander wrapper. No business logic beyond arg
   parsing, I/O, and exit codes.
+- **`@oav/oav-express4`** — first of the framework adapter family.
+  Thin: depends on `@aahoughton/oav-core` (transitive) and declares
+  `express ^4.0.0` as a peer; ships a `validateRequests` middleware
+  factory plus standalone `httpRequestFromExpress` and
+  `renderProblemDetails` helpers. Naming and option shapes
+  (`validateRequests`, `ValidateRequestsOptions`, `ExpressContext`,
+  `ErrorHandler<Ctx>`) are designed to stay identical across future
+  `oav-express5` / `oav-fastify` / `oav-hono` siblings — only the
+  framework-typed argument differs. Future `validateResponses` slots
+  in additively.
 
 ## Dependency graph (strictly enforced; no cycles)
 
 ```
-cli → validator → router
-               → spec → core
-               → formats → core
-               → schema → core
-               → core
-     → spec → core
-     → core
+cli         → validator → router
+                       → spec → core
+                       → formats → core
+                       → schema → core
+                       → core
+            → spec → core
+            → core
+oav-express4 → validator → ... (same as cli's chain)
+            → core
+            (peer: express ^4)
 ```
 
 ## How to add a new keyword

--- a/README.md
+++ b/README.md
@@ -21,13 +21,15 @@ walk programmatically.
 
 ## Install
 
-`oav` ships in two packages so consumers on constrained runtimes can
-skip what they don't use:
+`oav` ships in two core packages so consumers on constrained runtimes
+can skip what they don't use, plus framework adapter packages that
+build on either:
 
-| Package                | When to use                                                                                                                                                                                                                                                                                               |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@aahoughton/oav`      | Default. Batteries-included: YAML readers + the `oav` CLI. Depends on `yaml`; pulls in `commander` + `esbuild` for the CLI only (never imported from the library entry points, so bundlers tree-shake them out of application bundles; Node server runs load them only when the `oav` binary is invoked). |
-| `@aahoughton/oav-core` | Lean alternative. Zero runtime dependencies. Same programmatic surface as `@aahoughton/oav`, minus the YAML readers and CLI. Feed it JSON specs (or pre-parsed objects via the memory reader).                                                                                                            |
+| Package                    | When to use                                                                                                                                                                                                                                                                                               |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@aahoughton/oav`          | Default. Batteries-included: YAML readers + the `oav` CLI. Depends on `yaml`; pulls in `commander` + `esbuild` for the CLI only (never imported from the library entry points, so bundlers tree-shake them out of application bundles; Node server runs load them only when the `oav` binary is invoked). |
+| `@aahoughton/oav-core`     | Lean alternative. Zero runtime dependencies. Same programmatic surface as `@aahoughton/oav`, minus the YAML readers and CLI. Feed it JSON specs (or pre-parsed objects via the memory reader).                                                                                                            |
+| `@aahoughton/oav-express4` | Framework adapter for Express 4. Thin: imports the validator from `oav-core`, ships a middleware factory plus standalone helpers. Sibling adapters for Express 5, Fastify, and Hono will follow the same shape. See [`INTEGRATION.md`](./INTEGRATION.md).                                                 |
 
 ```bash
 npm install @aahoughton/oav
@@ -36,6 +38,10 @@ npm install @aahoughton/oav
 
 ```bash
 npm install @aahoughton/oav-core           # lean install, JSON-only
+```
+
+```bash
+npm install @aahoughton/oav-express4       # Express 4 + your choice of oav or oav-core
 ```
 
 `oav` re-exports `oav-core` at matching
@@ -289,12 +295,18 @@ app.use(async (req, res, next) => {
 
 See [**INTEGRATION.md**](./INTEGRATION.md) for:
 
-- Adapters for Express 4, Fastify, Next.js, Hono, Bun, and Deno.
+- Adapters for Express 4, Express 5, Fastify, Next.js, Hono, Bun, and Deno.
 - Recipes for file uploads (multer), response validation, security,
   ignoring paths, and the full status-code switch.
 - A migration table from `express-openapi-validator`, including
   where oav is stricter or more conformant and where you'll do more
   wiring by hand.
+
+For Express 4, the
+[`@aahoughton/oav-express4`](./packages/oav-express4/README.md)
+companion package ships the middleware as a one-liner — same
+defaults, async-aware `onError`. Sibling adapters for Express 5,
+Fastify, and Hono will follow the same shape.
 
 `oav` is not a drop-in for `express-openapi-validator`: you own the
 error → HTTP mapping, you wire up multer if you need file uploads,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -112,6 +112,10 @@ For rendering validation failures as an HTTP response:
 
 See the [Framework integration](../../README.md#framework-integration)
 section of the root README for Express / Fastify / Next.js snippets.
+For Express 4 specifically, the
+[`@aahoughton/oav-express4`](../oav-express4/README.md) companion
+package wraps these helpers as a one-liner middleware; sibling
+adapters for Express 5 / Fastify / Hono will follow the same shape.
 
 ## OpenAPI / HTTP types
 

--- a/packages/oav/README.md
+++ b/packages/oav/README.md
@@ -1,0 +1,80 @@
+# oav
+
+Batteries-included distribution of `@aahoughton/oav-core`. Adds YAML
+readers and the `oav` CLI on top of the lean validator package; the
+programmatic surface is identical.
+
+```ts
+import { createValidator, createYamlFileReader } from "@aahoughton/oav";
+import { loadSpec } from "@aahoughton/oav/spec";
+
+const { document } = await loadSpec({
+  reader: createYamlFileReader(),
+  entry: "openapi.yaml",
+});
+const validator = createValidator(document);
+```
+
+## When to use which
+
+| Package                | When to use                                                                                                                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@aahoughton/oav`      | Default. YAML support out of the box; ships the `oav` CLI as a `bin`. Pulls in `yaml`, `commander`, and `esbuild` (CLI-only).                                                                           |
+| `@aahoughton/oav-core` | Lean. Zero runtime dependencies. JSON specs only (or pre-parsed objects via the memory reader). Use on Cloudflare Workers, Vercel Edge, Lambda@Edge, or anywhere the YAML/CLI footprint isn't worth it. |
+
+`oav` re-exports every subpath of `oav-core` at matching paths
+(`oav/schema`, `oav/spec`, `oav/formats`, `oav/core`,
+`oav/schema/internals`, `oav/validator/internals`). Code written
+against one swaps to the other by changing the package name in
+imports — no surface changes.
+
+## What this package adds
+
+- **`createYamlFileReader()`** — file reader for `.yaml` / `.yml`
+  paths. Calling `oav-core`'s `createFileReader()` on a YAML path
+  throws an install-hint pointing here.
+- **`createSmartHttpReader()`** — HTTP reader that parses both JSON
+  and YAML by inspecting `Content-Type` / file extension.
+- **`parseYamlString(source)`** — exposed for callers loading YAML
+  out-of-band (e.g. fetched from a config service).
+- **The `oav` CLI binary** — `oav resolve`, `oav validate`,
+  `oav compile-schema`, `oav compile-spec`. See
+  [`packages/cli/README.md`](../cli/README.md) for commands and
+  flags.
+
+Everything else (`createValidator`, `compileSchema`, error helpers,
+formatters, `summarize`, `toProblemDetails`, HTTP-status helpers, …)
+is re-exported from `oav-core`. Documentation for those lives in:
+
+- [`packages/core/README.md`](../core/README.md) — error tree,
+  formatters, HTTP helpers.
+- [`packages/validator/README.md`](../validator/README.md) — the
+  HTTP validator.
+- [`packages/schema/README.md`](../schema/README.md) — the JSON
+  Schema compiler.
+- [`packages/spec/README.md`](../spec/README.md) — multi-file
+  loader, resolver, overlays.
+- [`packages/formats/README.md`](../formats/README.md) — built-in
+  string format validators.
+
+## Framework integration
+
+`oav` is a validator, not a middleware package — you write a short
+adapter between your HTTP framework and `validateRequest` /
+`validateResponse`. For Express 4 specifically, the
+[`@aahoughton/oav-express4`](../oav-express4/README.md) companion
+package ships the middleware as a one-liner with sensible defaults;
+sibling packages for Express 5, Fastify, and Hono will follow the
+same shape. See [`INTEGRATION.md`](../../INTEGRATION.md) for adapter
+recipes for every supported framework, plus migration notes from
+`express-openapi-validator`.
+
+## See also
+
+- [Top-level `README.md`](../../README.md) — full rationale, install
+  matrix, comparison.
+- [`INTEGRATION.md`](../../INTEGRATION.md) — adapter recipes,
+  security wiring, response validation, file uploads, migration.
+- [`OVERLAYS.md`](../../OVERLAYS.md) — extending an externally-owned
+  base spec at load time.
+- [`COMPARISON.md`](../../COMPARISON.md) — feature comparison vs Ajv.

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -34,6 +34,13 @@ can group by location. The top-level node's `code` (`"request"` vs
 detected on construction (or `undefined` if the field was missing or
 unsupported and a fallback was used — see `onUnknownVersion` below).
 
+For Express 4 integration, the
+[`@aahoughton/oav-express4`](../oav-express4/README.md) companion
+package ships a `validateRequests` middleware factory built on top of
+this validator, plus standalone helpers for callers composing their
+own middleware. Sibling adapters for Express 5 / Fastify / Hono will
+follow the same shape.
+
 ## Why this validator
 
 Native OpenAPI 3.0 dialect alongside 3.1 / 3.2, so `nullable`,


### PR DESCRIPTION
## Summary

Five doc surfaces went stale (or were missing) after the oav-express4 adapter landed in #180. This PR sweeps them.

- **`packages/oav/README.md`** — was missing entirely. Adds it: focused on what makes oav distinct from oav-core (YAML readers + CLI), with pointers to sibling READMEs for the rest of the surface.
- **Top-level `README.md`** — said *"ships in two packages"*; now it's three (and counting). Update the install table to include `@aahoughton/oav-express4` and add a one-paragraph nod under "Framework integration."
- **`CLAUDE.md`** — package list and dep graph didn't include the adapter. Add the entry + dep graph node showing the `validator` / `core` deps and the `express` peer.
- **`packages/core/README.md`** + **`packages/validator/README.md`** — neither mentioned adapters. Add a one-sentence "see also" pointer in each so someone reading those READMEs cold can discover the adapter family.

## Test plan

Doc-only change. No runtime behaviour, no API shifts.

- [x] `pnpm test` (716 pass)
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean