### PR TITLE
fix(validator)!: default validateSecurity to false

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -679,9 +679,15 @@ spec but not shape-checked at the validator layer. Failures surface as
 a single leaf error with `code: "security"` and `path: ["security"]`,
 mapping to HTTP 401 in the default status recipe.
 
-Disable with `createValidator(spec, { validateSecurity: false })` if
-you want schema checks only. See `ValidatorOptions.validateSecurity`
-for the option contract; this section is the recipe.
+**Off by default.** Real apps run auth middleware upstream of the
+validator, so by the time `validateRequest` runs the credential has
+already been verified. Enable with `createValidator(spec, {
+validateSecurity: true })` when there's no auth middleware (early
+dev / prototyping) or when the auth layer only decorates `req`
+without rejecting unauthenticated traffic. The check is shape-only
+and is **not** a substitute for actual credential verification.
+See `ValidatorOptions.validateSecurity` for the option contract;
+this section is the recipe.
 
 `express-openapi-validator`'s `securityHandlers` is a _credential-
 verifying_ dispatch table — you supply an auth function per scheme and
@@ -784,11 +790,11 @@ app.use(async (req, res, next) => {
 
 #### Security and file uploads
 
-| `express-openapi-validator` option | `oav` equivalent                                                                                                                  |
-| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `validateSecurity: true`           | Default — shape-only checks for `bearer` / `basic` / `apiKey`. Opt out with `createValidator(spec, { validateSecurity: false })`. |
-| `validateSecurity.handlers`        | Your own auth middleware, run before the validator — `oav` only checks credential **shape**, not validity.                        |
-| `fileUploader: true`               | Your own multer middleware (see [recipe](#file-uploads-with-multer)).                                                             |
+| `express-openapi-validator` option | `oav` equivalent                                                                                                                                                                                |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `validateSecurity: true`           | Off by default in oav (real apps gate security upstream of validation). Opt in with `createValidator(spec, { validateSecurity: true })` for shape-only checks on `bearer` / `basic` / `apiKey`. |
+| `validateSecurity.handlers`        | Your own auth middleware, run before the validator — `oav` only checks credential **shape**, not validity.                                                                                      |
+| `fileUploader: true`               | Your own multer middleware (see [recipe](#file-uploads-with-multer)).                                                                                                                           |
 
 #### Handler wiring
 

--- a/README.md
+++ b/README.md
@@ -226,17 +226,17 @@ npx swagger2openapi swagger.json -o openapi.json
 
 ## Configuring the validator
 
-| Option                  | Effect                                                                                                 |
-| ----------------------- | ------------------------------------------------------------------------------------------------------ |
-| `dialect`               | Force a specific schema dialect, bypassing version detection.                                          |
-| `formats`               | Extra string format validators merged on top of the built-ins.                                         |
-| `keywords`              | Register user-defined schema keywords (see below).                                                     |
-| `maxErrors`             | Cap on leaf errors; `1` is fast-fail, default is uncapped.                                             |
-| `strictQueryParameters` | Reject undeclared query parameters. Default `false`.                                                   |
-| `validateSecurity`      | Shape-only security check (bearer / basic / apiKey). Default `true`; set `false` to skip.              |
-| `ignoreUndocumented`    | Return `null` on requests whose path the router can't match. Default `false`.                          |
-| `ignorePaths`           | Predicate `(path) => boolean`; returning `true` short-circuits validation to `null` before routing.    |
-| `onUnknownVersion`      | Policy for specs with missing/unsupported `openapi`: `"fallback31"` (default), `"warn"`, or `"throw"`. |
+| Option                  | Effect                                                                                                                      |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `dialect`               | Force a specific schema dialect, bypassing version detection.                                                               |
+| `formats`               | Extra string format validators merged on top of the built-ins.                                                              |
+| `keywords`              | Register user-defined schema keywords (see below).                                                                          |
+| `maxErrors`             | Cap on leaf errors; `1` is fast-fail, default is uncapped.                                                                  |
+| `strictQueryParameters` | Reject undeclared query parameters. Default `false`.                                                                        |
+| `validateSecurity`      | Shape-only security check (bearer / basic / apiKey). Default `false` (auth middleware runs upstream); set `true` to opt in. |
+| `ignoreUndocumented`    | Return `null` on requests whose path the router can't match. Default `false`.                                               |
+| `ignorePaths`           | Predicate `(path) => boolean`; returning `true` short-circuits validation to `null` before routing.                         |
+| `onUnknownVersion`      | Policy for specs with missing/unsupported `openapi`: `"fallback31"` (default), `"warn"`, or `"throw"`.                      |
 
 ### Custom keywords
 

--- a/packages/oav-express4/README.md
+++ b/packages/oav-express4/README.md
@@ -76,6 +76,17 @@ validateRequests(validator, {
 
 ## Common patterns
 
+### Enable shape-only security checks (no auth middleware yet)
+
+`ValidatorOptions.validateSecurity` is off by default — real apps run auth middleware upstream of the validator, so by the time `validateRequests` runs the credential has already been verified. During early dev (no auth wired yet) or with decorator-only auth that just attaches `req.user`, opt in:
+
+```ts
+const validator = createValidator(spec, { validateSecurity: true });
+app.use(validateRequests(validator));
+```
+
+The check is shape-only — it confirms the declared credential is _present_, not that it's _valid_. Don't treat it as a substitute for auth middleware.
+
 ### Skip validation for paths the spec doesn't declare
 
 The validator owns this — pass it `ignorePaths` or `ignoreUndocumented` at construction. See `ValidatorOptions` in `@aahoughton/oav-core` for the contract.

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -86,17 +86,17 @@ the upstream test suites live in
 
 ## Options
 
-| Option                  | Effect                                                                                                             |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `dialect`               | Force a specific {@link Dialect}, bypassing version detection.                                                     |
-| `formats`               | Extra string format validators merged with `oav/formats`.                                                          |
-| `keywords`              | User-registered schema keywords (see below).                                                                       |
-| `maxErrors`             | Cap on leaf errors; `1` is fast-fail. Default: uncapped.                                                           |
-| `strictQueryParameters` | Reject undeclared query parameters. Default `false`.                                                               |
-| `validateSecurity`      | Shape-only security check (bearer / basic / apiKey credential location). Default `true`; set `false` to skip.      |
-| `ignoreUndocumented`    | Return `null` on requests whose path the router can't match. Default `false`.                                      |
-| `ignorePaths`           | `(path: string) => boolean` predicate that short-circuits validation when it returns `true` (runs before routing). |
-| `onUnknownVersion`      | `"fallback31"` \| `"warn"` \| `"throw"` when `openapi` is missing or unsupported. Default `"fallback31"`.          |
+| Option                  | Effect                                                                                                                                          |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dialect`               | Force a specific {@link Dialect}, bypassing version detection.                                                                                  |
+| `formats`               | Extra string format validators merged with `oav/formats`.                                                                                       |
+| `keywords`              | User-registered schema keywords (see below).                                                                                                    |
+| `maxErrors`             | Cap on leaf errors; `1` is fast-fail. Default: uncapped.                                                                                        |
+| `strictQueryParameters` | Reject undeclared query parameters. Default `false`.                                                                                            |
+| `validateSecurity`      | Shape-only security check (bearer / basic / apiKey credential location). Default `false` (auth middleware runs upstream); set `true` to opt in. |
+| `ignoreUndocumented`    | Return `null` on requests whose path the router can't match. Default `false`.                                                                   |
+| `ignorePaths`           | `(path: string) => boolean` predicate that short-circuits validation when it returns `true` (runs before routing).                              |
+| `onUnknownVersion`      | `"fallback31"` \| `"warn"` \| `"throw"` when `openapi` is missing or unsupported. Default `"fallback31"`.                                       |
 
 ## Custom keywords
 

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -353,10 +353,13 @@ export interface ValidatorOptions {
    * `mutualTLS` are accepted in the spec but not shape-checked at the
    * validator layer.
    *
-   * Defaults to `true` — migrating
-   * `express-openapi-validator`-with-`validateSecurity` consumers get
-   * the behaviour they're used to without extra wiring. Set `false` to
-   * bypass the check entirely.
+   * Defaults to `false`. Real apps gate security upstream of validation
+   * — by the time the validator runs, the auth middleware has already
+   * verified (or rejected) the credential. Opt in with `true` when
+   * there's no auth middleware (early dev / prototyping) or when the
+   * auth layer only decorates `req` without rejecting unauthenticated
+   * traffic. Opting in is shape-only and is **not** a substitute for
+   * actual credential verification.
    */
   validateSecurity?: boolean;
   /** When `true`, reject unknown query parameters (default: `false`). */
@@ -592,7 +595,7 @@ export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions
 
   const operationCache = new WeakMap<OperationObject, OperationCache>();
 
-  const validateSecurity = options.validateSecurity !== false;
+  const validateSecurity = options.validateSecurity === true;
 
   const cacheFor = (pathMatch: RouteMatch): OperationCache => {
     const existing = operationCache.get(pathMatch.operation);

--- a/packages/validator/test/security.test.ts
+++ b/packages/validator/test/security.test.ts
@@ -39,7 +39,7 @@ function firstLeaf(err: ValidationError | null): ValidationError | null {
 
 describe("security validation: bearer (http / bearer)", () => {
   const spec = specWith({ bearerAuth: { type: "http", scheme: "bearer" } }, [{ bearerAuth: [] }]);
-  const v = createValidator(spec);
+  const v = createValidator(spec, { validateSecurity: true });
 
   it("accepts Authorization: Bearer <token>", () => {
     expect(
@@ -91,7 +91,7 @@ describe("security validation: bearer (http / bearer)", () => {
 
 describe("security validation: basic (http / basic)", () => {
   const spec = specWith({ basicAuth: { type: "http", scheme: "basic" } }, [{ basicAuth: [] }]);
-  const v = createValidator(spec);
+  const v = createValidator(spec, { validateSecurity: true });
 
   it("accepts a well-formed Basic credential", () => {
     const creds = Buffer.from("user:pass").toString("base64");
@@ -134,7 +134,7 @@ describe("security validation: apiKey", () => {
     const spec = specWith({ apiKeyAuth: { type: "apiKey", in: "header", name: "X-API-Key" } }, [
       { apiKeyAuth: [] },
     ]);
-    const v = createValidator(spec);
+    const v = createValidator(spec, { validateSecurity: true });
     expect(v.validateRequest({ method: "GET", path: "/ping" })?.code).toBe("request");
     expect(
       v.validateRequest({ method: "GET", path: "/ping", headers: { "x-api-key": "abc" } }),
@@ -145,7 +145,7 @@ describe("security validation: apiKey", () => {
     const spec = specWith({ apiKeyAuth: { type: "apiKey", in: "header", name: "X-API-Key" } }, [
       { apiKeyAuth: [] },
     ]);
-    const v = createValidator(spec);
+    const v = createValidator(spec, { validateSecurity: true });
     const err = v.validateRequest({
       method: "GET",
       path: "/ping",
@@ -158,7 +158,7 @@ describe("security validation: apiKey", () => {
     const spec = specWith({ apiKeyAuth: { type: "apiKey", in: "query", name: "api_key" } }, [
       { apiKeyAuth: [] },
     ]);
-    const v = createValidator(spec);
+    const v = createValidator(spec, { validateSecurity: true });
     expect(v.validateRequest({ method: "GET", path: "/ping" })?.code).toBe("request");
     expect(
       v.validateRequest({ method: "GET", path: "/ping", query: { api_key: "abc" } }),
@@ -169,7 +169,7 @@ describe("security validation: apiKey", () => {
     const spec = specWith({ apiKeyAuth: { type: "apiKey", in: "cookie", name: "session" } }, [
       { apiKeyAuth: [] },
     ]);
-    const v = createValidator(spec);
+    const v = createValidator(spec, { validateSecurity: true });
     expect(v.validateRequest({ method: "GET", path: "/ping" })?.code).toBe("request");
     expect(
       v.validateRequest({ method: "GET", path: "/ping", cookies: { session: "abc" } }),
@@ -185,7 +185,7 @@ describe("security validation: OR across alternatives, AND within", () => {
     },
     [{ bearerAuth: [] }, { apiKeyAuth: [] }],
   );
-  const v = createValidator(spec);
+  const v = createValidator(spec, { validateSecurity: true });
 
   it("either scheme on its own satisfies the operation", () => {
     expect(
@@ -220,7 +220,7 @@ describe("security validation: OR across alternatives, AND within", () => {
       },
       [{ bearerAuth: [], apiKeyAuth: [] }],
     );
-    const andV = createValidator(andSpec);
+    const andV = createValidator(andSpec, { validateSecurity: true });
 
     // Only the bearer is present — AND fails.
     const err = andV.validateRequest({
@@ -248,7 +248,7 @@ describe("security validation: top-level vs operation-level", () => {
       [], // explicit opt-out on the operation
       [{ bearerAuth: [] }], // top-level requirement
     );
-    const v = createValidator(spec);
+    const v = createValidator(spec, { validateSecurity: true });
     expect(v.validateRequest({ method: "GET", path: "/ping" })).toBeNull();
   });
 
@@ -258,21 +258,26 @@ describe("security validation: top-level vs operation-level", () => {
       undefined, // operation omits the field
       [{ bearerAuth: [] }],
     );
-    const v = createValidator(spec);
+    const v = createValidator(spec, { validateSecurity: true });
     expect(v.validateRequest({ method: "GET", path: "/ping" })?.code).toBe("request");
   });
 });
 
 describe("security validation: configuration", () => {
-  it("validateSecurity: false bypasses the check entirely", () => {
+  it("defaults to off — security is not enforced unless validateSecurity: true is set", () => {
+    // The default reflects the "auth middleware runs upstream" reality:
+    // by the time the validator sees a request, the credential has
+    // already been verified (or rejected) by the host app's auth layer.
+    // Opt in with `true` for dev / prototyping without auth middleware
+    // or for decorator-only auth that doesn't reject unauthenticated.
     const spec = specWith({ bearerAuth: { type: "http", scheme: "bearer" } }, [{ bearerAuth: [] }]);
-    const v = createValidator(spec, { validateSecurity: false });
+    const v = createValidator(spec);
     expect(v.validateRequest({ method: "GET", path: "/ping" })).toBeNull();
   });
 
   it("an undeclared scheme name fails the check (fail-closed, no silent pass)", () => {
     const spec = specWith({ bearerAuth: { type: "http", scheme: "bearer" } }, [{ typoAuth: [] }]);
-    const v = createValidator(spec);
+    const v = createValidator(spec, { validateSecurity: true });
     const err = v.validateRequest({ method: "GET", path: "/ping" });
     expect(firstLeaf(err)?.code).toBe("security");
   });
@@ -301,7 +306,7 @@ describe("security validation: configuration", () => {
         },
       },
     };
-    const v = createValidator(doc);
+    const v = createValidator(doc, { validateSecurity: true });
     const err = v.validateRequest({
       method: "POST",
       path: "/echo",
@@ -324,7 +329,7 @@ describe("security validation: configuration", () => {
       },
       [{ oauth: ["read"] }],
     );
-    const v = createValidator(spec);
+    const v = createValidator(spec, { validateSecurity: true });
     // No headers / query — oauth2 isn't shape-checked, so pass.
     expect(v.validateRequest({ method: "GET", path: "/ping" })).toBeNull();
   });


### PR DESCRIPTION
## Summary

Flip \`ValidatorOptions.validateSecurity\` default from \`true\` to \`false\`.

## Why

The previous default chased eov compatibility, but in practice it's the wrong shape of help — surfaced during a current eov→oav migration where the migrating agent's first edit was to turn it off.

- **Real apps order auth first.** Logging → helmet → auth → body parsers → validation → handlers. By the time the validator runs, the credential has already been verified by the host's auth layer; the shape check is redundant.
- **Shape ≠ validity, and the option name doesn't say so.** A user reading \`validateSecurity: true\` can plausibly skip wiring real auth, thinking the validator has security covered. False confidence trap.
- **The opt-out shape was wrong.** Auth-having apps (the realistic case) had to set \`validateSecurity: false\` explicitly to stop the validator emitting spurious 401s. Right value, wrong direction.
- **Inconsistent with sibling defaults.** \`strictQueryParameters: false\`, \`ignoreUndocumented: false\` — the option surface is otherwise permissive. \`validateSecurity: true\` was the outlier.

Opt in with \`true\` for early dev / prototyping (no auth middleware yet) or when the auth layer only decorates \`req\` without rejecting. The check is shape-only — explicitly not a substitute for credential verification, and the new TSDoc says so.

## Behaviour change

\`ValidatorOptions.validateSecurity\` flips from default-true to default-false. Anyone relying on the previous default needs to add \`{ validateSecurity: true }\` explicitly. Pre-publish window — no real-world breakage.

## Test plan

- [x] Tests updated to opt in explicitly where they exercise the security path (\`packages/validator/test/security.test.ts\`).
- [x] New test pins the default-off behaviour.
- [x] Old \`"validateSecurity: false bypasses the check"\` test dropped — redundant post-flip.
- [x] \`pnpm test\` (716 pass)
- [x] \`pnpm lint\` clean
- [x] \`pnpm typecheck\` clean

## Docs

- \`packages/validator/src/validator.ts\` — TSDoc on \`ValidatorOptions.validateSecurity\` rewritten.
- \`INTEGRATION.md\` — security recipe leads with the new default; migration table entry rewritten.
- \`packages/validator/README.md\` — options table reflects the new default.
- \`packages/oav-express4/README.md\` — added a "common patterns" section explaining when to opt in.
- \`README.md\` — options table reflects the new default.

Closes #183