### PR TITLE
docs: migration trio + auth dispatch recipe + friction-batch follow-ons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,11 @@ pnpm typecheck                    # tsc -b (composite project references)
 tests run against `packages/*/src` directly — no need to build before
 testing.
 
+Use `pnpm pack` (not `npm pack`) for any workspace package. `npm pack`
+ships unrewritten `workspace:*` deps; the prepack guard rejects it
+with a hint, but the failure is a context switch best avoided by
+reaching for `pnpm pack` directly.
+
 ## Dev-only sub-packages (standalone; not in the workspace)
 
 - `conformance/` — upstream JSON Schema Test Suite + OpenAPI case

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -143,12 +143,43 @@ app.use(async (req, res, next) => {
 Requires `express.json()` registered before this middleware (and
 `cookie-parser` if you use the `cookies` field).
 
-**One known sharp edge with stock `express.json()`:**
+**Two sharp edges to know about:**
 
-**Malformed JSON throws before oav runs.** `express.json()` throws a
-`SyntaxError` on bad JSON, and Express's default error handler emits
-an HTML page. Install an Express error middleware to convert it to
-`application/problem+json` upstream of the validator.
+1. **Malformed JSON throws before oav runs.** `express.json()` throws
+   a `SyntaxError` on bad JSON, and Express's default error handler
+   emits an HTML page. Install an Express error middleware to convert
+   it to `application/problem+json` upstream of the validator.
+
+2. **Empty-body normalisation.** Some body parsers (streaming
+   variants, custom multi-format setups) leave `req.body === undefined`
+   for empty `{}`-equivalent payloads instead of an empty object. When
+   that happens, oav's `required`-field checks short-circuit on the
+   missing body — validation passes for what the client thinks is an
+   empty submission, even when the spec marks fields as `required`.
+   If your parser does this, normalise before calling `validateRequest`:
+
+   ```ts
+   body: req.body ?? {},
+   ```
+
+   Stock `express.json()` populates `req.body` to `{}` for an empty
+   JSON body, so the default Express stack doesn't hit this — but
+   migrators replacing eov often inherit alternative parsers (e.g.
+   `body-parser`'s streaming mode, fastify's bridge, custom
+   multipart middleware) that do.
+
+   For consumers using the [`@aahoughton/oav-express4`](https://www.npmjs.com/package/@aahoughton/oav-express4)
+   adapter, override the extractor:
+
+   ```ts
+   import { httpRequestFromExpress, validateRequests } from "@aahoughton/oav-express4";
+
+   app.use(
+     validateRequests(validator, {
+       toHttpRequest: (req) => ({ ...httpRequestFromExpress(req), body: req.body ?? {} }),
+     }),
+   );
+   ```
 
 (Unmatched `Content-Type` is handled correctly without extra wiring:
 even when `express.json()` leaves `req.body` empty for a non-JSON
@@ -447,9 +478,15 @@ own response shape.
 
 ### File uploads with multer
 
-`express-openapi-validator` bundles `multer`. `oav` does not: install
-multer yourself, run it before the validator, and reconstruct the
-body for the validator call.
+`express-openapi-validator` bundles `multer` (and pulls in
+`@types/multer` transitively). `oav` does neither: install both
+yourself, run multer before the validator, and reconstruct the body
+for the validator call.
+
+```sh
+pnpm add multer
+pnpm add -D @types/multer    # else every Express.Multer.File reference goes red
+```
 
 ```ts
 import multer from "multer";
@@ -618,9 +655,7 @@ app.get("/pets/:id", async (req, res) => {
     { status, contentType: "application/json", body },
   );
   if (err !== null) {
-    // In prod: log + return a generic 500.
-    // In dev: return the tree so you notice.
-    console.error(err);
+    log.warn("response validation failed", { path: req.path, err });
   }
   res.status(status).json(body);
 });
@@ -638,9 +673,9 @@ app.use((req, res, next) => {
       { status: res.statusCode, contentType: "application/json", body },
     );
     if (err !== null) {
-      // Decide your policy: log-only, add a header, hard fail, etc.
+      // Default: log + send anyway. See "Failure mode" below.
       res.setHeader("X-Response-Validation", "failed");
-      console.warn("response validation failed", err);
+      log.warn("response validation failed", { path: req.path, err });
     }
     return json(body);
   };
@@ -648,9 +683,53 @@ app.use((req, res, next) => {
 });
 ```
 
-The `res.json` wrapper is ~15 lines. The policy (log, header, hard
-fail, etc.) is whatever you choose to put in the `if (err !== null)`
-branch.
+The `res.json` wrapper is ~15 lines.
+
+#### Failure mode: log, don't fail-hard (by default)
+
+The previous snippets log + send-anyway because that's the right
+default. The instinct from `express-openapi-validator`-with-
+`validateResponses: { allErrors: true }` is to flip the failure
+into a 500 — don't, at least not without warning.
+
+**Why.** The strict-mode failure path runs on _every_ response,
+including the ones your error handler emits. If your error handler
+sends `{ error: "...", code: "..." }` for 4xx responses but the
+spec's `ErrorResponse` schema requires `title` (or sets
+`additionalProperties: false`, or expects different field names),
+fail-hard mode rewrites legitimate 4xx responses as 500s. That's
+worse than the original validation gap: the client now sees a
+server error for a request that was their fault, and your error
+budget burns for free.
+
+**The recommended progression:**
+
+1. **Ship with log-only.** You'll get coverage of every response
+   shape your handlers actually emit, including the error paths.
+2. **Read the logs.** Triage the failures: real bugs in handler
+   output go to the issue tracker; spec-vs-error-handler shape
+   mismatches go to the spec (or to a tighter error envelope).
+3. **Tighten gradually.** Once the log is quiet for a sustained
+   period, you can flip the policy in your `res.json` wrapper:
+
+   ```ts
+   if (err !== null) {
+     log.error("response validation failed (hard)", { path: req.path, err });
+     res.statusCode = 500;
+     return json(toProblemDetails(err, { instance: req.originalUrl }));
+   }
+   ```
+
+   Even then, consider gating the hard-fail on `process.env.NODE_ENV
+!== "production"` so dev sees the failure loudly while prod
+   stays log-only — error responses in prod are exactly when you
+   least want a 500-on-top-of-a-400.
+
+`express-openapi-validator`'s `validateResponses: { allErrors: true,
+removeAdditional: ... }` family of options encourages a flip-it-on-
+and-forget posture that this footgun discusses. `oav`'s "you write
+the policy" model is partly so you can sequence the rollout
+deliberately.
 
 ### Security / authentication
 
@@ -692,9 +771,67 @@ this section is the recipe.
 `express-openapi-validator`'s `securityHandlers` is a _credential-
 verifying_ dispatch table — you supply an auth function per scheme and
 eov calls it. `oav` has no equivalent; that role stays with your auth
-middleware. If you want the declarative shape, write a small function
-that walks the matched operation's `security` array (via
-`validator.getOperation`) and dispatches per scheme.
+middleware. If you want the declarative shape (per-scheme handlers
+keyed off the spec's `security:` declaration), write a small dispatcher
+that walks the matched operation via `validator.getOperation` and
+fans out per scheme:
+
+```ts
+type SchemeHandler = (
+  req: HttpRequest,
+  scopes: string[],
+) => Promise<{ ok: true; user: unknown } | { ok: false; reason: string }>;
+
+const handlers: Record<string, SchemeHandler> = {
+  bearerAuth: async (req, scopes) => {
+    const token = req.headers?.authorization?.toString().replace(/^Bearer /, "");
+    return verifyJwt(token, scopes); // your existing auth
+  },
+  apiKeyAuth: async (req) => verifyApiKey(req.headers?.["x-api-key"]),
+  // oauth2, basic, whatever else your spec declares
+};
+
+async function dispatchSecurity(
+  req: HttpRequest,
+): Promise<{ ok: true; user?: unknown } | { ok: false; reason: string }> {
+  const op = validator.getOperation({ method: req.method, path: req.path });
+  // Fall back to document-level security when the operation omits it.
+  const requirements = op?.operation.security ?? spec.security ?? [];
+  if (requirements.length === 0) return { ok: true };
+  // OpenAPI: each requirement object is AND across its scheme keys; the
+  // outer array is OR across requirements. First requirement that fully
+  // passes wins.
+  for (const requirement of requirements) {
+    let allPass = true;
+    let lastUser: unknown;
+    for (const [scheme, scopes] of Object.entries(requirement)) {
+      const handler = handlers[scheme];
+      if (!handler) {
+        allPass = false;
+        break;
+      }
+      const r = await handler(req, scopes);
+      if (!r.ok) {
+        allPass = false;
+        break;
+      }
+      lastUser = r.user;
+    }
+    if (allPass) return { ok: true, user: lastUser };
+  }
+  return { ok: false, reason: "no security requirement satisfied" };
+}
+```
+
+Mount the dispatcher as middleware _before_ `validateRequests` (or
+your inline validator middleware). Reject (`401` / `403` per your
+policy) on `{ ok: false }` before validation runs. The validator's
+own `validateSecurity` shape check is then redundant — leave it at
+its default `false`.
+
+For framework-adapter consumers (`oav-express4`, future siblings),
+the same dispatcher pattern works; only the request-shape extraction
+changes (`httpRequestFromExpress(req)`, etc.).
 
 ### Type coercion on body fields
 

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -140,8 +140,12 @@ app.use(async (req, res, next) => {
 });
 ```
 
-Requires `express.json()` registered before this middleware (and
-`cookie-parser` if you use the `cookies` field).
+Requires `express.json()` (or any equivalent middleware that
+populates `req.body` with a parsed object) registered before this
+middleware, and `cookie-parser` if you use the `cookies` field.
+Custom streaming parsers, `body-parser`, fastify's bridge, and
+app-specific middleware all work the same way — oav doesn't care
+_how_ `req.body` got populated, only that it's there.
 
 **Two sharp edges to know about:**
 
@@ -184,7 +188,14 @@ Requires `express.json()` registered before this middleware (and
 (Unmatched `Content-Type` is handled correctly without extra wiring:
 even when `express.json()` leaves `req.body` empty for a non-JSON
 request, oav sees the declared header, finds no matching media type
-in the spec, and returns a `content-type` leaf that maps to 415.)
+in the spec, and returns a `content-type` leaf that maps to 415. The
+sibling case — **no Content-Type AND no body** — returns `body` /
+400 instead of 415, since there's no client signal about format
+intent to be "wrong about." This is a divergence from
+`express-openapi-validator`, which returns 415 in both cases; oav's
+choice surfaces the more actionable message ("you didn't send a
+body"). Tests that exercise the 415 path need to send an explicit
+unmatched Content-Type.)
 
 ### Express 4
 
@@ -522,6 +533,17 @@ hit: a `{ type: "string", format: "binary" }` field in the spec is
 rewritten to an "accept anything" schema before compile, so a Buffer
 or Uint8Array passes without a string-type error. `format: "byte"`
 (base64) still validates as a string.
+
+**Watch out for `oneOf` / `anyOf` with binary fields.** The "accept
+anything" rewrite means every binary branch matches every input. A
+common spec pattern for "one file or many" —
+`oneOf [array<binary>, binary]` — is silently ambiguous: both
+branches match the same payload, so `oneOf` fails with
+`matchCount: 2`. The fix is usually to drop the `oneOf` and accept
+the array form (parsers like multer always deliver arrays anyway);
+the original spec was already ambiguous before oav surfaced it.
+`express-openapi-validator` was looser inside binary fields and
+silently accepted, masking the issue.
 
 ### Deriving middleware config from the spec
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -63,6 +63,15 @@ declaration merging.
 
 ## Formatters
 
+Which one to reach for:
+
+| Want                                                                      | Use          |
+| ------------------------------------------------------------------------- | ------------ |
+| One-line string for `response.message`, log lines, Sentry/NR group titles | `summarize`  |
+| Multi-line indented tree for stdout, log dumps, human reading             | `formatText` |
+| Structured tree for programmatic consumption / JSON round-trip            | `formatJson` |
+| One line per leaf for grep, CI diffs                                      | `formatFlat` |
+
 Tree formatters — produce strings suitable for stdout / logs.
 
 - `formatText(err, { maxDepth?, indent? })` — indented human-readable.
@@ -89,7 +98,12 @@ format \"email\""`).
 
 ## HTTP response helpers
 
-For rendering validation failures as an HTTP response:
+For rendering validation failures as an HTTP response. Two response
+builders, pick by envelope shape: **`toProblemDetails`** for RFC 9457
+`application/problem+json`; **`collectIssues`** when you're keeping a
+custom response shape (e.g. preserving an existing
+`{ message, errors: [...] }` envelope from a library you're
+migrating from).
 
 - `httpStatusFor(err, overrides?)` — maps a `ValidationError` tree to
   an HTTP status code. Defaults: `route` → 404, `method` → 405,

--- a/packages/oav-express4/README.md
+++ b/packages/oav-express4/README.md
@@ -37,6 +37,20 @@ app.post("/pets", (req, res) => res.json({ ok: true }));
 That's it. Invalid requests get a `400 application/problem+json` response (status from `httpStatusFor`, body from `toProblemDetails`, `Allow` header on 405). Valid requests reach your route handlers.
 
 > **Body parser ordering matters.** `express.json()` (or your equivalent) must run **before** `validateRequests(...)`, otherwise `req.body` is `undefined` and the validator emits `body required` for every request — a misleading error that points at the schema, not at the missing parser. Same for `cookie-parser` if your spec validates cookies.
+>
+> **Empty-body normalisation.** Some parsers (streaming variants, custom multi-format setups) leave `req.body === undefined` even after they run, for empty `{}`-equivalent payloads. When that happens, `required`-field checks short-circuit on the missing body — empty submissions pass validation. Normalise via `toHttpRequest`:
+>
+> ```ts
+> import { httpRequestFromExpress, validateRequests } from "@aahoughton/oav-express4";
+>
+> app.use(
+>   validateRequests(validator, {
+>     toHttpRequest: (req) => ({ ...httpRequestFromExpress(req), body: req.body ?? {} }),
+>   }),
+> );
+> ```
+>
+> Stock `express.json()` populates an empty body to `{}` and doesn't hit this — but migrators inheriting alternative parsers (e.g. `body-parser` streaming mode) often do.
 
 ## API
 
@@ -86,6 +100,57 @@ app.use(validateRequests(validator));
 ```
 
 The check is shape-only — it confirms the declared credential is _present_, not that it's _valid_. Don't treat it as a substitute for auth middleware.
+
+### Per-scheme auth dispatch (the eov `securityHandlers` shape)
+
+eov's `securityHandlers` is a per-scheme dispatch table — you supply an auth function per declared scheme and eov calls it. `oav-express4` doesn't ship this as a helper, but the recipe is small. Mount it as middleware _before_ `validateRequests`:
+
+```ts
+import type { Request } from "express";
+import { createValidator } from "@aahoughton/oav-core";
+
+type SchemeHandler = (req: Request, scopes: string[]) => Promise<boolean>;
+
+const handlers: Record<string, SchemeHandler> = {
+  bearerAuth: async (req, scopes) => {
+    const token = req.headers.authorization?.replace(/^Bearer /, "");
+    return verifyJwt(token, scopes);
+  },
+  apiKeyAuth: async (req) => {
+    const key = req.header("x-api-key");
+    return Boolean(key) && (await verifyApiKey(key));
+  },
+};
+
+app.use(async (req, res, next) => {
+  const op = validator.getOperation({ method: req.method, path: req.path });
+  const requirements = op?.operation.security ?? spec.security ?? [];
+  if (requirements.length === 0) return next();
+  for (const requirement of requirements) {
+    let allPass = true;
+    for (const [scheme, scopes] of Object.entries(requirement)) {
+      const handler = handlers[scheme];
+      if (!handler || !(await handler(req, scopes))) {
+        allPass = false;
+        break;
+      }
+    }
+    if (allPass) return next();
+  }
+  res.status(401).type("application/problem+json").json({
+    type: "about:blank",
+    title: "Unauthorized",
+    status: 401,
+    detail: "no security requirement satisfied",
+  });
+});
+
+app.use(validateRequests(validator)); // shape check off by default; redundant given the dispatcher above
+```
+
+OpenAPI semantics: each requirement object is AND across its scheme keys; the outer array is OR across requirements. The recipe walks them accordingly.
+
+If multiple projects end up copying this recipe, that's the signal to harvest into a `dispatchSecurity(...)` helper export — not yet.
 
 ### Skip validation for paths the spec doesn't declare
 

--- a/packages/oav-express4/README.md
+++ b/packages/oav-express4/README.md
@@ -36,7 +36,7 @@ app.post("/pets", (req, res) => res.json({ ok: true }));
 
 That's it. Invalid requests get a `400 application/problem+json` response (status from `httpStatusFor`, body from `toProblemDetails`, `Allow` header on 405). Valid requests reach your route handlers.
 
-> **Body parser ordering matters.** `express.json()` (or your equivalent) must run **before** `validateRequests(...)`, otherwise `req.body` is `undefined` and the validator emits `body required` for every request — a misleading error that points at the schema, not at the missing parser. Same for `cookie-parser` if your spec validates cookies.
+> **Body parser ordering matters.** `express.json()` (or your equivalent) must run **before** `validateRequests(...)`, otherwise `req.body` is `undefined` and the validator emits `body required` for every request — a misleading error that points at the schema, not at the missing parser. Same for `cookie-parser` if your spec validates cookies. Any middleware that populates `req.body` with a parsed object satisfies oav — `express.json()`, custom streaming parsers, `body-parser`, fastify's bridge, app-specific middleware all work the same way.
 >
 > **Empty-body normalisation.** Some parsers (streaming variants, custom multi-format setups) leave `req.body === undefined` even after they run, for empty `{}`-equivalent payloads. When that happens, `required`-field checks short-circuit on the missing body — empty submissions pass validation. Normalise via `toHttpRequest`:
 >
@@ -65,11 +65,15 @@ Returns an Express 4 `RequestHandler`.
 
 `onError` may be async — the middleware awaits it. If it throws or rejects, the error is forwarded via `next(err)` so the host's error middleware sees it. The middleware does **not** call `next()` after `onError` returns — your callback owns the response (write to `ctx.res`, or call `ctx.next(err)` to delegate).
 
+> **Validation failures don't traverse Express's error chain by default.** The default `onError` (`renderProblemDetails`) writes the response directly. If you're migrating from `express-openapi-validator` (which emits validation failures as `HttpError` through `next(err)`), your existing error middleware won't see oav's failures unless you forward them — see [Forward to Express's error middleware](#forward-to-expresss-error-middleware) below. Same goes for observability: see [Add observability without changing the response](#add-observability-without-changing-the-response).
+
 ### `httpRequestFromExpress(req)`
 
 Convert an Express 4 `Request` to oav's framework-agnostic `HttpRequest` shape. Read what's already on `req` — body parsing is the host app's responsibility.
 
 Header keys lowercased, path stripped of query string, cookies read from `req.cookies` if present.
+
+**Returns a fresh `HttpRequest`.** Top-level fields can be reassigned freely without affecting the original Express `req` — safe to spread (`{ ...httpRequestFromExpress(req), body: {} }`) or mutate in place. The values it references (`req.body`, `req.headers`) are still the originals; deep mutation would still leak, but reassignment doesn't.
 
 Use this when you want to compose your own middleware (e.g. validate inside an existing custom wrapper) without re-implementing the extraction.
 
@@ -195,6 +199,23 @@ app.use((err, _req, res, _next) => {
   // ... your existing error handler
 });
 ```
+
+### Add observability without changing the response
+
+Validation failures don't reach your registered Express error middleware by default (the middleware terminates the request itself). To log every failure while keeping the default problem-details response, compose `renderProblemDetails` after your log call:
+
+```ts
+app.use(
+  validateRequests(validator, {
+    onError: (err, ctx) => {
+      log.warn("validation failed", { path: ctx.req.path, code: err.code });
+      renderProblemDetails(err, ctx);
+    },
+  }),
+);
+```
+
+Three lines, no behaviour change for clients. Use this whenever your existing error pipeline (Sentry, structured logger, request-id correlation) needs to see validation failures.
 
 ### Async `onError` (remote logging, dynamic config)
 

--- a/packages/oav-express4/src/index.ts
+++ b/packages/oav-express4/src/index.ts
@@ -19,3 +19,11 @@ export { httpRequestFromExpress } from "./extract.js";
 export { renderProblemDetails } from "./render.js";
 export { validateRequests, type ValidateRequestsOptions } from "./middleware.js";
 export type { ErrorHandler, ExpressContext } from "./types.js";
+
+// Re-export the types that appear in our own option signatures. Strictly
+// not duplication of oav-core's surface — these ARE the adapter's
+// public contract, just borrowed for non-duplication reasons. Importing
+// them from this package means consumers don't have to know which
+// package owns them.
+export type { HttpRequest, ValidationError } from "@oav/core";
+export type { Validator } from "@oav/validator";


### PR DESCRIPTION
## Summary

11 issues, one PR. Originally the migration-doc trio (#168/#169/#170) plus the per-scheme auth dispatch recipe (#185); grew to absorb a friction batch (#186–#192) surfaced by a real eov→oav migration audit.

All doc / doc-adjacent. One small code change: type re-exports from oav-express4 (#186).

### Migration trio + auth recipe

- **#168** — Multipart recipe lists \`@types/multer\` alongside \`multer\` so migrators don't chase phantom red squiggles after eov leaves.
- **#169** — Empty-body normalisation note in the body-parser caveats. Some parsers (streaming, custom multipart) leave \`req.body === undefined\` for empty payloads; required-field checks short-circuit and empty submissions silently pass. Includes the adapter-flavoured \`toHttpRequest\` override.
- **#170** — Response-validation recipes lead with log-only as the recommended default; explicit footgun callout for the eov \`allErrors → 500\` instinct (rewrites legitimate 4xx as 500s when the error envelope doesn't pass strict \`ErrorResponse\` checks); worked example for the gradual-rollout pattern.
- **#185** — Per-scheme auth dispatch recipe in INTEGRATION.md security section + an Express-flavoured version in the oav-express4 README. Walks the OpenAPI semantics (AND within a requirement, OR across requirements). Note at the end: harvest into a \`dispatchSecurity\` helper export only if multiple projects copy the recipe.

### Friction-batch follow-ons (from migration audit)

- **#186** — Re-export \`HttpRequest\` / \`ValidationError\` / \`Validator\` from oav-express4. Thin doesn't preclude re-exporting the types that are part of the adapter's own option signatures.
- **#187** — INTEGRATION.md: document the no-CT / no-body → 400 behaviour as an explicit eov divergence (oav's choice is the more conservative one).
- **#188** — INTEGRATION.md: document the \`oneOf\` + binary bypass interaction. The \"accept anything\" rewrite means every binary branch matches, so \`oneOf [array<binary>, binary]\` silently fails with \`matchCount: 2\`.
- **#189** — CLAUDE.md: one-line note about \`pnpm pack\` vs \`npm pack\` for workspace consumers.
- **#190** — Clarify that any middleware populating \`req.body\` satisfies oav (\`express.json()\` isn't required).
- **#191** — packages/core/README: which-helper-when guides (formatters table, response-builders lead). Plus mutation-semantics clarification on \`httpRequestFromExpress\` (returns a fresh HttpRequest; top-level fields safe to reassign).
- **#192** — oav-express4 README: explicit note that validation failures don't traverse Express's error chain by default, plus an observability recipe (warn + render) alongside the existing forward-to-error-middleware pattern. The default short-circuit stays — the doc gap was discoverability for migrators expecting eov's \`next(HttpError)\` semantics.

## Test plan

Doc-only change with one minor code addition (type re-exports).

- [x] \`pnpm test\` — 716 pass
- [x] \`pnpm lint\` clean
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm --filter @aahoughton/oav-express4 build\` clean; type re-exports inlined into the .d.ts as expected.

Closes #168
Closes #169
Closes #170
Closes #185
Closes #186
Closes #187
Closes #188
Closes #189
Closes #190
Closes #191
Closes #192