### PR TITLE
docs: address #198 #199 #200 — multer global pattern, YAML constraint, pointer + envelope shapes

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -534,6 +534,50 @@ rewritten to an "accept anything" schema before compile, so a Buffer
 or Uint8Array passes without a string-type error. `format: "byte"`
 (base64) still validates as a string.
 
+#### Global validator + per-route multer
+
+The recipe above is per-route inline — multer and the validator both
+live inside the route handler. That works for single-upload-route
+apps. For an app with many routes and one (or a few) upload
+endpoints, a more idiomatic shape is **multer mounted at the route
+prefix, validator mounted globally**, with `toHttpRequest`
+synthesizing the spec-shaped body from `req.files`:
+
+```ts
+import multer from "multer";
+import { httpRequestFromExpress, validateRequests } from "@aahoughton/oav-express4";
+
+const upload = multer({ storage: multer.memoryStorage() });
+
+// Mount multer at the route prefix that needs it, before the global validator.
+app.use("/uploads", upload.any());
+
+// Global validator with toHttpRequest synthesizing body from req.files.
+app.use(
+  validateRequests(validator, {
+    toHttpRequest: (req) => {
+      const httpReq = httpRequestFromExpress(req);
+      const files = req.files as Express.Multer.File[] | undefined;
+      if (files && files.length > 0) {
+        // Match the spec's binary-field shape — array if many, single buffer if one.
+        // Adjust to your spec's actual field shape (named-files object, single-file
+        // property, etc.).
+        httpReq.body = files.length === 1 ? files[0]?.buffer : files.map((f) => f.buffer);
+      }
+      return httpReq;
+    },
+  }),
+);
+```
+
+The `toHttpRequest` extension point is a general seam for **any
+"reshape what oav sees"** use case — synthesizing a body from
+`req.files`, normalizing an empty body to `{}`, merging headers
+from an upstream proxy, anything that wants to live above the
+extraction layer without bypassing it. The empty-body normalization
+recipe earlier in this doc and this multer-body-synthesis recipe
+are two examples of the same pattern.
+
 **Watch out for `oneOf` / `anyOf` with binary fields.** The "accept
 anything" rewrite means every binary branch matches every input. A
 common spec pattern for "one file or many" —

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -120,9 +120,40 @@ migrating from).
   (first failing leaf). Pass `detail` explicitly for a structural
   summary like `` `${pd.issues.length} validation errors` `` or any
   other override.
-- `collectIssues(err)` — just the flat leaf list (with
-  `path` segments + RFC 6901 `pointer` strings), if you're rolling
-  your own response shape.
+- `collectIssues(err)` — just the flat leaf list, if you're rolling
+  your own response shape. Each issue carries both a raw `path`
+  (`PathSegment[]`) and a `pointer` — the same path **pre-formatted
+  as an [RFC 6901](https://www.rfc-editor.org/rfc/rfc6901) JSON
+  Pointer** string (e.g. `/body/users/3/email`). Use `pointer`
+  directly for response envelopes; `path` is the segments array if
+  you need programmatic access. Don't re-join `path` yourself —
+  `pointer` already handles RFC 6901's `~` / `/` escaping.
+
+### Common envelope shapes
+
+```ts
+// RFC 9457 (default) — one call.
+res
+  .status(httpStatusFor(err))
+  .type("application/problem+json")
+  .json(toProblemDetails(err, { instance: req.originalUrl }));
+
+// Custom envelope, eov-style flat list.
+res.status(httpStatusFor(err)).json({
+  message: summarize(err),
+  errors: collectIssues(err).map((i) => ({
+    path: i.pointer,
+    message: i.message,
+    errorCode: i.code,
+  })),
+});
+
+// Just the top-level summary (e.g. for a comma-joined "every leaf"
+// message that some pre-existing wire formats use):
+const joined = collectIssues(err)
+  .map((i) => i.message)
+  .join(", ");
+```
 
 See the [Framework integration](../../README.md#framework-integration)
 section of the root README for Express / Fastify / Next.js snippets.

--- a/packages/oav-express4/README.md
+++ b/packages/oav-express4/README.md
@@ -18,6 +18,8 @@ npm install @aahoughton/oav @aahoughton/oav-express4 express
 
 `express` is a peer dep — your app's existing install satisfies it.
 
+> **YAML specs.** `@aahoughton/oav-core` is JSON-only by design (zero runtime deps). If your spec is YAML, either install [`@aahoughton/oav`](https://www.npmjs.com/package/@aahoughton/oav) instead — it bundles the YAML readers and the CLI — or install `yaml` separately and parse the spec yourself before passing the parsed object to `createValidator`.
+
 ## Quick start
 
 ```ts
@@ -235,6 +237,35 @@ The middleware awaits the returned promise; rejections route to `next(err)`.
 ### Per-route mounting
 
 `validateRequests(...)` is route-aware (it derives the operation from method+path). Mount it once at the app level — per-route mounting is redundant and may cause double-validation under nested routers.
+
+### Global validator + per-route multer (file uploads)
+
+When the validator is mounted globally and one or a few routes accept file uploads via multer, mount multer at the route prefix that needs it (upstream of the global validator) and use `toHttpRequest` to synthesize the spec-shaped body from `req.files`:
+
+```ts
+import multer from "multer";
+import { httpRequestFromExpress, validateRequests } from "@aahoughton/oav-express4";
+
+const upload = multer({ storage: multer.memoryStorage() });
+app.use("/uploads", upload.any());
+
+app.use(
+  validateRequests(validator, {
+    toHttpRequest: (req) => {
+      const httpReq = httpRequestFromExpress(req);
+      const files = req.files as Express.Multer.File[] | undefined;
+      if (files && files.length > 0) {
+        httpReq.body = files.length === 1 ? files[0]?.buffer : files.map((f) => f.buffer);
+      }
+      return httpReq;
+    },
+  }),
+);
+```
+
+`toHttpRequest` is the general "reshape what oav sees" seam — synthesizing body from files, normalizing empty bodies, merging headers from an upstream proxy, anything that lives above the extraction layer. The empty-body normalization recipe higher in this README and this multer recipe are two examples of the same pattern.
+
+For per-route inline multer (validator called from inside the route handler) and the full multer recipe with text-field reassembly, see the [INTEGRATION.md file uploads section](https://github.com/aahoughton/oav/blob/main/INTEGRATION.md#file-uploads-with-multer).
 
 ## See also
 


### PR DESCRIPTION
## Summary

Three small docs from the second eov→oav migration audit. Bundled as one PR; same shape (small README / INTEGRATION additions).

### #198 — Global validator + per-route multer recipe

The existing per-route inline multer pattern works for single-upload-route apps. The global pattern (multer mounted at the route prefix, validator global, body synthesized via \`toHttpRequest\`) is more idiomatic for apps with many routes and one upload endpoint. Adds the recipe to INTEGRATION.md's file-uploads section and to the oav-express4 README's common-patterns section. Frames \`toHttpRequest\` as a general \"reshape what oav sees\" seam — the same pattern the empty-body normalisation recipe uses.

### #199 — JSON-only YAML clarification

Clarifies in the oav-express4 README install section that \`oav-core\` is JSON-only by design and gives the two ways to handle YAML specs (install \`oav\` for batteries-included, or install \`yaml\` yourself and parse before passing to \`createValidator\`). Doesn't prescribe a specific YAML-loading pattern — just calls out the constraint and the two options.

### #200 — pointer clarification + common envelope shapes

Two clarifications in \`packages/core/README.md\`:
- Spell out that \`ValidationIssue.pointer\` is the path pre-formatted as RFC 6901 — use it directly rather than re-joining \`path\`.
- Add a \"common envelope shapes\" worked-example block showing problem-details (RFC 9457), the eov-style flat list with \`collectIssues\`, and the comma-joined \"every leaf\" message recipe.

## Test plan

Doc-only.

- [x] \`pnpm test\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm typecheck\` clean

Closes #198
Closes #199
Closes #200