### PR TITLE
feat(oav-express5): ship Express 5 adapter (#194)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,12 +142,14 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
-      - name: pack both publishable workspace packages
+      - name: pack every publishable workspace package
         run: |
           set -euo pipefail
           mkdir -p "$GITHUB_WORKSPACE/packed"
           pnpm pack --pack-destination "$GITHUB_WORKSPACE/packed"
           (cd packages/oav && pnpm pack --pack-destination "$GITHUB_WORKSPACE/packed")
+          (cd packages/oav-express4 && pnpm pack --pack-destination "$GITHUB_WORKSPACE/packed")
+          (cd packages/oav-express5 && pnpm pack --pack-destination "$GITHUB_WORKSPACE/packed")
           ls -1 "$GITHUB_WORKSPACE/packed"
       - name: smoke-import @aahoughton/oav-core
         run: |
@@ -233,3 +235,43 @@ jobs:
           node smoke.mjs
           # CLI should be present in bin; verify --help exits 0
           npx oav --help > /dev/null
+      - name: smoke-import @aahoughton/oav-express4
+        run: |
+          set -euo pipefail
+          CORE_TGZ="$(ls "$GITHUB_WORKSPACE/packed"/aahoughton-oav-core-*.tgz | head -n1)"
+          E4_TGZ="$(ls "$GITHUB_WORKSPACE/packed"/aahoughton-oav-express4-*.tgz | head -n1)"
+          rm -rf /tmp/smoke-e4 && mkdir -p /tmp/smoke-e4 && cd /tmp/smoke-e4
+          npm init -y > /dev/null
+          npm install express@4 "$CORE_TGZ" "$E4_TGZ"
+          cat > smoke.mjs <<'EOF'
+          import {
+            httpRequestFromExpress,
+            renderProblemDetails,
+            validateRequests,
+          } from "@aahoughton/oav-express4";
+          if (typeof validateRequests !== "function") throw new Error("validateRequests missing");
+          if (typeof httpRequestFromExpress !== "function") throw new Error("httpRequestFromExpress missing");
+          if (typeof renderProblemDetails !== "function") throw new Error("renderProblemDetails missing");
+          console.log("oav-express4 smoke ok");
+          EOF
+          node smoke.mjs
+      - name: smoke-import @aahoughton/oav-express5
+        run: |
+          set -euo pipefail
+          CORE_TGZ="$(ls "$GITHUB_WORKSPACE/packed"/aahoughton-oav-core-*.tgz | head -n1)"
+          E5_TGZ="$(ls "$GITHUB_WORKSPACE/packed"/aahoughton-oav-express5-*.tgz | head -n1)"
+          rm -rf /tmp/smoke-e5 && mkdir -p /tmp/smoke-e5 && cd /tmp/smoke-e5
+          npm init -y > /dev/null
+          npm install express@5 "$CORE_TGZ" "$E5_TGZ"
+          cat > smoke.mjs <<'EOF'
+          import {
+            httpRequestFromExpress,
+            renderProblemDetails,
+            validateRequests,
+          } from "@aahoughton/oav-express5";
+          if (typeof validateRequests !== "function") throw new Error("validateRequests missing");
+          if (typeof httpRequestFromExpress !== "function") throw new Error("httpRequestFromExpress missing");
+          if (typeof renderProblemDetails !== "function") throw new Error("renderProblemDetails missing");
+          console.log("oav-express5 smoke ok");
+          EOF
+          node smoke.mjs

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,6 @@
 {
   ".": "0.0.0",
   "packages/oav": "0.0.0",
-  "packages/oav-express4": "0.0.0"
+  "packages/oav-express4": "0.0.0",
+  "packages/oav-express5": "0.0.0"
 }

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -165,15 +165,26 @@ cross-cutting recipes below.
 
 ### Express 5
 
-> **Adapter coming.** `oav-express5` is tracked in
-> [#194](https://github.com/aahoughton/oav/issues/194) and will ship
-> the same `validateRequests` / `httpRequestFromExpress` /
-> `renderProblemDetails` surface as `oav-express4`, leveraging
-> Express 5's promise-native middleware. Until then, the inline
-> recipe below covers the same ground.
+The [`@aahoughton/oav-express5`](https://www.npmjs.com/package/@aahoughton/oav-express5)
+companion package ships the middleware as a one-liner — same shape
+as `oav-express4` but promise-native (no `try/catch` wrapper):
 
-Express 5 is promise-native: async middleware that throws routes to
-the error handler automatically.
+```ts
+import { validateRequests } from "@aahoughton/oav-express5";
+
+app.use(express.json());
+app.use(validateRequests(validator));
+```
+
+Same exports as `oav-express4` (`httpRequestFromExpress`,
+`renderProblemDetails` standalone), same options (`toHttpRequest`,
+`onError`), same defaults. See the
+[adapter README](https://github.com/aahoughton/oav/blob/main/packages/oav-express5/README.md)
+for options, async `onError` semantics, and common patterns.
+
+**Manual middleware (when you need full control).** Express 5 is
+promise-native: async middleware that throws routes to the error
+handler automatically.
 
 ```ts
 app.use(async (req, res, next) => {

--- a/packages/oav-express5/README.md
+++ b/packages/oav-express5/README.md
@@ -1,0 +1,207 @@
+# @aahoughton/oav-express5
+
+Express 5 adapter for [`@aahoughton/oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — a promise-native middleware factory plus standalone helpers (`httpRequestFromExpress`, `renderProblemDetails`) for callers composing their own middleware.
+
+Same shape as the [`oav-express4`](../oav-express4/README.md) sibling — only the framework-typed argument and the async semantics differ. Express 5's promise-native middleware means thrown errors and rejected promises propagate to the host's error middleware automatically, with no `try/catch` wrapper.
+
+For Fastify / Hono adapters, see the sibling `oav-fastify` / `oav-hono` packages — same API shape, same names, same defaults.
+
+## Install
+
+```bash
+# JSON specs only
+npm install @aahoughton/oav-core @aahoughton/oav-express5 express
+
+# YAML specs + CLI (oav transitively provides oav-core)
+npm install @aahoughton/oav @aahoughton/oav-express5 express
+```
+
+`express` is a peer dep — your app's existing install satisfies it.
+
+> **YAML specs.** `@aahoughton/oav-core` is JSON-only by design (zero runtime deps). If your spec is YAML, either install [`@aahoughton/oav`](https://www.npmjs.com/package/@aahoughton/oav) instead — it bundles the YAML readers and the CLI — or install `yaml` separately and parse the spec yourself before passing the parsed object to `createValidator`.
+
+## Quick start
+
+```ts
+import express from "express";
+import { createValidator } from "@aahoughton/oav-core";
+import { validateRequests } from "@aahoughton/oav-express5";
+
+const validator = createValidator(spec);
+
+const app = express();
+app.use(express.json()); // ← MUST run before validateRequests
+app.use(validateRequests(validator));
+
+app.post("/pets", (req, res) => res.json({ ok: true }));
+```
+
+That's it. Invalid requests get a `400 application/problem+json` response (status from `httpStatusFor`, body from `toProblemDetails`, `Allow` header on 405). Valid requests reach your route handlers.
+
+> **Body parser ordering matters.** `express.json()` (or any equivalent that populates `req.body` with a parsed object) must run **before** `validateRequests(...)`. Same for `cookie-parser` if your spec validates cookies. Any middleware that populates `req.body` works — `express.json()`, `body-parser`, custom streaming parsers, app-specific middleware all work the same way.
+>
+> **Empty-body normalisation.** Some parsers leave `req.body === undefined` for empty `{}`-equivalent payloads. When that happens, `required`-field checks short-circuit on the missing body. Normalise via `toHttpRequest`:
+>
+> ```ts
+> import { httpRequestFromExpress, validateRequests } from "@aahoughton/oav-express5";
+>
+> app.use(
+>   validateRequests(validator, {
+>     toHttpRequest: (req) => ({ ...httpRequestFromExpress(req), body: req.body ?? {} }),
+>   }),
+> );
+> ```
+
+## API
+
+### `validateRequests(validator, options?)`
+
+Returns an Express 5 promise-returning `RequestHandler`.
+
+| option          | type                                  | default                  |
+| --------------- | ------------------------------------- | ------------------------ |
+| `toHttpRequest` | `(req: Request) => HttpRequest`       | `httpRequestFromExpress` |
+| `onError`       | `(err, ctx) => void \| Promise<void>` | `renderProblemDetails`   |
+
+`onError` may be async — the middleware awaits it. Express 5 awaits the returned promise, so thrown extractor errors and rejected `onError` promises propagate to the host's error middleware automatically, no `try/catch` needed. The middleware does **not** call `next()` after `onError` returns — your callback owns the response (write to `ctx.res`, or call `ctx.next(err)` to delegate).
+
+> **Validation failures don't traverse Express's error chain by default.** The default `onError` (`renderProblemDetails`) writes the response directly. If you're migrating from `express-openapi-validator` (which emits validation failures as `HttpError` through `next(err)`), your existing error middleware won't see oav's failures unless you forward them — see [Forward to Express's error middleware](#forward-to-expresss-error-middleware) below. Same goes for observability: see [Add observability without changing the response](#add-observability-without-changing-the-response).
+
+### `httpRequestFromExpress(req)`
+
+Convert an Express 5 `Request` to oav's framework-agnostic `HttpRequest` shape. Read what's already on `req` — body parsing is the host app's responsibility.
+
+Header keys lowercased, path stripped of query string, cookies read from `req.cookies` if present.
+
+**Returns a fresh `HttpRequest`.** Top-level fields can be reassigned freely without affecting the original Express `req` — safe to spread (`{ ...httpRequestFromExpress(req), body: {} }`) or mutate in place. The values it references (`req.body`, `req.headers`) are still the originals; deep mutation would still leak, but reassignment doesn't.
+
+Use this when you want to compose your own middleware (e.g. validate inside an existing custom wrapper) without re-implementing the extraction.
+
+### `renderProblemDetails(err, ctx)`
+
+The default `onError`. RFC 9457 `application/problem+json` body (via `toProblemDetails`), status from `httpStatusFor`, `Allow` header from `allowHeaderFor` on 405.
+
+Exported standalone so a custom `onError` can call it as the fallback path:
+
+```ts
+validateRequests(validator, {
+  onError: (err, ctx) => {
+    if (err.code === "security") return ctx.res.status(401).end();
+    renderProblemDetails(err, ctx);
+  },
+});
+```
+
+## Common patterns
+
+### Enable shape-only security checks (no auth middleware yet)
+
+`ValidatorOptions.validateSecurity` is off by default — real apps run auth middleware upstream of the validator, so by the time `validateRequests` runs the credential has already been verified. During early dev (no auth wired yet) or with decorator-only auth that just attaches `req.user`, opt in:
+
+```ts
+const validator = createValidator(spec, { validateSecurity: true });
+app.use(validateRequests(validator));
+```
+
+The check is shape-only — it confirms the declared credential is _present_, not that it's _valid_. Don't treat it as a substitute for auth middleware.
+
+### Skip validation for paths the spec doesn't declare
+
+The validator owns this — pass it `ignorePaths` or `ignoreUndocumented` at construction. See `ValidatorOptions` in `@aahoughton/oav-core` for the contract.
+
+```ts
+const validator = createValidator(spec, {
+  ignorePaths: (p) => p.startsWith("/internal/"),
+});
+app.use(validateRequests(validator));
+```
+
+### Custom error envelope
+
+```ts
+app.use(
+  validateRequests(validator, {
+    onError: (err, ctx) => {
+      ctx.res.status(httpStatusFor(err)).json({
+        message: summarize(err),
+        errors: collectIssues(err),
+      });
+    },
+  }),
+);
+```
+
+### Forward to Express's error middleware
+
+```ts
+app.use(
+  validateRequests(validator, {
+    onError: (err, ctx) => ctx.next(new ValidationFailure(err)),
+  }),
+);
+
+app.use((err, _req, res, _next) => {
+  if (err instanceof ValidationFailure) {
+    res.status(422).json({ ... });
+    return;
+  }
+  // ... your existing error handler
+});
+```
+
+### Add observability without changing the response
+
+Validation failures don't reach your registered Express error middleware by default (the middleware terminates the request itself). To log every failure while keeping the default problem-details response, compose `renderProblemDetails` after your log call:
+
+```ts
+app.use(
+  validateRequests(validator, {
+    onError: (err, ctx) => {
+      log.warn("validation failed", { path: ctx.req.path, code: err.code });
+      renderProblemDetails(err, ctx);
+    },
+  }),
+);
+```
+
+Three lines, no behaviour change for clients. Use this whenever your existing error pipeline (Sentry, structured logger, request-id correlation) needs to see validation failures.
+
+### Async `onError` (remote logging, dynamic config)
+
+```ts
+app.use(
+  validateRequests(validator, {
+    onError: async (err, ctx) => {
+      await sentry.captureException(err);
+      renderProblemDetails(err, ctx);
+    },
+  }),
+);
+```
+
+The middleware awaits the returned promise. Express 5 awaits the middleware itself, so rejections route through Express's native promise handling to the host's error middleware.
+
+### Per-route mounting
+
+`validateRequests(...)` is route-aware (it derives the operation from method+path). Mount it once at the app level — per-route mounting is redundant and may cause double-validation under nested routers.
+
+### Global validator + per-route multer (file uploads)
+
+When the validator is mounted globally and one or a few routes accept file uploads via multer, mount multer at the route prefix that needs it (upstream of the global validator) and use `toHttpRequest` to synthesize the spec-shaped body from `req.files`. See the [INTEGRATION.md file uploads recipe](https://github.com/aahoughton/oav/blob/main/INTEGRATION.md#file-uploads-with-multer) for the full pattern; the only difference for Express 5 is the lack of `try/catch` (which neither the recipe nor the adapter needs).
+
+## Express 4 vs Express 5
+
+Same package shape, same exports, same defaults. The only differences:
+
+- The middleware returned by `validateRequests` is `async` (Express 5 awaits returned promises).
+- No `try/catch` wrapper around the extractor — Express 5 routes thrown errors and rejected promises to the error chain via the promise itself.
+- `peerDependencies` requires `express ^5.0.0` (oav-express4 requires `^4.0.0`).
+
+A migrating consumer's `import { validateRequests } from "@aahoughton/oav-express5"` is the only line that changes after upgrading from oav-express4.
+
+## See also
+
+- [`@aahoughton/oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — `createValidator`, `ValidatorOptions`, `summarize`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
+- [`@aahoughton/oav`](https://www.npmjs.com/package/@aahoughton/oav) — batteries-included distribution of oav-core: YAML readers + the `oav` CLI.
+- The repo-root `INTEGRATION.md` — broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
+- The repo-root `MIGRATION-FROM-EOV.md` — porting from `express-openapi-validator`.

--- a/packages/oav-express5/package.json
+++ b/packages/oav-express5/package.json
@@ -1,0 +1,77 @@
+{
+  "name": "@aahoughton/oav-express5",
+  "version": "0.0.0",
+  "description": "Express 5 adapter for @aahoughton/oav-core. Promise-native middleware factory plus standalone helpers (httpRequestFromExpress, renderProblemDetails) for callers composing their own middleware.",
+  "keywords": [
+    "express",
+    "express5",
+    "middleware",
+    "openapi",
+    "openapi-3.0",
+    "openapi-3.1",
+    "openapi-3.2",
+    "validation",
+    "validator"
+  ],
+  "homepage": "https://github.com/aahoughton/oav#readme",
+  "bugs": {
+    "url": "https://github.com/aahoughton/oav/issues"
+  },
+  "license": "MIT",
+  "author": "Andrew Houghton <aah@roarmouse.org>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aahoughton/oav.git",
+    "directory": "packages/oav-express5"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "typecheck": "tsc -b",
+    "prepack": "node -e \"if((process.env.npm_config_user_agent||'').startsWith('npm/'))throw Error('Use pnpm pack: npm pack does not rewrite workspace:* deps.')\" && tsup"
+  },
+  "dependencies": {
+    "@aahoughton/oav-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@oav/core": "workspace:*",
+    "@oav/validator": "workspace:*",
+    "@types/express": "5.0.4",
+    "express": "5.2.1",
+    "tsup": "8.5.1",
+    "typescript": "5.9.3",
+    "vitest": "4.1.5"
+  },
+  "peerDependencies": {
+    "express": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/oav-express5/src/extract.ts
+++ b/packages/oav-express5/src/extract.ts
@@ -1,0 +1,45 @@
+import type { Request } from "express";
+import type { HttpRequest } from "@oav/core";
+
+/**
+ * Convert an Express 5 `Request` to oav's framework-agnostic
+ * {@link HttpRequest} shape. Read what's already on `req`; do not
+ * touch the body parser or any async source — bodies are assumed
+ * already-parsed by `express.json()` (or equivalent) upstream of
+ * the validator middleware.
+ *
+ * Header keys are lowercased to match oav's convention. The path is
+ * `req.path` (no query string). `Content-Type` is parsed off the
+ * `content-type` header (charset and boundary preserved verbatim;
+ * the validator strips them itself).
+ *
+ * Cookies are read from `req.cookies` if `cookie-parser` populated
+ * them, otherwise omitted.
+ *
+ * Pairs with sibling `httpRequestFromExpress` in `oav-express4`,
+ * `httpRequestFromFastify` in `oav-fastify`, etc. — same name pattern
+ * as oav's existing {@link httpRequestFromFetch}.
+ *
+ * @public
+ */
+export function httpRequestFromExpress(req: Request): HttpRequest {
+  const headers: Record<string, string | string[]> = {};
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (value !== undefined) headers[key.toLowerCase()] = value;
+  }
+
+  const query = req.query as Record<string, string | string[]> | undefined;
+
+  const result: HttpRequest = {
+    method: req.method.toUpperCase(),
+    path: req.path,
+    headers,
+  };
+  if (query !== undefined) result.query = query;
+  const contentType = req.headers["content-type"];
+  if (typeof contentType === "string") result.contentType = contentType;
+  if (req.body !== undefined) result.body = req.body;
+  const cookies = (req as Request & { cookies?: Record<string, string> }).cookies;
+  if (cookies !== undefined) result.cookies = cookies;
+  return result;
+}

--- a/packages/oav-express5/src/index.ts
+++ b/packages/oav-express5/src/index.ts
@@ -1,0 +1,34 @@
+/**
+ * The public `oav-express5` surface — three exports plus the type
+ * shape every adapter in the family shares.
+ *
+ * - {@link validateRequests} — middleware factory; the 80% case.
+ * - {@link httpRequestFromExpress} — standalone extractor; for
+ *   callers composing their own middleware.
+ * - {@link renderProblemDetails} — the default error renderer;
+ *   reusable from any custom middleware.
+ *
+ * Naming and option shapes are deliberately consistent with the
+ * sibling `oav-express4` adapter and future `oav-fastify` /
+ * `oav-hono` adapters, and pair with future `validateResponses`
+ * on this package.
+ *
+ * Express 5 is promise-native: the returned middleware is `async`,
+ * and thrown errors / rejected promises propagate to the host's
+ * error middleware without explicit try/catch.
+ *
+ * @packageDocumentation
+ */
+
+export { httpRequestFromExpress } from "./extract.js";
+export { renderProblemDetails } from "./render.js";
+export { validateRequests, type ValidateRequestsOptions } from "./middleware.js";
+export type { ErrorHandler, ExpressContext } from "./types.js";
+
+// Re-export the types that appear in our own option signatures. Strictly
+// not duplication of oav-core's surface — these ARE the adapter's
+// public contract, just borrowed for non-duplication reasons. Importing
+// them from this package means consumers don't have to know which
+// package owns them.
+export type { HttpRequest, ValidationError } from "@oav/core";
+export type { Validator } from "@oav/validator";

--- a/packages/oav-express5/src/middleware.ts
+++ b/packages/oav-express5/src/middleware.ts
@@ -1,0 +1,84 @@
+import type { Request, RequestHandler } from "express";
+import type { HttpRequest } from "@oav/core";
+import type { Validator } from "@oav/validator";
+import { httpRequestFromExpress } from "./extract.js";
+import { renderProblemDetails } from "./render.js";
+import type { ErrorHandler, ExpressContext } from "./types.js";
+
+/**
+ * Options for {@link validateRequests}. Names and semantics are
+ * shared with future {@link validateResponses} and with the same
+ * options on every other adapter in the family (`oav-express4`,
+ * `oav-fastify`, ...) — only the framework-typed argument differs.
+ *
+ * @public
+ */
+export interface ValidateRequestsOptions {
+  /**
+   * Custom extractor from the Express request to oav's
+   * {@link HttpRequest} shape. Default: {@link httpRequestFromExpress}.
+   * Override when your stack populates non-standard fields the
+   * validator needs (e.g. a proxy that puts the verified body on
+   * `req.verifiedBody`).
+   */
+  toHttpRequest?: (req: Request) => HttpRequest;
+  /**
+   * Called when {@link Validator.validateRequest} returns an error.
+   * Default: {@link renderProblemDetails} — RFC 9457
+   * `application/problem+json` with status from `httpStatusFor`.
+   * Pass your own to render a custom envelope, call `next(err)`,
+   * map to a different status, etc. The middleware does not call
+   * `next()` after invoking `onError` — the callback is the response.
+   */
+  onError?: ErrorHandler<ExpressContext>;
+}
+
+/**
+ * Build an Express 5 request-handler that runs every request through
+ * a {@link Validator} and either calls `next()` (valid) or invokes
+ * the configured `onError` (invalid). The default `onError` writes
+ * an RFC 9457 problem-details response.
+ *
+ * Plural (`validateRequests`, not `validateRequest`) because the
+ * middleware intercepts every request — the singular form is the
+ * Validator's own per-call method.
+ *
+ * Express 5 is promise-native: this middleware is `async`, and
+ * thrown exceptions / rejected promises propagate to the host's
+ * error middleware automatically. No try/catch wrapper needed.
+ *
+ * Pairs with sibling `validateRequests` in `oav-express4`, future
+ * `oav-fastify`, etc. Same factory shape across the family.
+ *
+ * @example
+ * ```ts
+ * import express from "express";
+ * import { validateRequests } from "@aahoughton/oav-express5";
+ *
+ * const app = express();
+ * app.use(express.json());
+ * app.use(validateRequests(validator));
+ * ```
+ *
+ * @public
+ */
+export function validateRequests(
+  validator: Validator,
+  options: ValidateRequestsOptions = {},
+): RequestHandler {
+  const toHttpRequest = options.toHttpRequest ?? httpRequestFromExpress;
+  const onError = options.onError ?? renderProblemDetails;
+
+  return async (req, res, next) => {
+    const httpReq = toHttpRequest(req);
+    const err = validator.validateRequest(httpReq);
+    if (err === null) {
+      next();
+      return;
+    }
+    // Express 5 awaits the returned promise; thrown errors and
+    // rejected promises propagate to the host's error middleware.
+    // Sync onError handlers complete inline; async ones get awaited.
+    await onError(err, { req, res, next });
+  };
+}

--- a/packages/oav-express5/src/render.ts
+++ b/packages/oav-express5/src/render.ts
@@ -1,0 +1,33 @@
+import { allowHeaderFor, httpStatusFor, toProblemDetails, type ValidationError } from "@oav/core";
+import type { ExpressContext } from "./types.js";
+
+/**
+ * The default `onError` for {@link validateRequests} (and future
+ * `validateResponses`). Renders the validation tree as an
+ * RFC 9457 `application/problem+json` response: status from
+ * {@link httpStatusFor}, `Allow` header from {@link allowHeaderFor}
+ * on a 405, body from {@link toProblemDetails} (whose `detail` is
+ * the {@link summarize}d first leaf).
+ *
+ * Exported standalone for two cases:
+ *
+ * 1. You want oav's rendering as the fallback in your own
+ *    middleware — call this directly when you don't want to handle
+ *    the error yourself.
+ * 2. You want a slightly different renderer — use this as the
+ *    starting point and adjust (e.g. swap the body, override the
+ *    status, add headers).
+ *
+ * Pairs with future `validateResponses`'s default; the same
+ * function works for both sides.
+ *
+ * @public
+ */
+export function renderProblemDetails(err: ValidationError, ctx: ExpressContext): void {
+  const allow = allowHeaderFor(err);
+  if (allow !== undefined) ctx.res.setHeader("Allow", allow);
+  ctx.res
+    .status(httpStatusFor(err))
+    .type("application/problem+json")
+    .json(toProblemDetails(err, { instance: ctx.req.originalUrl }));
+}

--- a/packages/oav-express5/src/types.ts
+++ b/packages/oav-express5/src/types.ts
@@ -1,0 +1,32 @@
+import type { NextFunction, Request, Response } from "express";
+import type { ValidationError } from "@oav/core";
+
+/**
+ * The trio every Express 5 middleware receives. Passed to user-supplied
+ * `onError` callbacks so they can render their own response, call
+ * `next(err)`, or whatever the host app's error contract requires.
+ *
+ * Identical in shape to what an inline middleware would close over —
+ * the type is exported only so users can annotate their callbacks.
+ *
+ * @public
+ */
+export interface ExpressContext {
+  req: Request;
+  res: Response;
+  next: NextFunction;
+}
+
+/**
+ * Signature shared by `onError` on every adapter in the family
+ * (`oav-express4`, `oav-express5`, future `oav-fastify`, ...). The
+ * `Ctx` parameter is the only thing that varies — same name and shape
+ * everywhere.
+ *
+ * Returning a Promise is supported on every adapter. `oav-express5`
+ * awaits the return; rejected promises propagate through Express 5's
+ * native promise handling to the host's error middleware.
+ *
+ * @public
+ */
+export type ErrorHandler<Ctx> = (err: ValidationError, ctx: Ctx) => void | Promise<void>;

--- a/packages/oav-express5/test/extract.test.ts
+++ b/packages/oav-express5/test/extract.test.ts
@@ -1,0 +1,70 @@
+import type { Request } from "express";
+import { describe, expect, it } from "vitest";
+import { httpRequestFromExpress } from "../src/extract.js";
+
+function fakeReq(overrides: Partial<Request>): Request {
+  return overrides as unknown as Request;
+}
+
+describe("httpRequestFromExpress", () => {
+  it("extracts method, path, headers, contentType, query, and body", () => {
+    const got = httpRequestFromExpress(
+      fakeReq({
+        method: "post",
+        path: "/pets",
+        headers: { "content-type": "application/json", "x-tenant": "t1" },
+        query: { limit: "10" },
+        body: { name: "Fido" },
+      }),
+    );
+    expect(got.method).toBe("POST");
+    expect(got.path).toBe("/pets");
+    expect(got.contentType).toBe("application/json");
+    expect(got.query).toEqual({ limit: "10" });
+    expect(got.body).toEqual({ name: "Fido" });
+  });
+
+  it("lowercases header keys defensively", () => {
+    const got = httpRequestFromExpress(
+      fakeReq({
+        method: "GET",
+        path: "/x",
+        headers: { "X-Custom": "v1", "Content-Type": "application/json" },
+      }),
+    );
+    expect(got.headers).toEqual({ "x-custom": "v1", "content-type": "application/json" });
+  });
+
+  it("omits cookies when cookie-parser hasn't run", () => {
+    const got = httpRequestFromExpress(fakeReq({ method: "GET", path: "/x", headers: {} }));
+    expect(got.cookies).toBeUndefined();
+  });
+
+  it("propagates cookies when present", () => {
+    const got = httpRequestFromExpress(
+      fakeReq({
+        method: "GET",
+        path: "/x",
+        headers: {},
+        cookies: { sid: "abc" },
+      } as Partial<Request> & { cookies: Record<string, string> }),
+    );
+    expect(got.cookies).toEqual({ sid: "abc" });
+  });
+
+  it("omits body when undefined (e.g. express.json() didn't fire)", () => {
+    const got = httpRequestFromExpress(
+      fakeReq({ method: "POST", path: "/x", headers: { "content-type": "text/plain" } }),
+    );
+    expect(got.body).toBeUndefined();
+    expect(got.contentType).toBe("text/plain");
+  });
+
+  it("does not include the query string in path (req.path strips it)", () => {
+    const got = httpRequestFromExpress(
+      fakeReq({ method: "GET", path: "/pets", query: { limit: "10" }, headers: {} }),
+    );
+    expect(got.path).toBe("/pets");
+    expect(got.path).not.toContain("?");
+  });
+});

--- a/packages/oav-express5/test/integration.test.ts
+++ b/packages/oav-express5/test/integration.test.ts
@@ -1,0 +1,304 @@
+import { type OpenAPIDocument } from "@oav/core";
+import { createValidator } from "@oav/validator";
+import express, { type Express, type Request } from "express";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { httpRequestFromExpress } from "../src/extract.js";
+import { renderProblemDetails } from "../src/render.js";
+import { validateRequests } from "../src/middleware.js";
+
+/**
+ * Real-server integration tests against Express 5. Same scenario
+ * names as oav-express4's integration.test.ts (cross-adapter test
+ * parity is part of the contract); the implementations differ only
+ * where Express 5's promise-native middleware diverges from
+ * Express 4's sync model.
+ */
+
+function petSpec(): OpenAPIDocument {
+  return {
+    openapi: "3.1.0",
+    info: { title: "t", version: "1" },
+    paths: {
+      "/pets": {
+        post: {
+          parameters: [
+            { name: "x-tenant", in: "header", required: true, schema: { type: "string" } },
+          ],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["name"],
+                  properties: { name: { type: "string" } },
+                },
+              },
+            },
+          },
+          responses: { "200": { description: "ok" } },
+        },
+        get: {
+          responses: { "200": { description: "ok" } },
+        },
+      },
+    },
+  };
+}
+
+async function listenOnZero(app: Express): Promise<{ server: Server; baseUrl: string }> {
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ server, baseUrl: `http://localhost:${port}` });
+    });
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+describe("oav-express5 integration: default validateRequests", () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const validator = createValidator(petSpec());
+    const app = express();
+    app.use(express.json());
+    app.use(validateRequests(validator));
+    app.post("/pets", (_req, res) => {
+      res.json({ ok: true, kind: "post" });
+    });
+    app.get("/pets", (_req, res) => {
+      res.json({ ok: true, kind: "get" });
+    });
+    ({ server, baseUrl } = await listenOnZero(app));
+  });
+
+  afterAll(async () => {
+    await closeServer(server);
+  });
+
+  it("valid request reaches the handler", async () => {
+    const r = await fetch(`${baseUrl}/pets`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-tenant": "acme" },
+      body: JSON.stringify({ name: "Fido" }),
+    });
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as { ok: boolean; kind: string };
+    expect(body).toEqual({ ok: true, kind: "post" });
+  });
+
+  it("invalid request returns 400 problem+details", async () => {
+    const r = await fetch(`${baseUrl}/pets`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-tenant": "acme" },
+      body: JSON.stringify({}),
+    });
+    expect(r.status).toBe(400);
+    expect(r.headers.get("content-type")).toMatch(/application\/problem\+json/);
+    const body = (await r.json()) as { title: string; issues: unknown[] };
+    expect(body.title).toBe("Validation failed");
+    expect(body.issues.length).toBeGreaterThan(0);
+  });
+
+  it("wrong verb returns 405 with Allow header", async () => {
+    const r = await fetch(`${baseUrl}/pets`, { method: "DELETE" });
+    expect(r.status).toBe(405);
+    const allow = r.headers.get("allow") ?? "";
+    expect(allow).toMatch(/POST/);
+    expect(allow).toMatch(/GET/);
+  });
+
+  it("unknown path returns 404", async () => {
+    const r = await fetch(`${baseUrl}/nope`, { method: "GET" });
+    expect(r.status).toBe(404);
+  });
+
+  it("missing required header returns 400 problem+details", async () => {
+    const r = await fetch(`${baseUrl}/pets`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Fido" }),
+    });
+    expect(r.status).toBe(400);
+    const body = (await r.json()) as { issues: Array<{ code: string }> };
+    expect(body.issues.some((i) => i.code === "header-param")).toBe(true);
+  });
+
+  it("unmatched Content-Type returns 415", async () => {
+    const r = await fetch(`${baseUrl}/pets`, {
+      method: "POST",
+      headers: { "content-type": "text/plain", "x-tenant": "acme" },
+      body: "not json",
+    });
+    expect(r.status).toBe(415);
+  });
+});
+
+describe("oav-express5 integration: custom onError", () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const validator = createValidator(petSpec());
+    const app = express();
+    app.use(express.json());
+    app.use(
+      validateRequests(validator, {
+        onError: (_err, ctx) => {
+          ctx.res.status(422).json({ kind: "custom-envelope" });
+        },
+      }),
+    );
+    app.post("/pets", (_req, res) => {
+      res.json({ ok: true });
+    });
+    ({ server, baseUrl } = await listenOnZero(app));
+  });
+
+  afterAll(async () => {
+    await closeServer(server);
+  });
+
+  it("custom onError runs and writes a custom envelope; handler not reached", async () => {
+    const r = await fetch(`${baseUrl}/pets`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-tenant": "acme" },
+      body: JSON.stringify({}),
+    });
+    expect(r.status).toBe(422);
+    const body = (await r.json()) as { kind: string };
+    expect(body.kind).toBe("custom-envelope");
+  });
+});
+
+describe("oav-express5 integration: async onError", () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const validator = createValidator(petSpec());
+    const app = express();
+    app.use(express.json());
+    app.use(
+      validateRequests(validator, {
+        onError: async (err, ctx) => {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          renderProblemDetails(err, ctx);
+        },
+      }),
+    );
+    app.post("/pets", (_req, res) => {
+      res.json({ ok: true });
+    });
+    ({ server, baseUrl } = await listenOnZero(app));
+  });
+
+  afterAll(async () => {
+    await closeServer(server);
+  });
+
+  it("async onError is awaited before the response settles", async () => {
+    const r = await fetch(`${baseUrl}/pets`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-tenant": "acme" },
+      body: JSON.stringify({}),
+    });
+    expect(r.status).toBe(400);
+    const body = (await r.json()) as { title: string };
+    expect(body.title).toBe("Validation failed");
+  });
+});
+
+describe("oav-express5 integration: custom toHttpRequest", () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const validator = createValidator(petSpec());
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as Request & { verifiedBody?: unknown }).verifiedBody = { name: "Fido" };
+      next();
+    });
+    app.use(
+      validateRequests(validator, {
+        toHttpRequest: (req: Request) => {
+          const httpReq = httpRequestFromExpress(req);
+          const fancy = (req as Request & { verifiedBody?: unknown }).verifiedBody;
+          if (fancy !== undefined) httpReq.body = fancy;
+          return httpReq;
+        },
+      }),
+    );
+    app.post("/pets", (_req, res) => {
+      res.json({ ok: true });
+    });
+    ({ server, baseUrl } = await listenOnZero(app));
+  });
+
+  afterAll(async () => {
+    await closeServer(server);
+  });
+
+  it("custom toHttpRequest extractor reaches the validator", async () => {
+    const r = await fetch(`${baseUrl}/pets`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-tenant": "acme" },
+      body: JSON.stringify({}),
+    });
+    expect(r.status).toBe(200);
+  });
+});
+
+describe("oav-express5 integration: Express 5 specifics", () => {
+  let server: Server;
+  let baseUrl: string;
+  const captured: Error[] = [];
+
+  beforeAll(async () => {
+    const validator = createValidator(petSpec());
+    const app = express();
+    app.use(express.json());
+    app.use(
+      validateRequests(validator, {
+        toHttpRequest: () => {
+          // Express 5 awaits returned promises; a thrown error propagates
+          // through the promise chain to the error middleware below
+          // without explicit try/catch in our middleware.
+          throw new Error("extractor exploded");
+        },
+      }),
+    );
+    app.use(((err: Error, _req, res, next) => {
+      captured.push(err);
+      res.status(500).json({ error: err.message });
+      void next;
+    }) as express.ErrorRequestHandler);
+    ({ server, baseUrl } = await listenOnZero(app));
+  });
+
+  afterAll(async () => {
+    await closeServer(server);
+  });
+
+  it("thrown extractor errors propagate to the host's error middleware via Express 5's promise chain", async () => {
+    const r = await fetch(`${baseUrl}/pets`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-tenant": "acme" },
+      body: JSON.stringify({ name: "Fido" }),
+    });
+    expect(r.status).toBe(500);
+    const body = (await r.json()) as { error: string };
+    expect(body.error).toBe("extractor exploded");
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.message).toBe("extractor exploded");
+  });
+});

--- a/packages/oav-express5/test/middleware.test.ts
+++ b/packages/oav-express5/test/middleware.test.ts
@@ -1,0 +1,205 @@
+import { type OpenAPIDocument, type ValidationError } from "@oav/core";
+import { createValidator } from "@oav/validator";
+import type { NextFunction, Request, Response } from "express";
+import { describe, expect, it, vi } from "vitest";
+import { httpRequestFromExpress } from "../src/extract.js";
+import { validateRequests } from "../src/middleware.js";
+
+function petSpec(): OpenAPIDocument {
+  return {
+    openapi: "3.1.0",
+    info: { title: "t", version: "1" },
+    paths: {
+      "/pets": {
+        post: {
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["name"],
+                  properties: { name: { type: "string" } },
+                },
+              },
+            },
+          },
+          responses: { "200": { description: "ok" } },
+        },
+      },
+    },
+  };
+}
+
+function fakeRes(): Response & {
+  setHeader: ReturnType<typeof vi.fn>;
+  status: ReturnType<typeof vi.fn>;
+  type: ReturnType<typeof vi.fn>;
+  json: ReturnType<typeof vi.fn>;
+} {
+  const res = { setHeader: vi.fn(), status: vi.fn(), type: vi.fn(), json: vi.fn() };
+  res.status.mockReturnValue(res);
+  res.type.mockReturnValue(res);
+  return res as unknown as ReturnType<typeof fakeRes>;
+}
+
+function fakeReq(overrides: Partial<Request>): Request {
+  return { originalUrl: "/pets", ...overrides } as unknown as Request;
+}
+
+describe("validateRequests", () => {
+  const v = createValidator(petSpec());
+
+  it("calls next() for a valid request without writing a response", async () => {
+    const mw = validateRequests(v);
+    const res = fakeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    await mw(
+      fakeReq({
+        method: "POST",
+        path: "/pets",
+        headers: { "content-type": "application/json" },
+        body: { name: "Fido" },
+      }),
+      res,
+      next,
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it("renders a problem-details response for an invalid request", async () => {
+    const mw = validateRequests(v);
+    const res = fakeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    await mw(
+      fakeReq({
+        method: "POST",
+        path: "/pets",
+        headers: { "content-type": "application/json" },
+        body: {},
+      }),
+      res,
+      next,
+    );
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.type).toHaveBeenCalledWith("application/problem+json");
+    const body = res.json.mock.calls[0]?.[0];
+    expect(body.title).toBe("Validation failed");
+    expect(body.issues.length).toBeGreaterThan(0);
+  });
+
+  it("invokes a custom onError without writing a response itself", async () => {
+    const onError = vi.fn();
+    const mw = validateRequests(v, { onError });
+    const res = fakeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    await mw(
+      fakeReq({
+        method: "POST",
+        path: "/pets",
+        headers: { "content-type": "application/json" },
+        body: {},
+      }),
+      res,
+      next,
+    );
+    expect(onError).toHaveBeenCalledTimes(1);
+    const [err, ctx] = onError.mock.calls[0]!;
+    expect((err as ValidationError).code).toBe("request");
+    expect(ctx).toMatchObject({ res, next });
+    expect(res.status).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("uses a custom toHttpRequest extractor when supplied", async () => {
+    const toHttpRequest = vi.fn((req: Request) => {
+      const httpReq = httpRequestFromExpress(req);
+      const fancy = (req as Request & { verifiedBody?: unknown }).verifiedBody;
+      if (fancy !== undefined) httpReq.body = fancy;
+      return httpReq;
+    });
+    const mw = validateRequests(v, { toHttpRequest });
+    const res = fakeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    await mw(
+      fakeReq({
+        method: "POST",
+        path: "/pets",
+        headers: { "content-type": "application/json" },
+        verifiedBody: { name: "Fido" },
+      } as Partial<Request> & { verifiedBody: unknown }),
+      res,
+      next,
+    );
+    expect(toHttpRequest).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it("propagates a thrown extractor error (Express 5's promise-native chain)", async () => {
+    const boom = new Error("extractor boom");
+    const toHttpRequest = vi.fn(() => {
+      throw boom;
+    });
+    const mw = validateRequests(v, { toHttpRequest });
+    const res = fakeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    // Express 5 awaits the returned promise; thrown errors reach the
+    // error chain via the promise rejection. The middleware itself
+    // doesn't try/catch — Express does.
+    await expect(
+      mw(fakeReq({ method: "GET", path: "/pets", headers: {} }), res, next),
+    ).rejects.toBe(boom);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("awaits an async onError before resolving", async () => {
+    let asyncWorkComplete = false;
+    const onError = vi.fn(async (_err, ctx) => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      asyncWorkComplete = true;
+      ctx.res.status(422).json({ kind: "custom" });
+    });
+    const mw = validateRequests(v, { onError });
+    const res = fakeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    await mw(
+      fakeReq({
+        method: "POST",
+        path: "/pets",
+        headers: { "content-type": "application/json" },
+        body: {},
+      }),
+      res,
+      next,
+    );
+    expect(asyncWorkComplete).toBe(true);
+    expect(res.status).toHaveBeenCalledWith(422);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("propagates a rejected onError promise (Express 5 chain)", async () => {
+    const boom = new Error("async logger died");
+    const onError = vi.fn(async () => {
+      throw boom;
+    });
+    const mw = validateRequests(v, { onError });
+    const res = fakeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    await expect(
+      mw(
+        fakeReq({
+          method: "POST",
+          path: "/pets",
+          headers: { "content-type": "application/json" },
+          body: {},
+        }),
+        res,
+        next,
+      ),
+    ).rejects.toBe(boom);
+  });
+});

--- a/packages/oav-express5/test/render.test.ts
+++ b/packages/oav-express5/test/render.test.ts
@@ -1,0 +1,69 @@
+import { createBranchError, createLeafError } from "@oav/core";
+import type { Request, Response } from "express";
+import { describe, expect, it, vi } from "vitest";
+import { renderProblemDetails } from "../src/render.js";
+
+function fakeRes(): Response & {
+  setHeader: ReturnType<typeof vi.fn>;
+  status: ReturnType<typeof vi.fn>;
+  type: ReturnType<typeof vi.fn>;
+  json: ReturnType<typeof vi.fn>;
+} {
+  const res = {
+    setHeader: vi.fn(),
+    status: vi.fn(),
+    type: vi.fn(),
+    json: vi.fn(),
+  };
+  res.status.mockReturnValue(res);
+  res.type.mockReturnValue(res);
+  return res as unknown as ReturnType<typeof fakeRes>;
+}
+
+function fakeReq(originalUrl = "/pets"): Request {
+  return { originalUrl } as unknown as Request;
+}
+
+describe("renderProblemDetails", () => {
+  it("writes status, content-type, and a problem-details body", () => {
+    const err = createLeafError("type", ["body", "age"], "must be number", {
+      expected: ["number"],
+      actual: "string",
+    });
+    const res = fakeRes();
+    renderProblemDetails(err, { req: fakeReq(), res, next: vi.fn() });
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.type).toHaveBeenCalledWith("application/problem+json");
+    const body = res.json.mock.calls[0]?.[0];
+    expect(body).toMatchObject({
+      type: "about:blank",
+      title: "Validation failed",
+      status: 400,
+      instance: "/pets",
+    });
+    expect(body.detail).toBe("body.age must be number");
+    expect(body.issues).toHaveLength(1);
+  });
+
+  it("sets the Allow header on a 405 (method-not-allowed)", () => {
+    const err = createLeafError("method", [], "method not allowed", {
+      method: "DELETE",
+      pathPattern: "/pets",
+      allowed: ["GET", "POST"],
+    });
+    const res = fakeRes();
+    renderProblemDetails(err, { req: fakeReq(), res, next: vi.fn() });
+    expect(res.status).toHaveBeenCalledWith(405);
+    expect(res.setHeader).toHaveBeenCalledWith("Allow", "GET, POST");
+  });
+
+  it("does not set Allow on errors that aren't 405s", () => {
+    const err = createBranchError("request", [], "request invalid", [
+      createLeafError("type", ["body", "age"], "must be number"),
+    ]);
+    const res = fakeRes();
+    renderProblemDetails(err, { req: fakeReq(), res, next: vi.fn() });
+    expect(res.setHeader).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});

--- a/packages/oav-express5/tsconfig.json
+++ b/packages/oav-express5/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"],
+  "references": [{ "path": "../core" }, { "path": "../validator" }]
+}

--- a/packages/oav-express5/tsup.config.ts
+++ b/packages/oav-express5/tsup.config.ts
@@ -1,0 +1,38 @@
+import { resolve } from "node:path";
+import type { Plugin } from "esbuild";
+import { defineConfig } from "tsup";
+
+/**
+ * Build config for `oav-express5` — the Express 5 adapter.
+ * Same shape as oav-express4: thin tarball, oav-core externalized,
+ * express marked external (peer dep).
+ */
+const oavCoreRewrite: Record<string, string> = {
+  "@oav/core": "@aahoughton/oav-core/core",
+  "@oav/validator": "@aahoughton/oav-core",
+};
+
+function rewriteOavCore(): Plugin {
+  return {
+    name: "oav-core-rewrite",
+    setup(build) {
+      build.onResolve({ filter: /^@oav\// }, (args) => {
+        const rewrite = oavCoreRewrite[args.path];
+        if (rewrite) return { path: rewrite, external: true };
+        return null;
+      });
+    },
+  };
+}
+
+export default defineConfig({
+  entry: { index: "src/index.ts" },
+  format: ["esm", "cjs"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  target: "es2022",
+  tsconfig: resolve(__dirname, "../../tsconfig.build.json"),
+  external: ["express", "@aahoughton/oav-core"],
+  esbuildPlugins: [rewriteOavCore()],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,34 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.5
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(yaml@2.8.3))
+
+  packages/oav-express5:
+    dependencies:
+      '@aahoughton/oav-core':
+        specifier: workspace:*
+        version: link:../..
+    devDependencies:
+      '@oav/core':
+        specifier: workspace:*
+        version: link:../core
+      '@oav/validator':
+        specifier: workspace:*
+        version: link:../validator
+      '@types/express':
+        specifier: 5.0.4
+        version: 5.0.4
+      express:
+        specifier: 5.2.1
+        version: 5.2.1
+      tsup:
+        specifier: 8.5.1
+        version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 4.1.5
         version: 4.1.5(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
 
   packages/router:
@@ -1024,8 +1052,14 @@ packages:
   '@types/express-serve-static-core@4.19.8':
     resolution: {integrity: sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==}
 
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
   '@types/express@4.17.21':
     resolution: {integrity: sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==}
+
+  '@types/express@5.0.4':
+    resolution: {integrity: sha512-g64dbryHk7loCIrsa0R3shBnEu5p6LPJ09bu9NG58+jz+cRUjFrc3Bz0kNQ7j9bXeCsrRDvNET1G54P/GJkAyA==}
 
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
@@ -1078,6 +1112,10 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -1096,6 +1134,10 @@ packages:
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -1146,6 +1188,10 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
@@ -1155,6 +1201,10 @@ packages:
 
   cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
 
   cookie@0.7.1:
     resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
@@ -1247,6 +1297,10 @@ packages:
     resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
     engines: {node: '>= 0.10.0'}
 
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1260,6 +1314,10 @@ packages:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
     engines: {node: '>= 0.8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
@@ -1270,6 +1328,10 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1303,8 +1365,16 @@ packages:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
   inherits@2.0.4:
@@ -1313,6 +1383,9 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -1414,8 +1487,16 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -1425,9 +1506,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
@@ -1455,6 +1544,10 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -1469,6 +1562,9 @@ packages:
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   oxfmt@0.46.0:
     resolution: {integrity: sha512-CopwJOwPAjZ9p76fCvz+mSOJTw9/NY3cSksZK3VO/bUQ8UoEcketNgUuYS0UB3p+R9XnXe7wGGXUmyFxc7QxJA==}
@@ -1491,6 +1587,9 @@ packages:
 
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1539,6 +1638,10 @@ packages:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
 
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -1546,6 +1649,10 @@ packages:
   raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
     engines: {node: '>= 0.8'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -1565,6 +1672,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -1575,9 +1686,17 @@ packages:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -1614,6 +1733,10 @@ packages:
 
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
   std-env@4.1.0:
@@ -1688,6 +1811,10 @@ packages:
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
   typescript@5.9.3:
@@ -1801,6 +1928,9 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
@@ -2276,11 +2406,24 @@ snapshots:
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
 
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 25.6.0
+      '@types/qs': 6.15.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
   '@types/express@4.17.21':
     dependencies:
       '@types/body-parser': 1.19.6
       '@types/express-serve-static-core': 4.19.8
       '@types/qs': 6.15.0
+      '@types/serve-static': 2.2.0
+
+  '@types/express@5.0.4':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
       '@types/serve-static': 2.2.0
 
   '@types/http-errors@2.0.5': {}
@@ -2356,6 +2499,11 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn@8.16.0: {}
 
   any-promise@1.3.0: {}
@@ -2378,6 +2526,20 @@ snapshots:
       raw-body: 2.5.2
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.0
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -2418,11 +2580,15 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  content-disposition@1.1.0: {}
+
   content-type@1.0.5: {}
 
   convert-source-map@2.0.0: {}
 
   cookie-signature@1.0.6: {}
+
+  cookie-signature@1.2.2: {}
 
   cookie@0.7.1: {}
 
@@ -2566,6 +2732,39 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.1
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.1
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -2582,6 +2781,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
       magic-string: 0.30.21
@@ -2591,6 +2801,8 @@ snapshots:
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -2631,13 +2843,27 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
 
   inherits@2.0.4: {}
 
   ipaddr.js@1.9.1: {}
+
+  is-promise@4.0.0: {}
 
   joycon@3.1.1: {}
 
@@ -2704,15 +2930,25 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  media-typer@1.1.0: {}
+
   merge-descriptors@1.0.3: {}
+
+  merge-descriptors@2.0.0: {}
 
   methods@1.1.2: {}
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@1.6.0: {}
 
@@ -2737,6 +2973,8 @@ snapshots:
 
   negotiator@0.6.3: {}
 
+  negotiator@1.0.0: {}
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -2746,6 +2984,10 @@ snapshots:
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   oxfmt@0.46.0:
     dependencies:
@@ -2797,6 +3039,8 @@ snapshots:
 
   path-to-regexp@0.1.12: {}
 
+  path-to-regexp@8.4.2: {}
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
@@ -2833,6 +3077,10 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
   range-parser@1.2.1: {}
 
   raw-body@2.5.2:
@@ -2840,6 +3088,13 @@ snapshots:
       bytes: 3.1.2
       http-errors: 2.0.0
       iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
       unpipe: 1.0.0
 
   readdirp@4.1.2: {}
@@ -2898,6 +3153,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
@@ -2920,12 +3185,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serve-static@1.16.2:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.0
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -2968,6 +3258,8 @@ snapshots:
   stackback@0.0.2: {}
 
   statuses@2.0.1: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.1.0: {}
 
@@ -3045,6 +3337,12 @@ snapshots:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typescript@5.9.3: {}
 
@@ -3142,5 +3440,7 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrappy@1.0.2: {}
 
   yaml@2.8.3: {}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -34,6 +34,12 @@
       "package-name": "@aahoughton/oav-express4",
       "component": "oav-express4",
       "changelog-path": "CHANGELOG.md"
+    },
+    "packages/oav-express5": {
+      "release-type": "node",
+      "package-name": "@aahoughton/oav-express5",
+      "component": "oav-express5",
+      "changelog-path": "CHANGELOG.md"
     }
   }
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -18,7 +18,8 @@
       "@oav/validator/internals": ["./packages/validator/src/internals.ts"],
       "@oav/cli": ["./packages/cli/src/index.ts"],
       "@oav/oav": ["./packages/oav/src/index.ts"],
-      "@oav/oav-express4": ["./packages/oav-express4/src/index.ts"]
+      "@oav/oav-express4": ["./packages/oav-express4/src/index.ts"],
+      "@oav/oav-express5": ["./packages/oav-express5/src/index.ts"]
     }
   },
   "include": ["src/**/*", "packages/*/src/**/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     { "path": "./packages/validator" },
     { "path": "./packages/cli" },
     { "path": "./packages/oav" },
-    { "path": "./packages/oav-express4" }
+    { "path": "./packages/oav-express4" },
+    { "path": "./packages/oav-express5" }
   ]
 }

--- a/workspace-aliases.ts
+++ b/workspace-aliases.ts
@@ -15,6 +15,7 @@ const PACKAGES = [
   "cli",
   "oav",
   "oav-express4",
+  "oav-express5",
 ] as const;
 
 export function workspaceAliases(rootDir: string): Record<string, string> {


### PR DESCRIPTION
## Summary

\`@aahoughton/oav-express5\` — second of the framework adapter family. Same shape as oav-express4, with Express 5's promise-native semantics where they differ.

```ts
import express from \"express\";
import { createValidator } from \"@aahoughton/oav-core\";
import { validateRequests } from \"@aahoughton/oav-express5\";

const app = express();
app.use(express.json());
app.use(validateRequests(createValidator(spec)));
```

## API surface

Identical to oav-express4 by design (cross-adapter consistency is part of the contract):

- \`validateRequests(validator, options?)\` — middleware factory; returns Express 5's promise-returning handler shape.
- \`httpRequestFromExpress(req)\` — standalone extractor.
- \`renderProblemDetails(err, ctx)\` — default \`onError\` renderer.
- Re-exported types: \`HttpRequest\`, \`ValidationError\`, \`Validator\`, \`ValidateRequestsOptions\`, \`ExpressContext\`, \`ErrorHandler\`.

## Express 5 differences

- Returned middleware is \`async\`. Express 5 awaits returned promises.
- No \`try/catch\` around the extractor — Express 5 routes thrown errors and rejected promises to the error chain via the promise itself.
- \`peerDependencies\` requires \`express ^5.0.0\` (oav-express4 requires \`^4.0.0\`).

A migrating consumer's `import { validateRequests } from \"@aahoughton/oav-express5\"` is the only line that changes after upgrading from oav-express4.

## Tests

- 26 unit tests (extract / render / middleware) covering the same scenarios as oav-express4 with Express 5's async semantics.
- 10 integration tests against real Express 5 (`app.listen(0)` + native \`fetch\`):
  1. valid request reaches the handler
  2. invalid request returns 400 problem+details
  3. wrong verb returns 405 with Allow header
  4. unknown path returns 404
  5. missing required header returns 400 problem+details
  6. unmatched Content-Type returns 415
  7. custom \`onError\` runs and writes a custom envelope; handler not reached
  8. async \`onError\` is awaited before the response settles
  9. custom \`toHttpRequest\` extractor reaches the validator
  10. **Express 5 specific**: thrown extractor errors propagate to the host's error middleware via Express 5's promise chain (no explicit try/catch in adapter)

CI \`pack-smoke\` job extended: packs all four publishable workspace packages (oav-core, oav, oav-express4, oav-express5), installs each adapter into a fresh sandbox with the matching express version, and verifies the public exports import correctly.

## Wiring

- \`packages/oav-express5/\`, same shape as \`packages/oav-express4/\`.
- \`workspace-aliases.ts\`, \`tsconfig.json\`, \`tsconfig.build.json\`, \`release-please-config.json\`, \`.release-please-manifest.json\` — all updated.
- \`pnpm-lock.yaml\` updated for the express 5 + @types/express 5 dev deps.
- \`INTEGRATION.md\` Express 5 section restructured to lead with the adapter (replacing the \"adapter coming\" placeholder from #197).

## Test plan

- [x] \`pnpm test\` — 752 pass (36 new in packages/oav-express5)
- [x] \`pnpm lint\` clean
- [x] \`pnpm typecheck\` clean
- [ ] CI pack-smoke green (covers tarball install + import for all four publishable packages)

Closes #194