### PR TITLE
feat(oav-fastify): ship Fastify adapter (#195)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,7 @@ jobs:
           (cd packages/oav && pnpm pack --pack-destination "$GITHUB_WORKSPACE/packed")
           (cd packages/oav-express4 && pnpm pack --pack-destination "$GITHUB_WORKSPACE/packed")
           (cd packages/oav-express5 && pnpm pack --pack-destination "$GITHUB_WORKSPACE/packed")
+          (cd packages/oav-fastify && pnpm pack --pack-destination "$GITHUB_WORKSPACE/packed")
           ls -1 "$GITHUB_WORKSPACE/packed"
       - name: smoke-import @aahoughton/oav-core
         run: |
@@ -273,5 +274,25 @@ jobs:
           if (typeof httpRequestFromExpress !== "function") throw new Error("httpRequestFromExpress missing");
           if (typeof renderProblemDetails !== "function") throw new Error("renderProblemDetails missing");
           console.log("oav-express5 smoke ok");
+          EOF
+          node smoke.mjs
+      - name: smoke-import @aahoughton/oav-fastify
+        run: |
+          set -euo pipefail
+          CORE_TGZ="$(ls "$GITHUB_WORKSPACE/packed"/aahoughton-oav-core-*.tgz | head -n1)"
+          F_TGZ="$(ls "$GITHUB_WORKSPACE/packed"/aahoughton-oav-fastify-*.tgz | head -n1)"
+          rm -rf /tmp/smoke-fastify && mkdir -p /tmp/smoke-fastify && cd /tmp/smoke-fastify
+          npm init -y > /dev/null
+          npm install fastify@5 "$CORE_TGZ" "$F_TGZ"
+          cat > smoke.mjs <<'EOF'
+          import {
+            httpRequestFromFastify,
+            renderProblemDetails,
+            validateRequests,
+          } from "@aahoughton/oav-fastify";
+          if (typeof validateRequests !== "function") throw new Error("validateRequests missing");
+          if (typeof httpRequestFromFastify !== "function") throw new Error("httpRequestFromFastify missing");
+          if (typeof renderProblemDetails !== "function") throw new Error("renderProblemDetails missing");
+          console.log("oav-fastify smoke ok");
           EOF
           node smoke.mjs

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,5 +2,6 @@
   ".": "0.0.0",
   "packages/oav": "0.0.0",
   "packages/oav-express4": "0.0.0",
-  "packages/oav-express5": "0.0.0"
+  "packages/oav-express5": "0.0.0",
+  "packages/oav-fastify": "0.0.0"
 }

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -219,14 +219,27 @@ that affect this pattern.
 
 ### Fastify
 
-> **Adapter coming.** `oav-fastify` is tracked in
-> [#195](https://github.com/aahoughton/oav/issues/195) and will ship
-> a Fastify hook (`validateRequests`) plus the standalone helpers,
-> matching the cross-adapter shape. Until then, the inline recipe
-> below covers the same ground.
+The [`@aahoughton/oav-fastify`](https://www.npmjs.com/package/@aahoughton/oav-fastify)
+companion package ships the hook as a one-liner — same shape as the
+Express adapters but Fastify-native (a `preValidation` hook, not
+middleware):
 
-Register as a `preValidation` hook so it runs after Fastify's own
-body parsing but before the route handler.
+```ts
+import { validateRequests } from "@aahoughton/oav-fastify";
+
+app.addHook("preValidation", validateRequests(validator));
+```
+
+Same cross-adapter exports (`httpRequestFromFastify`,
+`renderProblemDetails` standalone), same options (`toHttpRequest`,
+`onError`), same defaults. See the
+[adapter README](https://github.com/aahoughton/oav/blob/main/packages/oav-fastify/README.md)
+for options, async `onError` semantics, common patterns, and the
+relationship to Fastify's own per-route schema validation.
+
+**Manual hook (when you need full control).** Register as a
+`preValidation` hook so it runs after Fastify's own body parsing
+but before the route handler.
 
 ```ts
 fastify.addHook("preValidation", async (request, reply) => {

--- a/packages/oav-fastify/README.md
+++ b/packages/oav-fastify/README.md
@@ -1,0 +1,197 @@
+# @aahoughton/oav-fastify
+
+Fastify adapter for [`@aahoughton/oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — a `preValidation` hook factory plus standalone helpers (`httpRequestFromFastify`, `renderProblemDetails`) for callers composing their own hooks.
+
+Same shape as the Express siblings ([`oav-express4`](../oav-express4/README.md), [`oav-express5`](../oav-express5/README.md)) — only the framework-typed argument and Fastify's hook-vs-middleware distinction differ. Fastify is async-native, so thrown errors and rejected promises propagate to Fastify's error handler automatically, with no `try/catch` wrapper.
+
+For Hono / Bun adapters, see future sibling packages — same API shape, same names, same defaults.
+
+## Install
+
+```bash
+# JSON specs only
+npm install @aahoughton/oav-core @aahoughton/oav-fastify fastify
+
+# YAML specs + CLI (oav transitively provides oav-core)
+npm install @aahoughton/oav @aahoughton/oav-fastify fastify
+```
+
+`fastify` is a peer dep — your app's existing install satisfies it.
+
+> **YAML specs.** `@aahoughton/oav-core` is JSON-only by design (zero runtime deps). If your spec is YAML, either install [`@aahoughton/oav`](https://www.npmjs.com/package/@aahoughton/oav) instead — it bundles the YAML readers and the CLI — or install `yaml` separately and parse the spec yourself before passing the parsed object to `createValidator`.
+
+## Quick start
+
+```ts
+import Fastify from "fastify";
+import { createValidator } from "@aahoughton/oav-core";
+import { validateRequests } from "@aahoughton/oav-fastify";
+
+const validator = createValidator(spec);
+
+const app = Fastify();
+app.addHook("preValidation", validateRequests(validator));
+
+app.post("/pets", async () => ({ ok: true }));
+```
+
+That's it. Invalid requests get a `400 application/problem+json` response (status from `httpStatusFor`, body from `toProblemDetails`, `Allow` header on 405). Valid requests reach your route handlers.
+
+## Mount point: `preValidation`
+
+Fastify runs hooks in a fixed order:
+
+1. `onRequest` — request parsing not yet done
+2. `preParsing` — about to parse the body
+3. `preValidation` — body parsed; **this is where oav runs**
+4. `validation` — Fastify's per-route schema validation
+5. `preHandler` — about to call the route handler
+6. `handler`
+
+Mount on `preValidation` so oav sees the parsed body. If you also have per-route Fastify schemas declared, Fastify's own validation runs in step 4 (after this hook). Both can coexist — if oav rejects, Fastify's own validation never runs; if oav passes, Fastify's runs as usual. Authoring the same constraints in both places isn't recommended, but mixing them (oav for spec-driven validation, Fastify schemas for app-internal types) works.
+
+## API
+
+### `validateRequests(validator, options?)`
+
+Returns a Fastify `preValidationHookHandler`.
+
+| option          | type                                       | default                  |
+| --------------- | ------------------------------------------ | ------------------------ |
+| `toHttpRequest` | `(request: FastifyRequest) => HttpRequest` | `httpRequestFromFastify` |
+| `onError`       | `(err, ctx) => void \| Promise<void>`      | `renderProblemDetails`   |
+
+`onError` may be async — the hook awaits it. Fastify awaits the returned promise, so thrown extractor errors and rejected `onError` promises propagate to Fastify's `setErrorHandler` automatically, no `try/catch` needed. The hook does **not** call `reply.send()` after `onError` returns — your callback owns the response (write to `ctx.reply`, or throw to delegate to Fastify's error handler).
+
+> **Validation failures don't traverse Fastify's `setErrorHandler` by default.** The default `onError` (`renderProblemDetails`) writes the response directly. If you want validation failures in your existing error pipeline, throw from `onError` (Fastify routes throws to `setErrorHandler`) or compose a logger before `renderProblemDetails` — see [Add observability without changing the response](#add-observability-without-changing-the-response).
+
+### `httpRequestFromFastify(request)`
+
+Convert a `FastifyRequest` to oav's framework-agnostic `HttpRequest` shape. Read what's already on the request — body parsing is Fastify's responsibility (handled by content-type parsers before `preValidation`).
+
+Header keys passed through (Fastify already lowercases per HTTP spec), path stripped of query string from `request.url`, query taken from `request.query` (Fastify parses it into an object), cookies read from `request.cookies` if `@fastify/cookie` populated them.
+
+**Returns a fresh `HttpRequest`.** Top-level fields can be reassigned freely without affecting the original `FastifyRequest` — safe to spread (`{ ...httpRequestFromFastify(req), body: {} }`) or mutate in place.
+
+Use this when you want to compose your own hook (e.g. validate inside a custom plugin) without re-implementing the extraction.
+
+### `renderProblemDetails(err, ctx)`
+
+The default `onError`. RFC 9457 `application/problem+json` body (via `toProblemDetails`), status from `httpStatusFor`, `Allow` header from `allowHeaderFor` on 405.
+
+Exported standalone so a custom `onError` can call it as the fallback path:
+
+```ts
+validateRequests(validator, {
+  onError: (err, ctx) => {
+    if (err.code === "security") return ctx.reply.code(401).send();
+    renderProblemDetails(err, ctx);
+  },
+});
+```
+
+## Common patterns
+
+### Enable shape-only security checks (no auth middleware yet)
+
+`ValidatorOptions.validateSecurity` is off by default — real apps run auth middleware (or hooks) upstream of the validator. During early dev (no auth wired yet) or with decorator-only auth that just attaches `request.user`, opt in:
+
+```ts
+const validator = createValidator(spec, { validateSecurity: true });
+app.addHook("preValidation", validateRequests(validator));
+```
+
+The check is shape-only — it confirms the declared credential is _present_, not that it's _valid_. Don't treat it as a substitute for auth middleware.
+
+### Custom error envelope
+
+```ts
+app.addHook(
+  "preValidation",
+  validateRequests(validator, {
+    onError: (err, ctx) => {
+      ctx.reply.code(httpStatusFor(err)).send({
+        message: summarize(err),
+        errors: collectIssues(err),
+      });
+    },
+  }),
+);
+```
+
+### Forward to Fastify's `setErrorHandler`
+
+Throw from `onError` — Fastify routes thrown errors to `setErrorHandler`:
+
+```ts
+app.addHook(
+  "preValidation",
+  validateRequests(validator, {
+    onError: (err) => {
+      throw new ValidationFailure(err);
+    },
+  }),
+);
+
+app.setErrorHandler((err, _request, reply) => {
+  if (err instanceof ValidationFailure) {
+    reply.code(422).send({ ... });
+    return;
+  }
+  // ... your existing error handler
+});
+```
+
+### Add observability without changing the response
+
+Validation failures don't reach your registered `setErrorHandler` by default (the hook terminates the request itself). To log every failure while keeping the default problem-details response, compose `renderProblemDetails` after your log call:
+
+```ts
+app.addHook(
+  "preValidation",
+  validateRequests(validator, {
+    onError: (err, ctx) => {
+      log.warn("validation failed", { url: ctx.request.url, code: err.code });
+      renderProblemDetails(err, ctx);
+    },
+  }),
+);
+```
+
+Three lines, no behaviour change for clients. Use this whenever your existing error pipeline (Sentry, structured logger, request-id correlation) needs to see validation failures.
+
+### Async `onError` (remote logging, dynamic config)
+
+```ts
+app.addHook(
+  "preValidation",
+  validateRequests(validator, {
+    onError: async (err, ctx) => {
+      await sentry.captureException(err);
+      renderProblemDetails(err, ctx);
+    },
+  }),
+);
+```
+
+The hook awaits the returned promise; rejections propagate to Fastify's `setErrorHandler`.
+
+### Coexisting with Fastify per-route schemas
+
+Fastify's idiomatic per-route-schema pattern is independent of oav. The two can coexist in the same app:
+
+- Use **oav-fastify** when the OpenAPI spec is the source of truth — for endpoints whose contract is published / contract-tested / shared with other languages or services.
+- Use **Fastify per-route schemas** for app-internal types where you'd rather author the schema inline.
+
+If both fire on the same route, oav's `preValidation` hook runs first; if it passes, Fastify's `validation` step runs next. Don't author the same constraints in both places.
+
+### Comparison with `fastify-openapi-glue`
+
+[`fastify-openapi-glue`](https://www.npmjs.com/package/fastify-openapi-glue) reads an OpenAPI spec at startup and **generates routes + handler stubs from it**. oav-fastify is a different shape: it validates against the spec but you own the route declarations. Use `fastify-openapi-glue` if you want spec-driven scaffolding; use oav-fastify if your routes already exist and you want OpenAPI as the validation source of truth.
+
+## See also
+
+- [`@aahoughton/oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — `createValidator`, `ValidatorOptions`, `summarize`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
+- [`@aahoughton/oav`](https://www.npmjs.com/package/@aahoughton/oav) — batteries-included distribution of oav-core: YAML readers + the `oav` CLI.
+- The repo-root `INTEGRATION.md` — broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
+- The repo-root `MIGRATION-FROM-EOV.md` — porting from `express-openapi-validator`.

--- a/packages/oav-fastify/package.json
+++ b/packages/oav-fastify/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "@aahoughton/oav-fastify",
+  "version": "0.0.0",
+  "description": "Fastify adapter for @aahoughton/oav-core. preValidation hook factory plus standalone helpers (httpRequestFromFastify, renderProblemDetails) for callers composing their own hooks.",
+  "keywords": [
+    "fastify",
+    "hook",
+    "openapi",
+    "openapi-3.0",
+    "openapi-3.1",
+    "openapi-3.2",
+    "validation",
+    "validator"
+  ],
+  "homepage": "https://github.com/aahoughton/oav#readme",
+  "bugs": {
+    "url": "https://github.com/aahoughton/oav/issues"
+  },
+  "license": "MIT",
+  "author": "Andrew Houghton <aah@roarmouse.org>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aahoughton/oav.git",
+    "directory": "packages/oav-fastify"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "typecheck": "tsc -b",
+    "prepack": "node -e \"if((process.env.npm_config_user_agent||'').startsWith('npm/'))throw Error('Use pnpm pack: npm pack does not rewrite workspace:* deps.')\" && tsup"
+  },
+  "dependencies": {
+    "@aahoughton/oav-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@oav/core": "workspace:*",
+    "@oav/validator": "workspace:*",
+    "fastify": "5.8.5",
+    "tsup": "8.5.1",
+    "typescript": "5.9.3",
+    "vitest": "4.1.5"
+  },
+  "peerDependencies": {
+    "fastify": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/oav-fastify/src/extract.ts
+++ b/packages/oav-fastify/src/extract.ts
@@ -1,0 +1,51 @@
+import type { FastifyRequest } from "fastify";
+import type { HttpRequest } from "@oav/core";
+
+/**
+ * Convert a Fastify `FastifyRequest` to oav's framework-agnostic
+ * {@link HttpRequest} shape. Read what's already on the request;
+ * do not touch the body parser or any async source — bodies are
+ * assumed already-parsed by Fastify's content-type parsers
+ * (which run before `preValidation`).
+ *
+ * Header keys are already lowercased by Fastify (per HTTP spec); we
+ * pass them through. The path is extracted from `request.url` (which
+ * includes the query string) — query string is dropped from the
+ * `path` field and routed to `query` separately.
+ *
+ * Cookies are read from `request.cookies` if `@fastify/cookie` has
+ * populated them, otherwise omitted.
+ *
+ * Pairs with sibling `httpRequestFromExpress` in `oav-express4` /
+ * `oav-express5`, future `httpRequestFromHono`, etc. — same name
+ * pattern as oav's existing {@link httpRequestFromFetch}.
+ *
+ * @public
+ */
+export function httpRequestFromFastify(request: FastifyRequest): HttpRequest {
+  // request.url is /path?query — extract pathname.
+  const url = new URL(request.url, "http://localhost");
+  const headers: Record<string, string | string[]> = {};
+  for (const [key, value] of Object.entries(request.headers)) {
+    if (value !== undefined) headers[key.toLowerCase()] = value;
+  }
+
+  const result: HttpRequest = {
+    method: request.method.toUpperCase(),
+    path: url.pathname,
+    headers,
+  };
+
+  // Fastify parses query into an object; surface it directly.
+  const query = request.query as Record<string, string | string[]> | undefined;
+  if (query !== undefined && Object.keys(query).length > 0) result.query = query;
+
+  const contentType = request.headers["content-type"];
+  if (typeof contentType === "string") result.contentType = contentType;
+  if (request.body !== undefined) result.body = request.body;
+
+  // @fastify/cookie populates request.cookies; absent otherwise.
+  const cookies = (request as FastifyRequest & { cookies?: Record<string, string> }).cookies;
+  if (cookies !== undefined) result.cookies = cookies;
+  return result;
+}

--- a/packages/oav-fastify/src/index.ts
+++ b/packages/oav-fastify/src/index.ts
@@ -1,0 +1,35 @@
+/**
+ * The public `oav-fastify` surface — three exports plus the type
+ * shape every adapter in the family shares.
+ *
+ * - {@link validateRequests} — preValidation hook factory; the
+ *   80% case.
+ * - {@link httpRequestFromFastify} — standalone extractor; for
+ *   callers composing their own hooks.
+ * - {@link renderProblemDetails} — the default error renderer;
+ *   reusable from any custom hook.
+ *
+ * Naming and option shapes are deliberately consistent with the
+ * sibling `oav-express4` / `oav-express5` adapters and future
+ * `oav-hono` adapter, and pair with future `validateResponses` on
+ * this package.
+ *
+ * Fastify is async-native: the returned hook is `async`, and
+ * thrown errors / rejected promises propagate to Fastify's error
+ * handler without explicit try/catch.
+ *
+ * @packageDocumentation
+ */
+
+export { httpRequestFromFastify } from "./extract.js";
+export { renderProblemDetails } from "./render.js";
+export { validateRequests, type ValidateRequestsOptions } from "./middleware.js";
+export type { ErrorHandler, FastifyContext } from "./types.js";
+
+// Re-export the types that appear in our own option signatures. Strictly
+// not duplication of oav-core's surface — these ARE the adapter's
+// public contract, just borrowed for non-duplication reasons. Importing
+// them from this package means consumers don't have to know which
+// package owns them.
+export type { HttpRequest, ValidationError } from "@oav/core";
+export type { Validator } from "@oav/validator";

--- a/packages/oav-fastify/src/middleware.ts
+++ b/packages/oav-fastify/src/middleware.ts
@@ -1,0 +1,87 @@
+import type { FastifyRequest, preValidationHookHandler } from "fastify";
+import type { HttpRequest } from "@oav/core";
+import type { Validator } from "@oav/validator";
+import { httpRequestFromFastify } from "./extract.js";
+import { renderProblemDetails } from "./render.js";
+import type { ErrorHandler, FastifyContext } from "./types.js";
+
+/**
+ * Options for {@link validateRequests}. Names and semantics are
+ * shared with future {@link validateResponses} and with the same
+ * options on every other adapter in the family (`oav-express4`,
+ * `oav-express5`, future `oav-hono`, ...) — only the
+ * framework-typed argument differs.
+ *
+ * @public
+ */
+export interface ValidateRequestsOptions {
+  /**
+   * Custom extractor from the Fastify request to oav's
+   * {@link HttpRequest} shape. Default: {@link httpRequestFromFastify}.
+   * Override when your stack populates non-standard fields the
+   * validator needs (e.g. a proxy that puts the verified body on
+   * `request.verifiedBody`).
+   */
+  toHttpRequest?: (request: FastifyRequest) => HttpRequest;
+  /**
+   * Called when {@link Validator.validateRequest} returns an error.
+   * Default: {@link renderProblemDetails} — RFC 9457
+   * `application/problem+json` with status from `httpStatusFor`.
+   * Pass your own to render a custom envelope, throw (handed to
+   * Fastify's error handler), map to a different status, etc. The
+   * hook does not call `reply.send()` after invoking `onError` —
+   * the callback is the response.
+   */
+  onError?: ErrorHandler<FastifyContext>;
+}
+
+/**
+ * Build a Fastify `preValidation` hook that runs every request
+ * through a {@link Validator} and either resolves (valid) or
+ * invokes the configured `onError` (invalid). The default
+ * `onError` writes an RFC 9457 problem-details response.
+ *
+ * Plural (`validateRequests`, not `validateRequest`) because the
+ * hook intercepts every request — the singular form is the
+ * Validator's own per-call method.
+ *
+ * Mount on `preValidation` so it runs after Fastify's content-type
+ * parsers (which populate `request.body`) but before route
+ * handlers and Fastify's own per-route schema validation (which
+ * runs in the `validation` step). Both can coexist — Fastify's own
+ * per-route schemas run after this hook; oav's failures are
+ * surfaced first.
+ *
+ * Pairs with sibling `validateRequests` in `oav-express4` /
+ * `oav-express5`. Same factory shape across the family; only the
+ * returned framework-native handler differs.
+ *
+ * @example
+ * ```ts
+ * import Fastify from "fastify";
+ * import { validateRequests } from "@aahoughton/oav-fastify";
+ *
+ * const app = Fastify();
+ * app.addHook("preValidation", validateRequests(validator));
+ * ```
+ *
+ * @public
+ */
+export function validateRequests(
+  validator: Validator,
+  options: ValidateRequestsOptions = {},
+): preValidationHookHandler {
+  const toHttpRequest = options.toHttpRequest ?? httpRequestFromFastify;
+  const onError = options.onError ?? renderProblemDetails;
+
+  return async (request, reply) => {
+    const httpReq = toHttpRequest(request);
+    const err = validator.validateRequest(httpReq);
+    if (err === null) return;
+    // Fastify awaits the returned promise; thrown errors / rejected
+    // promises propagate to Fastify's error handler. The hook
+    // returns once onError settles — Fastify treats a sent reply
+    // as "we handled it, skip the route handler."
+    await onError(err, { request, reply });
+  };
+}

--- a/packages/oav-fastify/src/render.ts
+++ b/packages/oav-fastify/src/render.ts
@@ -1,0 +1,33 @@
+import { allowHeaderFor, httpStatusFor, toProblemDetails, type ValidationError } from "@oav/core";
+import type { FastifyContext } from "./types.js";
+
+/**
+ * The default `onError` for {@link validateRequests} (and future
+ * `validateResponses`). Renders the validation tree as an
+ * RFC 9457 `application/problem+json` response: status from
+ * {@link httpStatusFor}, `Allow` header from {@link allowHeaderFor}
+ * on a 405, body from {@link toProblemDetails} (whose `detail` is
+ * the {@link summarize}d first leaf).
+ *
+ * Exported standalone for two cases:
+ *
+ * 1. You want oav's rendering as the fallback in your own hook —
+ *    call this directly when you don't want to handle the error
+ *    yourself.
+ * 2. You want a slightly different renderer — use this as the
+ *    starting point and adjust (e.g. swap the body, override the
+ *    status, add headers).
+ *
+ * Pairs with sibling `renderProblemDetails` in `oav-express4` /
+ * `oav-express5`. Same logic, framework-native API.
+ *
+ * @public
+ */
+export function renderProblemDetails(err: ValidationError, ctx: FastifyContext): void {
+  const allow = allowHeaderFor(err);
+  if (allow !== undefined) ctx.reply.header("Allow", allow);
+  ctx.reply
+    .code(httpStatusFor(err))
+    .type("application/problem+json")
+    .send(toProblemDetails(err, { instance: ctx.request.url }));
+}

--- a/packages/oav-fastify/src/types.ts
+++ b/packages/oav-fastify/src/types.ts
@@ -1,0 +1,36 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+import type { ValidationError } from "@oav/core";
+
+/**
+ * The pair every Fastify hook receives. Passed to user-supplied
+ * `onError` callbacks so they can render their own response or
+ * delegate to Fastify's error handler.
+ *
+ * Identical in shape to what an inline hook would close over —
+ * the type is exported only so users can annotate their callbacks.
+ *
+ * Pairs with `ExpressContext` from `oav-express4` / `oav-express5`.
+ * Per-framework Context types use framework-native field names
+ * (`request`/`reply` here vs `req`/`res`/`next` for Express); the
+ * shape pattern is always "trigger + responder".
+ *
+ * @public
+ */
+export interface FastifyContext {
+  request: FastifyRequest;
+  reply: FastifyReply;
+}
+
+/**
+ * Signature shared by `onError` on every adapter in the family
+ * (`oav-express4`, `oav-express5`, `oav-fastify`, future
+ * `oav-hono`, ...). The `Ctx` parameter is the only thing that
+ * varies — same name and shape everywhere.
+ *
+ * Returning a Promise is supported on every adapter. `oav-fastify`
+ * awaits the return; rejected promises propagate through Fastify's
+ * native promise handling to its error handler.
+ *
+ * @public
+ */
+export type ErrorHandler<Ctx> = (err: ValidationError, ctx: Ctx) => void | Promise<void>;

--- a/packages/oav-fastify/test/extract.test.ts
+++ b/packages/oav-fastify/test/extract.test.ts
@@ -1,0 +1,77 @@
+import type { FastifyRequest } from "fastify";
+import { describe, expect, it } from "vitest";
+import { httpRequestFromFastify } from "../src/extract.js";
+
+function fakeReq(overrides: Partial<FastifyRequest>): FastifyRequest {
+  return overrides as unknown as FastifyRequest;
+}
+
+describe("httpRequestFromFastify", () => {
+  it("extracts method, path, headers, contentType, query, and body", () => {
+    const got = httpRequestFromFastify(
+      fakeReq({
+        method: "post",
+        url: "/pets?limit=10",
+        headers: { "content-type": "application/json", "x-tenant": "t1" },
+        query: { limit: "10" },
+        body: { name: "Fido" },
+      }),
+    );
+    expect(got.method).toBe("POST");
+    expect(got.path).toBe("/pets");
+    expect(got.contentType).toBe("application/json");
+    expect(got.query).toEqual({ limit: "10" });
+    expect(got.body).toEqual({ name: "Fido" });
+  });
+
+  it("strips query string from path", () => {
+    const got = httpRequestFromFastify(
+      fakeReq({ method: "GET", url: "/pets?limit=10&kind=dog", headers: {} }),
+    );
+    expect(got.path).toBe("/pets");
+    expect(got.path).not.toContain("?");
+  });
+
+  it("lowercases header keys defensively", () => {
+    const got = httpRequestFromFastify(
+      fakeReq({
+        method: "GET",
+        url: "/x",
+        headers: { "X-Custom": "v1", "Content-Type": "application/json" },
+      }),
+    );
+    expect(got.headers).toEqual({ "x-custom": "v1", "content-type": "application/json" });
+  });
+
+  it("omits cookies when @fastify/cookie hasn't run", () => {
+    const got = httpRequestFromFastify(fakeReq({ method: "GET", url: "/x", headers: {} }));
+    expect(got.cookies).toBeUndefined();
+  });
+
+  it("propagates cookies when present", () => {
+    const got = httpRequestFromFastify(
+      fakeReq({
+        method: "GET",
+        url: "/x",
+        headers: {},
+        cookies: { sid: "abc" },
+      } as Partial<FastifyRequest> & { cookies: Record<string, string> }),
+    );
+    expect(got.cookies).toEqual({ sid: "abc" });
+  });
+
+  it("omits body when undefined (e.g. content-type parser didn't fire)", () => {
+    const got = httpRequestFromFastify(
+      fakeReq({ method: "POST", url: "/x", headers: { "content-type": "text/plain" } }),
+    );
+    expect(got.body).toBeUndefined();
+    expect(got.contentType).toBe("text/plain");
+  });
+
+  it("omits empty query objects", () => {
+    const got = httpRequestFromFastify(
+      fakeReq({ method: "GET", url: "/x", headers: {}, query: {} }),
+    );
+    expect(got.query).toBeUndefined();
+  });
+});

--- a/packages/oav-fastify/test/hook.test.ts
+++ b/packages/oav-fastify/test/hook.test.ts
@@ -1,0 +1,202 @@
+import { type OpenAPIDocument, type ValidationError } from "@oav/core";
+import { createValidator } from "@oav/validator";
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import { httpRequestFromFastify } from "../src/extract.js";
+import { validateRequests } from "../src/middleware.js";
+
+function petSpec(): OpenAPIDocument {
+  return {
+    openapi: "3.1.0",
+    info: { title: "t", version: "1" },
+    paths: {
+      "/pets": {
+        post: {
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["name"],
+                  properties: { name: { type: "string" } },
+                },
+              },
+            },
+          },
+          responses: { "200": { description: "ok" } },
+        },
+      },
+    },
+  };
+}
+
+function fakeReply(): FastifyReply & {
+  header: ReturnType<typeof vi.fn>;
+  code: ReturnType<typeof vi.fn>;
+  type: ReturnType<typeof vi.fn>;
+  send: ReturnType<typeof vi.fn>;
+} {
+  const reply = { header: vi.fn(), code: vi.fn(), type: vi.fn(), send: vi.fn() };
+  reply.code.mockReturnValue(reply);
+  reply.type.mockReturnValue(reply);
+  return reply as unknown as ReturnType<typeof fakeReply>;
+}
+
+function fakeRequest(overrides: Partial<FastifyRequest>): FastifyRequest {
+  return { url: "/pets", ...overrides } as unknown as FastifyRequest;
+}
+
+describe("validateRequests", () => {
+  const v = createValidator(petSpec());
+
+  it("resolves without sending for a valid request", async () => {
+    const hook = validateRequests(v);
+    const reply = fakeReply();
+    await hook.call(
+      undefined as never,
+      fakeRequest({
+        method: "POST",
+        url: "/pets",
+        headers: { "content-type": "application/json" },
+        body: { name: "Fido" },
+      }),
+      reply,
+      () => {},
+    );
+    expect(reply.code).not.toHaveBeenCalled();
+    expect(reply.send).not.toHaveBeenCalled();
+  });
+
+  it("renders a problem-details response for an invalid request", async () => {
+    const hook = validateRequests(v);
+    const reply = fakeReply();
+    await hook.call(
+      undefined as never,
+      fakeRequest({
+        method: "POST",
+        url: "/pets",
+        headers: { "content-type": "application/json" },
+        body: {},
+      }),
+      reply,
+      () => {},
+    );
+    expect(reply.code).toHaveBeenCalledWith(400);
+    expect(reply.type).toHaveBeenCalledWith("application/problem+json");
+    const body = reply.send.mock.calls[0]?.[0];
+    expect(body.title).toBe("Validation failed");
+    expect(body.issues.length).toBeGreaterThan(0);
+  });
+
+  it("invokes a custom onError without writing a response itself", async () => {
+    const onError = vi.fn();
+    const hook = validateRequests(v, { onError });
+    const reply = fakeReply();
+    await hook.call(
+      undefined as never,
+      fakeRequest({
+        method: "POST",
+        url: "/pets",
+        headers: { "content-type": "application/json" },
+        body: {},
+      }),
+      reply,
+      () => {},
+    );
+    expect(onError).toHaveBeenCalledTimes(1);
+    const [err, ctx] = onError.mock.calls[0]!;
+    expect((err as ValidationError).code).toBe("request");
+    expect(ctx).toMatchObject({ reply });
+    expect(reply.code).not.toHaveBeenCalled();
+    expect(reply.send).not.toHaveBeenCalled();
+  });
+
+  it("uses a custom toHttpRequest extractor when supplied", async () => {
+    const toHttpRequest = vi.fn((req: FastifyRequest) => {
+      const httpReq = httpRequestFromFastify(req);
+      const fancy = (req as FastifyRequest & { verifiedBody?: unknown }).verifiedBody;
+      if (fancy !== undefined) httpReq.body = fancy;
+      return httpReq;
+    });
+    const hook = validateRequests(v, { toHttpRequest });
+    const reply = fakeReply();
+    await hook.call(
+      undefined as never,
+      fakeRequest({
+        method: "POST",
+        url: "/pets",
+        headers: { "content-type": "application/json" },
+        verifiedBody: { name: "Fido" },
+      } as Partial<FastifyRequest> & { verifiedBody: unknown }),
+      reply,
+      () => {},
+    );
+    expect(toHttpRequest).toHaveBeenCalledTimes(1);
+    expect(reply.send).not.toHaveBeenCalled();
+  });
+
+  it("propagates a thrown extractor error (Fastify's promise chain catches it)", async () => {
+    const boom = new Error("extractor boom");
+    const toHttpRequest = vi.fn(() => {
+      throw boom;
+    });
+    const hook = validateRequests(v, { toHttpRequest });
+    const reply = fakeReply();
+    await expect(
+      hook.call(
+        undefined as never,
+        fakeRequest({ method: "GET", url: "/pets", headers: {} }),
+        reply,
+        () => {},
+      ),
+    ).rejects.toBe(boom);
+    expect(reply.code).not.toHaveBeenCalled();
+  });
+
+  it("awaits an async onError before resolving", async () => {
+    let asyncWorkComplete = false;
+    const onError = vi.fn(async (_err, ctx) => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      asyncWorkComplete = true;
+      ctx.reply.code(422).send({ kind: "custom" });
+    });
+    const hook = validateRequests(v, { onError });
+    const reply = fakeReply();
+    await hook.call(
+      undefined as never,
+      fakeRequest({
+        method: "POST",
+        url: "/pets",
+        headers: { "content-type": "application/json" },
+        body: {},
+      }),
+      reply,
+      () => {},
+    );
+    expect(asyncWorkComplete).toBe(true);
+    expect(reply.code).toHaveBeenCalledWith(422);
+  });
+
+  it("propagates a rejected onError promise (Fastify chain)", async () => {
+    const boom = new Error("async logger died");
+    const onError = vi.fn(async () => {
+      throw boom;
+    });
+    const hook = validateRequests(v, { onError });
+    const reply = fakeReply();
+    await expect(
+      hook.call(
+        undefined as never,
+        fakeRequest({
+          method: "POST",
+          url: "/pets",
+          headers: { "content-type": "application/json" },
+          body: {},
+        }),
+        reply,
+        () => {},
+      ),
+    ).rejects.toBe(boom);
+  });
+});

--- a/packages/oav-fastify/test/integration.test.ts
+++ b/packages/oav-fastify/test/integration.test.ts
@@ -1,0 +1,284 @@
+import { type OpenAPIDocument } from "@oav/core";
+import { createValidator } from "@oav/validator";
+import Fastify, { type FastifyInstance, type FastifyRequest } from "fastify";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { httpRequestFromFastify } from "../src/extract.js";
+import { renderProblemDetails } from "../src/render.js";
+import { validateRequests } from "../src/middleware.js";
+
+/**
+ * Real-server integration tests against Fastify. Uses
+ * `fastify.inject()` (Fastify-native synthetic-request API) instead
+ * of `app.listen(0)` + native fetch — `inject` is so idiomatic in
+ * Fastify-land that bending the cross-adapter native-fetch
+ * convention here earns its keep. Same `it()` names as the Express
+ * adapters' integration suites; the implementations differ only
+ * where Fastify diverges from Express.
+ */
+
+function petSpec(): OpenAPIDocument {
+  return {
+    openapi: "3.1.0",
+    info: { title: "t", version: "1" },
+    paths: {
+      "/pets": {
+        post: {
+          parameters: [
+            { name: "x-tenant", in: "header", required: true, schema: { type: "string" } },
+          ],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["name"],
+                  properties: { name: { type: "string" } },
+                },
+              },
+            },
+          },
+          responses: { "200": { description: "ok" } },
+        },
+        get: {
+          responses: { "200": { description: "ok" } },
+        },
+      },
+    },
+  };
+}
+
+describe("oav-fastify integration: default validateRequests", () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    const validator = createValidator(petSpec());
+    app = Fastify();
+    app.addHook("preValidation", validateRequests(validator));
+    app.post("/pets", async () => ({ ok: true, kind: "post" }));
+    app.get("/pets", async () => ({ ok: true, kind: "get" }));
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("valid request reaches the handler", async () => {
+    const r = await app.inject({
+      method: "POST",
+      url: "/pets",
+      headers: { "content-type": "application/json", "x-tenant": "acme" },
+      payload: JSON.stringify({ name: "Fido" }),
+    });
+    expect(r.statusCode).toBe(200);
+    expect(r.json()).toEqual({ ok: true, kind: "post" });
+  });
+
+  it("invalid request returns 400 problem+details", async () => {
+    const r = await app.inject({
+      method: "POST",
+      url: "/pets",
+      headers: { "content-type": "application/json", "x-tenant": "acme" },
+      payload: JSON.stringify({}),
+    });
+    expect(r.statusCode).toBe(400);
+    expect(r.headers["content-type"]).toMatch(/application\/problem\+json/);
+    const body = r.json() as { title: string; issues: unknown[] };
+    expect(body.title).toBe("Validation failed");
+    expect(body.issues.length).toBeGreaterThan(0);
+  });
+
+  it("wrong verb returns 405 with Allow header", async () => {
+    const r = await app.inject({ method: "DELETE", url: "/pets" });
+    expect(r.statusCode).toBe(405);
+    const allow = (r.headers.allow as string | undefined) ?? "";
+    expect(allow).toMatch(/POST/);
+    expect(allow).toMatch(/GET/);
+  });
+
+  it("unknown path returns 404", async () => {
+    const r = await app.inject({ method: "GET", url: "/nope" });
+    expect(r.statusCode).toBe(404);
+  });
+
+  it("missing required header returns 400 problem+details", async () => {
+    const r = await app.inject({
+      method: "POST",
+      url: "/pets",
+      headers: { "content-type": "application/json" },
+      payload: JSON.stringify({ name: "Fido" }),
+    });
+    expect(r.statusCode).toBe(400);
+    const body = r.json() as { issues: Array<{ code: string }> };
+    expect(body.issues.some((i) => i.code === "header-param")).toBe(true);
+  });
+
+  it("unmatched Content-Type returns 415", async () => {
+    const r = await app.inject({
+      method: "POST",
+      url: "/pets",
+      headers: { "content-type": "text/plain", "x-tenant": "acme" },
+      payload: "not json",
+    });
+    expect(r.statusCode).toBe(415);
+  });
+});
+
+describe("oav-fastify integration: custom onError", () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    const validator = createValidator(petSpec());
+    app = Fastify();
+    app.addHook(
+      "preValidation",
+      validateRequests(validator, {
+        onError: (_err, ctx) => {
+          ctx.reply.code(422).send({ kind: "custom-envelope" });
+        },
+      }),
+    );
+    app.post("/pets", async () => ({ ok: true }));
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("custom onError runs and writes a custom envelope; handler not reached", async () => {
+    const r = await app.inject({
+      method: "POST",
+      url: "/pets",
+      headers: { "content-type": "application/json", "x-tenant": "acme" },
+      payload: JSON.stringify({}),
+    });
+    expect(r.statusCode).toBe(422);
+    expect(r.json()).toEqual({ kind: "custom-envelope" });
+  });
+});
+
+describe("oav-fastify integration: async onError", () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    const validator = createValidator(petSpec());
+    app = Fastify();
+    app.addHook(
+      "preValidation",
+      validateRequests(validator, {
+        onError: async (err, ctx) => {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          renderProblemDetails(err, ctx);
+        },
+      }),
+    );
+    app.post("/pets", async () => ({ ok: true }));
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("async onError is awaited before the response settles", async () => {
+    const r = await app.inject({
+      method: "POST",
+      url: "/pets",
+      headers: { "content-type": "application/json", "x-tenant": "acme" },
+      payload: JSON.stringify({}),
+    });
+    expect(r.statusCode).toBe(400);
+    const body = r.json() as { title: string };
+    expect(body.title).toBe("Validation failed");
+  });
+});
+
+describe("oav-fastify integration: custom toHttpRequest", () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    const validator = createValidator(petSpec());
+    app = Fastify();
+    app.addHook("preHandler", async (request) => {
+      (request as FastifyRequest & { verifiedBody?: unknown }).verifiedBody = { name: "Fido" };
+    });
+    app.addHook(
+      "preValidation",
+      validateRequests(validator, {
+        toHttpRequest: (request) => {
+          const httpReq = httpRequestFromFastify(request);
+          const fancy = (request as FastifyRequest & { verifiedBody?: unknown }).verifiedBody;
+          if (fancy !== undefined) httpReq.body = fancy;
+          return httpReq;
+        },
+      }),
+    );
+    // preHandler runs after preValidation; need to set verifiedBody earlier.
+    app.addHook("onRequest", async (request) => {
+      (request as FastifyRequest & { verifiedBody?: unknown }).verifiedBody = { name: "Fido" };
+    });
+    app.post("/pets", async () => ({ ok: true }));
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("custom toHttpRequest extractor reaches the validator", async () => {
+    const r = await app.inject({
+      method: "POST",
+      url: "/pets",
+      headers: { "content-type": "application/json", "x-tenant": "acme" },
+      payload: JSON.stringify({}),
+    });
+    expect(r.statusCode).toBe(200);
+  });
+});
+
+describe("oav-fastify integration: Fastify specifics", () => {
+  let app: FastifyInstance;
+  const captured: Error[] = [];
+
+  beforeAll(async () => {
+    const validator = createValidator(petSpec());
+    app = Fastify();
+    app.addHook(
+      "preValidation",
+      validateRequests(validator, {
+        toHttpRequest: () => {
+          // Fastify is async-native: thrown errors propagate via the
+          // promise chain to Fastify's setErrorHandler without explicit
+          // try/catch in our hook.
+          throw new Error("extractor exploded");
+        },
+      }),
+    );
+    app.setErrorHandler((err, _request, reply) => {
+      captured.push(err);
+      reply.code(500).send({ error: err.message });
+    });
+    app.post("/pets", async () => ({ ok: true }));
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("thrown extractor errors propagate to Fastify's setErrorHandler via the promise chain", async () => {
+    const r = await app.inject({
+      method: "POST",
+      url: "/pets",
+      headers: { "content-type": "application/json", "x-tenant": "acme" },
+      payload: JSON.stringify({ name: "Fido" }),
+    });
+    expect(r.statusCode).toBe(500);
+    const body = r.json() as { error: string };
+    expect(body.error).toBe("extractor exploded");
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.message).toBe("extractor exploded");
+  });
+});

--- a/packages/oav-fastify/test/render.test.ts
+++ b/packages/oav-fastify/test/render.test.ts
@@ -1,0 +1,69 @@
+import { createBranchError, createLeafError } from "@oav/core";
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import { renderProblemDetails } from "../src/render.js";
+
+function fakeReply(): FastifyReply & {
+  header: ReturnType<typeof vi.fn>;
+  code: ReturnType<typeof vi.fn>;
+  type: ReturnType<typeof vi.fn>;
+  send: ReturnType<typeof vi.fn>;
+} {
+  const reply = {
+    header: vi.fn(),
+    code: vi.fn(),
+    type: vi.fn(),
+    send: vi.fn(),
+  };
+  reply.code.mockReturnValue(reply);
+  reply.type.mockReturnValue(reply);
+  return reply as unknown as ReturnType<typeof fakeReply>;
+}
+
+function fakeRequest(url = "/pets"): FastifyRequest {
+  return { url } as unknown as FastifyRequest;
+}
+
+describe("renderProblemDetails", () => {
+  it("writes status, content-type, and a problem-details body", () => {
+    const err = createLeafError("type", ["body", "age"], "must be number", {
+      expected: ["number"],
+      actual: "string",
+    });
+    const reply = fakeReply();
+    renderProblemDetails(err, { request: fakeRequest(), reply });
+    expect(reply.code).toHaveBeenCalledWith(400);
+    expect(reply.type).toHaveBeenCalledWith("application/problem+json");
+    const body = reply.send.mock.calls[0]?.[0];
+    expect(body).toMatchObject({
+      type: "about:blank",
+      title: "Validation failed",
+      status: 400,
+      instance: "/pets",
+    });
+    expect(body.detail).toBe("body.age must be number");
+    expect(body.issues).toHaveLength(1);
+  });
+
+  it("sets the Allow header on a 405 (method-not-allowed)", () => {
+    const err = createLeafError("method", [], "method not allowed", {
+      method: "DELETE",
+      pathPattern: "/pets",
+      allowed: ["GET", "POST"],
+    });
+    const reply = fakeReply();
+    renderProblemDetails(err, { request: fakeRequest(), reply });
+    expect(reply.code).toHaveBeenCalledWith(405);
+    expect(reply.header).toHaveBeenCalledWith("Allow", "GET, POST");
+  });
+
+  it("does not set Allow on errors that aren't 405s", () => {
+    const err = createBranchError("request", [], "request invalid", [
+      createLeafError("type", ["body", "age"], "must be number"),
+    ]);
+    const reply = fakeReply();
+    renderProblemDetails(err, { request: fakeRequest(), reply });
+    expect(reply.header).not.toHaveBeenCalled();
+    expect(reply.code).toHaveBeenCalledWith(400);
+  });
+});

--- a/packages/oav-fastify/tsconfig.json
+++ b/packages/oav-fastify/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"],
+  "references": [{ "path": "../core" }, { "path": "../validator" }]
+}

--- a/packages/oav-fastify/tsup.config.ts
+++ b/packages/oav-fastify/tsup.config.ts
@@ -1,0 +1,38 @@
+import { resolve } from "node:path";
+import type { Plugin } from "esbuild";
+import { defineConfig } from "tsup";
+
+/**
+ * Build config for `oav-fastify` — the Fastify adapter.
+ * Same shape as oav-express4 / oav-express5: thin tarball,
+ * oav-core externalized, fastify marked external (peer dep).
+ */
+const oavCoreRewrite: Record<string, string> = {
+  "@oav/core": "@aahoughton/oav-core/core",
+  "@oav/validator": "@aahoughton/oav-core",
+};
+
+function rewriteOavCore(): Plugin {
+  return {
+    name: "oav-core-rewrite",
+    setup(build) {
+      build.onResolve({ filter: /^@oav\// }, (args) => {
+        const rewrite = oavCoreRewrite[args.path];
+        if (rewrite) return { path: rewrite, external: true };
+        return null;
+      });
+    },
+  };
+}
+
+export default defineConfig({
+  entry: { index: "src/index.ts" },
+  format: ["esm", "cjs"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  target: "es2022",
+  tsconfig: resolve(__dirname, "../../tsconfig.build.json"),
+  external: ["fastify", "@aahoughton/oav-core"],
+  esbuildPlugins: [rewriteOavCore()],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,31 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.5
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(yaml@2.8.3))
+
+  packages/oav-fastify:
+    dependencies:
+      '@aahoughton/oav-core':
+        specifier: workspace:*
+        version: link:../..
+    devDependencies:
+      '@oav/core':
+        specifier: workspace:*
+        version: link:../core
+      '@oav/validator':
+        specifier: workspace:*
+        version: link:../validator
+      fastify:
+        specifier: 5.8.5
+        version: 5.8.5
+      tsup:
+        specifier: 8.5.1
+        version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 4.1.5
         version: 4.1.5(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
 
   packages/router:
@@ -526,6 +551,24 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@fastify/ajv-compiler@4.0.5':
+    resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+
+  '@fastify/error@4.2.0':
+    resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    resolution: {integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==}
+
+  '@fastify/forwarded@3.0.1':
+    resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
+
+  '@fastify/proxy-addr@5.1.0':
+    resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -791,6 +834,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
@@ -1108,6 +1154,9 @@ packages:
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
+  abstract-logging@2.0.1:
+    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -1121,6 +1170,17 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -1130,6 +1190,13 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
+  avvio@9.2.0:
+    resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
 
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
@@ -1210,6 +1277,10 @@ packages:
     resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
     engines: {node: '>= 0.6'}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -1230,6 +1301,10 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
@@ -1301,6 +1376,27 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  fast-decode-uri-component@1.0.1:
+    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stringify@6.3.0:
+    resolution: {integrity: sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA==}
+
+  fast-querystring@1.1.2:
+    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fastify@5.8.5:
+    resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1317,6 +1413,10 @@ packages:
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
+
+  find-my-way@9.5.0:
+    resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
+    engines: {node: '>=20'}
 
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
@@ -1384,12 +1484,25 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  ipaddr.js@2.3.0:
+    resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
+    engines: {node: '>= 10'}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  json-schema-ref-resolver@3.0.0:
+    resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  light-my-request@6.6.0:
+    resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1559,6 +1672,10 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -1601,6 +1718,16 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
@@ -1630,6 +1757,12 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  process-warning@4.0.1:
+    resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
+
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -1641,6 +1774,9 @@ packages:
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -1658,9 +1794,28 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+
+  ret@0.5.0:
+    resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
+    engines: {node: '>=10'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   rolldown@1.0.0-rc.15:
     resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
@@ -1679,8 +1834,24 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  safe-regex2@5.1.1:
+    resolution: {integrity: sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==}
+    hasBin: true
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   send@0.19.0:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
@@ -1697,6 +1868,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -1720,6 +1894,9 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1727,6 +1904,10 @@ packages:
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -1754,6 +1935,10 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  thread-stream@4.0.0:
+    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
+    engines: {node: '>=20'}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -1775,6 +1960,10 @@ packages:
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
+
+  toad-cache@3.7.0:
+    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
+    engines: {node: '>=12'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -2111,6 +2300,29 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
+  '@fastify/ajv-compiler@4.0.5':
+    dependencies:
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      fast-uri: 3.1.0
+
+  '@fastify/error@4.2.0': {}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    dependencies:
+      fast-json-stringify: 6.3.0
+
+  '@fastify/forwarded@3.0.1': {}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    dependencies:
+      dequal: 2.0.3
+
+  '@fastify/proxy-addr@5.1.0':
+    dependencies:
+      '@fastify/forwarded': 3.0.1
+      ipaddr.js: 2.3.0
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2247,6 +2459,8 @@ snapshots:
 
   '@oxlint/binding-win32-x64-msvc@1.61.0':
     optional: true
+
+  '@pinojs/redact@0.4.0': {}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     optional: true
@@ -2494,6 +2708,8 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  abstract-logging@2.0.1: {}
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -2506,11 +2722,29 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   any-promise@1.3.0: {}
 
   array-flatten@1.1.1: {}
 
   assertion-error@2.0.1: {}
+
+  atomic-sleep@1.0.0: {}
+
+  avvio@9.2.0:
+    dependencies:
+      '@fastify/error': 4.2.0
+      fastq: 1.20.1
 
   body-parser@1.20.3:
     dependencies:
@@ -2592,6 +2826,8 @@ snapshots:
 
   cookie@0.7.1: {}
 
+  cookie@1.1.1: {}
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -2601,6 +2837,8 @@ snapshots:
       ms: 2.1.3
 
   depd@2.0.0: {}
+
+  dequal@2.0.3: {}
 
   destroy@1.2.0: {}
 
@@ -2765,6 +3003,47 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  fast-decode-uri-component@1.0.1: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stringify@6.3.0:
+    dependencies:
+      '@fastify/merge-json-schemas': 0.2.1
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      fast-uri: 3.1.0
+      json-schema-ref-resolver: 3.0.0
+      rfdc: 1.4.1
+
+  fast-querystring@1.1.2:
+    dependencies:
+      fast-decode-uri-component: 1.0.1
+
+  fast-uri@3.1.0: {}
+
+  fastify@5.8.5:
+    dependencies:
+      '@fastify/ajv-compiler': 4.0.5
+      '@fastify/error': 4.2.0
+      '@fastify/fast-json-stringify-compiler': 5.0.3
+      '@fastify/proxy-addr': 5.1.0
+      abstract-logging: 2.0.1
+      avvio: 9.2.0
+      fast-json-stringify: 6.3.0
+      find-my-way: 9.5.0
+      light-my-request: 6.6.0
+      pino: 10.3.1
+      process-warning: 5.0.0
+      rfdc: 1.4.1
+      secure-json-parse: 4.1.0
+      semver: 7.7.4
+      toad-cache: 3.7.0
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -2791,6 +3070,12 @@ snapshots:
       statuses: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  find-my-way@9.5.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-querystring: 1.1.2
+      safe-regex2: 5.1.1
 
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
@@ -2863,9 +3148,23 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  ipaddr.js@2.3.0: {}
+
   is-promise@4.0.0: {}
 
   joycon@3.1.1: {}
+
+  json-schema-ref-resolver@3.0.0:
+    dependencies:
+      dequal: 2.0.3
+
+  json-schema-traverse@1.0.0: {}
+
+  light-my-request@6.6.0:
+    dependencies:
+      cookie: 1.1.1
+      process-warning: 4.0.1
+      set-cookie-parser: 2.7.2
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -2981,6 +3280,8 @@ snapshots:
 
   obug@2.1.1: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -3047,6 +3348,26 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.0.0
+
   pirates@4.0.7: {}
 
   pkg-types@1.3.1:
@@ -3068,6 +3389,10 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  process-warning@4.0.1: {}
+
+  process-warning@5.0.0: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -3080,6 +3405,8 @@ snapshots:
   qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
+
+  quick-format-unescaped@4.0.4: {}
 
   range-parser@1.2.1: {}
 
@@ -3099,7 +3426,17 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  real-require@0.2.0: {}
+
+  require-from-string@2.0.2: {}
+
   resolve-from@5.0.0: {}
+
+  ret@0.5.0: {}
+
+  reusify@1.1.0: {}
+
+  rfdc@1.4.1: {}
 
   rolldown@1.0.0-rc.15:
     dependencies:
@@ -3165,7 +3502,17 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  safe-regex2@5.1.1:
+    dependencies:
+      ret: 0.5.0
+
+  safe-stable-stringify@2.5.0: {}
+
   safer-buffer@2.1.2: {}
+
+  secure-json-parse@4.1.0: {}
+
+  semver@7.7.4: {}
 
   send@0.19.0:
     dependencies:
@@ -3219,6 +3566,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  set-cookie-parser@2.7.2: {}
+
   setprototypeof@1.2.0: {}
 
   side-channel-list@1.0.1:
@@ -3251,9 +3600,15 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
+
+  split2@4.2.0: {}
 
   stackback@0.0.2: {}
 
@@ -3281,6 +3636,10 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  thread-stream@4.0.0:
+    dependencies:
+      real-require: 0.2.0
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -3295,6 +3654,8 @@ snapshots:
   tinypool@2.1.0: {}
 
   tinyrainbow@3.1.0: {}
+
+  toad-cache@3.7.0: {}
 
   toidentifier@1.0.1: {}
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -40,6 +40,12 @@
       "package-name": "@aahoughton/oav-express5",
       "component": "oav-express5",
       "changelog-path": "CHANGELOG.md"
+    },
+    "packages/oav-fastify": {
+      "release-type": "node",
+      "package-name": "@aahoughton/oav-fastify",
+      "component": "oav-fastify",
+      "changelog-path": "CHANGELOG.md"
     }
   }
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -19,7 +19,8 @@
       "@oav/cli": ["./packages/cli/src/index.ts"],
       "@oav/oav": ["./packages/oav/src/index.ts"],
       "@oav/oav-express4": ["./packages/oav-express4/src/index.ts"],
-      "@oav/oav-express5": ["./packages/oav-express5/src/index.ts"]
+      "@oav/oav-express5": ["./packages/oav-express5/src/index.ts"],
+      "@oav/oav-fastify": ["./packages/oav-fastify/src/index.ts"]
     }
   },
   "include": ["src/**/*", "packages/*/src/**/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     { "path": "./packages/cli" },
     { "path": "./packages/oav" },
     { "path": "./packages/oav-express4" },
-    { "path": "./packages/oav-express5" }
+    { "path": "./packages/oav-express5" },
+    { "path": "./packages/oav-fastify" }
   ]
 }

--- a/workspace-aliases.ts
+++ b/workspace-aliases.ts
@@ -16,6 +16,7 @@ const PACKAGES = [
   "oav",
   "oav-express4",
   "oav-express5",
+  "oav-fastify",
 ] as const;
 
 export function workspaceAliases(rootDir: string): Record<string, string> {


### PR DESCRIPTION
## Summary

\`@aahoughton/oav-fastify\` — third of the framework adapter family. Same shape as oav-express4 / oav-express5; only the framework-typed argument and Fastify's hook-vs-middleware distinction differ.

```ts
import Fastify from \"fastify\";
import { createValidator } from \"@aahoughton/oav-core\";
import { validateRequests } from \"@aahoughton/oav-fastify\";

const app = Fastify();
app.addHook(\"preValidation\", validateRequests(createValidator(spec)));
```

## API surface

Cross-adapter consistency: same export names, same option names, same defaults, same TSDoc shape.

- \`validateRequests(validator, options?)\` — returns a Fastify \`preValidationHookHandler\` (hook, not middleware). Mount via \`fastify.addHook(\"preValidation\", ...)\`.
- \`httpRequestFromFastify(request)\` — standalone extractor.
- \`renderProblemDetails(err, ctx)\` — default \`onError\` renderer; writes via \`reply.code(...).type(...).send(...)\`.
- Re-exported types: \`HttpRequest\`, \`ValidationError\`, \`Validator\`, \`ValidateRequestsOptions\`, \`FastifyContext\`, \`ErrorHandler\`.

\`FastifyContext { request, reply }\` follows the framework-native field-naming convention from CLAUDE.md (matches Fastify's own; no \`next\` since Fastify uses promise return / \`reply.send\` to indicate completion).

## Mount-point conventions

Hook mounts on \`preValidation\` so it sees Fastify-parsed bodies. If the user has per-route Fastify schemas declared, Fastify's own validation runs in the next step (\`validation\`). Both can coexist; oav rejects first, Fastify's runs only on success.

## Tests

- 27 unit tests (extract / render / hook).
- 10 integration tests using \`fastify.inject()\` (Fastify-native synthetic-request API). Bending the cross-adapter native-fetch convention because \`inject\` is so idiomatic in Fastify-land that avoiding it would feel perverse.
- Same scenario \`it()\` names as oav-express4 / oav-express5:
  1. valid request reaches the handler
  2. invalid request returns 400 problem+details
  3. wrong verb returns 405 with Allow header
  4. unknown path returns 404
  5. missing required header returns 400 problem+details
  6. unmatched Content-Type returns 415
  7. custom \`onError\` runs and writes a custom envelope; handler not reached
  8. async \`onError\` is awaited before the response settles
  9. custom \`toHttpRequest\` extractor reaches the validator
  10. **Fastify specific**: thrown extractor errors propagate to \`setErrorHandler\` via the promise chain (no explicit try/catch in adapter)

CI \`pack-smoke\` job extended: packs all five publishable workspace packages (oav-core, oav, oav-express4, oav-express5, oav-fastify), installs each adapter into a fresh sandbox with the matching framework, verifies public exports import correctly.

## Wiring

- \`packages/oav-fastify/\`, same shape as the Express adapters.
- \`workspace-aliases.ts\`, \`tsconfig.json\`, \`tsconfig.build.json\`, \`release-please-config.json\`, \`.release-please-manifest.json\` — all updated.
- \`pnpm-lock.yaml\` updated for fastify 5.x dev dep.
- \`INTEGRATION.md\` Fastify section restructured to lead with the adapter (replacing the \"adapter coming\" placeholder from #197).

## Test plan

- [x] \`pnpm test\` — 779 pass (37 new in packages/oav-fastify)
- [x] \`pnpm lint\` clean
- [x] \`pnpm typecheck\` clean
- [ ] CI pack-smoke green (covers tarball install + import for all five publishable packages)

Closes #195