### PR TITLE
docs: tightening pass — remove unshipped-adapter promises, drop defensive language

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,30 +171,35 @@ options)` returns a `Validator` exposing `validateRequest(req)`,
   `readBodyFromFetch`) for Next.js / Hono / Bun / Deno consumers.
 - **`@oav/cli`** — thin commander wrapper. No business logic beyond arg
   parsing, I/O, and exit codes.
-- **`@oav/oav-express4`** — first of the framework adapter family.
-  Thin: depends on `@aahoughton/oav-core` (transitive) and declares
-  `express ^4.0.0` as a peer; ships a `validateRequests` middleware
-  factory plus standalone `httpRequestFromExpress` and
-  `renderProblemDetails` helpers. Naming and option shapes
-  (`validateRequests`, `ValidateRequestsOptions`, `ExpressContext`,
-  `ErrorHandler<Ctx>`) are designed to stay identical across future
-  `oav-express5` / `oav-fastify` / `oav-hono` siblings — only the
-  framework-typed argument differs. Future `validateResponses` slots
-  in additively.
+- **`@oav/oav-express4`**, **`@oav/oav-express5`**, **`@oav/oav-fastify`** —
+  framework adapters. Thin: depend on `@aahoughton/oav-core`
+  (transitive) and declare the matching framework as a peer. Each
+  exports `validateRequests` (the middleware/hook factory),
+  `httpRequestFrom<Framework>` (the standalone extractor), and
+  `renderProblemDetails` (the default error renderer). Option and
+  type names (`ValidateRequestsOptions`, `ErrorHandler<Ctx>`) are
+  identical across the family; per-framework `Context` types use
+  framework-native field names (`ExpressContext { req, res, next }`,
+  `FastifyContext { request, reply }`). The `oav-express5` / Fastify
+  variants are async-native and don't need `try/catch`; `oav-express4`
+  forwards thrown errors via `next(err)`. A future `validateResponses`
+  slots in additively on each adapter.
 
 ## Dependency graph (strictly enforced; no cycles)
 
 ```
-cli         → validator → router
-                       → spec → core
-                       → formats → core
-                       → schema → core
-                       → core
-            → spec → core
-            → core
-oav-express4 → validator → ... (same as cli's chain)
-            → core
-            (peer: express ^4)
+cli           → validator → router
+                         → spec → core
+                         → formats → core
+                         → schema → core
+                         → core
+              → spec → core
+              → core
+oav-express4  → validator → ... (same as cli's chain)
+              → core
+              (peer: express ^4)
+oav-express5  → same chain, peer: express ^5
+oav-fastify   → same chain, peer: fastify ^5
 ```
 
 ## How to add a new keyword

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -3,9 +3,8 @@
 A recipe book for wiring `oav` into HTTP frameworks. `oav` is a
 validator, not a middleware package — you write a short adapter
 between your framework and `validateRequest` / `validateResponse`,
-or use one of the companion adapter packages (`oav-express4`, future
-`oav-express5` / `oav-fastify` / `oav-hono`) that ships the wiring
-for you.
+or use one of the companion adapter packages: `oav-express4`,
+`oav-express5`, `oav-fastify`.
 
 This document is organised:
 
@@ -119,16 +118,17 @@ app.use(express.json()); // any middleware that populates req.body satisfies oav
 app.use(validateRequests(validator));
 ```
 
-Sensible defaults: RFC 9457 `application/problem+json` body via
-`toProblemDetails`, status from `httpStatusFor`, `Allow` header from
-`allowHeaderFor` on 405. The package also exports
+Defaults: status from `httpStatusFor`, `Allow` header from
+`allowHeaderFor` on 405, body from `toProblemDetails` (RFC 9457
+`application/problem+json`). The package also exports
 `httpRequestFromExpress(req)` (the extractor) and
 `renderProblemDetails(err, ctx)` (the default renderer) standalone,
 for callers composing their own middleware. See the
 [adapter README](https://github.com/aahoughton/oav/blob/main/packages/oav-express4/README.md)
-for options (`toHttpRequest`, `onError`), async `onError` semantics,
-custom envelope recipes, and the patterns in the cross-cutting
-section below.
+for the options (`toHttpRequest`, `onError`), async `onError`
+semantics, and adapter-specific patterns. Cross-cutting recipes
+(body parsers, file uploads, security, response validation) are
+below.
 
 **Manual middleware (when you need full control).** Same shape as
 the Express 5 snippet below, with one twist: Express 4 doesn't
@@ -976,6 +976,6 @@ stay framework-shaped rather than competitor-shaped:
   option map (eov → oav), features not carried over, features
   added.
 
-Future migration docs (from-fastify-inline, from-zod-first, etc.)
-will follow the same pattern — focused, one-page references, linked
-from here.
+When other migration paths surface (from-fastify-inline,
+from-zod-first), they get their own focused docs in the same
+shape, linked from here.

--- a/README.md
+++ b/README.md
@@ -25,23 +25,20 @@ walk programmatically.
 can skip what they don't use, plus framework adapter packages that
 build on either:
 
-| Package                    | When to use                                                                                                                                                                                                                                                                                               |
-| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@aahoughton/oav`          | Default. Batteries-included: YAML readers + the `oav` CLI. Depends on `yaml`; pulls in `commander` + `esbuild` for the CLI only (never imported from the library entry points, so bundlers tree-shake them out of application bundles; Node server runs load them only when the `oav` binary is invoked). |
-| `@aahoughton/oav-core`     | Lean alternative. Zero runtime dependencies. Same programmatic surface as `@aahoughton/oav`, minus the YAML readers and CLI. Feed it JSON specs (or pre-parsed objects via the memory reader).                                                                                                            |
-| `@aahoughton/oav-express4` | Framework adapter for Express 4. Thin: imports the validator from `oav-core`, ships a middleware factory plus standalone helpers. Sibling adapters for Express 5, Fastify, and Hono will follow the same shape. See [`INTEGRATION.md`](./INTEGRATION.md).                                                 |
+| Package                    | When to use                                                                                                                                                                                                                                                                                      |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `@aahoughton/oav`          | Batteries-included: YAML readers + the `oav` CLI. Depends on `yaml`; pulls in `commander` + `esbuild` for the CLI only (never imported from the library entry points, so bundlers tree-shake them out of application bundles; Node server runs load them only when the `oav` binary is invoked). |
+| `@aahoughton/oav-core`     | Lean. Zero runtime dependencies. Same programmatic surface as `@aahoughton/oav`, minus the YAML readers and CLI. Feed it JSON specs (or pre-parsed objects via the memory reader).                                                                                                               |
+| `@aahoughton/oav-express4` | Express 4 framework adapter. Thin: imports the validator from `oav-core`, exports a middleware factory plus standalone helpers. See [`INTEGRATION.md`](./INTEGRATION.md).                                                                                                                        |
+| `@aahoughton/oav-express5` | Express 5 framework adapter. Same exports as `oav-express4`; promise-native middleware shape.                                                                                                                                                                                                    |
+| `@aahoughton/oav-fastify`  | Fastify framework adapter. Same exports as the Express adapters; ships a `preValidation` hook instead of middleware.                                                                                                                                                                             |
 
 ```bash
-npm install @aahoughton/oav
-# or: pnpm add @aahoughton/oav
-```
-
-```bash
-npm install @aahoughton/oav-core           # lean install, JSON-only
-```
-
-```bash
-npm install @aahoughton/oav-express4       # Express 4 + your choice of oav or oav-core
+npm install @aahoughton/oav            # YAML + CLI
+npm install @aahoughton/oav-core       # JSON only, zero runtime deps
+npm install @aahoughton/oav-express4   # Express 4 adapter (transitively pulls oav-core)
+npm install @aahoughton/oav-express5   # Express 5 adapter
+npm install @aahoughton/oav-fastify    # Fastify adapter
 ```
 
 `oav` re-exports `oav-core` at matching
@@ -295,24 +292,27 @@ app.use(async (req, res, next) => {
 
 See [**INTEGRATION.md**](./INTEGRATION.md) for:
 
-- Adapters for Express 4, Express 5, Fastify, Next.js, Hono, Bun, and Deno.
+- Adapter packages for Express 4, Express 5, and Fastify; recipes for Next.js, Hono, Bun, and Deno via the Web Standards adapter.
 - Recipes for file uploads (multer), response validation, security,
   ignoring paths, and the full status-code switch.
 - A migration table from `express-openapi-validator`, including
   where oav is stricter or more conformant and where you'll do more
   wiring by hand.
 
-For Express 4, the
-[`@aahoughton/oav-express4`](./packages/oav-express4/README.md)
-companion package ships the middleware as a one-liner — same
-defaults, async-aware `onError`. Sibling adapters for Express 5,
-Fastify, and Hono will follow the same shape.
+Companion adapter packages cover the common framework wiring:
+[`@aahoughton/oav-express4`](./packages/oav-express4/README.md),
+[`@aahoughton/oav-express5`](./packages/oav-express5/README.md),
+[`@aahoughton/oav-fastify`](./packages/oav-fastify/README.md). They
+share the same export names and option shapes; only the
+framework-typed argument differs.
 
-`oav` is not a drop-in for `express-openapi-validator`: you own the
-error → HTTP mapping, you wire up multer if you need file uploads,
-and you run your own auth middleware. In exchange you get a
-structured error tree, native OpenAPI 3.0 semantics, overlays, and
-no monkey-patching of `req` or `res`.
+`oav` is not a drop-in for `express-openapi-validator`: the
+adapters cover the request-validation middleware, but you own the
+error → HTTP mapping if you customise it, you wire up multer if you
+need file uploads, and you run your own auth middleware. The error
+tree is structured (`code`/`path`/`message`/`params`/`children`),
+the OpenAPI 3.0 dialect is built in rather than translated to
+2020-12, and the validator does not mutate `req` or `res`.
 
 ## Modules
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -14,13 +14,11 @@ oav --help
 npx @aahoughton/oav validate openapi.yaml --request req.http
 ```
 
-The CLI lives in the batteries-included `oav` package, not
-the lean `oav-core` — `oav-core` doesn't ship a `bin` or
-any CLI glue. `oav` pulls in `commander` (argv parsing)
-and `esbuild` (AOT bundling for `compile-schema` / `compile-spec`) as
-regular dependencies, so the CLI runs out of the box after one
-install. Users who only need the programmatic API and want a smaller
-footprint install `oav-core` instead.
+The CLI lives in the `oav` package, not `oav-core` — `oav-core`
+doesn't ship a `bin` or any CLI glue. `oav` carries `commander`
+(argv parsing) and `esbuild` (AOT bundling for `compile-schema` /
+`compile-spec`) as regular dependencies. Users who only need the
+programmatic API install `oav-core` instead.
 
 ## Commands
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -157,10 +157,10 @@ const joined = collectIssues(err)
 
 See the [Framework integration](../../README.md#framework-integration)
 section of the root README for Express / Fastify / Next.js snippets.
-For Express 4 specifically, the
-[`@aahoughton/oav-express4`](../oav-express4/README.md) companion
-package wraps these helpers as a one-liner middleware; sibling
-adapters for Express 5 / Fastify / Hono will follow the same shape.
+Companion adapter packages wrap these helpers as middleware /
+hooks: [`oav-express4`](../oav-express4/README.md),
+[`oav-express5`](../oav-express5/README.md),
+[`oav-fastify`](../oav-fastify/README.md).
 
 ## OpenAPI / HTTP types
 

--- a/packages/oav-express4/README.md
+++ b/packages/oav-express4/README.md
@@ -4,7 +4,7 @@ Express 4 adapter for [`@aahoughton/oav-core`](https://www.npmjs.com/package/@aa
 
 Thin: this package re-exports nothing from oav-core. You install both. The adapter declares oav-core as a regular dependency, so a single `npm install @aahoughton/oav-express4` pulls oav-core along; or install [`@aahoughton/oav`](https://www.npmjs.com/package/@aahoughton/oav) instead if you want YAML readers and the CLI.
 
-For Express 5 / Fastify / Hono adapters, see the sibling `oav-express5` / `oav-fastify` / `oav-hono` packages — same API shape, same names, same defaults.
+Sibling packages: [`oav-express5`](../oav-express5/README.md), [`oav-fastify`](../oav-fastify/README.md). Same export names, option shapes, and defaults; only the framework-typed argument differs.
 
 ## Install
 
@@ -36,7 +36,7 @@ app.use(validateRequests(validator));
 app.post("/pets", (req, res) => res.json({ ok: true }));
 ```
 
-That's it. Invalid requests get a `400 application/problem+json` response (status from `httpStatusFor`, body from `toProblemDetails`, `Allow` header on 405). Valid requests reach your route handlers.
+Invalid requests receive a `400 application/problem+json` response (status from `httpStatusFor`, body from `toProblemDetails`, `Allow` header on 405). Valid requests reach the route handlers.
 
 > **Body parser ordering matters.** `express.json()` (or your equivalent) must run **before** `validateRequests(...)`, otherwise `req.body` is `undefined` and the validator emits `body required` for every request — a misleading error that points at the schema, not at the missing parser. Same for `cookie-parser` if your spec validates cookies. Any middleware that populates `req.body` with a parsed object satisfies oav — `express.json()`, custom streaming parsers, `body-parser`, fastify's bridge, app-specific middleware all work the same way.
 >
@@ -217,7 +217,7 @@ app.use(
 );
 ```
 
-Three lines, no behaviour change for clients. Use this whenever your existing error pipeline (Sentry, structured logger, request-id correlation) needs to see validation failures.
+Use this whenever your existing error pipeline (Sentry, structured logger, request-id correlation) needs to see validation failures without changing the response shape.
 
 ### Async `onError` (remote logging, dynamic config)
 

--- a/packages/oav-express5/README.md
+++ b/packages/oav-express5/README.md
@@ -4,7 +4,7 @@ Express 5 adapter for [`@aahoughton/oav-core`](https://www.npmjs.com/package/@aa
 
 Same shape as the [`oav-express4`](../oav-express4/README.md) sibling — only the framework-typed argument and the async semantics differ. Express 5's promise-native middleware means thrown errors and rejected promises propagate to the host's error middleware automatically, with no `try/catch` wrapper.
 
-For Fastify / Hono adapters, see the sibling `oav-fastify` / `oav-hono` packages — same API shape, same names, same defaults.
+Sibling packages: [`oav-express4`](../oav-express4/README.md), [`oav-fastify`](../oav-fastify/README.md). Same export names, option shapes, and defaults; only the framework-typed argument differs.
 
 ## Install
 
@@ -36,7 +36,7 @@ app.use(validateRequests(validator));
 app.post("/pets", (req, res) => res.json({ ok: true }));
 ```
 
-That's it. Invalid requests get a `400 application/problem+json` response (status from `httpStatusFor`, body from `toProblemDetails`, `Allow` header on 405). Valid requests reach your route handlers.
+Invalid requests receive a `400 application/problem+json` response (status from `httpStatusFor`, body from `toProblemDetails`, `Allow` header on 405). Valid requests reach the route handlers.
 
 > **Body parser ordering matters.** `express.json()` (or any equivalent that populates `req.body` with a parsed object) must run **before** `validateRequests(...)`. Same for `cookie-parser` if your spec validates cookies. Any middleware that populates `req.body` works — `express.json()`, `body-parser`, custom streaming parsers, app-specific middleware all work the same way.
 >
@@ -164,7 +164,7 @@ app.use(
 );
 ```
 
-Three lines, no behaviour change for clients. Use this whenever your existing error pipeline (Sentry, structured logger, request-id correlation) needs to see validation failures.
+Use this whenever your existing error pipeline (Sentry, structured logger, request-id correlation) needs to see validation failures without changing the response shape.
 
 ### Async `onError` (remote logging, dynamic config)
 

--- a/packages/oav-fastify/README.md
+++ b/packages/oav-fastify/README.md
@@ -4,7 +4,7 @@ Fastify adapter for [`@aahoughton/oav-core`](https://www.npmjs.com/package/@aaho
 
 Same shape as the Express siblings ([`oav-express4`](../oav-express4/README.md), [`oav-express5`](../oav-express5/README.md)) — only the framework-typed argument and Fastify's hook-vs-middleware distinction differ. Fastify is async-native, so thrown errors and rejected promises propagate to Fastify's error handler automatically, with no `try/catch` wrapper.
 
-For Hono / Bun adapters, see future sibling packages — same API shape, same names, same defaults.
+Sibling packages: [`oav-express4`](../oav-express4/README.md), [`oav-express5`](../oav-express5/README.md). Same export names, option shapes, and defaults; only the framework-typed argument differs.
 
 ## Install
 
@@ -35,7 +35,7 @@ app.addHook("preValidation", validateRequests(validator));
 app.post("/pets", async () => ({ ok: true }));
 ```
 
-That's it. Invalid requests get a `400 application/problem+json` response (status from `httpStatusFor`, body from `toProblemDetails`, `Allow` header on 405). Valid requests reach your route handlers.
+Invalid requests receive a `400 application/problem+json` response (status from `httpStatusFor`, body from `toProblemDetails`, `Allow` header on 405). Valid requests reach the route handlers.
 
 ## Mount point: `preValidation`
 
@@ -158,7 +158,7 @@ app.addHook(
 );
 ```
 
-Three lines, no behaviour change for clients. Use this whenever your existing error pipeline (Sentry, structured logger, request-id correlation) needs to see validation failures.
+Use this whenever your existing error pipeline (Sentry, structured logger, request-id correlation) needs to see validation failures without changing the response shape.
 
 ### Async `onError` (remote logging, dynamic config)
 

--- a/packages/oav/README.md
+++ b/packages/oav/README.md
@@ -19,7 +19,7 @@ const validator = createValidator(document);
 
 | Package                | When to use                                                                                                                                                                                             |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@aahoughton/oav`      | Default. YAML support out of the box; ships the `oav` CLI as a `bin`. Pulls in `yaml`, `commander`, and `esbuild` (CLI-only).                                                                           |
+| `@aahoughton/oav`      | Includes YAML readers and the `oav` CLI binary. Pulls in `yaml`, `commander`, and `esbuild` (CLI-only).                                                                                                 |
 | `@aahoughton/oav-core` | Lean. Zero runtime dependencies. JSON specs only (or pre-parsed objects via the memory reader). Use on Cloudflare Workers, Vercel Edge, Lambda@Edge, or anywhere the YAML/CLI footprint isn't worth it. |
 
 `oav` re-exports every subpath of `oav-core` at matching paths
@@ -59,15 +59,14 @@ is re-exported from `oav-core`. Documentation for those lives in:
 
 ## Framework integration
 
-`oav` is a validator, not a middleware package — you write a short
-adapter between your HTTP framework and `validateRequest` /
-`validateResponse`. For Express 4 specifically, the
-[`@aahoughton/oav-express4`](../oav-express4/README.md) companion
-package ships the middleware as a one-liner with sensible defaults;
-sibling packages for Express 5, Fastify, and Hono will follow the
-same shape. See [`INTEGRATION.md`](../../INTEGRATION.md) for adapter
-recipes for every supported framework, plus migration notes from
-`express-openapi-validator`.
+`oav` is a validator, not a middleware package. Companion adapter
+packages cover the framework wiring:
+[`oav-express4`](../oav-express4/README.md),
+[`oav-express5`](../oav-express5/README.md),
+[`oav-fastify`](../oav-fastify/README.md). See
+[`INTEGRATION.md`](../../INTEGRATION.md) for adapter recipes plus
+manual integration patterns for Next.js, Hono, Bun, and Deno via
+the Web Standards adapter.
 
 ## See also
 

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -34,12 +34,12 @@ can group by location. The top-level node's `code` (`"request"` vs
 detected on construction (or `undefined` if the field was missing or
 unsupported and a fallback was used — see `onUnknownVersion` below).
 
-For Express 4 integration, the
-[`@aahoughton/oav-express4`](../oav-express4/README.md) companion
-package ships a `validateRequests` middleware factory built on top of
-this validator, plus standalone helpers for callers composing their
-own middleware. Sibling adapters for Express 5 / Fastify / Hono will
-follow the same shape.
+Companion adapter packages wrap the validator as middleware /
+hooks: [`oav-express4`](../oav-express4/README.md),
+[`oav-express5`](../oav-express5/README.md),
+[`oav-fastify`](../oav-fastify/README.md). Each exports the same
+`validateRequests` factory plus standalone helpers
+(`httpRequestFrom<Framework>`, `renderProblemDetails`).
 
 ## Why this validator
 


### PR DESCRIPTION
## Summary

Audit pass across all docs. Three classes of fix:

### 1. Don't promise what we haven't shipped

Removed every reference to a future \`oav-hono\` sibling package — it isn't on the roadmap, and the docs were repeatedly promising it as a forthcoming sibling alongside the shipped adapters. The shipped adapter family is \`oav-express4\`, \`oav-express5\`, \`oav-fastify\`; that's what the docs now say.

Files affected: \`README.md\`, \`INTEGRATION.md\`, \`CLAUDE.md\`, all three adapter READMEs, \`packages/core/README.md\`, \`packages/oav/README.md\`, \`packages/validator/README.md\`.

### 2. Drop defensive / promotional framing

- \`That's it.\` sentences in adapter READMEs → state what the defaults produce, no editorial.
- \`Sensible defaults: ...\` → describe what the defaults are.
- \`Three lines, no behaviour change\` → drop the \"three lines\" framing.
- \`Out of the box\` → drop where it was decorative.
- \`Default. Batteries-included.\` → describe what's included.

### 3. Completeness in package listings

The root \`README.md\` install table and snippets now list all five publishable packages (oav, oav-core, oav-express4, oav-express5, oav-fastify), not just oav-express4 with \"more to come\" framing. Cross-reference sections in \`packages/core/README.md\`, \`packages/oav/README.md\`, \`packages/validator/README.md\` updated to list the actual sibling adapters by name.

\`CLAUDE.md\` package-architecture section consolidates the three adapters into one entry (they share the same shape) and updates the dependency graph to show all three. The \"future ... siblings\" phrasing replaced with present-tense fact.

### What was kept

Legitimate \`Hono\` / \`Bun\` / \`Deno\` mentions where they describe those frameworks as targets via the Web Standards adapter (which they genuinely are), not as future oav-* packages.

## Test plan

Doc-only change.

- [x] \`pnpm test\` clean
- [x] \`pnpm lint\` clean
- [x] No behaviour change