### PR TITLE
ci: rename pr-title job from lint to pr-title

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,7 +12,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  lint:
+  pr-title:
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1


### PR DESCRIPTION
## Summary

- The `ci.yml` workflow already publishes a status check called `lint`. The `pr-title.yml` workflow's identically-named job collided, so two `lint` checks appeared on every PR.
- Renaming the pr-title job makes the just-added `required_status_checks` ruleset entries unambiguous (`lint` for ci, `pr-title` for the conventional-commits gate).
- This is also the bootstrap PR for the new ruleset: `pull_request` events use the workflow file from the PR head, so the renamed job runs on this PR and self-satisfies the new requirement.

## Test plan

- [x] CI shows a check named `pr-title` (not a second `lint`)
- [x] All required checks pass and the PR becomes mergeable