### PR TITLE
ci: pin express major in oav-express{4,5} dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,15 @@ updates:
       # auto-PRs; bump it deliberately when the time is right.
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      # Each oav-express{4,5} adapter pins to its corresponding express
+      # major on purpose — that's the whole point of having two
+      # packages. A semver-major bump here would silently turn the v4
+      # adapter into a v5 adapter (or vice versa). Within-major patch /
+      # minor bumps still flow through dev-minor-and-patch.
+      - dependency-name: "express"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/express"
+        update-types: ["version-update:semver-major"]
     groups:
       types:
         patterns:


### PR DESCRIPTION
## Summary

- Adds `express` and `@types/express` to the root `dependabot.yml` ignore list for `version-update:semver-major`.
- Without this, Dependabot bundles them and proposes `express 4.21.2 → 5.x` in `packages/oav-express4` (see #209) — which would silently convert the v4 adapter into a v5 one. Same risk in the other direction once express 6 lands.
- Within-major patch / minor bumps still flow through the existing `dev-minor-and-patch` group.

After this lands, `@dependabot recreate` on #209 will regenerate it without the express major bump.

## Test plan

- [ ] CI passes (no behavioural change; YAML config only)