### PR TITLE
chore(ci,release): drop redundant pnpm build; document missing prepublishOnly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,9 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm build
+      # No explicit `pnpm build`: each publishable package's prepack
+      # rebuilds on `pnpm pack` below, so the explicit step is wasted
+      # work. Builds still happen — just via prepack.
       - name: pack every publishable workspace package
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,9 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
       - run: pnpm install --frozen-lockfile
-      - run: pnpm build
+      # No explicit `pnpm build`: each package's prepack rebuilds on
+      # `pnpm -r publish` below. (Vitest aliases the workspace src
+      # directly, so `pnpm test` doesn't need a prebuilt dist either.)
       - run: pnpm test
       # Publish every non-private workspace package. Currently that's
       # @aahoughton/oav-core (root) and @aahoughton/oav (packages/oav);

--- a/packages/oav-express4/package.json
+++ b/packages/oav-express4/package.json
@@ -73,5 +73,6 @@
   },
   "engines": {
     "node": ">=22"
-  }
+  },
+  "//": "No prepublishOnly: release.yml runs `pnpm test` from root before `pnpm -r publish`. Per-package publish (`cd packages/<x> && pnpm publish`) is not the supported path; it would skip the test gate."
 }

--- a/packages/oav-express5/package.json
+++ b/packages/oav-express5/package.json
@@ -73,5 +73,6 @@
   },
   "engines": {
     "node": ">=22"
-  }
+  },
+  "//": "No prepublishOnly: release.yml runs `pnpm test` from root before `pnpm -r publish`. Per-package publish (`cd packages/<x> && pnpm publish`) is not the supported path; it would skip the test gate."
 }

--- a/packages/oav-fastify/package.json
+++ b/packages/oav-fastify/package.json
@@ -71,5 +71,6 @@
   },
   "engines": {
     "node": ">=22"
-  }
+  },
+  "//": "No prepublishOnly: release.yml runs `pnpm test` from root before `pnpm -r publish`. Per-package publish (`cd packages/<x> && pnpm publish`) is not the supported path; it would skip the test gate."
 }

--- a/packages/oav/package.json
+++ b/packages/oav/package.json
@@ -142,5 +142,6 @@
   },
   "engines": {
     "node": ">=22"
-  }
+  },
+  "//": "No prepublishOnly: release.yml runs `pnpm test` from root before `pnpm -r publish`. Per-package publish (`cd packages/<x> && pnpm publish`) is not the supported path; it would skip the test gate."
 }


### PR DESCRIPTION
Closes #177.

## Summary

Two small publish-tooling cleanups that became possible after #167 made `prepack` structural.

### 1. Drop explicit `pnpm build` before pack/publish

`ci.yml` (pack-smoke job) and `release.yml` (publish job) both ran `pnpm build` ahead of the pack/publish step. Each publishable package's `prepack` now rebuilds at pack/publish time, so the explicit step is wasted work.

The `build` / `conformance` / `typecheck` jobs keep their explicit `pnpm build` — they don't pack, so prepack never fires.

Verified locally: deleted `packages/oav-express4/dist/`, ran `pnpm pack` from that package, confirmed `dist/` reappeared.

> Side note: `pnpm -r publish` still builds `packages/oav` twice — once via root's `prepack: pnpm build` (which recurses into `oav`), once via `oav`'s own `prepack: tsup`. ~30s; not worth env-sniffing in every prepack to short-circuit.

### 2. Document missing `prepublishOnly` on each publishable package

Root has `prepublishOnly: pnpm test`. The four publishable packages (`oav`, `oav-express4`, `oav-express5`, `oav-fastify`) don't — so a manual `cd packages/<x> && pnpm publish` would skip the test gate. `release.yml`'s `pnpm test` covers the supported release-please flow; this is a defense-in-depth gap only for the manual per-package-publish path, which isn't supported.

Chose to document via a `"//"` comment in each publishable `package.json` rather than wiring per-package `prepublishOnly: pnpm test`. The latter would re-run subset coverage in CI for no gain — root's vitest already covers all packages via workspace aliases (`vitest.config.ts`), so the per-package runs would be strict subsets of work that just happened.

## Test plan

- [x] `pnpm lint` clean locally
- [x] `pnpm test` clean locally (779/779)
- [x] Verified prepack fires on `pnpm pack` (deleted dist, repacked, dist reappeared)
- [ ] CI green on PR
- [ ] Next release-please publish proves the prepack chain works end-to-end (no PR-time signal for this)