### PR TITLE
feat(core): add formatSummary + toJsonObject; deprecate three misnamed exports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,9 @@ in CI — they're tsx-run dev tooling, breakage shows up when you run them.
 - **`@oav/core`** — the shared error-tree model plus the helpers every
   other package and most consumers need. `ValidationError` tree
   (children always an array), path segments as `(string | number)[]`,
-  the three formatters (`formatText` / `formatJson` / `formatFlat`)
+  the canonical formatters (`formatText` / `formatSummary` / `toJsonObject`;
+  legacy aliases `formatJson` / `formatFlat` / `summarize` are still exported
+  but deprecated, removal in v2.0)
   and the named-format dispatch (`formatError`, `formatErrors`,
   `KNOWN_OUTPUT_FORMATS`), `httpStatusFor` / `allowHeaderFor` /
   `toProblemDetails` for HTTP framing, RFC 6901 `resolveJsonPointer`,

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -13,7 +13,7 @@ This document is organised:
   `validateResponse` work with.
 - **[Supporting helpers](#supporting-helpers)** —
   `httpStatusFor`, `allowHeaderFor`, `toProblemDetails`,
-  `summarize`, `collectIssues`. The recipes below assume these.
+  `formatSummary`, `collectIssues`. The recipes below assume these.
 - **[Per-framework integration](#per-framework-integration)** —
   Express 4, Express 5, Fastify, Next.js, Hono, Bun, Deno. Each
   section leads with the adapter (where one exists) and falls back
@@ -78,16 +78,19 @@ lean install). The recipes below assume these are in scope.
   [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html)
   `application/problem+json` body with the failing leaves carried in
   an `issues` field (a non-standard field alongside the required
-  ones). The `detail` field defaults to `summarize(err)` (a one-line
-  description of the first failing leaf); pass `detail` explicitly
-  for an override.
+  ones). The `detail` field defaults to `formatSummary(err)` (a
+  one-line description of the first failing leaf); pass `detail`
+  explicitly for an override.
 
-- **`summarize(err, opts?)`** — single-line summary of the first
-  failing leaf as `<dotted-path> <message>`. Use it directly for log
-  lines, error-monitoring titles (Sentry/New Relic group by message),
-  or as the top-level `message` field in custom response envelopes.
-  See `SummarizeOptions.select` for the leaf-picking policy
-  (`"first"` / `"deepest"` / `{ byCode }`).
+- **`formatSummary(err, opts?)`** — render the error tree as a
+  string. Default is a single line summarising the first failing
+  leaf as `<dotted-path> <message>` — use it for log lines,
+  error-monitoring titles (Sentry/New Relic group by message), or
+  as the top-level `message` field in custom response envelopes.
+  Pass `{ select: "all" }` for a multi-line enumeration of every
+  leaf — the EOV-style "every issue in a single message" shape.
+  See `FormatSummaryOptions.select` for the full policy
+  (`"first"` / `"deepest"` / `"all"` / `{ byCode }`).
 
 - **`collectIssues(err)`** — flat leaf list. Each issue carries both
   a raw `path: PathSegment[]` and a pre-formatted RFC 6901 `pointer`
@@ -98,8 +101,8 @@ lean install). The recipes below assume these are in scope.
 import {
   allowHeaderFor,
   collectIssues,
+  formatSummary,
   httpStatusFor,
-  summarize,
   toProblemDetails,
 } from "@aahoughton/oav";
 ```

--- a/MIGRATION-FROM-EOV.md
+++ b/MIGRATION-FROM-EOV.md
@@ -44,18 +44,18 @@ The behaviour deltas surfaced by real eov→oav migrations. Most are
 defensible improvements; a few are cosmetic. Either way, expect
 fixture / test churn.
 
-| What                               | eov                                                   | oav                                                                                                                                                        |
-| ---------------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Empty POST, no Content-Type**    | 415 unsupported-media-type                            | 400 body-required (no client signal to be "wrong about")                                                                                                   |
-| **Path-parameter label**           | `/params/<name>` in error paths                       | `/path/<name>` (OpenAPI's actual location name)                                                                                                            |
-| **404 message wording**            | `"not found"`                                         | `"no route matches POST /path/here"` (more actionable)                                                                                                     |
-| **Top-level message**              | every leaf joined                                     | first leaf only (`summarize` default); per-leaf details still in `errors[]`                                                                                |
-| **Top-level `path` on 404s**       | offending URL                                         | `[]` (empty array → `""` pointer); same kind of error, different rendering                                                                                 |
-| **`errorCode` names**              | `required.openapi.validation`                         | bare codes (`required`); the `.openapi.validation` suffix was always noise                                                                                 |
-| **`oneOf` with binary fields**     | silently accepted (looser inside binary fields)       | surfaces the genuine ambiguity with `matchCount: 2`; see [INTEGRATION.md → File uploads](./INTEGRATION.md#file-uploads-with-multer) for the spec-level fix |
-| **Error response monkey-patching** | `res.send("{...}")` (string form) caught via wrappers | not caught unless you write the wrapper yourself; see [INTEGRATION.md → Response validation](./INTEGRATION.md#response-validation-no-monkey-patching)      |
-| **Optional `openapi` version**     | throws on missing / unsupported                       | silently uses 3.1 by default; see `onUnknownVersion`                                                                                                       |
-| **`format` semantics**             | always assertive in OpenAPI context                   | assertive in OpenAPI context; annotation-only under raw `jsonSchemaDialect` (per 2020-12 default)                                                          |
+| What                               | eov                                                                                         | oav                                                                                                                                                                                                                        |
+| ---------------------------------- | ------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Empty POST, no Content-Type**    | 415 unsupported-media-type                                                                  | 400 body-required (no client signal to be "wrong about")                                                                                                                                                                   |
+| **Path-parameter label**           | `/params/<name>` in error paths                                                             | `/path/<name>` (OpenAPI's actual location name)                                                                                                                                                                            |
+| **404 message wording**            | `"not found"`                                                                               | `"no route matches POST /path/here"` (more actionable)                                                                                                                                                                     |
+| **Top-level message**              | first leaf by default; every leaf `, `-joined under `validateRequests: { allErrors: true }` | configurable via `formatSummary`: `{ select: "first" }` (default; first leaf) or `{ select: "all" }` (every leaf, newline-joined). Per-leaf details always in `errors[]` / `issues[]`. Shape differs from eov — see below. |
+| **Top-level `path` on 404s**       | offending URL                                                                               | `[]` (empty array → `""` pointer); same kind of error, different rendering                                                                                                                                                 |
+| **`errorCode` names**              | `required.openapi.validation`                                                               | bare codes (`required`); the `.openapi.validation` suffix was always noise                                                                                                                                                 |
+| **`oneOf` with binary fields**     | silently accepted (looser inside binary fields)                                             | surfaces the genuine ambiguity with `matchCount: 2`; see [INTEGRATION.md → File uploads](./INTEGRATION.md#file-uploads-with-multer) for the spec-level fix                                                                 |
+| **Error response monkey-patching** | `res.send("{...}")` (string form) caught via wrappers                                       | not caught unless you write the wrapper yourself; see [INTEGRATION.md → Response validation](./INTEGRATION.md#response-validation-no-monkey-patching)                                                                      |
+| **Optional `openapi` version**     | throws on missing / unsupported                                                             | silently uses 3.1 by default; see `onUnknownVersion`                                                                                                                                                                       |
+| **`format` semantics**             | always assertive in OpenAPI context                                                         | assertive in OpenAPI context; annotation-only under raw `jsonSchemaDialect` (per 2020-12 default)                                                                                                                          |
 
 For the `oneOf [array<binary>, binary]` pattern specifically: the
 spec was already ambiguous before oav surfaced it (the `format:
@@ -187,3 +187,37 @@ createValidator(spec, { formats: fromAjvFormats(myAjvFormats) });
 Schema 2020-12 §6.3), so ajv's `type: "number"` format entries are
 effectively no-ops — the function never runs on non-string data.
 Keep them in the map if it's simpler; they cost nothing.
+
+## All-issues output (eov's `allErrors`)
+
+`eov`'s default puts the first failing leaf in the top-level
+`message`. With `validateRequests: { allErrors: true }`, eov instead
+`, `-joins every issue into one `message` string.
+
+`oav` defaults to the same first-leaf summary. For an all-issues
+string, use `formatSummary` with `{ select: "all" }`:
+
+```ts
+import { formatSummary } from "@aahoughton/oav-core";
+
+// Default — first failing leaf, equivalent to eov's default `message`:
+formatSummary(err);
+// "body.users[0].email must match format \"email\""
+
+// All leaves, one per line — equivalent in scope to eov's `allErrors`:
+formatSummary(err, { select: "all" });
+// body.users[0].email — must match format "email" [format]
+// body.users[1].age — must be >= 0 [minimum]
+```
+
+Shape differs from eov in three ways: `oav` uses dotted paths
+(`body.users[0].email`) instead of slash-separated
+(`request/body/users/0/email`); separates each entry with `\n`
+rather than `, `; and appends the error `[code]`. If you need exact
+parity for an existing client, post-process the string or render
+your own using `collectIssues(err)`.
+
+The same `formatSummary` powers the `detail` field of
+`toProblemDetails` — pass `{ detail: formatSummary(err, { select: "all" }) }`
+to override the default and emit the all-issues form in your
+RFC 9457 response body.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -63,36 +63,44 @@ declaration merging.
 
 ## Formatters
 
+Naming convention: **`format*`** returns a string (humans, logs,
+CLI, response bodies); **`to*`** returns an object (machine
+consumers, JSON serialization).
+
 Which one to reach for:
 
-| Want                                                                      | Use          |
-| ------------------------------------------------------------------------- | ------------ |
-| One-line string for `response.message`, log lines, Sentry/NR group titles | `summarize`  |
-| Multi-line indented tree for stdout, log dumps, human reading             | `formatText` |
-| Structured tree for programmatic consumption / JSON round-trip            | `formatJson` |
-| One line per leaf for grep, CI diffs                                      | `formatFlat` |
+| Want                                                                       | Use                                     |
+| -------------------------------------------------------------------------- | --------------------------------------- |
+| One-line summary for `response.message`, log lines, Sentry/NR group titles | `formatSummary(err)`                    |
+| Every leaf, one per line — flat enumeration (EOV-style, grep, CI diffs)    | `formatSummary(err, { select: "all" })` |
+| Multi-line indented tree for stdout, log dumps, human reading              | `formatText(err)`                       |
+| Structured tree for programmatic consumption / JSON round-trip             | `toJsonObject(err)`                     |
 
-Tree formatters — produce strings suitable for stdout / logs.
+Detail:
 
-- `formatText(err, { maxDepth?, indent? })` — indented human-readable.
-- `formatJson(err)` — deep copy that round-trips through `JSON.stringify`.
-- `formatFlat(err)` — one line per leaf.
+- **`formatText(err, { maxDepth?, indent? })`** — indented
+  human-readable tree. One line per node.
 
-Single-line summary — for response-body `message` fields, log lines,
-error-monitoring titles, and `Error.message`:
-
-- `summarize(err, { select? })` — picks one leaf and renders it as
+- **`formatSummary(err, { select? })`** — render the tree as a
+  string. Default picks one leaf and renders it as
   `<dotted-path> <message>` (e.g. `"body.users[0].email must match
-format \"email\""`).
+format \"email\""`). Selection options:
   - `select: "first"` (default) — first leaf in tree-traversal
-    order. Matches `express-openapi-validator`'s top-level message.
+    order.
   - `select: "deepest"` — leaf with the longest path; more
     informative on `oneOf` / composition trees.
+  - `select: "all"` — every leaf, one per line, each with path,
+    message, and `[code]`. The "every issue in a single message"
+    shape; use this when migrating from validators that emit a
+    flat enumeration by default.
   - `select: { byCode: ["content-type", "required", ...] }` —
     priority list. Returns the first leaf matching the
     highest-priority listed code; falls back to `"first"` if no
     match. Useful when the wire format wants to surface specific
     failure categories first.
+
+- **`toJsonObject(err)`** — deep copy that round-trips losslessly
+  through `JSON.stringify` / `JSON.parse`.
 
 `countErrors(err)` returns the total number of nodes in the tree.
 
@@ -116,7 +124,7 @@ migrating from).
 - `toProblemDetails(err, { type?, title?, status?, detail?, instance? })` —
   RFC 9457 `application/problem+json` envelope with a typed `issues`
   array as an extension member. Defaults: `about:blank` type,
-  `"Validation failed"` title, status `400`, and `detail` = `summarize(err)`
+  `"Validation failed"` title, status `400`, and `detail` = `formatSummary(err)`
   (first failing leaf). Pass `detail` explicitly for a structural
   summary like `` `${pd.issues.length} validation errors` `` or any
   other override.
@@ -140,7 +148,7 @@ res
 
 // Custom envelope, eov-style flat list.
 res.status(httpStatusFor(err)).json({
-  message: summarize(err),
+  message: formatSummary(err),
   errors: collectIssues(err).map((i) => ({
     path: i.pointer,
     message: i.message,
@@ -148,9 +156,11 @@ res.status(httpStatusFor(err)).json({
   })),
 });
 
-// Just the top-level summary (e.g. for a comma-joined "every leaf"
-// message that some pre-existing wire formats use):
-const joined = collectIssues(err)
+// Every-leaf "joined message" shape (some pre-existing wire formats
+// use this — e.g. eov under `validateRequests: { allErrors: true }`):
+formatSummary(err, { select: "all" }); // newline-joined
+// Or for a comma-joined variant:
+collectIssues(err)
   .map((i) => i.message)
   .join(", ");
 ```

--- a/packages/core/src/format-output.ts
+++ b/packages/core/src/format-output.ts
@@ -1,4 +1,4 @@
-import { formatFlat, formatJson, formatText } from "./format.js";
+import { formatSummary, formatText, toJsonObject } from "./format.js";
 import type { ValidationError } from "./errors.js";
 
 /**
@@ -59,9 +59,9 @@ export function formatError(
   if (typeof renderer === "function") return renderer(err);
   switch (renderer) {
     case "json":
-      return JSON.stringify(formatJson(err), null, 2);
+      return JSON.stringify(toJsonObject(err), null, 2);
     case "flat":
-      return formatFlat(err);
+      return formatSummary(err, { select: "all" });
     case "text":
     default:
       return formatText(err, depth !== undefined ? { maxDepth: depth } : {});

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -18,8 +18,8 @@ export interface FormatOptions {
  * @remarks
  * Every node renders as `<path> — <message> [<code>]`. Children are indented
  * under their parent. The output is meant for terminals and logs, not for
- * programmatic consumption — use {@link formatJson} or {@link formatFlat}
- * for that.
+ * programmatic consumption — use {@link toJsonObject} or
+ * {@link formatSummary} for that.
  *
  * @param error - Root of the error tree.
  * @param options - Optional rendering settings.
@@ -53,110 +53,115 @@ export function formatText(error: ValidationError, options: FormatOptions = {}):
 }
 
 /**
- * Render a {@link ValidationError} tree as the raw tree — identical to the
- * input, but guaranteed to round-trip through `JSON.stringify`/`JSON.parse`.
+ * Return a {@link ValidationError} tree as a JSON-safe plain object.
+ *
+ * @remarks
+ * The returned object has the same shape as the input but is freshly
+ * constructed (deep-cloned `children`, `path`, and `params`), so it
+ * round-trips losslessly through `JSON.stringify` / `JSON.parse`.
  *
  * @param error - Root of the error tree.
  * @returns The same tree, safe to hand to `JSON.stringify`.
  *
  * @example
  * ```ts
- * JSON.stringify(formatJson(rootError), null, 2);
+ * JSON.stringify(toJsonObject(rootError), null, 2);
  * ```
  *
  * @public
  */
-export function formatJson(error: ValidationError): ValidationError {
+export function toJsonObject(error: ValidationError): ValidationError {
   return {
     code: error.code,
     path: [...error.path],
     message: error.message,
     params: { ...error.params },
-    children: error.children.map(formatJson),
+    children: error.children.map(toJsonObject),
   };
 }
 
 /**
- * Render every leaf of a {@link ValidationError} tree as one line, each
- * prefixed with the joined path. Intended for `grep`-style consumption and
- * `diff`s in CI.
- *
- * @param error - Root of the error tree.
- * @returns A newline-separated string, one line per leaf.
- *
- * @example
- * ```ts
- * const flat = formatFlat(rootError);
- * // body.users[0].email — must match format "email" [format]
- * // body.users[1].age — must be >= 0 [minimum]
- * ```
- *
- * @public
- */
-export function formatFlat(error: ValidationError): string {
-  const lines: string[] = [];
-  for (const leaf of collectLeaves(error)) {
-    const location = joinPath(leaf.path);
-    const pathPart = location.length > 0 ? `${location} — ` : "";
-    lines.push(`${pathPart}${leaf.message} [${leaf.code}]`);
-  }
-  return lines.join("\n");
-}
-
-/**
- * Leaf-selection policy for {@link summarize}.
+ * Leaf-selection policy for {@link formatSummary}.
  *
  * - `"first"` — the first leaf in tree-traversal order. Matches
  *   `express-openapi-validator`'s top-level `message`. The default.
  * - `"deepest"` — the leaf with the longest path. More informative
  *   on `oneOf` / composition trees where the structural cause sits
  *   one or two levels in. Tiebreak: first encountered.
+ * - `"all"` — every leaf, one per line, each prefixed with its path
+ *   and suffixed with its `[code]`. Use this when you want a flat
+ *   enumeration of every issue (e.g. EOV-style flat error messages,
+ *   `grep`-friendly logs, CI diffs).
  * - `{ byCode }` — priority list of error codes. Returns the first
  *   leaf whose `code` matches the highest-priority entry; if no leaf
  *   matches any listed code, falls back to the `"first"` policy.
  *
  * @public
  */
-export type SummarizeSelect = "first" | "deepest" | { byCode: readonly string[] };
+export type FormatSummarySelect = "first" | "deepest" | "all" | { byCode: readonly string[] };
 
 /**
- * Options for {@link summarize}.
+ * Options for {@link formatSummary}.
  *
  * @public
  */
-export interface SummarizeOptions {
-  /** How to pick the leaf to summarise. Defaults to `"first"`. */
-  select?: SummarizeSelect;
+export interface FormatSummaryOptions {
+  /** How to pick which leaf (or leaves) to summarise. Defaults to `"first"`. */
+  select?: FormatSummarySelect;
 }
 
 /**
- * Render a {@link ValidationError} tree as a single human-readable line —
- * the kind of string every HTTP adapter needs for response-body
- * `message` fields, log lines, error-monitoring titles, and
- * `Error.message`.
+ * Render a {@link ValidationError} tree as a string — the workhorse for
+ * HTTP response-body `message` fields, log lines, error-monitoring
+ * titles, and `Error.message`.
  *
- * Picks one leaf per the {@link SummarizeOptions.select} policy and
- * renders it as `<dotted-path> <message>` (or just `<message>` when
- * the path is empty). Use {@link formatFlat} or {@link formatText}
- * when you need the full tree.
+ * Two output shapes depending on {@link FormatSummaryOptions.select}:
+ *
+ * - **Single-leaf modes** (`"first"`, `"deepest"`, `{ byCode }`) pick one
+ *   leaf and render it as `<dotted-path> <message>` (or just `<message>`
+ *   when the path is empty). One line.
+ * - **All-leaves mode** (`"all"`) enumerates every leaf, one per line,
+ *   as `<dotted-path> — <message> [<code>]`. Use this for the EOV-style
+ *   "every issue in a single message" shape.
+ *
+ * For the indented full-tree view, use {@link formatText}; for the raw
+ * JSON-safe object, use {@link toJsonObject}.
  *
  * @example
  * ```ts
- * summarize(rootError);
+ * formatSummary(rootError);
  * // "body.users[0].email must match format \"email\""
  *
- * summarize(rootError, { select: { byCode: ["content-type", "required"] } });
- * // returns the content-type leaf if any, else the first required leaf,
+ * formatSummary(rootError, { select: "deepest" });
+ * // The leaf with the longest path — useful on oneOf trees.
+ *
+ * formatSummary(rootError, { select: "all" });
+ * // Every leaf, one per line. EOV-style flat output:
+ * //   body.users[0].email — must match format "email" [format]
+ * //   body.users[1].age — must be >= 0 [minimum]
+ *
+ * formatSummary(rootError, { select: { byCode: ["content-type", "required"] } });
+ * // The first content-type leaf if any, else the first required leaf,
  * // else the first leaf overall.
  * ```
  *
  * @public
  */
-export function summarize(error: ValidationError, options: SummarizeOptions = {}): string {
+export function formatSummary(error: ValidationError, options: FormatSummaryOptions = {}): string {
   const select = options.select ?? "first";
   // collectLeaves defines a leaf as any node with no children, so even
   // a single-leaf root yields one entry — leaves[0] is always present.
   const leaves = collectLeaves(error);
+
+  if (select === "all") {
+    const lines: string[] = [];
+    for (const leaf of leaves) {
+      const location = joinPath(leaf.path);
+      const pathPart = location.length > 0 ? `${location} — ` : "";
+      lines.push(`${pathPart}${leaf.message} [${leaf.code}]`);
+    }
+    return lines.join("\n");
+  }
 
   let chosen: ValidationError = leaves[0]!;
   if (select === "deepest") {
@@ -196,4 +201,58 @@ export function countErrors(error: ValidationError): number {
     n += 1;
   });
   return n;
+}
+
+// ---------------------------------------------------------------------------
+// Deprecated: kept exported for source compatibility; absent from user-facing
+// docs. Behaviour identical to the new canonical names. Removal in v2.0.
+// ---------------------------------------------------------------------------
+
+/**
+ * @deprecated Use {@link toJsonObject} — same return shape, name reflects
+ *   that it returns an object, not a string.
+ *
+ * @public
+ */
+export function formatJson(error: ValidationError): ValidationError {
+  return toJsonObject(error);
+}
+
+/**
+ * Options for the deprecated {@link summarize}. Use
+ * {@link FormatSummaryOptions} instead.
+ *
+ * @deprecated Use {@link FormatSummaryOptions}.
+ *
+ * @public
+ */
+export interface SummarizeOptions {
+  /** @deprecated See {@link FormatSummaryOptions.select}. */
+  select?: SummarizeSelect;
+}
+
+/**
+ * @deprecated Use {@link FormatSummarySelect}. Note: the new type also
+ *   accepts `"all"` for flat all-leaves output.
+ *
+ * @public
+ */
+export type SummarizeSelect = "first" | "deepest" | { byCode: readonly string[] };
+
+/**
+ * @deprecated Use {@link formatSummary} — same defaults and behaviour.
+ *
+ * @public
+ */
+export function summarize(error: ValidationError, options: SummarizeOptions = {}): string {
+  return formatSummary(error, options);
+}
+
+/**
+ * @deprecated Use `formatSummary(err, { select: "all" })`.
+ *
+ * @public
+ */
+export function formatFlat(error: ValidationError): string {
+  return formatSummary(error, { select: "all" });
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,9 +19,13 @@ export {
   countErrors,
   formatFlat,
   formatJson,
+  formatSummary,
   formatText,
   summarize,
+  toJsonObject,
   type FormatOptions,
+  type FormatSummaryOptions,
+  type FormatSummarySelect,
   type SummarizeOptions,
   type SummarizeSelect,
 } from "./format.js";

--- a/packages/core/src/problem-details.ts
+++ b/packages/core/src/problem-details.ts
@@ -1,5 +1,5 @@
 import { collectLeaves, type PathSegment, type ValidationError } from "./errors.js";
-import { summarize } from "./format.js";
+import { formatSummary } from "./format.js";
 
 /**
  * A single validation issue flattened for client consumption. Produced
@@ -67,7 +67,7 @@ export interface ProblemDetailsOptions {
   instance?: string;
   /**
    * Override the human-readable `detail`. Defaults to
-   * {@link summarize}(error) — a single line describing the first
+   * {@link formatSummary}(error) — a single line describing the first
    * failing leaf (e.g. `"body.users[0].email must match format \"email\""`).
    * Pass an explicit string for a structural summary like
    * `` `${issues.length} validation error(s)` `` if you'd rather
@@ -124,7 +124,7 @@ export function toProblemDetails(
     type: options.type ?? "about:blank",
     title: options.title ?? "Validation failed",
     status: options.status ?? 400,
-    detail: options.detail ?? summarize(error),
+    detail: options.detail ?? formatSummary(error),
     issues,
   };
   if (options.instance !== undefined) result.instance = options.instance;

--- a/packages/core/test/format.test.ts
+++ b/packages/core/test/format.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { createBranchError, createLeafError, type ValidationError } from "../src/errors.js";
-import { countErrors, formatFlat, formatJson, formatText, summarize } from "../src/format.js";
+import {
+  countErrors,
+  formatFlat,
+  formatJson,
+  formatSummary,
+  formatText,
+  summarize,
+  toJsonObject,
+} from "../src/format.js";
 
 /** A realistic 4-level oneOf failure used by several formatter assertions. */
 function sampleTree(): ValidationError {
@@ -110,7 +118,80 @@ describe("countErrors", () => {
   });
 });
 
-describe("summarize", () => {
+describe("toJsonObject", () => {
+  it("returns a tree that survives JSON.stringify → JSON.parse", () => {
+    const tree = sampleTree();
+    const roundTripped = JSON.parse(JSON.stringify(toJsonObject(tree)));
+    expect(roundTripped).toEqual(tree);
+  });
+
+  it("deep-copies children and params", () => {
+    const tree = sampleTree();
+    const cloned = toJsonObject(tree);
+    expect(cloned).not.toBe(tree);
+    expect(cloned.children).not.toBe(tree.children);
+    const firstChild = cloned.children[0];
+    if (firstChild === undefined) throw new Error("unreachable");
+    firstChild.message = "mutated";
+    expect(tree.children[0]?.message).not.toBe("mutated");
+  });
+});
+
+describe("formatSummary", () => {
+  it('defaults to "first" — picks the first leaf in tree-traversal order', () => {
+    expect(formatSummary(sampleTree())).toBe("body.purr must be boolean");
+  });
+
+  it('"deepest" picks the leaf with the longest path', () => {
+    const tree = createBranchError("body", ["body"], "bad", [
+      createLeafError("required", ["body"], "missing name"),
+      createLeafError("type", ["body", "items", 3, "name"], "must be string"),
+    ]);
+    expect(formatSummary(tree, { select: "first" })).toBe("body missing name");
+    expect(formatSummary(tree, { select: "deepest" })).toBe("body.items[3].name must be string");
+  });
+
+  it('"all" enumerates every leaf, one per line, in formatFlat shape', () => {
+    const out = formatSummary(sampleTree(), { select: "all" });
+    const lines = out.split("\n");
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe("body.purr — must be boolean [type]");
+    expect(lines[1]).toBe('body — must have required property "bark" [required]');
+  });
+
+  it('"all" output is byte-identical to the deprecated formatFlat for the same tree', () => {
+    const tree = sampleTree();
+    expect(formatSummary(tree, { select: "all" })).toBe(formatFlat(tree));
+  });
+
+  it("byCode returns the first leaf matching the highest-priority listed code", () => {
+    const tree = createBranchError("request", [], "request invalid", [
+      createLeafError("type", ["body", "age"], "must be number"),
+      createLeafError("content-type", ["body"], 'Content-Type "text/plain" not accepted'),
+      createLeafError("required", ["body"], "missing name"),
+    ]);
+    expect(formatSummary(tree, { select: { byCode: ["content-type", "required"] } })).toBe(
+      'body Content-Type "text/plain" not accepted',
+    );
+    expect(formatSummary(tree, { select: { byCode: ["required", "content-type"] } })).toBe(
+      "body missing name",
+    );
+  });
+
+  it('byCode falls back to "first" when no leaf matches any listed code', () => {
+    const tree = createLeafError("type", ["body", "age"], "must be number");
+    expect(formatSummary(tree, { select: { byCode: ["content-type", "security"] } })).toBe(
+      "body.age must be number",
+    );
+  });
+
+  it("renders a path-less leaf as just the message", () => {
+    const tree = createLeafError("route", [], "no matching route");
+    expect(formatSummary(tree)).toBe("no matching route");
+  });
+});
+
+describe("summarize (deprecated)", () => {
   it('defaults to "first" — picks the first leaf in tree-traversal order', () => {
     expect(summarize(sampleTree())).toBe("body.purr must be boolean");
   });

--- a/packages/core/test/problem-details.test.ts
+++ b/packages/core/test/problem-details.test.ts
@@ -68,7 +68,7 @@ describe("toProblemDetails", () => {
     expect(pd.type).toBe("about:blank");
     expect(pd.title).toBe("Validation failed");
     expect(pd.status).toBe(400);
-    // detail summarises the first leaf via summarize(); the structural
+    // detail summarises the first leaf via formatSummary(); the structural
     // count is still in `issues.length` for callers that need it.
     expect(pd.detail).toBe("body missing name");
     expect(pd.instance).toBeUndefined();

--- a/packages/oav-express4/README.md
+++ b/packages/oav-express4/README.md
@@ -176,7 +176,7 @@ app.use(
   validateRequests(validator, {
     onError: (err, ctx) => {
       ctx.res.status(httpStatusFor(err)).json({
-        message: summarize(err),
+        message: formatSummary(err),
         errors: collectIssues(err),
       });
     },
@@ -269,6 +269,6 @@ For per-route inline multer (validator called from inside the route handler) and
 
 ## See also
 
-- [`@aahoughton/oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — `createValidator`, `ValidatorOptions`, `summarize`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
+- [`@aahoughton/oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — `createValidator`, `ValidatorOptions`, `formatSummary`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
 - [`@aahoughton/oav`](https://www.npmjs.com/package/@aahoughton/oav) — batteries-included distribution of oav-core: YAML readers + the `oav` CLI.
 - The repo-root `INTEGRATION.md` — broader recipes (security, file uploads, response validation, migration from `express-openapi-validator`).

--- a/packages/oav-express4/src/render.ts
+++ b/packages/oav-express4/src/render.ts
@@ -7,7 +7,7 @@ import type { ExpressContext } from "./types.js";
  * RFC 9457 `application/problem+json` response: status from
  * {@link httpStatusFor}, `Allow` header from {@link allowHeaderFor}
  * on a 405, body from {@link toProblemDetails} (whose `detail` is
- * the {@link summarize}d first leaf).
+ * the first failing leaf via {@link formatSummary}).
  *
  * Exported standalone for two cases:
  *

--- a/packages/oav-express4/test/render.test.ts
+++ b/packages/oav-express4/test/render.test.ts
@@ -41,7 +41,7 @@ describe("renderProblemDetails", () => {
       status: 400,
       instance: "/pets",
     });
-    // detail comes from summarize() — first leaf, "<path> <message>".
+    // detail comes from formatSummary() — first leaf, "<path> <message>".
     expect(body.detail).toBe("body.age must be number");
     expect(body.issues).toHaveLength(1);
   });

--- a/packages/oav-express5/README.md
+++ b/packages/oav-express5/README.md
@@ -123,7 +123,7 @@ app.use(
   validateRequests(validator, {
     onError: (err, ctx) => {
       ctx.res.status(httpStatusFor(err)).json({
-        message: summarize(err),
+        message: formatSummary(err),
         errors: collectIssues(err),
       });
     },
@@ -201,7 +201,7 @@ A migrating consumer's `import { validateRequests } from "@aahoughton/oav-expres
 
 ## See also
 
-- [`@aahoughton/oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — `createValidator`, `ValidatorOptions`, `summarize`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
+- [`@aahoughton/oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — `createValidator`, `ValidatorOptions`, `formatSummary`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
 - [`@aahoughton/oav`](https://www.npmjs.com/package/@aahoughton/oav) — batteries-included distribution of oav-core: YAML readers + the `oav` CLI.
 - The repo-root `INTEGRATION.md` — broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
 - The repo-root `MIGRATION-FROM-EOV.md` — porting from `express-openapi-validator`.

--- a/packages/oav-express5/src/render.ts
+++ b/packages/oav-express5/src/render.ts
@@ -7,7 +7,7 @@ import type { ExpressContext } from "./types.js";
  * RFC 9457 `application/problem+json` response: status from
  * {@link httpStatusFor}, `Allow` header from {@link allowHeaderFor}
  * on a 405, body from {@link toProblemDetails} (whose `detail` is
- * the {@link summarize}d first leaf).
+ * the first failing leaf via {@link formatSummary}).
  *
  * Exported standalone for two cases:
  *

--- a/packages/oav-fastify/README.md
+++ b/packages/oav-fastify/README.md
@@ -111,7 +111,7 @@ app.addHook(
   validateRequests(validator, {
     onError: (err, ctx) => {
       ctx.reply.code(httpStatusFor(err)).send({
-        message: summarize(err),
+        message: formatSummary(err),
         errors: collectIssues(err),
       });
     },
@@ -191,7 +191,7 @@ If both fire on the same route, oav's `preValidation` hook runs first; if it pas
 
 ## See also
 
-- [`@aahoughton/oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — `createValidator`, `ValidatorOptions`, `summarize`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
+- [`@aahoughton/oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — `createValidator`, `ValidatorOptions`, `formatSummary`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
 - [`@aahoughton/oav`](https://www.npmjs.com/package/@aahoughton/oav) — batteries-included distribution of oav-core: YAML readers + the `oav` CLI.
 - The repo-root `INTEGRATION.md` — broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
 - The repo-root `MIGRATION-FROM-EOV.md` — porting from `express-openapi-validator`.

--- a/packages/oav-fastify/src/render.ts
+++ b/packages/oav-fastify/src/render.ts
@@ -7,7 +7,7 @@ import type { FastifyContext } from "./types.js";
  * RFC 9457 `application/problem+json` response: status from
  * {@link httpStatusFor}, `Allow` header from {@link allowHeaderFor}
  * on a 405, body from {@link toProblemDetails} (whose `detail` is
- * the {@link summarize}d first leaf).
+ * the first failing leaf via {@link formatSummary}).
  *
  * Exported standalone for two cases:
  *

--- a/packages/oav/README.md
+++ b/packages/oav/README.md
@@ -43,7 +43,7 @@ imports — no surface changes.
   flags.
 
 Everything else (`createValidator`, `compileSchema`, error helpers,
-formatters, `summarize`, `toProblemDetails`, HTTP-status helpers, …)
+formatters, `formatSummary`, `toProblemDetails`, HTTP-status helpers, …)
 is re-exported from `oav-core`. Documentation for those lives in:
 
 - [`packages/core/README.md`](../core/README.md) — error tree,


### PR DESCRIPTION
Closes #217.

## Summary

The error-result-and-transform surface in `@oav/core` now follows a single naming convention:

- **`format*`** — returns a string (humans, logs, CLI, response bodies)
- **`to*`** — returns an object (machine consumers, JSON serialization)

`toProblemDetails` already followed this; the three misfits get canonical names alongside, with the old ones kept as `@deprecated` aliases for v1.x and slated for removal in v2.0.

### New exports

- **`formatSummary(err, opts?)`** — replaces `summarize`, and via `select: "all"` also covers what `formatFlat` did. The single function exposes the full leaf-selection axis (`first` / `deepest` / `all` / `{ byCode }`).
- **`toJsonObject(err)`** — replaces `formatJson`; same return shape; name reflects that it returns an object, not a string.

### Deprecations (behaviour unchanged; absent from user-facing docs)

| Old | New equivalent |
|---|---|
| `summarize(err, opts)` | `formatSummary(err, opts)` |
| `formatFlat(err)` | `formatSummary(err, { select: "all" })` |
| `formatJson(err)` | `toJsonObject(err)` |

Old names still exported, still work — but get no mention in any doc. An EOV-migrating user (or agent) searching for "summarize" finds nothing user-facing; the only summary helper they discover is `formatSummary`, with the `select: "all"` route to flat all-leaves output prominent in its TSDoc, the core README formatter table, and the new MIGRATION-FROM-EOV "All-issues output" section.

### Verification of EOV behavior

Stood up a real `express-openapi-validator` server in `/tmp` to verify the migration doc claims before writing them. Findings:

- EOV default is **first-error-only**, identical to oav default — _not_ "every leaf joined" as the old migration table claimed.
- The joined-everything shape is opt-in via `validateRequests: { allErrors: true }`, and the join is `, ` (comma-space).
- oav's `formatSummary({ select: "all" })` is `\n`-joined, with `[code]` suffix and dotted (vs slash) paths.

Migration doc now states this accurately and shows users how to recover exact-parity output if needed.

## Why additive-only

Despite being v1.x, the package shipped recently and the existing user base is null. Even so, kept this purely additive: deprecation, no removal. v2.0 (separate issue when timing makes sense) will pull the old symbols and rework the CLI dispatcher.

## Internal hygiene

`format-output.ts` dispatcher and `problem-details.ts` `toProblemDetails` switch to the new names internally so we don't surface our own deprecation warnings on every typecheck. Output byte-identical (existing tests prove this).

## Test plan

- [x] `pnpm lint` clean locally
- [x] `pnpm test` passes (788 tests, +9 new for `formatSummary` + `toJsonObject`; existing tests for the deprecated paths kept and still pass — proves behaviour unchanged)
- [x] `pnpm typecheck` clean
- [x] Manual EOV behaviour verification documented above
- [ ] CI green
- [ ] Spot-check that the published `@aahoughton/oav-core` typings show `@deprecated` strikethroughs in IDE hover (will surface on next install after this lands)