### PR TITLE
chore(release): switch to npm trusted publishing via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,17 +59,23 @@ jobs:
       # `pnpm -r publish` below. (Vitest aliases the workspace src
       # directly, so `pnpm test` doesn't need a prebuilt dist either.)
       - run: pnpm test
-      # Publish every non-private workspace package. Currently that's
-      # @aahoughton/oav-core (root) and @aahoughton/oav (packages/oav);
-      # the @oav/* workspace packages are private and are skipped.
+      # Publish every non-private workspace package: @aahoughton/oav-core
+      # (root), @aahoughton/oav (packages/oav), and the framework
+      # adapters @aahoughton/oav-express4, oav-express5, oav-fastify.
+      # The @oav/* internal workspace packages are private and skipped.
+      #
+      # Auth: npm trusted publishing via GitHub Actions OIDC. The
+      # `id-token: write` permission above lets pnpm exchange a GitHub
+      # OIDC token for an npm publish token at request time — no
+      # NPM_TOKEN secret in this workflow. Each published package must
+      # have a trusted publisher configured on npmjs.com pointing at
+      # `aahoughton/oav` + this workflow file.
       #
       # --no-git-checks: the release-please commit is on main but CI
       # checks it out in detached-HEAD mode, which pnpm otherwise refuses.
       # --access public: required the first time a scoped package publishes;
       # harmless afterwards.
-      # --provenance: attaches a signed build attestation (uses the
-      # id-token: write OIDC permission above) so npmjs shows a
-      # "verified" badge on the published tarball.
+      # --provenance: attaches a signed build attestation so npmjs shows
+      # a "verified" badge on the published tarball (also uses the OIDC
+      # token).
       - run: pnpm -r publish --access public --provenance --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Drops `NODE_AUTH_TOKEN` env var from the `publish` step in `release.yml`. pnpm exchanges the GitHub Actions OIDC token (`id-token: write` is already granted for provenance) for an npm publish token at request time. No NPM_TOKEN secret is read by this workflow anymore.
- Updates the stale publish-list comment that named only \`oav-core\` and \`oav\` — the three framework adapters (oav-express4, oav-express5, oav-fastify) all ship from this same workflow now. (The fold-in noted at the close of #215.)

## Pre-flight checklist (out of scope here; verify before merge)

Each published package needs a trusted publisher configured on npmjs.com pointing at this repo + this workflow file:

- [ ] @aahoughton/oav-core
- [ ] @aahoughton/oav
- [ ] @aahoughton/oav-express4
- [ ] @aahoughton/oav-express5
- [ ] @aahoughton/oav-fastify

For each: organization \`aahoughton\`, repository \`oav\`, workflow filename \`release.yml\`, environment empty (we don't use one).

## Test plan

- [x] `pnpm lint` clean locally
- [ ] CI green on PR
- [ ] **Verification happens at release time.** No PR-time signal can prove the OIDC handshake works — the next release-please PR's publish step will be the first real test. If it fails on any package, that package's trusted publisher config is the place to look.
- [ ] After a successful release: the \`NPM_TOKEN\` repository secret can be revoked.

## Rollback

If the OIDC publish fails on a package whose trusted-publisher config is wrong:
1. Fix the trusted publisher config on npmjs.com (no code change needed).
2. Re-run the failed \`publish\` job from the Actions tab — it picks up the new config without needing a new git commit.

If something more fundamental breaks (e.g. pnpm version compatibility), revert this commit and re-add NPM_TOKEN as a fast escape hatch.