### PR TITLE
fix(release): unblock OIDC trusted publishing; add dispatch recovery handle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,13 @@ name: release
 on:
   push:
     branches: [main]
+  # Manual trigger: re-fires the publish job for the most recent
+  # release tag without needing release-please to mint a new one.
+  # Use this to recover from a transient publish failure (network,
+  # registry hiccup, trusted-publisher misconfiguration on a single
+  # package). `pnpm -r publish` is idempotent — it skips already-
+  # published versions and only attempts the missing ones.
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -35,11 +42,15 @@ jobs:
 
   publish:
     needs: release-please
-    # Fires only when release-please merges a release PR (tag + GitHub
-    # Release just created). Regular pushes to main still trigger the
-    # release-please job above, but it exits without `release_created`
-    # when all it did was update the in-flight release PR.
-    if: needs.release-please.outputs.release_created == 'true'
+    # Fires when release-please merges a release PR (tag + GitHub
+    # Release just created), OR when this workflow is manually
+    # dispatched (recovery from a partial / failed publish).
+    # Regular pushes to main run release-please above but skip
+    # publish — release-please's `release_created` is `false` while
+    # it's only updating the in-flight release PR.
+    if: |
+      needs.release-please.outputs.release_created == 'true' ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -53,7 +64,15 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          registry-url: https://registry.npmjs.org
+          # Deliberately no `registry-url`. setup-node would otherwise
+          # write a `.npmrc` containing
+          # `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` and
+          # export `NODE_AUTH_TOKEN=XXXXX-XXXXX-XXXXX-XXXXX` (its
+          # placeholder). pnpm/npm would then publish using that bogus
+          # token instead of falling through to the OIDC trusted-
+          # publisher exchange — which is exactly what we want it to do.
+          # The default registry is registry.npmjs.org, so omitting this
+          # parameter doesn't change where things publish.
       - run: pnpm install --frozen-lockfile
       # No explicit `pnpm build`: each package's prepack rebuilds on
       # `pnpm -r publish` below. (Vitest aliases the workspace src


### PR DESCRIPTION
## What broke

The 1.1.0 publish failed at the first package with \`404 Not Found - PUT https://registry.npmjs.org/@aahoughton%2Foav-core\`. Looking at the publish-step env block in the failed run:

\`\`\`
NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
\`\`\`

That's setup-node's *placeholder* — it always exports it when \`registry-url\` is configured. setup-node also writes a \`.npmrc\` containing \`//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}\`, so pnpm/npm published with the literal placeholder string and got rejected. **OIDC trusted publishing was never even attempted** — pnpm saw "I have an auth token" and skipped the OIDC exchange.

Provenance was signed (Sigstore via GitHub OIDC, separate codepath) — that's why "Signed provenance statement" appears right before the 404.

Nothing was published. The 1.1.0 git tag and GitHub release exist but no \`1.1.0\` is on npm.

## The fix

Two pieces:

### 1. Drop \`registry-url\` from setup-node

setup-node's \`.npmrc\` write is what blocks the OIDC fall-through. Removing the parameter skips the write entirely. The default registry is \`registry.npmjs.org\`, so this doesn't change where publishes go — only the auth path.

### 2. Add \`workflow_dispatch\` + relaxed publish gate

GitHub re-runs use the workflow file from the *original* commit, so re-running the failed run wouldn't pick up this fix. Adding manual dispatch lets us fire the publish job against an existing release tag once the fix lands.

The publish-job gate now accepts either \`release_created == 'true'\` (normal release flow) OR \`event_name == 'workflow_dispatch'\` (manual recovery). \`pnpm -r publish\` is idempotent against already-published versions, so re-firing only attempts the missing ones — safe to dispatch repeatedly.

## Recovering 1.1.0 after merge

1. Eyeball trusted-publisher configs on npmjs.com for all 5 packages (org \`aahoughton\`, repo \`oav\`, workflow \`release.yml\`, environment empty).
2. Manually dispatch the \`release\` workflow from the Actions tab.
3. publish fires under the new release.yml; npm/pnpm do the OIDC exchange; 1.1.0 ships across all 5 packages.

If trusted publisher is misconfigured on package N, that one's publish step fails; recover by fixing it on npmjs.com and re-dispatching.

## Test plan

- [x] \`pnpm lint\` clean locally
- [x] CI green on PR
- [ ] After merge: confirm publish-job env block in the dispatched run no longer shows \`NODE_AUTH_TOKEN: XXXXX-...\` (it should be absent)
- [ ] After merge + dispatch: 5 packages at 1.1.0 visible on npmjs.com with provenance badges