### PR TITLE
fix(release): revert OIDC; pnpm publish doesn't do trusted-publisher exchange

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,15 +64,7 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          # Deliberately no `registry-url`. setup-node would otherwise
-          # write a `.npmrc` containing
-          # `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` and
-          # export `NODE_AUTH_TOKEN=XXXXX-XXXXX-XXXXX-XXXXX` (its
-          # placeholder). pnpm/npm would then publish using that bogus
-          # token instead of falling through to the OIDC trusted-
-          # publisher exchange — which is exactly what we want it to do.
-          # The default registry is registry.npmjs.org, so omitting this
-          # parameter doesn't change where things publish.
+          registry-url: https://registry.npmjs.org
       - run: pnpm install --frozen-lockfile
       # No explicit `pnpm build`: each package's prepack rebuilds on
       # `pnpm -r publish` below. (Vitest aliases the workspace src
@@ -83,18 +75,24 @@ jobs:
       # adapters @aahoughton/oav-express4, oav-express5, oav-fastify.
       # The @oav/* internal workspace packages are private and skipped.
       #
-      # Auth: npm trusted publishing via GitHub Actions OIDC. The
-      # `id-token: write` permission above lets pnpm exchange a GitHub
-      # OIDC token for an npm publish token at request time — no
-      # NPM_TOKEN secret in this workflow. Each published package must
-      # have a trusted publisher configured on npmjs.com pointing at
-      # `aahoughton/oav` + this workflow file.
+      # Auth: long-lived NPM_TOKEN secret. We attempted OIDC trusted
+      # publishing in #220/#221; both failed because pnpm publish does
+      # not yet implement the OIDC token exchange (it shells out to
+      # npm CLI for publish, but the auth path doesn't trigger
+      # npm 11.5+'s trusted-publisher flow consistently — see
+      # https://github.com/pnpm/pnpm/issues/9812 and the 2026-01-14
+      # comment on that issue showing it still fails on Node 24 + npm
+      # 11.6 via pnpm). Revisit when pnpm ships native trusted-publisher
+      # support, or when we move publish off `pnpm publish`.
       #
       # --no-git-checks: the release-please commit is on main but CI
       # checks it out in detached-HEAD mode, which pnpm otherwise refuses.
       # --access public: required the first time a scoped package publishes;
       # harmless afterwards.
       # --provenance: attaches a signed build attestation so npmjs shows
-      # a "verified" badge on the published tarball (also uses the OIDC
-      # token).
+      # a "verified" badge on the published tarball (uses the
+      # `id-token: write` permission for Sigstore signing — independent
+      # of npm publish auth).
       - run: pnpm -r publish --access public --provenance --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

The OIDC trusted-publishing attempt across #220 and #221 didn't work. Reverting to NPM_TOKEN auth so 1.1.0 can ship; keeping the `workflow_dispatch` recovery handle from #221.

## What we tried, what failed

**Attempt 1 (#220):** Drop `NODE_AUTH_TOKEN` from the publish step; rely on the existing setup-node `registry-url` config to handle auth via OIDC fall-through.
- Failed with `404 Not Found` on the first package. Cause: setup-node's `registry-url` parameter writes a `.npmrc` containing `_authToken=\${NODE_AUTH_TOKEN}` AND exports `NODE_AUTH_TOKEN=XXXXX-...` (its placeholder when no value is provided). pnpm published with the literal placeholder string.

**Attempt 2 (#221):** Drop `registry-url` from setup-node so no `.npmrc` is written; pnpm should then "fall through" to OIDC.
- Failed with `ENEEDAUTH` — no token, no \`.npmrc\`, no OIDC attempt. **pnpm publish does not implement npm's trusted-publisher OIDC exchange.** Provenance signing happened in attempt 1 (it's a separate Sigstore code path, not pnpm's auth) but doesn't happen in attempt 2 either, since pnpm bails before reaching that step.

## Upstream context

[pnpm/pnpm#9812](https://github.com/pnpm/pnpm/issues/9812) tracks this. The maintainer closed it on the basis that "pnpm shells out to npm publish, just upgrade your local npm CLI to ≥11.5.1." But the most recent comment (2026-01-14) reports that even on Node 24 + npm 11.6, trusted publishing still fails via `pnpm publish` while working via `npm publish` on the same runner. So the "shell out to npm" reasoning is at minimum inconsistent in practice.

## What this PR does

Reverts the OIDC-related changes:
- Restores \`registry-url: https://registry.npmjs.org\` on setup-node.
- Re-adds \`NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}\` env on the publish step.
- Updates the auth comment block to explain why we're back on NPM_TOKEN and link to pnpm/pnpm#9812.

Keeps from #221 (independently useful, not OIDC-specific):
- \`workflow_dispatch\` trigger.
- \`publish\` job's relaxed gate (\`release_created || workflow_dispatch\`).

## Recovering 1.1.0 after merge

1. Dispatch the workflow from the Actions tab.
2. publish runs with the working NPM_TOKEN auth path (same one that shipped 1.0.0).
3. 1.1.0 across all 5 packages should appear on npmjs.com within a couple minutes, with provenance badges intact.

## Follow-up

Will file a tracking issue for "Real OIDC trusted publishing." Three plausible paths:
- (a) Wait for pnpm to implement native trusted-publisher support (pnpm/pnpm#9812).
- (b) Custom OIDC-exchange step before \`pnpm publish\` — write a step that hits npm's exchange endpoint with the GitHub OIDC token, sets the result as \`NODE_AUTH_TOKEN\`.
- (c) Switch the publish path off pnpm to direct \`npm publish\` — needs \`pnpm pack\` first to substitute workspace:* deps, then per-package \`npm publish <tarball>\`.

## Test plan

- [x] \`pnpm lint\` clean
- [x] CI green
- [ ] After merge: dispatch workflow, verify all 5 packages publish at 1.1.0 with provenance