### PR TITLE
fix(docs): cross-link gaps, custom-envelope worked example, parseYamlString cast hint

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -58,7 +58,7 @@ children hang off `body`, `query.<name>`, `headers.<name>`, etc.
 
 ## Supporting helpers
 
-All shipped from `@aahoughton/oav` (or `@aahoughton/oav-core` for the
+All shipped from `oav` (or `oav-core` for the
 lean install). The recipes below assume these are in scope.
 
 - **`httpStatusFor(err, overrides?)`** — maps a `ValidationError`
@@ -111,7 +111,7 @@ import {
 
 ### Express 4
 
-The [`@aahoughton/oav-express4`](https://www.npmjs.com/package/@aahoughton/oav-express4)
+The [`oav-express4`](https://www.npmjs.com/package/@aahoughton/oav-express4)
 companion package ships the middleware as a one-liner:
 
 ```ts
@@ -168,7 +168,7 @@ cross-cutting recipes below.
 
 ### Express 5
 
-The [`@aahoughton/oav-express5`](https://www.npmjs.com/package/@aahoughton/oav-express5)
+The [`oav-express5`](https://www.npmjs.com/package/@aahoughton/oav-express5)
 companion package ships the middleware as a one-liner — same shape
 as `oav-express4` but promise-native (no `try/catch` wrapper):
 
@@ -222,7 +222,7 @@ that affect this pattern.
 
 ### Fastify
 
-The [`@aahoughton/oav-fastify`](https://www.npmjs.com/package/@aahoughton/oav-fastify)
+The [`oav-fastify`](https://www.npmjs.com/package/@aahoughton/oav-fastify)
 companion package ships the hook as a one-liner — same shape as the
 Express adapters but Fastify-native (a `preValidation` hook, not
 middleware):
@@ -472,6 +472,76 @@ For richer response envelopes, `toProblemDetails` produces
 `application/problem+json` with the failing leaves as an `issues`
 field. `collectIssues` is the raw flat leaf list if you want to roll
 your own response shape.
+
+### Preserving an existing client error envelope
+
+Migrating an existing service may mean a documented client
+contract you can't change without breaking callers. Keep your
+envelope, fill it from `collectIssues` (per-issue path,
+message, code) plus `formatSummary` (top-level summary) plus
+`httpStatusFor` (status). Don't walk the tree by hand — the helpers
+already do the right thing for nested branches, route/method
+top-levels, and security/content-type leaves under `request` /
+`response` wrappers.
+
+```ts
+import { collectIssues, formatSummary, httpStatusFor, type ValidationError } from "@aahoughton/oav";
+
+// .. or whatever your clients already parse.
+type ClientError = {
+  message: string;
+  errors: Array<{ path: string; message: string; errorCode: string }>;
+};
+
+function toClientError(err: ValidationError): ClientError {
+  return {
+    message: formatSummary(err),
+    errors: collectIssues(err).map((issue) => ({
+      path: issue.pointer, // RFC 6901, e.g. "/body/email"
+      message: issue.message,
+      errorCode: issue.code, // bare code, e.g. "required"
+    })),
+  };
+}
+
+app.use(
+  validateRequests(validator, {
+    onError: (err, ctx) => {
+      ctx.res.status(httpStatusFor(err)).json(toClientError(err));
+    },
+  }),
+);
+```
+
+For a `POST /contacts` whose body has `age: 42` (over a `maximum: 30`)
+and `email: "not-an-email"` (fails `format: email`), the response would be:
+
+```json
+{
+  "message": "body.age must be <= 30",
+  "errors": [
+    {
+      "path": "/body/age",
+      "message": "must be <= 30",
+      "errorCode": "maximum"
+    },
+    {
+      "path": "/body/email",
+      "message": "must match format email",
+      "errorCode": "format"
+    }
+  ]
+}
+```
+
+`pointer` prefixes are `/body`, `/query`, `/header`, `/path`,
+`/cookie` (not `/params` — that's an `express-openapi-validator`
+quirk; see [MIGRATION-FROM-EOV.md](./MIGRATION-FROM-EOV.md) for the
+full diff). Each `issue.params` carries machine-readable detail
+(e.g. `{ maximum: 30, actual: 42 }` for `maximum`,
+`{ format: "email", actual: "not-an-email" }` for `format`) if you
+want to surface structured details too — `BuiltInErrorParams` in
+`oav-core` documents the shape per code.
 
 ### Body parser caveats
 

--- a/MIGRATION-FROM-EOV.md
+++ b/MIGRATION-FROM-EOV.md
@@ -4,7 +4,7 @@ A focused reference for porting an Express app off
 `express-openapi-validator` (eov) onto `oav`. Reads as a punch list,
 not a tutorial — for integration recipes, see
 [INTEGRATION.md](./INTEGRATION.md). For Express 4 specifically, the
-[`@aahoughton/oav-express4`](./packages/oav-express4/README.md)
+[`oav-express4`](./packages/oav-express4/README.md)
 companion package gets you most of eov's ergonomics back as a
 one-liner; the recipes in this doc work whether you use the adapter
 or write the middleware inline.

--- a/README.md
+++ b/README.md
@@ -26,17 +26,18 @@ headers.
 
 ## Install
 
-`oav` ships in two core packages so consumers on constrained runtimes
-can skip what they don't use, plus framework adapter packages that
-build on either:
+`oav` ships in two core packages, plus framework adapter packages that
+build on either `oav` or `oav-core` -- if you don't need YAML support,
+you can skip `oav` entirely — the lean path for zero-dependency / edge
+targets:
 
-| Package                    | When to use                                                                                                                                                                                                                                                                                      |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `@aahoughton/oav`          | Batteries-included: YAML readers + the `oav` CLI. Depends on `yaml`; pulls in `commander` + `esbuild` for the CLI only (never imported from the library entry points, so bundlers tree-shake them out of application bundles; Node server runs load them only when the `oav` binary is invoked). |
-| `@aahoughton/oav-core`     | Lean. Zero runtime dependencies. Same programmatic surface as `@aahoughton/oav`, minus the YAML readers and CLI. Feed it JSON specs (or pre-parsed objects via the memory reader).                                                                                                               |
-| `@aahoughton/oav-express4` | Express 4 framework adapter. Thin: imports the validator from `oav-core`, exports a middleware factory plus standalone helpers. See [`INTEGRATION.md`](./INTEGRATION.md).                                                                                                                        |
-| `@aahoughton/oav-express5` | Express 5 framework adapter. Same exports as `oav-express4`; promise-native middleware shape.                                                                                                                                                                                                    |
-| `@aahoughton/oav-fastify`  | Fastify framework adapter. Same exports as the Express adapters; ships a `preValidation` hook instead of middleware.                                                                                                                                                                             |
+| Package        | When to use                                                                                                                                                                                                                                                                                      |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `oav`          | Batteries-included: YAML readers + the `oav` CLI. Depends on `yaml`; pulls in `commander` + `esbuild` for the CLI only (never imported from the library entry points, so bundlers tree-shake them out of application bundles; Node server runs load them only when the `oav` binary is invoked). |
+| `oav-core`     | Lean. Zero runtime dependencies. Same programmatic surface as `oav`, minus the YAML readers and CLI. Feed it JSON specs (or pre-parsed objects via the memory reader).                                                                                                                           |
+| `oav-express4` | Express 4 framework adapter. Thin: imports the validator from `oav-core`, exports a middleware factory plus standalone helpers. See [`INTEGRATION.md`](./INTEGRATION.md).                                                                                                                        |
+| `oav-express5` | Express 5 framework adapter. Same exports as `oav-express4`; promise-native middleware shape.                                                                                                                                                                                                    |
+| `oav-fastify`  | Fastify framework adapter. Same exports as the Express adapters; ships a `preValidation` hook instead of middleware.                                                                                                                                                                             |
 
 ```bash
 npm install @aahoughton/oav            # YAML + CLI
@@ -302,9 +303,9 @@ See [**INTEGRATION.md**](./INTEGRATION.md) for:
   wiring by hand.
 
 Companion adapter packages cover the common framework wiring:
-[`@aahoughton/oav-express4`](./packages/oav-express4/README.md),
-[`@aahoughton/oav-express5`](./packages/oav-express5/README.md),
-[`@aahoughton/oav-fastify`](./packages/oav-fastify/README.md). They
+[`oav-express4`](./packages/oav-express4/README.md),
+[`oav-express5`](./packages/oav-express5/README.md),
+[`oav-fastify`](./packages/oav-fastify/README.md). They
 share the same export names and option shapes; only the
 framework-typed argument differs.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -5,8 +5,8 @@ Imported by every other module in the package and — because the error
 tree is what `validateRequest` / `validateResponse` return — the
 closest thing to a "read me first" for library consumers.
 
-This subpath is available from both `@aahoughton/oav/core` and
-`@aahoughton/oav-core/core`; the imports below work identically
+This subpath is available from both `oav/core` and
+`oav-core/core`; the imports below work identically
 against either package.
 
 ```ts

--- a/packages/oav-express4/README.md
+++ b/packages/oav-express4/README.md
@@ -1,10 +1,12 @@
-# @aahoughton/oav-express4
+# oav-express4
 
-Express 4 adapter for [`@aahoughton/oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — a request-validator middleware factory plus standalone helpers (`httpRequestFromExpress`, `renderProblemDetails`) for callers composing their own middleware.
+Express 4 adapter for [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — a request-validator middleware factory plus standalone helpers (`httpRequestFromExpress`, `renderProblemDetails`) for callers composing their own middleware.
 
-Thin: this package re-exports nothing from oav-core. You install both. The adapter declares oav-core as a regular dependency, so a single `npm install @aahoughton/oav-express4` pulls oav-core along; or install [`@aahoughton/oav`](https://www.npmjs.com/package/@aahoughton/oav) instead if you want YAML readers and the CLI.
+Thin: this package re-exports nothing from oav-core. You install both. The adapter declares oav-core as a regular dependency, so a single `npm install @aahoughton/oav-express4` pulls oav-core along; or install [`oav`](https://www.npmjs.com/package/@aahoughton/oav) instead if you want YAML readers and the CLI.
 
 Sibling packages: [`oav-express5`](../oav-express5/README.md), [`oav-fastify`](../oav-fastify/README.md). Same export names, option shapes, and defaults; only the framework-typed argument differs.
+
+> **Migrating from `express-openapi-validator`?** See [MIGRATION-FROM-EOV.md](../../MIGRATION-FROM-EOV.md) for behavior differences (path-label `/params/` → `/path/`, `errorCode` namespacing, status mapping) and a worked porting walkthrough.
 
 ## Install
 
@@ -18,7 +20,7 @@ npm install @aahoughton/oav @aahoughton/oav-express4 express
 
 `express` is a peer dep — your app's existing install satisfies it.
 
-> **YAML specs.** `@aahoughton/oav-core` is JSON-only by design (zero runtime deps). If your spec is YAML, either install [`@aahoughton/oav`](https://www.npmjs.com/package/@aahoughton/oav) instead — it bundles the YAML readers and the CLI — or install `yaml` separately and parse the spec yourself before passing the parsed object to `createValidator`.
+> **YAML specs.** `oav-core` is JSON-only by design (zero runtime deps). If your spec is YAML, either install [`oav`](https://www.npmjs.com/package/@aahoughton/oav) instead — it bundles the YAML readers and the CLI — or install `yaml` separately and parse the spec yourself before passing the parsed object to `createValidator`.
 
 ## Quick start
 
@@ -160,7 +162,7 @@ If multiple projects end up copying this recipe, that's the signal to harvest in
 
 ### Skip validation for paths the spec doesn't declare
 
-The validator owns this — pass it `ignorePaths` or `ignoreUndocumented` at construction. See `ValidatorOptions` in `@aahoughton/oav-core` for the contract.
+The validator owns this — pass it `ignorePaths` or `ignoreUndocumented` at construction. See `ValidatorOptions` in `oav-core` for the contract.
 
 ```ts
 const validator = createValidator(spec, {
@@ -269,6 +271,7 @@ For per-route inline multer (validator called from inside the route handler) and
 
 ## See also
 
-- [`@aahoughton/oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — `createValidator`, `ValidatorOptions`, `formatSummary`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
-- [`@aahoughton/oav`](https://www.npmjs.com/package/@aahoughton/oav) — batteries-included distribution of oav-core: YAML readers + the `oav` CLI.
-- The repo-root `INTEGRATION.md` — broader recipes (security, file uploads, response validation, migration from `express-openapi-validator`).
+- [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — `createValidator`, `ValidatorOptions`, `formatSummary`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
+- [`oav`](https://www.npmjs.com/package/@aahoughton/oav) — batteries-included distribution of oav-core: YAML readers + the `oav` CLI.
+- The repo-root [`INTEGRATION.md`](../../INTEGRATION.md) — broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
+- The repo-root [`MIGRATION-FROM-EOV.md`](../../MIGRATION-FROM-EOV.md) — porting from `express-openapi-validator`.

--- a/packages/oav-express5/README.md
+++ b/packages/oav-express5/README.md
@@ -1,10 +1,12 @@
-# @aahoughton/oav-express5
+# oav-express5
 
-Express 5 adapter for [`@aahoughton/oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — a promise-native middleware factory plus standalone helpers (`httpRequestFromExpress`, `renderProblemDetails`) for callers composing their own middleware.
+Express 5 adapter for [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — a promise-native middleware factory plus standalone helpers (`httpRequestFromExpress`, `renderProblemDetails`) for callers composing their own middleware.
 
 Same shape as the [`oav-express4`](../oav-express4/README.md) sibling — only the framework-typed argument and the async semantics differ. Express 5's promise-native middleware means thrown errors and rejected promises propagate to the host's error middleware automatically, with no `try/catch` wrapper.
 
 Sibling packages: [`oav-express4`](../oav-express4/README.md), [`oav-fastify`](../oav-fastify/README.md). Same export names, option shapes, and defaults; only the framework-typed argument differs.
+
+> **Migrating from `express-openapi-validator`?** See [MIGRATION-FROM-EOV.md](../../MIGRATION-FROM-EOV.md) for behavior differences (path-label `/params/` → `/path/`, `errorCode` namespacing, status mapping) and a worked porting walkthrough.
 
 ## Install
 
@@ -18,7 +20,7 @@ npm install @aahoughton/oav @aahoughton/oav-express5 express
 
 `express` is a peer dep — your app's existing install satisfies it.
 
-> **YAML specs.** `@aahoughton/oav-core` is JSON-only by design (zero runtime deps). If your spec is YAML, either install [`@aahoughton/oav`](https://www.npmjs.com/package/@aahoughton/oav) instead — it bundles the YAML readers and the CLI — or install `yaml` separately and parse the spec yourself before passing the parsed object to `createValidator`.
+> **YAML specs.** `oav-core` is JSON-only by design (zero runtime deps). If your spec is YAML, either install [`oav`](https://www.npmjs.com/package/@aahoughton/oav) instead — it bundles the YAML readers and the CLI — or install `yaml` separately and parse the spec yourself before passing the parsed object to `createValidator`.
 
 ## Quick start
 
@@ -107,7 +109,7 @@ The check is shape-only — it confirms the declared credential is _present_, no
 
 ### Skip validation for paths the spec doesn't declare
 
-The validator owns this — pass it `ignorePaths` or `ignoreUndocumented` at construction. See `ValidatorOptions` in `@aahoughton/oav-core` for the contract.
+The validator owns this — pass it `ignorePaths` or `ignoreUndocumented` at construction. See `ValidatorOptions` in `oav-core` for the contract.
 
 ```ts
 const validator = createValidator(spec, {
@@ -201,7 +203,7 @@ A migrating consumer's `import { validateRequests } from "@aahoughton/oav-expres
 
 ## See also
 
-- [`@aahoughton/oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — `createValidator`, `ValidatorOptions`, `formatSummary`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
-- [`@aahoughton/oav`](https://www.npmjs.com/package/@aahoughton/oav) — batteries-included distribution of oav-core: YAML readers + the `oav` CLI.
-- The repo-root `INTEGRATION.md` — broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
-- The repo-root `MIGRATION-FROM-EOV.md` — porting from `express-openapi-validator`.
+- [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — `createValidator`, `ValidatorOptions`, `formatSummary`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
+- [`oav`](https://www.npmjs.com/package/@aahoughton/oav) — batteries-included distribution of oav-core: YAML readers + the `oav` CLI.
+- The repo-root [`INTEGRATION.md`](../../INTEGRATION.md) — broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
+- The repo-root [`MIGRATION-FROM-EOV.md`](../../MIGRATION-FROM-EOV.md) — porting from `express-openapi-validator`.

--- a/packages/oav-fastify/README.md
+++ b/packages/oav-fastify/README.md
@@ -1,6 +1,6 @@
-# @aahoughton/oav-fastify
+# oav-fastify
 
-Fastify adapter for [`@aahoughton/oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — a `preValidation` hook factory plus standalone helpers (`httpRequestFromFastify`, `renderProblemDetails`) for callers composing their own hooks.
+Fastify adapter for [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — a `preValidation` hook factory plus standalone helpers (`httpRequestFromFastify`, `renderProblemDetails`) for callers composing their own hooks.
 
 Same shape as the Express siblings ([`oav-express4`](../oav-express4/README.md), [`oav-express5`](../oav-express5/README.md)) — only the framework-typed argument and Fastify's hook-vs-middleware distinction differ. Fastify is async-native, so thrown errors and rejected promises propagate to Fastify's error handler automatically, with no `try/catch` wrapper.
 
@@ -18,7 +18,7 @@ npm install @aahoughton/oav @aahoughton/oav-fastify fastify
 
 `fastify` is a peer dep — your app's existing install satisfies it.
 
-> **YAML specs.** `@aahoughton/oav-core` is JSON-only by design (zero runtime deps). If your spec is YAML, either install [`@aahoughton/oav`](https://www.npmjs.com/package/@aahoughton/oav) instead — it bundles the YAML readers and the CLI — or install `yaml` separately and parse the spec yourself before passing the parsed object to `createValidator`.
+> **YAML specs.** `oav-core` is JSON-only by design (zero runtime deps). If your spec is YAML, either install [`oav`](https://www.npmjs.com/package/@aahoughton/oav) instead — it bundles the YAML readers and the CLI — or install `yaml` separately and parse the spec yourself before passing the parsed object to `createValidator`.
 
 ## Quick start
 
@@ -191,7 +191,7 @@ If both fire on the same route, oav's `preValidation` hook runs first; if it pas
 
 ## See also
 
-- [`@aahoughton/oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — `createValidator`, `ValidatorOptions`, `formatSummary`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
-- [`@aahoughton/oav`](https://www.npmjs.com/package/@aahoughton/oav) — batteries-included distribution of oav-core: YAML readers + the `oav` CLI.
+- [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — `createValidator`, `ValidatorOptions`, `formatSummary`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
+- [`oav`](https://www.npmjs.com/package/@aahoughton/oav) — batteries-included distribution of oav-core: YAML readers + the `oav` CLI.
 - The repo-root `INTEGRATION.md` — broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
 - The repo-root `MIGRATION-FROM-EOV.md` — porting from `express-openapi-validator`.

--- a/packages/oav/README.md
+++ b/packages/oav/README.md
@@ -1,6 +1,6 @@
 # oav
 
-Batteries-included distribution of `@aahoughton/oav-core`. Adds YAML
+Batteries-included distribution of `oav-core`. Adds YAML
 readers and the `oav` CLI on top of the lean validator package; the
 programmatic surface is identical.
 
@@ -17,10 +17,10 @@ const validator = createValidator(document);
 
 ## When to use which
 
-| Package                | When to use                                                                                                                                                                                             |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@aahoughton/oav`      | Includes YAML readers and the `oav` CLI binary. Pulls in `yaml`, `commander`, and `esbuild` (CLI-only).                                                                                                 |
-| `@aahoughton/oav-core` | Lean. Zero runtime dependencies. JSON specs only (or pre-parsed objects via the memory reader). Use on Cloudflare Workers, Vercel Edge, Lambda@Edge, or anywhere the YAML/CLI footprint isn't worth it. |
+| Package    | When to use                                                                                                                                                                                             |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `oav`      | Includes YAML readers and the `oav` CLI binary. Pulls in `yaml`, `commander`, and `esbuild` (CLI-only).                                                                                                 |
+| `oav-core` | Lean. Zero runtime dependencies. JSON specs only (or pre-parsed objects via the memory reader). Use on Cloudflare Workers, Vercel Edge, Lambda@Edge, or anywhere the YAML/CLI footprint isn't worth it. |
 
 `oav` re-exports every subpath of `oav-core` at matching paths
 (`oav/schema`, `oav/spec`, `oav/formats`, `oav/core`,

--- a/packages/oav/src/yaml.ts
+++ b/packages/oav/src/yaml.ts
@@ -143,14 +143,16 @@ export function createSmartHttpReader(): DocumentReader {
  * package's `createMemoryReader` with pre-parsed objects can convert
  * YAML sources once at setup time.
  *
+ * Returns `unknown` because YAML is dynamic; cast to
+ * {@link OpenAPIDocument} (or your own narrower type) when feeding
+ * the result to `createValidator`.
+ *
  * @example
  * ```ts
- * import { createMemoryReader } from "@aahoughton/oav/spec";
- * import { parseYamlString } from "@aahoughton/oav";
+ * import { createValidator, parseYamlString, type OpenAPIDocument } from "@aahoughton/oav";
  *
- * const reader = createMemoryReader(
- *   new Map([["spec.yaml", parseYamlString("openapi: 3.1.0\ninfo: { title: t, version: 1 }")]]),
- * );
+ * const spec = parseYamlString(yamlSource) as OpenAPIDocument;
+ * const validator = createValidator(spec);
  * ```
  *
  * @public

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -5,11 +5,11 @@ this when you want to stitch a spec together before handing it to
 `createValidator`.
 
 This module is available at matching subpaths in both
-`@aahoughton/oav/spec` and `@aahoughton/oav-core/spec`. The examples
+`oav/spec` and `oav-core/spec`. The examples
 below import from `@aahoughton/oav`; substitute `@aahoughton/oav-core`
 if you're on the lean package.
 
-> **`@aahoughton/oav-core` ships JSON readers only.** Calling
+> **`oav-core` ships JSON readers only.** Calling
 > `createFileReader()` or `createHttpReader()` on a `.yaml` / `.yml`
 > path throws an install-hint error. For YAML support, install
 > `@aahoughton/oav` (for the bundled `createYamlFileReader`) or

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -78,7 +78,7 @@ the upstream test suites live in
 | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `validateRequest(req)`                        | Check an `HttpRequest` against the spec. Returns `null` on success or a `ValidationError` tree.                                                                     |
 | `validateResponse(req, res)`                  | Check an `HttpResponse` against the spec (request is used only for method + path). Returns `null` or a tree.                                                        |
-| `validateFetchRequest<T>(request, opts?)`     | Convenience for Web Standards `Request`: reads URL, headers, body; returns a discriminated union with a typed body. See INTEGRATION.md.                             |
+| `validateFetchRequest<T>(request, opts?)`     | Convenience for Web Standards `Request`: reads URL, headers, body; returns a discriminated union with a typed body. See [INTEGRATION.md](../../INTEGRATION.md).     |
 | `validateFetchResponse<T>(request, response)` | Symmetric Web Standards `Response` check. Useful for contract-testing an upstream.                                                                                  |
 | `getOperation({ method, path })`              | Startup-time introspection: returns the resolved, overlay-applied `OperationObject` + matched template for a (method, path) pair.                                   |
 | `detectedVersion`                             | The `openapi` string detected on construction, or `undefined` for an unrecognised / missing version (see `onUnknownVersion`).                                       |


### PR DESCRIPTION
A small batch of doc clarity fixes from a recent migration walkthrough. Group them under one polish issue since each is small and they overlap on the same files.

- Each Express adapter README (`packages/oav-express4`, `packages/oav-express5`): add a short "migrating from `express-openapi-validator`?" callout linking `MIGRATION-FROM-EOV.md`.
- `INTEGRATION.md`: add a worked custom-envelope recipe — `collectIssues` mapped into an existing client error shape, with a literal failing-request → response JSON snippet so `pointer` strings appear concretely.
- `packages/oav/src/yaml.ts`: in the `parseYamlString` JSDoc example, show the `as OpenAPIDocument` cast so a paste-the-example user doesn't eat a TS error.
- `packages/validator/README.md`: the bare "See INTEGRATION.md" needs an actual link.

Closes #229.