### PR TITLE
docs: move root markdown into docs/ subdir

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,12 +66,12 @@ and let the user's own logic fail in a familiar way.
 ### Type as canonical contract
 
 TSDoc on the type is the API reference. Prose docs (READMEs,
-INTEGRATION.md) are recipes — worked examples that show how the
-pieces compose, with backreferences to the type for the contract.
+docs/integration.md) are recipes — worked examples that show how
+the pieces compose, with backreferences to the type for the contract.
 When adding a new option-bearing interface, lead its TSDoc with a
 roadmap of the field groups so editor tooling surfaces the surface
-on first read. When adding a recipe in INTEGRATION.md, include a
-"see {type}" backreference so the reader knows where the source of
+on first read. When adding a recipe in docs/integration.md, include
+a "see {type}" backreference so the reader knows where the source of
 truth lives.
 
 ### Scope discipline

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ validator. Two primary drivers:
   application-side patches. `applyOverlays` rewrites the document
   at load time. Custom keywords, formats, and dialects plug into
   the compiler the same way, so per-tenant validation rules don't
-  require forking. See [OVERLAYS.md](./OVERLAYS.md).
+  require forking. See [docs/overlays.md](./docs/overlays.md).
 - **Validators that fit in microservice runners.** `oav
 compile-spec openapi.yaml` emits a single zero-dependency ES
   module exposing the full validator surface. Targets Cloudflare
@@ -35,7 +35,7 @@ targets:
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `oav`          | Batteries-included: YAML readers + the `oav` CLI. Depends on `yaml`; pulls in `commander` + `esbuild` for the CLI only (never imported from the library entry points, so bundlers tree-shake them out of application bundles; Node server runs load them only when the `oav` binary is invoked). |
 | `oav-core`     | Lean. Zero runtime dependencies. Same programmatic surface as `oav`, minus the YAML readers and CLI. Feed it JSON specs (or pre-parsed objects via the memory reader).                                                                                                                           |
-| `oav-express4` | Express 4 framework adapter. Thin: imports the validator from `oav-core`, exports a middleware factory plus standalone helpers. See [`INTEGRATION.md`](./INTEGRATION.md).                                                                                                                        |
+| `oav-express4` | Express 4 framework adapter. Thin: imports the validator from `oav-core`, exports a middleware factory plus standalone helpers. See [`docs/integration.md`](./docs/integration.md).                                                                                                              |
 | `oav-express5` | Express 5 framework adapter. Same exports as `oav-express4`; promise-native middleware shape.                                                                                                                                                                                                    |
 | `oav-fastify`  | Fastify framework adapter. Same exports as the Express adapters; ships a `preValidation` hook instead of middleware.                                                                                                                                                                             |
 
@@ -102,7 +102,7 @@ oav's primary alternative is
 `compileSchema`, or via
 [`express-openapi-validator`](https://github.com/cdimascio/express-openapi-validator)
 for HTTP validation. (Migrating from EOV specifically:
-[MIGRATION-FROM-EOV.md](./MIGRATION-FROM-EOV.md).)
+[docs/migration-from-eov.md](./docs/migration-from-eov.md).)
 
 Numbers below are from the [`performance/`](./performance/README.md)
 benchmark on AWS c7i.large (Intel Sapphire Rapids, Node 22). Your
@@ -132,7 +132,7 @@ For typical HTTP workloads — 1k–10k req/sec × ~1 validation per
 request — the difference is invisible at any of those numbers. For
 validation-heavy code (millions of validations per second), Ajv wins.
 
-Full per-shape breakdown: [`COMPARISON.md`](./COMPARISON.md). Raw
+Full per-shape breakdown: [`docs/comparison.md`](./docs/comparison.md). Raw
 benchmark data and methodology:
 [`performance/README.md`](./performance/README.md).
 
@@ -293,7 +293,7 @@ app.use(async (req, res, next) => {
 });
 ```
 
-See [**INTEGRATION.md**](./INTEGRATION.md) for:
+See [**docs/integration.md**](./docs/integration.md) for:
 
 - Adapter packages for Express 4, Express 5, and Fastify; recipes for Next.js, Hono, Bun, and Deno via the Web Standards adapter.
 - Recipes for file uploads (multer), response validation, security,
@@ -358,7 +358,7 @@ Runnable, self-contained TypeScript examples in
 
 Runtime-behaviour corners. For a feature-scope comparison against
 Ajv (draft versions, `$data`, async validation, etc.) see
-[COMPARISON.md](./COMPARISON.md).
+[docs/comparison.md](./docs/comparison.md).
 
 - `$dynamicRef` behaves like `$ref` with anchor lookup — no runtime
   dynamic-scope traversal.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -11,7 +11,7 @@ combined — schema validation plus HTTP-layer checks — and trades
 differently on a handful of specifics, catalogued below.
 
 This document is about behaviour and capabilities. For raw numbers
-and methodology see [`performance/README.md`](./performance/README.md);
+and methodology see [`performance/README.md`](../performance/README.md);
 the shape of the trade-off is sketched below.
 
 ## Performance sketch
@@ -30,7 +30,7 @@ The takeaway: ajv wins steady-state validate throughput on a spec you
 compile once and reuse; oav wins anywhere validator construction is
 part of the hot path (per-request, per-tenant, per-test, edge
 cold-starts). Full methodology, raw numbers, and the benchmark
-harness live in [`performance/README.md`](./performance/README.md).
+harness live in [`performance/README.md`](../performance/README.md).
 
 ## Where Ajv (+ express-openapi-validator) does more
 
@@ -75,7 +75,7 @@ Capabilities that the Ajv stack covers and oav does not.
   common use case — cross-field constraints like `max >= min` —
   works in oav via an object-level custom keyword that sees the
   whole object and reaches siblings directly; see
-  [`examples/cross-field-validation.ts`](./examples/cross-field-validation.ts).
+  [`examples/cross-field-validation.ts`](../examples/cross-field-validation.ts).
   Trade-off: the constraint sits on the parent object in the schema
   rather than inside the constrained field's own subschema.
 - **Async validation.** Ajv supports async formats and keywords (e.g.
@@ -88,7 +88,7 @@ Capabilities that the Ajv stack covers and oav does not.
   validation but doesn't verify credentials),
   `operationHandlers` filesystem auto-loading, and `ignorePaths` /
   `ignoreUndocumented` are one-liner options. oav leaves these to the
-  adapter — see [`INTEGRATION.md`](./INTEGRATION.md) for recipes.
+  adapter — see [`integration.md`](./integration.md) for recipes.
 
 ## Where oav does more
 
@@ -206,4 +206,4 @@ when compile throughput matters (1–2 orders of magnitude above ajv,
 8× on Stripe's real-world spec; see the performance sketch above).
 
 For benchmark numbers rather than feature comparisons, see
-[`performance/README.md`](./performance/README.md).
+[`performance/README.md`](../performance/README.md).

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -18,13 +18,21 @@ This document is organised:
   Express 4, Express 5, Fastify, Next.js, Hono, Bun, Deno. Each
   section leads with the adapter (where one exists) and falls back
   to the manual inline recipe.
-- **[Cross-cutting recipes](#cross-cutting-recipes)** —
-  status-code mapping, file uploads, response validation, security,
-  type coercion, ignoring paths. Linked from the per-framework
-  sections.
+- **[Cross-cutting recipes](#cross-cutting-recipes)** — linked from
+  the per-framework sections:
+  - [Status-code mapping](#status-code-mapping)
+  - [Preserving an existing client error envelope](#preserving-an-existing-client-error-envelope)
+  - [Body parser caveats](#body-parser-caveats)
+  - [File uploads with multer](#file-uploads-with-multer)
+  - [Deriving middleware config from the spec](#deriving-middleware-config-from-the-spec)
+  - [Streaming bodies, large uploads, and the `readBody` override](#streaming-bodies-large-uploads-and-the-readbody-override)
+  - [Response validation (no monkey-patching)](#response-validation-no-monkey-patching)
+  - [Security / authentication](#security--authentication)
+  - [Type coercion on body fields](#type-coercion-on-body-fields)
+  - [Ignoring paths not in the spec](#ignoring-paths-not-in-the-spec)
 - **[Migration paths](#migration-paths)** — pointers to focused
   migration docs (currently only
-  [MIGRATION-FROM-EOV.md](./MIGRATION-FROM-EOV.md) for
+  [migration-from-eov.md](./migration-from-eov.md) for
   `express-openapi-validator`).
 
 ## What the validator expects
@@ -536,7 +544,7 @@ and `email: "not-an-email"` (fails `format: email`), the response would be:
 
 `pointer` prefixes are `/body`, `/query`, `/header`, `/path`,
 `/cookie` (not `/params` — that's an `express-openapi-validator`
-quirk; see [MIGRATION-FROM-EOV.md](./MIGRATION-FROM-EOV.md) for the
+quirk; see [migration-from-eov.md](./migration-from-eov.md) for the
 full diff). Each `issue.params` carries machine-readable detail
 (e.g. `{ maximum: 30, actual: 42 }` for `maximum`,
 `{ format: "email", actual: "not-an-email" }` for `format`) if you
@@ -726,7 +734,7 @@ app.post("/uploads", upload.any() /* validator + handler as above */);
 route-match + `$ref` resolution + overlay application that validation
 does, but hands the result back as plain OpenAPI shapes — read
 whatever declaration you need. `digestOperation` (see
-[`examples/spec-digest.ts`](./examples/spec-digest.ts)) is a recipe
+[`examples/spec-digest.ts`](../examples/spec-digest.ts)) is a recipe
 that pulls the common middleware-config facts into a flat shape:
 content types, body limits, required headers, security. Copy it into
 your project and adjust the interpretation choices
@@ -1044,7 +1052,7 @@ app.use(async (req, res, next) => {
 Focused migration docs live in their own files so this guide can
 stay framework-shaped rather than competitor-shaped:
 
-- **[MIGRATION-FROM-EOV.md](./MIGRATION-FROM-EOV.md)** — migrating
+- **[migration-from-eov.md](./migration-from-eov.md)** — migrating
   from `express-openapi-validator`. Behavior-difference reference,
   option map (eov → oav), features not carried over, features
   added.

--- a/docs/migration-from-eov.md
+++ b/docs/migration-from-eov.md
@@ -3,8 +3,8 @@
 A focused reference for porting an Express app off
 `express-openapi-validator` (eov) onto `oav`. Reads as a punch list,
 not a tutorial — for integration recipes, see
-[INTEGRATION.md](./INTEGRATION.md). For Express 4 specifically, the
-[`oav-express4`](./packages/oav-express4/README.md)
+[integration.md](./integration.md). For Express 4 specifically, the
+[`oav-express4`](../packages/oav-express4/README.md)
 companion package gets you most of eov's ergonomics back as a
 one-liner; the recipes in this doc work whether you use the adapter
 or write the middleware inline.
@@ -32,11 +32,11 @@ auth wiring where needed. In exchange:
 - **Built-in OpenAPI 3.0 dialect.** `nullable: true`, boolean
   `exclusiveMaximum`, and `$ref`-suppresses-siblings are in the
   compiler's dialect dispatch — no preprocessing step. See the
-  [conformance report](./conformance/REPORT.md) for pass / fail
+  [conformance report](../conformance/REPORT.md) for pass / fail
   counts by category.
 - **Overlays.** Extend an externally-owned base spec (Supabase,
   Hasura, PocketBase, a gateway-published document) with
-  `applyOverlays` at load time. See [OVERLAYS.md](./OVERLAYS.md).
+  `applyOverlays` at load time. See [overlays.md](./overlays.md).
 
 ## Behavior differences to watch for
 
@@ -52,8 +52,8 @@ fixture / test churn.
 | **Top-level message**              | first leaf by default; every leaf `, `-joined under `validateRequests: { allErrors: true }` | configurable via `formatSummary`: `{ select: "first" }` (default; first leaf) or `{ select: "all" }` (every leaf, newline-joined). Per-leaf details always in `errors[]` / `issues[]`. Shape differs from eov — see below. |
 | **Top-level `path` on 404s**       | offending URL                                                                               | `[]` (empty array → `""` pointer); same kind of error, different rendering                                                                                                                                                 |
 | **`errorCode` names**              | `required.openapi.validation`                                                               | bare codes (`required`); the `.openapi.validation` suffix was always noise                                                                                                                                                 |
-| **`oneOf` with binary fields**     | silently accepted (looser inside binary fields)                                             | surfaces the genuine ambiguity with `matchCount: 2`; see [INTEGRATION.md → File uploads](./INTEGRATION.md#file-uploads-with-multer) for the spec-level fix                                                                 |
-| **Error response monkey-patching** | `res.send("{...}")` (string form) caught via wrappers                                       | not caught unless you write the wrapper yourself; see [INTEGRATION.md → Response validation](./INTEGRATION.md#response-validation-no-monkey-patching)                                                                      |
+| **`oneOf` with binary fields**     | silently accepted (looser inside binary fields)                                             | surfaces the genuine ambiguity with `matchCount: 2`; see [integration.md → File uploads](./integration.md#file-uploads-with-multer) for the spec-level fix                                                                 |
+| **Error response monkey-patching** | `res.send("{...}")` (string form) caught via wrappers                                       | not caught unless you write the wrapper yourself; see [integration.md → Response validation](./integration.md#response-validation-no-monkey-patching)                                                                      |
 | **Optional `openapi` version**     | throws on missing / unsupported                                                             | silently uses 3.1 by default; see `onUnknownVersion`                                                                                                                                                                       |
 | **`format` semantics**             | always assertive in OpenAPI context                                                         | assertive in OpenAPI context; annotation-only under raw `jsonSchemaDialect` (per 2020-12 default)                                                                                                                          |
 
@@ -106,8 +106,8 @@ makes sense for your API.
 | eov option                  | oav equivalent                                                                                                                                                                                                                       |
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `validateSecurity: true`    | Off by default in oav (real apps gate security upstream of validation). Opt in with `createValidator(spec, { validateSecurity: true })` for shape-only checks on `bearer` / `basic` / `apiKey`.                                      |
-| `validateSecurity.handlers` | Your own auth middleware, run before the validator — `oav` only checks credential **shape**, not validity. For declarative per-scheme dispatch, see the [INTEGRATION.md security recipe](./INTEGRATION.md#per-scheme-auth-dispatch). |
-| `fileUploader: true`        | Your own multer middleware — see [INTEGRATION.md file uploads](./INTEGRATION.md#file-uploads-with-multer).                                                                                                                           |
+| `validateSecurity.handlers` | Your own auth middleware, run before the validator — `oav` only checks credential **shape**, not validity. For declarative per-scheme dispatch, see the [integration.md security recipe](./integration.md#per-scheme-auth-dispatch). |
+| `fileUploader: true`        | Your own multer middleware — see [integration.md file uploads](./integration.md#file-uploads-with-multer).                                                                                                                           |
 
 ### Handler wiring
 
@@ -117,13 +117,13 @@ makes sense for your API.
 
 ## Features not carried over
 
-- **Auto-multer.** Replace with the [multer recipe](./INTEGRATION.md#file-uploads-with-multer) (~15 lines per upload route, or one global setup).
-- **Security handler dispatch.** Use your existing auth middleware, or the [per-scheme dispatch recipe](./INTEGRATION.md#per-scheme-auth-dispatch).
+- **Auto-multer.** Replace with the [multer recipe](./integration.md#file-uploads-with-multer) (~15 lines per upload route, or one global setup).
+- **Security handler dispatch.** Use your existing auth middleware, or the [per-scheme dispatch recipe](./integration.md#per-scheme-auth-dispatch).
 - **`operationHandlers` filesystem routing.** Write Express routes
   manually or keep whatever routing you had.
 - **`res.json` wrapping for automatic response validation.** Call
   `validateResponse` explicitly where you need it, or wrap `res.json`
-  yourself (~15 lines; see the [response-validation recipe](./INTEGRATION.md#response-validation-no-monkey-patching)).
+  yourself (~15 lines; see the [response-validation recipe](./integration.md#response-validation-no-monkey-patching)).
 - **`serDes` payload mutations.** Do these in your handler rather
   than the validator.
 - **Typed error classes** (`BadRequest`, `Unauthorized`, etc.). Use
@@ -135,10 +135,10 @@ makes sense for your API.
   per-code `params` typed via `BuiltInErrorParams`. Narrowing happens
   on fields rather than message strings.
 - **Built-in 3.0 dialect.** No translation layer over 2020-12. See
-  [conformance/REPORT.md](./conformance/REPORT.md) for pass / fail
+  [conformance/REPORT.md](../conformance/REPORT.md) for pass / fail
   counts by category.
 - **Overlays.** Extend externally-owned specs at load time —
-  see [OVERLAYS.md](./OVERLAYS.md).
+  see [overlays.md](./overlays.md).
 - **Smaller install footprint.** `oav` depends on `yaml`,
   `commander`, and `esbuild` (the latter two for CLI + AOT compile
   output); `oav-core` is the lean alternative with zero
@@ -153,7 +153,7 @@ makes sense for your API.
   the edge of a queue processor outside any HTTP framework.
 - **AOT compilation.** `oav compile-spec spec.yaml` emits a
   zero-runtime-deps validator for edge / serverless deployments.
-  See the [CLI README](./packages/cli/README.md#compile-spec-output).
+  See the [CLI README](../packages/cli/README.md#compile-spec-output).
 
 ## Format-shape note
 

--- a/docs/overlays.md
+++ b/docs/overlays.md
@@ -163,7 +163,7 @@ your deployment serves that patching it piecewise is noisier than
 starting fresh.
 
 Runnable demo:
-[`examples/overlay-petstore-endpoint.ts`](./examples/overlay-petstore-endpoint.ts)
+[`examples/overlay-petstore-endpoint.ts`](../examples/overlay-petstore-endpoint.ts)
 — adds a gateway-required `X-Tenant` header to `POST /pets`.
 
 ## Things to know
@@ -194,7 +194,7 @@ Runnable demo:
 
 ## Related
 
-- [`examples/overlay-petstore-schema.ts`](./examples/overlay-petstore-schema.ts)
+- [`examples/overlay-petstore-schema.ts`](../examples/overlay-petstore-schema.ts)
   and
-  [`examples/overlay-petstore-endpoint.ts`](./examples/overlay-petstore-endpoint.ts)
+  [`examples/overlay-petstore-endpoint.ts`](../examples/overlay-petstore-endpoint.ts)
   — runnable end-to-end demos.

--- a/examples/README.md
+++ b/examples/README.md
@@ -36,7 +36,7 @@ for `@aahoughton/oav` in import specifiers that don't touch
 | `overlay-petstore-endpoint.ts` | `petstore.yaml`       | Require an `X-Tenant` header on `POST /pets` via an endpoint overlay                |
 | `spec-digest.ts`               | `uploads.yaml`        | Derive middleware config (multer limits, required headers) from the spec at startup |
 
-See [`OVERLAYS.md`](../OVERLAYS.md) for a walk-through of the overlay
+See [`docs/overlays.md`](../docs/overlays.md) for a walk-through of the overlay
 shape and when to use each section (`extendSchemas`, `replaceSchemas`,
 `overrides`, `addPaths`).
 

--- a/packages/oav-express4/README.md
+++ b/packages/oav-express4/README.md
@@ -6,7 +6,7 @@ Thin: this package re-exports nothing from oav-core. You install both. The adapt
 
 Sibling packages: [`oav-express5`](../oav-express5/README.md), [`oav-fastify`](../oav-fastify/README.md). Same export names, option shapes, and defaults; only the framework-typed argument differs.
 
-> **Migrating from `express-openapi-validator`?** See [MIGRATION-FROM-EOV.md](../../MIGRATION-FROM-EOV.md) for behavior differences (path-label `/params/` → `/path/`, `errorCode` namespacing, status mapping) and a worked porting walkthrough.
+> **Migrating from `express-openapi-validator`?** See [docs/migration-from-eov.md](../../docs/migration-from-eov.md) for behavior differences (path-label `/params/` → `/path/`, `errorCode` namespacing, status mapping) and a worked porting walkthrough.
 
 ## Install
 
@@ -267,11 +267,11 @@ app.use(
 
 `toHttpRequest` is the general "reshape what oav sees" seam — synthesizing body from files, normalizing empty bodies, merging headers from an upstream proxy, anything that lives above the extraction layer. The empty-body normalization recipe higher in this README and this multer recipe are two examples of the same pattern.
 
-For per-route inline multer (validator called from inside the route handler) and the full multer recipe with text-field reassembly, see the [INTEGRATION.md file uploads section](https://github.com/aahoughton/oav/blob/main/INTEGRATION.md#file-uploads-with-multer).
+For per-route inline multer (validator called from inside the route handler) and the full multer recipe with text-field reassembly, see the [integration.md file uploads section](https://github.com/aahoughton/oav/blob/main/docs/integration.md#file-uploads-with-multer).
 
 ## See also
 
 - [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — `createValidator`, `ValidatorOptions`, `formatSummary`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
 - [`oav`](https://www.npmjs.com/package/@aahoughton/oav) — batteries-included distribution of oav-core: YAML readers + the `oav` CLI.
-- The repo-root [`INTEGRATION.md`](../../INTEGRATION.md) — broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
-- The repo-root [`MIGRATION-FROM-EOV.md`](../../MIGRATION-FROM-EOV.md) — porting from `express-openapi-validator`.
+- The repo-root [`docs/integration.md`](../../docs/integration.md) — broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
+- The repo-root [`docs/migration-from-eov.md`](../../docs/migration-from-eov.md) — porting from `express-openapi-validator`.

--- a/packages/oav-express5/README.md
+++ b/packages/oav-express5/README.md
@@ -6,7 +6,7 @@ Same shape as the [`oav-express4`](../oav-express4/README.md) sibling — only t
 
 Sibling packages: [`oav-express4`](../oav-express4/README.md), [`oav-fastify`](../oav-fastify/README.md). Same export names, option shapes, and defaults; only the framework-typed argument differs.
 
-> **Migrating from `express-openapi-validator`?** See [MIGRATION-FROM-EOV.md](../../MIGRATION-FROM-EOV.md) for behavior differences (path-label `/params/` → `/path/`, `errorCode` namespacing, status mapping) and a worked porting walkthrough.
+> **Migrating from `express-openapi-validator`?** See [docs/migration-from-eov.md](../../docs/migration-from-eov.md) for behavior differences (path-label `/params/` → `/path/`, `errorCode` namespacing, status mapping) and a worked porting walkthrough.
 
 ## Install
 
@@ -189,7 +189,7 @@ The middleware awaits the returned promise. Express 5 awaits the middleware itse
 
 ### Global validator + per-route multer (file uploads)
 
-When the validator is mounted globally and one or a few routes accept file uploads via multer, mount multer at the route prefix that needs it (upstream of the global validator) and use `toHttpRequest` to synthesize the spec-shaped body from `req.files`. See the [INTEGRATION.md file uploads recipe](https://github.com/aahoughton/oav/blob/main/INTEGRATION.md#file-uploads-with-multer) for the full pattern; the only difference for Express 5 is the lack of `try/catch` (which neither the recipe nor the adapter needs).
+When the validator is mounted globally and one or a few routes accept file uploads via multer, mount multer at the route prefix that needs it (upstream of the global validator) and use `toHttpRequest` to synthesize the spec-shaped body from `req.files`. See the [integration.md file uploads recipe](https://github.com/aahoughton/oav/blob/main/docs/integration.md#file-uploads-with-multer) for the full pattern; the only difference for Express 5 is the lack of `try/catch` (which neither the recipe nor the adapter needs).
 
 ## Express 4 vs Express 5
 
@@ -205,5 +205,5 @@ A migrating consumer's `import { validateRequests } from "@aahoughton/oav-expres
 
 - [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — `createValidator`, `ValidatorOptions`, `formatSummary`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
 - [`oav`](https://www.npmjs.com/package/@aahoughton/oav) — batteries-included distribution of oav-core: YAML readers + the `oav` CLI.
-- The repo-root [`INTEGRATION.md`](../../INTEGRATION.md) — broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
-- The repo-root [`MIGRATION-FROM-EOV.md`](../../MIGRATION-FROM-EOV.md) — porting from `express-openapi-validator`.
+- The repo-root [`docs/integration.md`](../../docs/integration.md) — broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
+- The repo-root [`docs/migration-from-eov.md`](../../docs/migration-from-eov.md) — porting from `express-openapi-validator`.

--- a/packages/oav-fastify/README.md
+++ b/packages/oav-fastify/README.md
@@ -193,5 +193,5 @@ If both fire on the same route, oav's `preValidation` hook runs first; if it pas
 
 - [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — `createValidator`, `ValidatorOptions`, `formatSummary`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
 - [`oav`](https://www.npmjs.com/package/@aahoughton/oav) — batteries-included distribution of oav-core: YAML readers + the `oav` CLI.
-- The repo-root `INTEGRATION.md` — broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
-- The repo-root `MIGRATION-FROM-EOV.md` — porting from `express-openapi-validator`.
+- The repo-root `docs/integration.md` — broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
+- The repo-root `docs/migration-from-eov.md` — porting from `express-openapi-validator`.

--- a/packages/oav/README.md
+++ b/packages/oav/README.md
@@ -64,7 +64,7 @@ packages cover the framework wiring:
 [`oav-express4`](../oav-express4/README.md),
 [`oav-express5`](../oav-express5/README.md),
 [`oav-fastify`](../oav-fastify/README.md). See
-[`INTEGRATION.md`](../../INTEGRATION.md) for adapter recipes plus
+[`docs/integration.md`](../../docs/integration.md) for adapter recipes plus
 manual integration patterns for Next.js, Hono, Bun, and Deno via
 the Web Standards adapter.
 
@@ -72,8 +72,8 @@ the Web Standards adapter.
 
 - [Top-level `README.md`](../../README.md) — full rationale, install
   matrix, comparison.
-- [`INTEGRATION.md`](../../INTEGRATION.md) — adapter recipes,
+- [`docs/integration.md`](../../docs/integration.md) — adapter recipes,
   security wiring, response validation, file uploads, migration.
-- [`OVERLAYS.md`](../../OVERLAYS.md) — extending an externally-owned
+- [`docs/overlays.md`](../../docs/overlays.md) — extending an externally-owned
   base spec at load time.
-- [`COMPARISON.md`](../../COMPARISON.md) — feature comparison vs Ajv.
+- [`docs/comparison.md`](../../docs/comparison.md) — feature comparison vs Ajv.

--- a/packages/schema/src/keywords/meta-data.ts
+++ b/packages/schema/src/keywords/meta-data.ts
@@ -45,7 +45,7 @@ export const descriptionKeyword = annotationKeyword("description");
  * `default` — a suggested default value for the schema. Preserved as
  * metadata only; oav never injects defaults into request bodies or
  * response bodies (see the `useDefaults` discussion in
- * [`COMPARISON.md`](../../../COMPARISON.md) if you need that behaviour).
+ * [`docs/comparison.md`](../../../docs/comparison.md) if you need that behaviour).
  *
  * @public
  */

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -74,15 +74,15 @@ the upstream test suites live in
 
 ## Validator methods
 
-| Method                                        | Purpose                                                                                                                                                             |
-| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `validateRequest(req)`                        | Check an `HttpRequest` against the spec. Returns `null` on success or a `ValidationError` tree.                                                                     |
-| `validateResponse(req, res)`                  | Check an `HttpResponse` against the spec (request is used only for method + path). Returns `null` or a tree.                                                        |
-| `validateFetchRequest<T>(request, opts?)`     | Convenience for Web Standards `Request`: reads URL, headers, body; returns a discriminated union with a typed body. See [INTEGRATION.md](../../INTEGRATION.md).     |
-| `validateFetchResponse<T>(request, response)` | Symmetric Web Standards `Response` check. Useful for contract-testing an upstream.                                                                                  |
-| `getOperation({ method, path })`              | Startup-time introspection: returns the resolved, overlay-applied `OperationObject` + matched template for a (method, path) pair.                                   |
-| `detectedVersion`                             | The `openapi` string detected on construction, or `undefined` for an unrecognised / missing version (see `onUnknownVersion`).                                       |
-| `warnings`                                    | `readonly string[]` — warnings accumulated at construction time (`onUnknownVersion: "warn"` or `dialect`-suppressed category error). Empty when neither path fires. |
+| Method                                        | Purpose                                                                                                                                                                   |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `validateRequest(req)`                        | Check an `HttpRequest` against the spec. Returns `null` on success or a `ValidationError` tree.                                                                           |
+| `validateResponse(req, res)`                  | Check an `HttpResponse` against the spec (request is used only for method + path). Returns `null` or a tree.                                                              |
+| `validateFetchRequest<T>(request, opts?)`     | Convenience for Web Standards `Request`: reads URL, headers, body; returns a discriminated union with a typed body. See [docs/integration.md](../../docs/integration.md). |
+| `validateFetchResponse<T>(request, response)` | Symmetric Web Standards `Response` check. Useful for contract-testing an upstream.                                                                                        |
+| `getOperation({ method, path })`              | Startup-time introspection: returns the resolved, overlay-applied `OperationObject` + matched template for a (method, path) pair.                                         |
+| `detectedVersion`                             | The `openapi` string detected on construction, or `undefined` for an unrecognised / missing version (see `onUnknownVersion`).                                             |
+| `warnings`                                    | `readonly string[]` — warnings accumulated at construction time (`onUnknownVersion: "warn"` or `dialect`-suppressed category error). Empty when neither path fires.       |
 
 ## Options
 


### PR DESCRIPTION
## Summary

- Move `INTEGRATION.md`, `OVERLAYS.md`, `COMPARISON.md`, `MIGRATION-FROM-EOV.md` into a new `docs/` directory; lowercase filenames for consistency.
- Update all cross-references across READMEs, `CLAUDE.md`, package READMEs, and one TSDoc comment in `meta-data.ts`.
- Within the moved files, sibling cross-refs flatten (`./X.md` instead of `../docs/X.md`); root-relative refs (`./examples/`, `./conformance/`, `./performance/`, `./packages/`) gain a `../` prefix.
- A small unstaged TOC expansion in `docs/integration.md` rides along — moves with the file via `git mv`.

This is the first of two README-reorg PRs. The README itself is unchanged here apart from updated link targets — pruning the README and creating new files (`docs/configuration.md`, `docs/modules.md`) is a follow-up.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (post-format)
- [x] `pnpm test` — 788/788 pass
- [x] `grep -r INTEGRATION.md|OVERLAYS.md|COMPARISON.md|MIGRATION-FROM-EOV.md` returns nothing in tracked files
- [ ] Browse the rendered PR diff on GitHub to spot-check link rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)