### PR TITLE
feat(core)!: formatSummary separator + includeCode

### DIFF
--- a/docs/migration-from-eov.md
+++ b/docs/migration-from-eov.md
@@ -200,24 +200,31 @@ string, use `formatSummary` with `{ select: "all" }`:
 ```ts
 import { formatSummary } from "@aahoughton/oav-core";
 
-// Default — first failing leaf, equivalent to eov's default `message`:
+// Default: first failing leaf, equivalent to eov's default `message`.
 formatSummary(err);
 // "body.users[0].email must match format \"email\""
 
-// All leaves, one per line — equivalent in scope to eov's `allErrors`:
+// All leaves, one per line. oav's default all-issues shape.
 formatSummary(err, { select: "all" });
-// body.users[0].email — must match format "email" [format]
-// body.users[1].age — must be >= 0 [minimum]
+// body.users[0].email must match format "email" [format]
+// body.users[1].age must be >= 0 [minimum]
+
+// eov-shaped: comma-joined, no [code] suffix.
+formatSummary(err, { select: "all", separator: ", ", includeCode: false });
+// body.users[0].email must match format "email", body.users[1].age must be >= 0
 ```
 
-Shape differs from eov in three ways: `oav` uses dotted paths
-(`body.users[0].email`) instead of slash-separated
-(`request/body/users/0/email`); separates each entry with `\n`
-rather than `, `; and appends the error `[code]`. If you need exact
-parity for an existing client, post-process the string or render
-your own using `collectIssues(err)`.
+`separator` controls the joiner between leaves. `includeCode` toggles
+the trailing ` [<code>]`. Both are ignored under single-leaf modes
+(`first` / `deepest` / `byCode`). See
+[`FormatSummaryOptions`](../packages/core/src/format.ts) for the type.
+
+One delta from `eov` remains. `oav` uses dotted paths
+(`body.users[0].email`) where `eov` uses slash-separated
+(`request/body/users/0/email`). If your client pattern-matches on the
+exact `eov` string, render your own with `collectLeaves(err)`.
 
 The same `formatSummary` powers the `detail` field of
-`toProblemDetails` — pass `{ detail: formatSummary(err, { select: "all" }) }`
-to override the default and emit the all-issues form in your
-RFC 9457 response body.
+`toProblemDetails`. Pass
+`{ detail: formatSummary(err, { select: "all", separator: ", ", includeCode: false }) }`
+to emit an `eov`-shaped string in your RFC 9457 response body.

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -16,9 +16,9 @@ export interface FormatOptions {
  * Render a {@link ValidationError} tree as an indented human-readable string.
  *
  * @remarks
- * Every node renders as `<path> — <message> [<code>]`. Children are indented
- * under their parent. The output is meant for terminals and logs, not for
- * programmatic consumption — use {@link toJsonObject} or
+ * Every node renders as `<path> <message> [<code>]`. Children are indented
+ * under their parent. The output is meant for terminals and logs, not
+ * programmatic consumption; use {@link toJsonObject} or
  * {@link formatSummary} for that.
  *
  * @param error - Root of the error tree.
@@ -44,7 +44,7 @@ export function formatText(error: ValidationError, options: FormatOptions = {}):
     }
     const prefix = indent.repeat(depth);
     const location = joinPath(node.path);
-    const pathPart = location.length > 0 ? `${location} — ` : "";
+    const pathPart = location.length > 0 ? `${location} ` : "";
     lines.push(`${prefix}${pathPart}${node.message} [${node.code}]`);
     for (const child of node.children) render(child, depth + 1);
   };
@@ -83,16 +83,16 @@ export function toJsonObject(error: ValidationError): ValidationError {
 /**
  * Leaf-selection policy for {@link formatSummary}.
  *
- * - `"first"` — the first leaf in tree-traversal order. Matches
+ * - `"first"`: the first leaf in tree-traversal order. Matches
  *   `express-openapi-validator`'s top-level `message`. The default.
- * - `"deepest"` — the leaf with the longest path. More informative
+ * - `"deepest"`: the leaf with the longest path. More informative
  *   on `oneOf` / composition trees where the structural cause sits
  *   one or two levels in. Tiebreak: first encountered.
- * - `"all"` — every leaf, one per line, each prefixed with its path
+ * - `"all"`: every leaf, one per line, each prefixed with its path
  *   and suffixed with its `[code]`. Use this when you want a flat
- *   enumeration of every issue (e.g. EOV-style flat error messages,
+ *   enumeration of every issue (e.g. eov-style flat error messages,
  *   `grep`-friendly logs, CI diffs).
- * - `{ byCode }` — priority list of error codes. Returns the first
+ * - `{ byCode }`: priority list of error codes. Returns the first
  *   leaf whose `code` matches the highest-priority entry; if no leaf
  *   matches any listed code, falls back to the `"first"` policy.
  *
@@ -108,10 +108,22 @@ export type FormatSummarySelect = "first" | "deepest" | "all" | { byCode: readon
 export interface FormatSummaryOptions {
   /** How to pick which leaf (or leaves) to summarise. Defaults to `"first"`. */
   select?: FormatSummarySelect;
+  /**
+   * Separator between leaves under `select: "all"`. Defaults to `"\n"`.
+   * Set to `", "` for `eov`-style flat output. No effect on single-leaf
+   * modes (`"first"`, `"deepest"`, `{ byCode }`).
+   */
+  separator?: string;
+  /**
+   * Whether to suffix each leaf with ` [<code>]` under `select: "all"`.
+   * Defaults to `true`. Set to `false` for `eov`-style output. No effect
+   * on single-leaf modes (which never include the code).
+   */
+  includeCode?: boolean;
 }
 
 /**
- * Render a {@link ValidationError} tree as a string — the workhorse for
+ * Render a {@link ValidationError} tree as a string. The workhorse for
  * HTTP response-body `message` fields, log lines, error-monitoring
  * titles, and `Error.message`.
  *
@@ -120,9 +132,11 @@ export interface FormatSummaryOptions {
  * - **Single-leaf modes** (`"first"`, `"deepest"`, `{ byCode }`) pick one
  *   leaf and render it as `<dotted-path> <message>` (or just `<message>`
  *   when the path is empty). One line.
- * - **All-leaves mode** (`"all"`) enumerates every leaf, one per line,
- *   as `<dotted-path> — <message> [<code>]`. Use this for the EOV-style
- *   "every issue in a single message" shape.
+ * - **All-leaves mode** (`"all"`) enumerates every leaf, one per leaf,
+ *   joined by {@link FormatSummaryOptions.separator} (default `"\n"`),
+ *   each rendered as `<dotted-path> <message> [<code>]`. The trailing
+ *   ` [<code>]` is suppressed when {@link FormatSummaryOptions.includeCode}
+ *   is `false`. Tune both for `eov`-style flat output.
  *
  * For the indented full-tree view, use {@link formatText}; for the raw
  * JSON-safe object, use {@link toJsonObject}.
@@ -133,12 +147,17 @@ export interface FormatSummaryOptions {
  * // "body.users[0].email must match format \"email\""
  *
  * formatSummary(rootError, { select: "deepest" });
- * // The leaf with the longest path — useful on oneOf trees.
+ * // The leaf with the longest path. Useful on oneOf trees.
  *
  * formatSummary(rootError, { select: "all" });
- * // Every leaf, one per line. EOV-style flat output:
- * //   body.users[0].email — must match format "email" [format]
- * //   body.users[1].age — must be >= 0 [minimum]
+ * // Every leaf, one per line:
+ * //   body.users[0].email must match format "email" [format]
+ * //   body.users[1].age must be >= 0 [minimum]
+ *
+ * formatSummary(rootError, { select: "all", separator: ", ", includeCode: false });
+ * // eov-shaped flat output. (Path style still differs: eov uses
+ * // slash-separated paths.)
+ * //   body.users[0].email must match format "email", body.users[1].age must be >= 0
  *
  * formatSummary(rootError, { select: { byCode: ["content-type", "required"] } });
  * // The first content-type leaf if any, else the first required leaf,
@@ -150,17 +169,20 @@ export interface FormatSummaryOptions {
 export function formatSummary(error: ValidationError, options: FormatSummaryOptions = {}): string {
   const select = options.select ?? "first";
   // collectLeaves defines a leaf as any node with no children, so even
-  // a single-leaf root yields one entry — leaves[0] is always present.
+  // a single-leaf root yields one entry; leaves[0] is always present.
   const leaves = collectLeaves(error);
 
   if (select === "all") {
+    const separator = options.separator ?? "\n";
+    const includeCode = options.includeCode ?? true;
     const lines: string[] = [];
     for (const leaf of leaves) {
       const location = joinPath(leaf.path);
-      const pathPart = location.length > 0 ? `${location} — ` : "";
-      lines.push(`${pathPart}${leaf.message} [${leaf.code}]`);
+      const pathPart = location.length > 0 ? `${location} ` : "";
+      const codePart = includeCode ? ` [${leaf.code}]` : "";
+      lines.push(`${pathPart}${leaf.message}${codePart}`);
     }
-    return lines.join("\n");
+    return lines.join(separator);
   }
 
   let chosen: ValidationError = leaves[0]!;
@@ -209,8 +231,8 @@ export function countErrors(error: ValidationError): number {
 // ---------------------------------------------------------------------------
 
 /**
- * @deprecated Use {@link toJsonObject} — same return shape, name reflects
- *   that it returns an object, not a string.
+ * @deprecated Use {@link toJsonObject}. Same return shape; the new name
+ *   reflects that it returns an object, not a string.
  *
  * @public
  */
@@ -240,7 +262,7 @@ export interface SummarizeOptions {
 export type SummarizeSelect = "first" | "deepest" | { byCode: readonly string[] };
 
 /**
- * @deprecated Use {@link formatSummary} — same defaults and behaviour.
+ * @deprecated Use {@link formatSummary}. Same defaults and behaviour.
  *
  * @public
  */

--- a/packages/core/test/format.test.ts
+++ b/packages/core/test/format.test.ts
@@ -42,12 +42,12 @@ describe("formatText", () => {
   it("renders a 4-level tree with nested indentation and codes", () => {
     const out = formatText(sampleTree());
     const lines = out.split("\n");
-    expect(lines[0]).toBe("body — request body invalid [body]");
-    expect(lines[1]).toBe("  body — must match exactly one of 2 schemas [oneOf]");
-    expect(lines[2]).toBe("    body — branch 0 (Cat) failed [branch]");
-    expect(lines[3]).toBe("      body.purr — must be boolean [type]");
-    expect(lines[4]).toBe("    body — branch 1 (Dog) failed [branch]");
-    expect(lines[5]).toBe('      body — must have required property "bark" [required]');
+    expect(lines[0]).toBe("body request body invalid [body]");
+    expect(lines[1]).toBe("  body must match exactly one of 2 schemas [oneOf]");
+    expect(lines[2]).toBe("    body branch 0 (Cat) failed [branch]");
+    expect(lines[3]).toBe("      body.purr must be boolean [type]");
+    expect(lines[4]).toBe("    body branch 1 (Dog) failed [branch]");
+    expect(lines[5]).toBe('      body must have required property "bark" [required]');
   });
 
   it("truncates at maxDepth with an ellipsis marker", () => {
@@ -60,13 +60,13 @@ describe("formatText", () => {
     // Boundary: depth==maxDepth must still render (the rule is `depth >
     // maxDepth`, not `>=`). Pin it so an off-by-one regression here would
     // be caught.
-    expect(lines).toContain("    body — branch 0 (Cat) failed [branch]");
-    expect(lines).toContain("    body — branch 1 (Dog) failed [branch]");
+    expect(lines).toContain("    body branch 0 (Cat) failed [branch]");
+    expect(lines).toContain("    body branch 1 (Dog) failed [branch]");
   });
 
   it("allows overriding the indent string", () => {
     const out = formatText(sampleTree(), { indent: "\t" });
-    expect(out.split("\n")[1]).toMatch(/^\tbody — must match/);
+    expect(out.split("\n")[1]).toMatch(/^\tbody must match/);
   });
 
   it("omits the path prefix when the path is empty", () => {
@@ -99,8 +99,8 @@ describe("formatFlat", () => {
     const out = formatFlat(sampleTree());
     const lines = out.split("\n");
     expect(lines).toHaveLength(2);
-    expect(lines[0]).toBe("body.purr — must be boolean [type]");
-    expect(lines[1]).toBe('body — must have required property "bark" [required]');
+    expect(lines[0]).toBe("body.purr must be boolean [type]");
+    expect(lines[1]).toBe('body must have required property "bark" [required]');
   });
 
   it("flattens deep nesting to a single leaf-per-line report", () => {
@@ -108,7 +108,7 @@ describe("formatFlat", () => {
     for (let i = 0; i < 10; i += 1) {
       node = createBranchError(`level-${i}`, [], "branch", [node]);
     }
-    expect(formatFlat(node)).toBe("deep.x — bad [type]");
+    expect(formatFlat(node)).toBe("deep.x bad [type]");
   });
 });
 
@@ -138,7 +138,7 @@ describe("toJsonObject", () => {
 });
 
 describe("formatSummary", () => {
-  it('defaults to "first" — picks the first leaf in tree-traversal order', () => {
+  it('defaults to "first" and picks the first leaf in tree-traversal order', () => {
     expect(formatSummary(sampleTree())).toBe("body.purr must be boolean");
   });
 
@@ -155,13 +155,46 @@ describe("formatSummary", () => {
     const out = formatSummary(sampleTree(), { select: "all" });
     const lines = out.split("\n");
     expect(lines).toHaveLength(2);
-    expect(lines[0]).toBe("body.purr — must be boolean [type]");
-    expect(lines[1]).toBe('body — must have required property "bark" [required]');
+    expect(lines[0]).toBe("body.purr must be boolean [type]");
+    expect(lines[1]).toBe('body must have required property "bark" [required]');
   });
 
   it('"all" output is byte-identical to the deprecated formatFlat for the same tree', () => {
     const tree = sampleTree();
     expect(formatSummary(tree, { select: "all" })).toBe(formatFlat(tree));
+  });
+
+  it('"all" honours a custom separator', () => {
+    const out = formatSummary(sampleTree(), { select: "all", separator: ", " });
+    expect(out).toBe(
+      'body.purr must be boolean [type], body must have required property "bark" [required]',
+    );
+  });
+
+  it('"all" suppresses the trailing [code] when includeCode is false', () => {
+    const out = formatSummary(sampleTree(), { select: "all", includeCode: false });
+    const lines = out.split("\n");
+    expect(lines).toEqual(["body.purr must be boolean", 'body must have required property "bark"']);
+  });
+
+  it('"all" with eov-shape options composes separator + includeCode orthogonally', () => {
+    const out = formatSummary(sampleTree(), {
+      select: "all",
+      separator: ", ",
+      includeCode: false,
+    });
+    expect(out).toBe('body.purr must be boolean, body must have required property "bark"');
+  });
+
+  it("separator and includeCode have no effect on single-leaf modes", () => {
+    const tree = sampleTree();
+    const opts = { separator: ", ", includeCode: false } as const;
+    expect(formatSummary(tree, { select: "first", ...opts })).toBe(
+      formatSummary(tree, { select: "first" }),
+    );
+    expect(formatSummary(tree, { select: "deepest", ...opts })).toBe(
+      formatSummary(tree, { select: "deepest" }),
+    );
   });
 
   it("byCode returns the first leaf matching the highest-priority listed code", () => {
@@ -192,7 +225,7 @@ describe("formatSummary", () => {
 });
 
 describe("summarize (deprecated)", () => {
-  it('defaults to "first" — picks the first leaf in tree-traversal order', () => {
+  it('defaults to "first" and picks the first leaf in tree-traversal order', () => {
     expect(summarize(sampleTree())).toBe("body.purr must be boolean");
   });
 


### PR DESCRIPTION
## Summary

- Add \`separator\` and \`includeCode\` options to \`FormatSummaryOptions\` so eov migrators can emit a comma-joined, code-suffix-free string without rolling their own join over \`collectLeaves\`. Closes #234.
- Update \`docs/migration-from-eov.md\` to document the new options and the eov-shape recipe. Closes #233.
- Drop the \` — \` separator from \`formatText\`, \`formatFlat\`, and \`formatSummary \"all\"\` line shape. Output is now \`<path> <message> [<code>]\`, matching the single-leaf summary mode.

## Breaking change

Anyone snapshotting the old em-dash-separated output of \`formatText\` / \`formatFlat\` / \`formatSummary { select: \"all\" }\` will need to update fixtures. Function signatures and option types are unchanged.

## eov parity status

Two of the three eov-shape deltas listed in the migration doc are now configurable in one call:

\`\`\`ts
formatSummary(err, { select: \"all\", separator: \", \", includeCode: false });
// body.users[0].email must match format \"email\", body.users[1].age must be >= 0
\`\`\`

Path style (\`body.users[0].email\` vs eov's \`request/body/users/0/email\`) still differs. Documented; consumers needing exact byte-parity render their own with \`collectLeaves(err)\`.

## Follow-up

Filed #240 for the wider em-dash scrub across prose / TSDoc. Out of scope here.

## Test plan

- [x] \`pnpm test\` (792 tests passing)
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [ ] CI green