### PR TITLE
chore: add Prose Style guidance and scrub em-dashes repo-wide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md — project-internal notes for contributors using Claude Code
+# CLAUDE.md: project-internal notes for contributors using Claude Code
 
 ## Contribution principles
 
@@ -11,7 +11,7 @@ _whether_ and _what shape_.
 When a design choice has real tradeoffs (fat vs thin adapter, mocks
 vs integration tests, one PR vs many, opinionated default vs escape
 hatch), say so. Recommend a lean. Defer the call rather than picking
-silently — a half-articulated choice that survives review is harder
+silently. A half-articulated choice that survives review is harder
 to revisit than one that was explicitly weighed. The point is the
 surfacing, not the agonizing: options + lean + decision space, not
 exhaustive analysis.
@@ -23,13 +23,13 @@ addition, a default-behavior shift), open the conversation before
 writing code. Sketch the API shape, list open questions, recommend
 defaults. The cost of one round-trip on the design saves several on
 the implementation when an early choice would have wanted to be
-different. For small fixes and obvious changes, just do it — judgment.
+different. For small fixes and obvious changes, just do it; judgment.
 
 ### Naming and consistency
 
 Names that pair (`request`/`response`, `validateRequest`/`validateResponse`,
 `Validator`/`ValidatorOptions`, `httpRequestFromExpress`/`httpRequestFromFetch`)
-carry meaning beyond what each name says alone — a reader should be
+carry meaning beyond what each name says alone: a reader should be
 able to predict one from the other. When you add a new symbol, look
 for the sibling that should pair with it, even if you're only writing
 one half today. Across-package symmetry is a feature: every adapter
@@ -38,8 +38,8 @@ with only the framework-typed argument varying. Per-framework types
 use framework-native names (`ExpressContext`, `FastifyContext`); names
 that sit above the framework boundary stay identical everywhere.
 
-If a name reads awkwardly in user code (`requestValidator(validator)`
-— three "validator"s, three meanings), that's a signal to rename, not
+If a name reads awkwardly in user code (`requestValidator(validator)`,
+three "validator"s, three meanings), that's a signal to rename, not
 to add a comment.
 
 ### Forward-compatible API shapes
@@ -66,13 +66,39 @@ and let the user's own logic fail in a familiar way.
 ### Type as canonical contract
 
 TSDoc on the type is the API reference. Prose docs (READMEs,
-docs/integration.md) are recipes — worked examples that show how
+docs/integration.md) are recipes: worked examples that show how
 the pieces compose, with backreferences to the type for the contract.
 When adding a new option-bearing interface, lead its TSDoc with a
 roadmap of the field groups so editor tooling surfaces the surface
 on first read. When adding a recipe in docs/integration.md, include
 a "see {type}" backreference so the reader knows where the source of
 truth lives.
+
+### Prose Style
+
+LLM-like writing breaks reader flow. Readers familiar with the
+patterns notice them, snap out of whatever they were absorbing, and
+have to reset. Avoid the patterns for the reader's sake, not for
+camouflage. Applies to docs, TSDoc, commit messages, PR descriptions,
+and code comments. The big ones:
+
+- **Em-dash.** Replace `—` with a period, comma, semicolon,
+  parenthesis, or colon.
+- **Contrastive negation.** "Not X, it's Y" / "not just X, but Y" /
+  "this isn't a fix, it's a rewrite." Make the affirmative claim
+  directly.
+- **Filler and hedging.** Throat-clearers ("honestly," "frankly,"
+  "essentially") and stacked hedges ("may," "might," "could
+  potentially") read as AI; drop them. Different from substantive
+  adverbial use, e.g. the "honestly" in "Surface tradeoffs honestly"
+  above.
+- **Over-promising vocabulary.** "Robust," "elegant," "powerful,"
+  "seamless," "comprehensive," "delve," "leverage," "unlock."
+  Substantiate concretely or drop.
+
+Generated output (error messages, log lines, anything the code itself
+emits) is ASCII-only, simple, and concise. Data passed through from a
+spec or user input is unchanged.
 
 ### Scope discipline
 
@@ -82,14 +108,14 @@ all touched the same script surface and shipped together).
 Anything that could be reverted independently → separate PR.
 Adjacent cleanups noticed during a fix → file as a `polish` issue,
 don't sneak in. The `polish` label exists for "real but not urgent"
-work — fix when next touching the area, not preemptively.
+work: fix when next touching the area, not preemptively.
 
 ### Verify before declaring done
 
 For substantive changes (new packages, behavior shifts, packaging
 work), exercise the change end-to-end before committing. Mocks
 cover the logic; smoke tests prove the integration. Bug fixes
-start with a reproducer — confirming the bug exists rules out
+start with a reproducer; confirming the bug exists rules out
 fixing the wrong thing. The pack-smoke CI job catches install
 regressions; if your change touches packaging, run the smoke
 locally too (`pnpm pack` + `npm install` in `/tmp`).
@@ -107,7 +133,7 @@ pnpm typecheck                    # tsc -b (composite project references)
 ```
 
 `pnpm test` uses vitest with workspace aliases from `vitest.config.ts` so
-tests run against `packages/*/src` directly — no need to build before
+tests run against `packages/*/src` directly; no need to build before
 testing.
 
 Use `pnpm pack` (not `npm pack`) for any workspace package. `npm pack`
@@ -117,20 +143,20 @@ reaching for `pnpm pack` directly.
 
 ## Dev-only sub-packages (standalone; not in the workspace)
 
-- `conformance/` — upstream JSON Schema Test Suite + OpenAPI case
+- `conformance/`: upstream JSON Schema Test Suite + OpenAPI case
   harness. `cd conformance && pnpm install` to bootstrap.
-- `performance/` — compile / validate benchmarks against other JSON
+- `performance/`: compile / validate benchmarks against other JSON
   Schema validators. `cd performance && pnpm install` to bootstrap.
 
 Both have their own `package.json` + `pnpm-workspace.yaml` (with empty
 `packages:` list so pnpm treats them as isolated roots). Their
 external dev-dependencies (benchmark runners, competing validators,
 `tsx`) are NOT in the main workspace install. Neither is type-checked
-in CI — they're tsx-run dev tooling, breakage shows up when you run them.
+in CI; they're tsx-run dev tooling, breakage shows up when you run them.
 
 ## Architecture, package by package
 
-- **`@oav/core`** — the shared error-tree model plus the helpers every
+- **`@oav/core`**: the shared error-tree model plus the helpers every
   other package and most consumers need. `ValidationError` tree
   (children always an array), path segments as `(string | number)[]`,
   the canonical formatters (`formatText` / `formatSummary` / `toJsonObject`;
@@ -141,7 +167,7 @@ in CI — they're tsx-run dev tooling, breakage shows up when you run them.
   `toProblemDetails` for HTTP framing, RFC 6901 `resolveJsonPointer`,
   shared OpenAPI / HTTP types, and `detectOpenAPIVersion`. Everything
   else depends on this; nothing here depends on the others.
-- **`@oav/schema`** — the JSON Schema 2020-12 compiler. Walks a schema,
+- **`@oav/schema`**: the JSON Schema 2020-12 compiler. Walks a schema,
   dispatches each keyword via `KeywordDefinition.compile(ctx)`, assembles
   the generated JS source, and `eval`s it through `new Function(deps, src)`.
   Boolean schemas (`true`/`false`) are first-class. `$ref` uses an
@@ -149,18 +175,18 @@ in CI — they're tsx-run dev tooling, breakage shows up when you run them.
   The public barrel holds what keyword authors need; codegen mechanics
   (`NAMES`, `pathJoinExpr`, `rawExpr`, `quoteString`, runtime helpers,
   `SchemaRegistry`, `SUBSCHEMA_*_POSITIONS`, `createKeywordContext`)
-  live behind the `oav/schema/internals` subpath — reach
+  live behind the `oav/schema/internals` subpath. Reach
   for them only when a plugin genuinely needs them (not covered by
   semver).
-- **`@oav/formats`** — pure string validators; exported as a `Record<string,
+- **`@oav/formats`**: pure string validators; exported as a `Record<string,
 (s: string) => boolean>` suitable for `compileSchema`'s `formats` option.
-- **`@oav/spec`** — `DocumentReader` abstraction (file/http/memory/composite)
+- **`@oav/spec`**: `DocumentReader` abstraction (file/http/memory/composite)
   plus `resolveSpec()` which inlines external `$ref`s and leaves circular
   ones as internal refs. `applyOverlays()` handles the extension system.
-- **`@oav/router`** — a sorted-list route matcher. Routes are sorted once
+- **`@oav/router`**: a sorted-list route matcher. Routes are sorted once
   at construction (more-literal segments first); `match` is a linear scan,
   O(routes × segments). Cheap for typical OpenAPI spec sizes.
-- **`@oav/validator`** — the HTTP orchestrator. `createValidator(spec,
+- **`@oav/validator`**: the HTTP orchestrator. `createValidator(spec,
 options)` returns a `Validator` exposing `validateRequest(req)`,
   `validateResponse(req, res)`, and `getOperation({ method, path })`.
   Per-operation parameter / body / response schemas are pre-compiled
@@ -171,9 +197,9 @@ options)` returns a `Validator` exposing `validateRequest(req)`,
   error paths are unambiguous. Also exports the Fetch-API adapter
   (`httpRequestFromFetch`, `httpResponseFromFetch`,
   `readBodyFromFetch`) for Next.js / Hono / Bun / Deno consumers.
-- **`@oav/cli`** — thin commander wrapper. No business logic beyond arg
+- **`@oav/cli`**: thin commander wrapper. No business logic beyond arg
   parsing, I/O, and exit codes.
-- **`@oav/oav-express4`**, **`@oav/oav-express5`**, **`@oav/oav-fastify`** —
+- **`@oav/oav-express4`**, **`@oav/oav-express5`**, **`@oav/oav-fastify`**:
   framework adapters. Thin: depend on `@aahoughton/oav-core`
   (transitive) and declare the matching framework as a peer. Each
   exports `validateRequests` (the middleware/hook factory),
@@ -208,25 +234,25 @@ oav-fastify   → same chain, peer: fastify ^5
 
 1. Create `packages/schema/src/keywords/<area>.ts` exporting a
    `KeywordDefinition` with `keyword`, `vocabulary`, `compile(ctx)`.
-   Flags on the definition itself drive compiler specialisation —
-   set them correctly or performance optimisations silently mis-fire:
-   - `applicator: true` — keyword descends into subschemas (items,
+   Flags on the definition itself drive compiler specialisation.
+   Set them correctly or performance optimisations silently mis-fire:
+   - `applicator: true`: keyword descends into subschemas (items,
      properties, allOf, not, …). Drives the inliner to use the
      function-call path for multi-keyword schemas containing this
      keyword. A missed flag costs correctness (inlined applicators can
      skip per-function evaluated-keys state) and speed (V8 can't
      monomorphise a huge inline body).
-   - `annotation: true` — keyword is metadata only, emits no runtime
+   - `annotation: true`: keyword is metadata only, emits no runtime
      code (`title`, `description`, `$id`, `$schema`, `$comment`, …).
      Lets the inliner count keyword density correctly and avoids
      spurious "unknown-keyword" diagnostics.
-   - `evaluates: { properties?: true; items?: true }` — keyword
+   - `evaluates: { properties?: true; items?: true }`: keyword
      contributes to evaluated-keys / evaluated-items tracking for
      `unevaluated*`.
 
    `ctx.predicate` is `true` when the user requested predicate mode
    (`compileSchema(..., { predicate: true })`). Most keywords don't
-   need to read this — `ctx.emitError`, `ctx.leafErrorExpr`,
+   need to read this; `ctx.emitError`, `ctx.leafErrorExpr`,
    `ctx.validateSubschema`, and `ctx.emitBudgetBreak` all do the
    right thing automatically. Branch on it only when your keyword
    reads a sub-validator's return value (composition keywords,
@@ -234,29 +260,29 @@ oav-fastify   → same chain, peer: fastify ^5
    "Predicate mode" section below.
 
    The context (`KeywordCompileContext`) offers:
-   - `ctx.gen` — code emitter (see the `CodeEmitter` interface).
-   - `ctx.data`, `ctx.path`, `ctx.errors` — JS expressions for the
+   - `ctx.gen`: code emitter (see the `CodeEmitter` interface).
+   - `ctx.data`, `ctx.path`, `ctx.errors`: JS expressions for the
      current data, path array, and error accumulator.
-   - `ctx.schema`, `ctx.parentSchema` — the keyword's value and the
+   - `ctx.schema`, `ctx.parentSchema`: the keyword's value and the
      surrounding schema object.
-   - `ctx.emitError(kind, expr)` / `ctx.errorStatement(kind, expr)` —
+   - `ctx.emitError(kind, expr)` / `ctx.errorStatement(kind, expr)`:
      push an error expression (`"leaf"` = counts against `maxErrors`,
      `"lift"` = propagating an already-counted sub-validator result).
-   - `ctx.leafErrorExpr(codeExpr, msgExpr, paramsExpr, extraSegments?)`
-     — build a `deps.createLeafError(...)` call. Pass any per-error
+   - `ctx.leafErrorExpr(codeExpr, msgExpr, paramsExpr, extraSegments?)`:
+     build a `deps.createLeafError(...)` call. Pass any per-error
      trailing path segment (e.g. a missing property name) via
      `extraSegments` so the runtime helper splices them; the helper
      also picks up any segments pending from an enclosing inlined
      `validateSubschema` call. `ctx.branchErrorExpr(...)` is the
      equivalent for branch errors.
-   - `ctx.validateSubschema(schema, dataExpr, { segment? })` — the
+   - `ctx.validateSubschema(schema, dataExpr, { segment? })`: the
      common "descend into a subschema" pattern (inlines when simple).
-   - `ctx.compileSubschema(schema) -> fnName` — lower-level; use when
+   - `ctx.compileSubschema(schema) -> fnName`: lower-level; use when
      a keyword needs the sub-validator's return value for its own
      logic (composition keywords do this).
    - `ctx.resolveRef(ref)`, `ctx.evaluatedPropertiesVar` /
-     `ctx.evaluatedItemsVar` — for `$ref` and unevaluated-tracking.
-   - `ctx.effectivePathExpr` — JS expression for the runtime path
+     `ctx.evaluatedItemsVar`: for `$ref` and unevaluated-tracking.
+   - `ctx.effectivePathExpr`: JS expression for the runtime path
      including any pending inline segments. Reach for this only when
      passing the path to something other than the error helpers
      (e.g. a user-supplied custom-keyword callback).
@@ -266,12 +292,12 @@ oav-fastify   → same chain, peer: fastify ^5
 3. Re-export from `keywords/index.ts` and top-level `src/index.ts`.
 4. Add a `test/keyword-<name>.test.ts` that compiles a schema, validates
    good + bad data, and asserts on `code` / `path` / `params` /
-   `children` structure — never on generated code strings.
+   `children` structure; never on generated code strings.
 5. Add an entry to `BuiltInErrorParams` in `packages/core/src/errors.ts`
    describing the new error `code` and the shape of its `params`
    object. The compiler can't check this (errors are emitted through
    generated JS source), but it's the documented contract consumers
-   narrow against — drift here is a silent bug.
+   narrow against; drift here is a silent bug.
 
 ## How to add a new format
 
@@ -284,11 +310,11 @@ oav-fastify   → same chain, peer: fastify ^5
 
 Output format dispatch lives in `@oav/core` (not the CLI) so library
 consumers can render by format name too. Programmatic callers can also
-pass a renderer function directly — `formatError(err, (e) => ...)` —
+pass a renderer function directly (`formatError(err, (e) => ...)`)
 without forking the switch.
 
 1. Add the name to `KNOWN_OUTPUT_FORMATS` in
-   `packages/core/src/format-output.ts` — the `OutputFormat` type and
+   `packages/core/src/format-output.ts`. The `OutputFormat` type and
    the CLI's Commander `--format` validator are both derived from it.
 2. Add the rendering function to `packages/core/src/format.ts` (or emit
    straight from the leaves).
@@ -300,13 +326,13 @@ without forking the switch.
 By default the compiler collects every error into a tree. For very
 large payloads (e.g. a 10 MB JSON array where every element fails the
 same way) that's wasted CPU and memory. `compileSchema(schema,
-{ maxErrors: N })` — also exposed on `@oav/validator`'s
-`createValidator` — caps the tree at N leaves and short-circuits the
+{ maxErrors: N })` (also exposed on `@oav/validator`'s
+`createValidator`) caps the tree at N leaves and short-circuits the
 hot loops once the budget is exhausted. `maxErrors: 1` is the classic
 fast-fail mode; the returned `{ valid: false, error, truncated: true }`
 tells consumers their report is partial. Codegen is specialised: when
 `maxErrors` is left unset, the generated source is identical to before
-(no budget checks, no `truncated` tracking) — zero overhead for
+(no budget checks, no `truncated` tracking); zero overhead for
 callers who don't opt in.
 
 `maxErrors` must be a positive integer (>= 1). `compileSchema` and
@@ -317,16 +343,16 @@ collection entirely.
 The budget semantics show up at the keyword-authoring level through
 the `kind` argument on `ctx.emitError` / `ctx.errorStatement`:
 
-- `ctx.emitError("leaf", expr)` — a **fresh leaf error**; counts
+- `ctx.emitError("leaf", expr)`: a **fresh leaf error**; counts
   against the budget. Use when the keyword itself is constructing a
   `createLeafError(...)` expression.
-- `ctx.emitError("lift", expr)` — a **lift**: propagating a
+- `ctx.emitError("lift", expr)`: a **lift**, propagating a
   sub-validator's already-counted error up the tree, or wrapping
   already-counted children in a `createBranchError`. Always
   unconditional.
 
 Using the wrong kind silently miscounts errors against the budget.
-The `kind` is a required argument — TypeScript enforces that a choice
+The `kind` is a required argument; TypeScript enforces that a choice
 is made at every call site; the correctness of the choice is on the
 author.
 
@@ -342,7 +368,7 @@ to `return false;`. Generated subfunctions drop the `path` parameter
 
 Predicate mode is mutually exclusive with a finite `maxErrors`; the
 compiler throws if both are set. The two options are semantically
-incompatible — predicate already short-circuits on the first failure,
+incompatible; predicate already short-circuits on the first failure,
 so there is nothing to count.
 
 For **keyword authors**, most keywords get predicate mode for free
@@ -350,8 +376,8 @@ because `ctx.emitError("leaf" | "lift", expr)` collapses to `return
 false;` when `ctx.predicate === true`; `ctx.withPathSegment`,
 `ctx.validateSubschema`, and `ctx.emitBudgetBreak` are similarly
 predicate-aware. You only need to branch on `ctx.predicate` when your
-keyword reads a sub-validator's return value for its own control flow
-— composition keywords (`allOf`, `anyOf`, `oneOf`, `not`,
+keyword reads a sub-validator's return value for its own control flow:
+composition keywords (`allOf`, `anyOf`, `oneOf`, `not`,
 `if`/`then`/`else`, `dependentSchemas`), `contains`, `discriminator`,
 `$ref`, and `$dynamicRef` all do this. In predicate mode subfunctions
 return `boolean` (not `ValidationError | null`) and don't take a
@@ -370,7 +396,7 @@ construction time via `detectOpenAPIVersion` and picks a dialect:
 | 3.1.x        | Supported | JSON Schema 2020-12                |
 | 3.2.x        | Supported | JSON Schema 2020-12 + QUERY method |
 
-Dispatch is a one-liner inside `createValidator` — `dialectFor(version)`.
+Dispatch is a one-liner inside `createValidator`: `dialectFor(version)`.
 The check runs once at construction; there's no per-request branching,
 so adding more versions adds zero runtime cost.
 
@@ -396,17 +422,17 @@ Only three things vary from 2020-12; everything else (numeric / string
 Keywords not present in 3.0 (`const`, `if`/`then`/`else`, `contains`,
 `patternProperties`, `propertyNames`, `unevaluatedProperties`/`Items`,
 `prefixItems`, `$defs`, `$id`, anchors, `$dynamicRef`) are simply not
-in the 3.0 vocabulary stack — schemas that use them are treated as
+in the 3.0 vocabulary stack; schemas that use them are treated as
 having an unknown field, which 2020-12 allows in every dialect.
 
 ### Running tests per version
 
 - **Schema-level tests** (`packages/schema/test/*`) are
-  dialect-agnostic — they compile schemas with the default 2020-12
+  dialect-agnostic; they compile schemas with the default 2020-12
   vocab and assert on 2020-12 semantics. Dialect-specific keyword
   tests sit next to their keyword files where sensible.
 - **HTTP-level conformance** lives in
-  `conformance/openapi-cases/petstore-{30,31,32}/` — one petstore per
+  `conformance/openapi-cases/petstore-{30,31,32}/`, one petstore per
   version, each exercising the version's distinctive features (3.0:
   `nullable`, boolean `exclusiveMinimum`; 3.2: QUERY method).
 - **Validator integration tests** in
@@ -415,7 +441,7 @@ having an unknown field, which 2020-12 allows in every dialect.
 
 ## Known limitations
 
-- `$dynamicRef` currently behaves like `$ref` with an anchor lookup — no
+- `$dynamicRef` currently behaves like `$ref` with an anchor lookup; no
   runtime dynamic-scope traversal. Good enough for schemas that don't
   actually rewire the extension point at runtime.
 - `unevaluated*` evaluated-key tracking is gated at compile time on

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ OpenAPI **3.0** / **3.1** / **3.2** HTTP request and response
 validator. Two primary drivers:
 
 - **Tenant overrides over a base spec.** When tenants extend a
-  shared API — adding a required header on one route, refining a
-  schema, requiring auth where the base spec didn't — they need to
+  shared API (adding a required header on one route, refining a
+  schema, requiring auth where the base spec didn't), they need to
   document those changes in the spec they ship, not as
   application-side patches. `applyOverlays` rewrites the document
   at load time. Custom keywords, formats, and dialects plug into
@@ -14,7 +14,7 @@ validator. Two primary drivers:
 - **Validators that fit in microservice runners.** `oav
 compile-spec openapi.yaml` emits a single zero-dependency ES
   module exposing the full validator surface. Targets Cloudflare
-  Workers, Vercel Edge, Lambda@Edge, Deno Deploy — runtimes where
+  Workers, Vercel Edge, Lambda@Edge, Deno Deploy: runtimes where
   `new Function()` is unavailable, or where dependency footprint
   matters. `--only "POST /pets"` (repeatable) scopes the output to
   specific operations without touching the source spec.
@@ -28,8 +28,8 @@ headers.
 
 `oav` ships in two core packages, plus framework adapter packages that
 build on either `oav` or `oav-core` -- if you don't need YAML support,
-you can skip `oav` entirely — the lean path for zero-dependency / edge
-targets:
+you can skip `oav` entirely (the lean path for zero-dependency / edge
+targets):
 
 | Package        | When to use                                                                                                                                                                                                                                                                                      |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -95,7 +95,7 @@ config.
 ## How it compares
 
 oav's primary alternative is
-[Ajv](https://github.com/ajv-validator/ajv) — directly for
+[Ajv](https://github.com/ajv-validator/ajv): directly for
 `compileSchema`, or via
 [`express-openapi-validator`](https://github.com/cdimascio/express-openapi-validator)
 for HTTP validation. (Migrating from EOV specifically:
@@ -114,19 +114,19 @@ hardware will vary.
 
 Ajv compile is essentially constant overhead per schema; oav scales
 with shape. The advantage shows up wherever validator construction
-sits in the hot path — per-request, per-tenant, per-test, edge
+sits in the hot path: per-request, per-tenant, per-test, edge
 cold-start, AOT module emit.
 
 **Validate: roughly tied on simple shapes; Ajv wins on complex.**
 
 Both libraries are sub-microsecond per check on typical OpenAPI
 bodies. On complex `oneOf`/`allOf` or large arrays, Ajv leads by
-2–4× (say 100 ns → 400 ns per call, or 1.7 µs → 4 µs). oav's
+2–4× (say 100 ns to 400 ns per call, or 1.7 µs to 4 µs). oav's
 `predicate` mode (`compileSchema(..., { predicate: true })`) closes
 most of that gap for yes/no use cases.
 
-For typical HTTP workloads — 1k–10k req/sec × ~1 validation per
-request — the difference is invisible at any of those numbers. For
+For typical HTTP workloads (1k–10k req/sec × ~1 validation per
+request), the difference is invisible at any of those numbers. For
 validation-heavy code (millions of validations per second), Ajv wins.
 
 Full per-shape breakdown: [`docs/comparison.md`](./docs/comparison.md). Raw
@@ -163,8 +163,8 @@ oav resolve openapi.yaml
 oav validate openapi.yaml --request req.http
 oav validate openapi.yaml --path "POST /pets" --body payload.json
 oav validate openapi.yaml --path "GET /pets" --response --status 200 --body resp.json
-oav compile-schema schema.json -o validator.mjs             # JSON Schema → standalone validator
-oav compile-spec openapi.yaml  -o validator.mjs             # OpenAPI   → standalone HTTP validator (edge / Lambda)
+oav compile-schema schema.json -o validator.mjs             # JSON Schema -> standalone validator
+oav compile-spec openapi.yaml  -o validator.mjs             # OpenAPI   -> standalone HTTP validator (edge / Lambda)
 ```
 
 Flags: `--format text|json|flat`, `--depth n`, `--overlay file`
@@ -192,7 +192,7 @@ one of the built-in dialects (`jsonSchemaDialect`, `openapi31Dialect`,
 3.1 dialect by default; configure with
 `onUnknownVersion: "throw" | "warn" | "fallback31"`.
 
-**Swagger 2.0 specs** aren't supported directly — `createValidator`
+**Swagger 2.0 specs** aren't supported directly: `createValidator`
 throws on `swagger: "2.0"` documents. Convert to OpenAPI 3.0 first with
 [`swagger2openapi`](https://github.com/Mermade/oas-kit/tree/main/packages/swagger2openapi)
 and pass the 3.0 output to `createValidator`:
@@ -268,7 +268,7 @@ Runtime-behaviour corners. For a feature-scope comparison against
 Ajv (draft versions, `$data`, async validation, etc.) see
 [docs/comparison.md](./docs/comparison.md).
 
-- `$dynamicRef` behaves like `$ref` with anchor lookup — no runtime dynamic-scope traversal.
+- `$dynamicRef` behaves like `$ref` with anchor lookup; no runtime dynamic-scope traversal.
 - `style: deepObject` query parameters support only single-level nesting (`obj[key]=value`); OpenAPI 3.0–3.2 don't define nested semantics.
 - `pattern` keywords and `format: "regex"` compile to the JavaScript
   built-in `RegExp`, which has no execution timeout. If your OpenAPI
@@ -288,4 +288,4 @@ conformance and performance sub-packages are described there and in
 
 ## License
 
-MIT — see [LICENSE](./LICENSE).
+MIT. See [LICENSE](./LICENSE).

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -7,7 +7,7 @@ in the ecosystem and have done so for years. This document maps what
 each project does so you can pick the one that fits.
 
 oav covers the same ground as Ajv + `express-openapi-validator`
-combined — schema validation plus HTTP-layer checks — and trades
+combined (schema validation plus HTTP-layer checks), and trades
 differently on a handful of specifics, catalogued below.
 
 This document is about behaviour and capabilities. For raw numbers
@@ -41,13 +41,13 @@ Capabilities that the Ajv stack covers and oav does not.
   OpenAPI 3.0's constrained dialect only; earlier drafts and JTD are
   not supported.
 - **Data-mutating options.** `coerceTypes`, `removeAdditional`, and
-  `useDefaults` let Ajv mutate the validated value in place — coercing
+  `useDefaults` let Ajv mutate the validated value in place: coercing
   strings to numbers, stripping undeclared properties, filling missing
   properties from `default`. oav treats validation as a yes/no
   question and does not mutate inputs.
-- **Schema-level AOT — programmatic surface.** Ajv's `standaloneCode`
+- **Schema-level AOT (programmatic surface).** Ajv's `standaloneCode`
   is a library API that takes a map of named schemas and emits one
-  module with interlinked validators — cross-schema `$ref`s resolve
+  module with interlinked validators: cross-schema `$ref`s resolve
   at emit time, CommonJS or ESM output. `oav compile-schema` is
   CLI-only and single-schema: multi-schema projects need to run it
   per schema, with a preceding `oav resolve` step to inline any
@@ -72,7 +72,7 @@ Capabilities that the Ajv stack covers and oav does not.
 - **`$data` references.** Ajv's non-standard extension where one
   keyword's value comes from the data being validated
   (`{ minimum: { $data: "1/min" } }`). oav doesn't implement it. The
-  common use case — cross-field constraints like `max >= min` —
+  common use case (cross-field constraints like `max >= min`)
   works in oav via an object-level custom keyword that sees the
   whole object and reaches siblings directly; see
   [`examples/cross-field-validation.ts`](../examples/cross-field-validation.ts).
@@ -84,11 +84,11 @@ Capabilities that the Ajv stack covers and oav does not.
 - **`express-openapi-validator` conveniences.** `req.body` /
   `req.query` type coercion, `res.json` interception for response
   validation, `fileUploader` (multer integration), `securityHandlers`
-  (credential-verifying dispatch — oav does shape-only security
+  (credential-verifying dispatch; oav does shape-only security
   validation but doesn't verify credentials),
   `operationHandlers` filesystem auto-loading, and `ignorePaths` /
   `ignoreUndocumented` are one-liner options. oav leaves these to the
-  adapter — see [`integration.md`](./integration.md) for recipes.
+  adapter; see [`integration.md`](./integration.md) for recipes.
 
 ## Where oav does more
 
@@ -97,7 +97,7 @@ Capabilities oav has that Ajv (alone or with
 
 - **HTTP-aware validation.** Route matching, content-type negotiation,
   parameter `style` / `explode` deserialisation, response status
-  matching (exact → NXX class → default) are part of one
+  matching (exact, then NXX class, then default) are part of one
   `validateRequest` / `validateResponse` call. Ajv is a JSON Schema
   validator; wiring the HTTP layer on top of it is what
   `express-openapi-validator` does, and only for Express.
@@ -132,8 +132,8 @@ type: "string" }` to `{ type: ["string", "number", "boolean",
 "object", "array"] }` with an `x-eov-type` side channel to narrow
   back). Different mechanism, equivalent behaviour.
 - **First-class overlays.** `applyOverlays` rewrites an
-  externally-owned base spec at load time — add a required header to
-  every operation, extend a component schema, swap a response shape —
+  externally-owned base spec at load time (add a required header to
+  every operation, extend a component schema, swap a response shape)
   without forking or preprocessing the upstream file.
 - **Structured error tree.** Errors preserve the applicator structure
   (`oneOf` with per-branch `children`, `allOf` with failed-conjunct
@@ -150,13 +150,13 @@ type: "string" }` to `{ type: ["string", "number", "boolean",
   N leaves; the generated code short-circuits hot loops when the
   budget is exhausted. Ajv has `allErrors: true | false` but no
   explicit count budget. When unset, oav's codegen emits plain
-  `errors.push` with no runtime checks — zero overhead for the
+  `errors.push` with no runtime checks; zero overhead for the
   uncapped case.
 - **Direction-aware body transforms.** Request-body validators reject
   `readOnly` properties and exempt them from `required`; response-body
   validators do the same for `writeOnly`. Applied as a pre-compile
   transform so the compiler itself is direction-agnostic.
-- **Discriminator.** First-class OpenAPI discriminator support — a
+- **Discriminator.** First-class OpenAPI discriminator support: a
   single-dispatch alternative to `oneOf` whose error message names the
   offending property and value rather than listing per-branch
   failures. eov supports discriminator by preprocessing the schema
@@ -180,7 +180,7 @@ Ajv 8 has four runtime dependencies:
 | `require-from-string`  | Load compiled-validator source as a module (standalone codegen) |
 
 oav's compiler and validator have zero runtime dependencies. The lean
-`oav-core` package ships exactly that — no runtime deps —
+`oav-core` package ships exactly that (no runtime deps),
 and accepts JSON specs. The batteries-included `oav`
 package layers `yaml` on top for `.yaml` spec files and adds the `oav`
 CLI (with `commander` as an optional peer). The two efficiency
@@ -201,7 +201,7 @@ steady-state validate throughput on a schema you compile once, a
 large userbase, multi-draft support, or the one-line middleware
 integration. Pick oav when you want a structured error tree,
 overlays over specs you don't own, a bundled OpenAPI 3.0 dialect,
-explicit control over where validation runs in your HTTP stack — or
+explicit control over where validation runs in your HTTP stack, or
 when compile throughput matters (1–2 orders of magnitude above ajv,
 8× on Stripe's real-world spec; see the performance sketch above).
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,24 +1,24 @@
 # Integration guide
 
 A recipe book for wiring `oav` into HTTP frameworks. `oav` is a
-validator, not a middleware package — you write a short adapter
+validator, not a middleware package: you write a short adapter
 between your framework and `validateRequest` / `validateResponse`,
-or use one of the companion adapter packages: `oav-express4`,
-`oav-express5`, `oav-fastify`.
+or use one of the companion adapter packages (`oav-express4`,
+`oav-express5`, `oav-fastify`).
 
 This document is organised:
 
-- **[What the validator expects](#what-the-validator-expects)** —
+- **[What the validator expects](#what-the-validator-expects)**:
   the framework-agnostic shapes `validateRequest` and
   `validateResponse` work with.
-- **[Supporting helpers](#supporting-helpers)** —
+- **[Supporting helpers](#supporting-helpers)**:
   `httpStatusFor`, `allowHeaderFor`, `toProblemDetails`,
   `formatSummary`, `collectIssues`. The recipes below assume these.
-- **[Per-framework integration](#per-framework-integration)** —
+- **[Per-framework integration](#per-framework-integration)**:
   Express 4, Express 5, Fastify, Next.js, Hono, Bun, Deno. Each
   section leads with the adapter (where one exists) and falls back
   to the manual inline recipe.
-- **[Cross-cutting recipes](#cross-cutting-recipes)** — linked from
+- **[Cross-cutting recipes](#cross-cutting-recipes)**, linked from
   the per-framework sections:
   - [Status-code mapping](#status-code-mapping)
   - [Preserving an existing client error envelope](#preserving-an-existing-client-error-envelope)
@@ -30,7 +30,7 @@ This document is organised:
   - [Security / authentication](#security--authentication)
   - [Type coercion on body fields](#type-coercion-on-body-fields)
   - [Ignoring paths not in the spec](#ignoring-paths-not-in-the-spec)
-- **[Migration paths](#migration-paths)** — pointers to focused
+- **[Migration paths](#migration-paths)**: pointers to focused
   migration docs (currently only
   [migration-from-eov.md](./migration-from-eov.md) for
   `express-openapi-validator`).
@@ -69,20 +69,20 @@ children hang off `body`, `query.<name>`, `headers.<name>`, etc.
 All shipped from `oav` (or `oav-core` for the
 lean install). The recipes below assume these are in scope.
 
-- **`httpStatusFor(err, overrides?)`** — maps a `ValidationError`
+- **`httpStatusFor(err, overrides?)`**: maps a `ValidationError`
   tree to an HTTP status: `route` → 404, `method` → 405, `security`
   (leaf) → 401, `content-type` (leaf) → 415, `status` (leaf) → 500,
   everything else → 400. Pass `{ default: 422 }` (or any other key)
-  to override a slot. The helper inspects the tree correctly —
+  to override a slot. The helper inspects the tree correctly:
   writing this switch by hand is a common mistake, because
   `"content-type"` / `"security"` / `"status"` appear as leaves
   under a top-level `"request"` / `"response"` branch, not as
   `err.code` directly.
 
-- **`allowHeaderFor(err)`** — returns the `Allow` header value for a
+- **`allowHeaderFor(err)`**: returns the `Allow` header value for a
   405 (RFC 9110 §15.5.6 requires it) or `undefined` otherwise.
 
-- **`toProblemDetails(err, opts?)`** — renders the error tree as an
+- **`toProblemDetails(err, opts?)`**: renders the error tree as an
   [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html)
   `application/problem+json` body with the failing leaves carried in
   an `issues` field (a non-standard field alongside the required
@@ -90,17 +90,17 @@ lean install). The recipes below assume these are in scope.
   one-line description of the first failing leaf); pass `detail`
   explicitly for an override.
 
-- **`formatSummary(err, opts?)`** — render the error tree as a
+- **`formatSummary(err, opts?)`**: render the error tree as a
   string. Default is a single line summarising the first failing
-  leaf as `<dotted-path> <message>` — use it for log lines,
+  leaf as `<dotted-path> <message>`; use it for log lines,
   error-monitoring titles (Sentry/New Relic group by message), or
   as the top-level `message` field in custom response envelopes.
   Pass `{ select: "all" }` for a multi-line enumeration of every
-  leaf — the EOV-style "every issue in a single message" shape.
+  leaf (the EOV-style "every issue in a single message" shape).
   See `FormatSummaryOptions.select` for the full policy
   (`"first"` / `"deepest"` / `"all"` / `{ byCode }`).
 
-- **`collectIssues(err)`** — flat leaf list. Each issue carries both
+- **`collectIssues(err)`**: flat leaf list. Each issue carries both
   a raw `path: PathSegment[]` and a pre-formatted RFC 6901 `pointer`
   string. Use this when you're keeping a custom envelope shape
   rather than RFC 9457 problem-details.
@@ -177,7 +177,7 @@ cross-cutting recipes below.
 ### Express 5
 
 The [`oav-express5`](https://www.npmjs.com/package/@aahoughton/oav-express5)
-companion package ships the middleware as a one-liner — same shape
+companion package ships the middleware as a one-liner: same shape
 as `oav-express4` but promise-native (no `try/catch` wrapper):
 
 ```ts
@@ -222,7 +222,7 @@ Requires `express.json()` (or any equivalent middleware that
 populates `req.body` with a parsed object) registered before this
 middleware, and `cookie-parser` if you use the `cookies` field.
 Custom streaming parsers, `body-parser`, fastify's bridge, and
-app-specific middleware all work the same way — oav doesn't care
+app-specific middleware all work the same way; oav doesn't care
 _how_ `req.body` got populated, only that it's there.
 
 See [body-parser caveats](#body-parser-caveats) for sharp edges
@@ -231,7 +231,7 @@ that affect this pattern.
 ### Fastify
 
 The [`oav-fastify`](https://www.npmjs.com/package/@aahoughton/oav-fastify)
-companion package ships the hook as a one-liner — same shape as the
+companion package ships the hook as a one-liner: same shape as the
 Express adapters but Fastify-native (a `preValidation` hook, not
 middleware):
 
@@ -289,10 +289,10 @@ schema validation when you author schemas inline.
 ### Next.js (App Router), Hono, Bun, Deno
 
 These frameworks dispatch to Web Standards `Request` handlers per
-route. Each also has a cross-cutting hook — Next.js's `proxy.ts`
-(renamed from `middleware.ts` in Next 16; both still work), Hono's
-`app.use('*', ...)`, Bun / Deno framework-specific hooks — so you
-can pick. Use per-route when you want the `<Body>` generic to flow
+route. Each also has a cross-cutting hook (Next.js's `proxy.ts`,
+renamed from `middleware.ts` in Next 16, with both still working;
+Hono's `app.use('*', ...)`; Bun / Deno framework-specific hooks),
+so you can pick. Use per-route when you want the `<Body>` generic to flow
 into the typed success branch; use the cross-cutting hook when you'd
 rather register the adapter once.
 
@@ -338,7 +338,7 @@ Three things to know:
   `?ids=1&ids=2` into `query.ids = ["1", "2"]`. Single values stay
   strings.
 
-**Next.js — cross-cutting alternative.** `proxy.ts` (or
+**Next.js, cross-cutting alternative.** `proxy.ts` (or
 `middleware.ts` on Next 15) runs on every request. Since Next 15
 middleware supports the Node runtime and Next buffers the body,
 you can put the adapter there instead:
@@ -370,7 +370,7 @@ export async function middleware(request: NextRequest) {
 Pick one: per-route gives you `<T>`-typed bodies; the cross-cutting
 hook gives you one-and-done registration but the handler doesn't see
 a typed body (middleware and handler both read the request, and Next
-clones between them — but the per-route handler can't know what the
+clones between them, but the per-route handler can't know what the
 middleware validated).
 
 **Fully bespoke body handling.** If the built-in body parsing doesn't
@@ -385,7 +385,7 @@ const { httpRequest } = await httpRequestFromFetch(request);
 const err = validator.validateRequest(httpRequest);
 ```
 
-**Hono — cross-cutting alternative.** `app.use('*', mw)` can host
+**Hono, cross-cutting alternative.** `app.use('*', mw)` can host
 the adapter. Hono parallels the per-route Standard-Schema validator
 pattern (`@hono/zod-validator` etc.), so per-route with a typed
 `<T>` is the native idiom and `c.req.valid('json')` is the
@@ -394,7 +394,7 @@ the same shape via `c.req.raw`.
 
 **Hono gotcha**: `c.req.raw.body` is a one-shot stream. Don't run
 `validateFetchRequest` in BOTH global middleware AND a per-route
-handler on the same request — the handler's call sees a consumed
+handler on the same request; the handler's call sees a consumed
 body and fails. Pick one. If using global middleware, stash the
 validated body for handlers:
 
@@ -415,7 +415,7 @@ app.post("/pets", (c) => {
 ```
 
 **Bun / Deno.** Pick a framework (Hono, Elysia on Bun; Hono, Oak on
-Deno) and use its hook idiom — same guidance as above, just under a
+Deno) and use its hook idiom; same guidance as above, just under a
 different name. For a raw `Bun.serve` / `Deno.serve` handler,
 `validateFetchRequest` is the natural fit; there's no hook layer to
 register against.
@@ -454,7 +454,7 @@ Default mapping:
 | any leaf `code: "status"`       | 500    |
 | otherwise                       | 400    |
 
-Override any slot with the second argument — e.g. APIs that use 422
+Override any slot with the second argument, e.g. APIs that use 422
 for schema errors:
 
 ```ts
@@ -462,7 +462,7 @@ httpStatusFor(err, { default: 422 });
 ```
 
 Why not write the switch by hand? The obvious `switch (err.code)`
-misses `content-type`, `security`, and `status` — those codes are
+misses `content-type`, `security`, and `status`; those codes are
 leaves under a top-level `"request"` / `"response"` wrapper, not the
 top-level code itself. `httpStatusFor` handles the tree shape
 correctly.
@@ -487,7 +487,7 @@ Migrating an existing service may mean a documented client
 contract you can't change without breaking callers. Keep your
 envelope, fill it from `collectIssues` (per-issue path,
 message, code) plus `formatSummary` (top-level summary) plus
-`httpStatusFor` (status). Don't walk the tree by hand — the helpers
+`httpStatusFor` (status). Don't walk the tree by hand; the helpers
 already do the right thing for nested branches, route/method
 top-levels, and security/content-type leaves under `request` /
 `response` wrappers.
@@ -543,17 +543,17 @@ and `email: "not-an-email"` (fails `format: email`), the response would be:
 ```
 
 `pointer` prefixes are `/body`, `/query`, `/header`, `/path`,
-`/cookie` (not `/params` — that's an `express-openapi-validator`
+`/cookie` (not `/params`, which is an `express-openapi-validator`
 quirk; see [migration-from-eov.md](./migration-from-eov.md) for the
 full diff). Each `issue.params` carries machine-readable detail
 (e.g. `{ maximum: 30, actual: 42 }` for `maximum`,
 `{ format: "email", actual: "not-an-email" }` for `format`) if you
-want to surface structured details too — `BuiltInErrorParams` in
+want to surface structured details too. `BuiltInErrorParams` in
 `oav-core` documents the shape per code.
 
 ### Body parser caveats
 
-oav doesn't parse bodies — it validates already-parsed bodies. Two
+oav doesn't parse bodies; it validates already-parsed bodies. Two
 sharp edges that bite both inline middleware and the
 `oav-express4` adapter:
 
@@ -566,7 +566,7 @@ sharp edges that bite both inline middleware and the
    variants, custom multi-format setups) leave `req.body === undefined`
    for empty `{}`-equivalent payloads instead of an empty object. When
    that happens, oav's `required`-field checks short-circuit on the
-   missing body — validation passes for what the client thinks is an
+   missing body, so validation passes for what the client thinks is an
    empty submission, even when the spec marks fields as `required`.
    If your parser does this, normalise before calling `validateRequest`:
 
@@ -575,7 +575,7 @@ sharp edges that bite both inline middleware and the
    ```
 
    Stock `express.json()` populates `req.body` to `{}` for an empty
-   JSON body, so the default Express stack doesn't hit this — but
+   JSON body, so the default Express stack doesn't hit this, but
    alternative parsers (`body-parser`'s streaming mode, fastify's
    bridge, custom multipart middleware) often do.
 
@@ -595,7 +595,7 @@ sharp edges that bite both inline middleware and the
 even when `express.json()` leaves `req.body` empty for a non-JSON
 request, oav sees the declared header, finds no matching media type
 in the spec, and returns a `content-type` leaf that maps to 415. The
-sibling case — **no Content-Type AND no body** — returns `body` /
+sibling case (**no Content-Type AND no body**) returns `body` /
 400 instead of 415, since there's no client signal about format
 intent to be "wrong about." Tests that exercise the 415 path need to
 send an explicit unmatched Content-Type.)
@@ -647,7 +647,7 @@ or Uint8Array passes without a string-type error. `format: "byte"`
 
 #### Global validator + per-route multer
 
-The recipe above is per-route inline — multer and the validator both
+The recipe above is per-route inline: multer and the validator both
 live inside the route handler. That works for single-upload-route
 apps. For an app with many routes and one (or a few) upload
 endpoints, a more idiomatic shape is **multer mounted at the route
@@ -670,7 +670,7 @@ app.use(
       const httpReq = httpRequestFromExpress(req);
       const files = req.files as Express.Multer.File[] | undefined;
       if (files && files.length > 0) {
-        // Match the spec's binary-field shape — array if many, single buffer if one.
+        // Match the spec's binary-field shape: array if many, single buffer if one.
         // Adjust to your spec's actual field shape (named-files object, single-file
         // property, etc.).
         httpReq.body = files.length === 1 ? files[0]?.buffer : files.map((f) => f.buffer);
@@ -682,7 +682,7 @@ app.use(
 ```
 
 The `toHttpRequest` extension point is a general seam for **any
-"reshape what oav sees"** use case — synthesizing a body from
+"reshape what oav sees"** use case: synthesizing a body from
 `req.files`, normalizing an empty body to `{}`, merging headers
 from an upstream proxy, anything that wants to live above the
 extraction layer without bypassing it. The empty-body normalization
@@ -691,8 +691,8 @@ multer-body-synthesis recipe are two examples of the same pattern.
 
 **Watch out for `oneOf` / `anyOf` with binary fields.** The "accept
 anything" rewrite means every binary branch matches every input. A
-common spec pattern for "one file or many" —
-`oneOf [array<binary>, binary]` — is silently ambiguous: both
+common spec pattern for "one file or many"
+(`oneOf [array<binary>, binary]`) is silently ambiguous: both
 branches match the same payload, so `oneOf` fails with
 `matchCount: 2`. The fix is usually to drop the `oneOf` and accept
 the array form (parsers like multer always deliver arrays anyway);
@@ -732,7 +732,7 @@ app.post("/uploads", upload.any() /* validator + handler as above */);
 `getOperation` returns the resolved, overlay-applied
 `OperationObject` for a (method, path) pair. It does the same
 route-match + `$ref` resolution + overlay application that validation
-does, but hands the result back as plain OpenAPI shapes — read
+does, but hands the result back as plain OpenAPI shapes; read
 whatever declaration you need. `digestOperation` (see
 [`examples/spec-digest.ts`](../examples/spec-digest.ts)) is a recipe
 that pulls the common middleware-config facts into a flat shape:
@@ -743,8 +743,8 @@ recognise, etc.) to fit your domain.
 
 The getter is startup-time introspection, not part of validation. Its
 job is to make the spec the single source of truth for middleware
-configuration — multer's `fileSize`, body-parser content types, auth
-middleware assertions — so duplicated magic numbers can't drift
+configuration (multer's `fileSize`, body-parser content types, auth
+middleware assertions) so duplicated magic numbers can't drift
 against the validator's own view.
 
 ### Streaming bodies, large uploads, and the `readBody` override
@@ -862,7 +862,7 @@ The `res.json` wrapper is ~15 lines.
 #### Failure mode: log, don't fail-hard (by default)
 
 The previous snippets log + send-anyway because that's the right
-default. The instinct to flip the failure into a 500 — don't, at
+default. The instinct to flip the failure into a 500: don't, at
 least not without warning.
 
 **Why.** The strict-mode failure path runs on _every_ response,
@@ -895,7 +895,7 @@ budget burns for free.
 
    Even then, consider gating the hard-fail on `process.env.NODE_ENV
 !== "production"` so dev sees the failure loudly while prod
-   stays log-only — error responses in prod are exactly when you
+   stays log-only; error responses in prod are exactly when you
    least want a 500-on-top-of-a-400.
 
 ### Security / authentication
@@ -917,9 +917,9 @@ The shape check (when enabled) runs against each operation's
 `security:` (or document-level `security:` when the operation doesn't
 override). Supported:
 
-- `http` with `scheme: "bearer"` — requires `Authorization: Bearer <non-empty>`.
-- `http` with `scheme: "basic"` — requires `Authorization: Basic <base64>`; the base64 must decode to a `user:pass` shape (no credential verification).
-- `apiKey` in `header`, `query`, or `cookie` — declared name must be present and non-empty.
+- `http` with `scheme: "bearer"`: requires `Authorization: Bearer <non-empty>`.
+- `http` with `scheme: "basic"`: requires `Authorization: Basic <base64>`; the base64 must decode to a `user:pass` shape (no credential verification).
+- `apiKey` in `header`, `query`, or `cookie`: declared name must be present and non-empty.
 
 `oauth2`, `openIdConnect`, and `mutualTLS` schemes are accepted in the
 spec but not shape-checked at the validator layer. Failures surface as
@@ -993,7 +993,7 @@ async function dispatchSecurity(
 Mount the dispatcher as middleware _before_ `validateRequests` (or
 your inline validator middleware). Reject (`401` / `403` per your
 policy) on `{ ok: false }` before validation runs. The validator's
-own `validateSecurity` shape check is then redundant — leave it at
+own `validateSecurity` shape check is then redundant; leave it at
 its default `false`.
 
 For framework-adapter consumers (`oav-express4`, future siblings),
@@ -1029,7 +1029,7 @@ createValidator(spec, {
 
 `ignorePaths` runs before the router; `ignoreUndocumented` only
 applies to paths the router couldn't match. Both leave `method`
-errors (405 — path exists, verb doesn't) alone. See
+errors (405; path exists, verb doesn't) alone. See
 `ValidatorOptions.ignorePaths` / `ValidatorOptions.ignoreUndocumented`
 for the option contracts.
 
@@ -1052,7 +1052,7 @@ app.use(async (req, res, next) => {
 Focused migration docs live in their own files so this guide can
 stay framework-shaped rather than competitor-shaped:
 
-- **[migration-from-eov.md](./migration-from-eov.md)** — migrating
+- **[migration-from-eov.md](./migration-from-eov.md)**: migrating
   from `express-openapi-validator`. Behavior-difference reference,
   option map (eov → oav), features not carried over, features
   added.

--- a/docs/migration-from-eov.md
+++ b/docs/migration-from-eov.md
@@ -2,7 +2,7 @@
 
 A focused reference for porting an Express app off
 `express-openapi-validator` (eov) onto `oav`. Reads as a punch list,
-not a tutorial — for integration recipes, see
+not a tutorial; for integration recipes, see
 [integration.md](./integration.md). For Express 4 specifically, the
 [`oav-express4`](../packages/oav-express4/README.md)
 companion package gets you most of eov's ergonomics back as a
@@ -19,7 +19,7 @@ auth wiring where needed. In exchange:
 
 - **You own the error → HTTP mapping.** A small switch statement
   maps the validator's stable `code` field to whatever status codes
-  your API contract requires — `httpStatusFor` covers the common
+  your API contract requires; `httpStatusFor` covers the common
   case in one call.
 - **No wrapping of `res.json`.** eov wraps the response methods to
   auto-intercept. `oav` reads its arguments and returns a result; it
@@ -31,7 +31,7 @@ auth wiring where needed. In exchange:
   `err.params.missing`) instead of parsing message strings.
 - **Built-in OpenAPI 3.0 dialect.** `nullable: true`, boolean
   `exclusiveMaximum`, and `$ref`-suppresses-siblings are in the
-  compiler's dialect dispatch — no preprocessing step. See the
+  compiler's dialect dispatch; no preprocessing step. See the
   [conformance report](../conformance/REPORT.md) for pass / fail
   counts by category.
 - **Overlays.** Extend an externally-owned base spec (Supabase,
@@ -40,28 +40,28 @@ auth wiring where needed. In exchange:
 
 ## Behavior differences to watch for
 
-The behaviour deltas surfaced by real eov→oav migrations. Most are
+The behaviour deltas surfaced by real eov-to-oav migrations. Most are
 defensible improvements; a few are cosmetic. Either way, expect
 fixture / test churn.
 
-| What                               | eov                                                                                         | oav                                                                                                                                                                                                                        |
-| ---------------------------------- | ------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Empty POST, no Content-Type**    | 415 unsupported-media-type                                                                  | 400 body-required (no client signal to be "wrong about")                                                                                                                                                                   |
-| **Path-parameter label**           | `/params/<name>` in error paths                                                             | `/path/<name>` (OpenAPI's actual location name)                                                                                                                                                                            |
-| **404 message wording**            | `"not found"`                                                                               | `"no route matches POST /path/here"` (more actionable)                                                                                                                                                                     |
-| **Top-level message**              | first leaf by default; every leaf `, `-joined under `validateRequests: { allErrors: true }` | configurable via `formatSummary`: `{ select: "first" }` (default; first leaf) or `{ select: "all" }` (every leaf, newline-joined). Per-leaf details always in `errors[]` / `issues[]`. Shape differs from eov — see below. |
-| **Top-level `path` on 404s**       | offending URL                                                                               | `[]` (empty array → `""` pointer); same kind of error, different rendering                                                                                                                                                 |
-| **`errorCode` names**              | `required.openapi.validation`                                                               | bare codes (`required`); the `.openapi.validation` suffix was always noise                                                                                                                                                 |
-| **`oneOf` with binary fields**     | silently accepted (looser inside binary fields)                                             | surfaces the genuine ambiguity with `matchCount: 2`; see [integration.md → File uploads](./integration.md#file-uploads-with-multer) for the spec-level fix                                                                 |
-| **Error response monkey-patching** | `res.send("{...}")` (string form) caught via wrappers                                       | not caught unless you write the wrapper yourself; see [integration.md → Response validation](./integration.md#response-validation-no-monkey-patching)                                                                      |
-| **Optional `openapi` version**     | throws on missing / unsupported                                                             | silently uses 3.1 by default; see `onUnknownVersion`                                                                                                                                                                       |
-| **`format` semantics**             | always assertive in OpenAPI context                                                         | assertive in OpenAPI context; annotation-only under raw `jsonSchemaDialect` (per 2020-12 default)                                                                                                                          |
+| What                               | eov                                                                                         | oav                                                                                                                                                                                                                       |
+| ---------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Empty POST, no Content-Type**    | 415 unsupported-media-type                                                                  | 400 body-required (no client signal to be "wrong about")                                                                                                                                                                  |
+| **Path-parameter label**           | `/params/<name>` in error paths                                                             | `/path/<name>` (OpenAPI's actual location name)                                                                                                                                                                           |
+| **404 message wording**            | `"not found"`                                                                               | `"no route matches POST /path/here"` (more actionable)                                                                                                                                                                    |
+| **Top-level message**              | first leaf by default; every leaf `, `-joined under `validateRequests: { allErrors: true }` | configurable via `formatSummary`: `{ select: "first" }` (default; first leaf) or `{ select: "all" }` (every leaf, newline-joined). Per-leaf details always in `errors[]` / `issues[]`. Shape differs from eov; see below. |
+| **Top-level `path` on 404s**       | offending URL                                                                               | `[]` (empty array, `""` pointer); same kind of error, different rendering                                                                                                                                                 |
+| **`errorCode` names**              | `required.openapi.validation`                                                               | bare codes (`required`); the `.openapi.validation` suffix was always noise                                                                                                                                                |
+| **`oneOf` with binary fields**     | silently accepted (looser inside binary fields)                                             | surfaces the genuine ambiguity with `matchCount: 2`; see [integration.md, File uploads](./integration.md#file-uploads-with-multer) for the spec-level fix                                                                 |
+| **Error response monkey-patching** | `res.send("{...}")` (string form) caught via wrappers                                       | not caught unless you write the wrapper yourself; see [integration.md, Response validation](./integration.md#response-validation-no-monkey-patching)                                                                      |
+| **Optional `openapi` version**     | throws on missing / unsupported                                                             | silently uses 3.1 by default; see `onUnknownVersion`                                                                                                                                                                      |
+| **`format` semantics**             | always assertive in OpenAPI context                                                         | assertive in OpenAPI context; annotation-only under raw `jsonSchemaDialect` (per 2020-12 default)                                                                                                                         |
 
 For the `oneOf [array<binary>, binary]` pattern specifically: the
 spec was already ambiguous before oav surfaced it (the `format:
 binary` bypass means both branches match anything). eov's looser
 acceptance masked the issue. Drop the `oneOf` and accept the array
-form — multer always delivers arrays — or fix the spec however
+form (multer always delivers arrays), or fix the spec however
 makes sense for your API.
 
 ## Option map
@@ -79,13 +79,13 @@ makes sense for your API.
 | eov option                          | oav equivalent                                                                                             |
 | ----------------------------------- | ---------------------------------------------------------------------------------------------------------- |
 | `validateRequests: true`            | `validator.validateRequest(...)` in your middleware, or `validateRequests(validator)` from `oav-express4`. |
-| `validateRequests.allErrors`        | Default — `oav` always collects every leaf. Bound cost with `maxErrors: N`.                                |
+| `validateRequests.allErrors`        | Default; `oav` always collects every leaf. Bound cost with `maxErrors: N`.                                 |
 | `validateRequests.coerceTypes`      | Query scalars coerced by default; body coercion not supported (see recipe).                                |
 | `validateRequests.removeAdditional` | Not supported. `additionalProperties: false` rejects; there is no silent-drop mode.                        |
 | `validateRequests.discriminator`    | Native, always on for OpenAPI specs.                                                                       |
 | `serDes`                            | Not supported. Pre- or post-transform the payload in your handler if you need `Date` / `ObjectId` / etc.   |
-| `ignorePaths` (regex/fn)            | `createValidator(spec, { ignorePaths: (p) => ... })` — predicate that short-circuits before routing.       |
-| `ignoreUndocumented`                | `createValidator(spec, { ignoreUndocumented: true })` — returns `null` on paths the router doesn't match.  |
+| `ignorePaths` (regex/fn)            | `createValidator(spec, { ignorePaths: (p) => ... })`: predicate that short-circuits before routing.        |
+| `ignoreUndocumented`                | `createValidator(spec, { ignoreUndocumented: true })`: returns `null` on paths the router doesn't match.   |
 
 ### Response validation
 
@@ -95,19 +95,19 @@ makes sense for your API.
 
 ### Formats and custom keywords
 
-| eov option                          | oav equivalent                                                                                             |
-| ----------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `formats`                           | `createValidator(spec, { formats: { ... } })` — see [format-shape note](#format-shape-note) below.         |
-| `validateFormats: "fast" \| "full"` | N/A — single-pass validation; the built-in formats are RFC-sourced.                                        |
-| `ajvFormats`                        | Pass custom format functions via the `formats` option — see [format-shape note](#format-shape-note) below. |
+| eov option                          | oav equivalent                                                                                            |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `formats`                           | `createValidator(spec, { formats: { ... } })`; see [format-shape note](#format-shape-note) below.         |
+| `validateFormats: "fast" \| "full"` | N/A: single-pass validation; the built-in formats are RFC-sourced.                                        |
+| `ajvFormats`                        | Pass custom format functions via the `formats` option; see [format-shape note](#format-shape-note) below. |
 
 ### Security and file uploads
 
-| eov option                  | oav equivalent                                                                                                                                                                                                                       |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `validateSecurity: true`    | Off by default in oav (real apps gate security upstream of validation). Opt in with `createValidator(spec, { validateSecurity: true })` for shape-only checks on `bearer` / `basic` / `apiKey`.                                      |
-| `validateSecurity.handlers` | Your own auth middleware, run before the validator — `oav` only checks credential **shape**, not validity. For declarative per-scheme dispatch, see the [integration.md security recipe](./integration.md#per-scheme-auth-dispatch). |
-| `fileUploader: true`        | Your own multer middleware — see [integration.md file uploads](./integration.md#file-uploads-with-multer).                                                                                                                           |
+| eov option                  | oav equivalent                                                                                                                                                                                                                      |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `validateSecurity: true`    | Off by default in oav (real apps gate security upstream of validation). Opt in with `createValidator(spec, { validateSecurity: true })` for shape-only checks on `bearer` / `basic` / `apiKey`.                                     |
+| `validateSecurity.handlers` | Your own auth middleware, run before the validator. `oav` only checks credential **shape**, not validity. For declarative per-scheme dispatch, see the [integration.md security recipe](./integration.md#per-scheme-auth-dispatch). |
+| `fileUploader: true`        | Your own multer middleware; see [integration.md file uploads](./integration.md#file-uploads-with-multer).                                                                                                                           |
 
 ### Handler wiring
 
@@ -137,7 +137,7 @@ makes sense for your API.
 - **Built-in 3.0 dialect.** No translation layer over 2020-12. See
   [conformance/REPORT.md](../conformance/REPORT.md) for pass / fail
   counts by category.
-- **Overlays.** Extend externally-owned specs at load time —
+- **Overlays.** Extend externally-owned specs at load time;
   see [overlays.md](./overlays.md).
 - **Smaller install footprint.** `oav` depends on `yaml`,
   `commander`, and `esbuild` (the latter two for CLI + AOT compile
@@ -185,7 +185,7 @@ createValidator(spec, { formats: fromAjvFormats(myAjvFormats) });
 
 `oav`'s `format` keyword only applies to string values (per JSON
 Schema 2020-12 §6.3), so ajv's `type: "number"` format entries are
-effectively no-ops — the function never runs on non-string data.
+effectively no-ops; the function never runs on non-string data.
 Keep them in the map if it's simpler; they cost nothing.
 
 ## All-issues output (eov's `allErrors`)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -23,11 +23,11 @@ Per-framework adapter packages share the same export names and option
 shapes as each other; only the framework-typed argument differs. Each
 has its own README:
 
-- [`oav-express4`](../packages/oav-express4/README.md) — Express 4 (peer: `express ^4`).
-- [`oav-express5`](../packages/oav-express5/README.md) — Express 5 (peer: `express ^5`); promise-native middleware shape.
-- [`oav-fastify`](../packages/oav-fastify/README.md) — Fastify (peer: `fastify ^5`); ships a `preValidation` hook instead of middleware.
+- [`oav-express4`](../packages/oav-express4/README.md): Express 4 (peer: `express ^4`).
+- [`oav-express5`](../packages/oav-express5/README.md): Express 5 (peer: `express ^5`); promise-native middleware shape.
+- [`oav-fastify`](../packages/oav-fastify/README.md): Fastify (peer: `fastify ^5`); ships a `preValidation` hook instead of middleware.
 
 For Next.js, Hono, Bun, and Deno, use the Web Standards adapter
-(`httpRequestFromFetch`, `validateFetchRequest`) directly — no
+(`httpRequestFromFetch`, `validateFetchRequest`) directly; no
 framework-specific package. See
 [`docs/integration.md`](./integration.md).

--- a/docs/overlays.md
+++ b/docs/overlays.md
@@ -2,8 +2,8 @@
 
 Overlays patch an OpenAPI document in memory before the validator is
 constructed. They exist for a specific job: letting you consume a spec
-you don't own — an upstream framework's published document, a
-gateway's spec, a vendor API — and add, augment, replace, or remove
+you don't own (an upstream framework's published document, a
+gateway's spec, a vendor API) and add, augment, replace, or remove
 parts of it to match your deployment, without forking the file.
 
 ## When you want one
@@ -11,19 +11,19 @@ parts of it to match your deployment, without forking the file.
 - **Your deployment requires headers or query parameters the upstream
   spec doesn't declare.** Use `overrides` with `upsertParameters`.
 - **The upstream schema is close to what you ship but missing a
-  field.** Use `extendSchemas` — adds constraints via `allOf` while
+  field.** Use `extendSchemas`: adds constraints via `allOf` while
   preserving the original shape.
 - **The upstream schema is wrong for your deployment.** Use
-  `replaceSchemas` — swaps the schema out entirely, no merge.
+  `replaceSchemas`: swaps the schema out entirely, no merge.
 - **You need a route the upstream doesn't expose.** Use `addPaths`.
-- **Upstream declares something you want gone** — a parameter you
+- **Upstream declares something you want gone** (a parameter you
   don't accept, a response status you never return, a path you don't
-  serve. Use one of the `remove*` verbs.
+  serve). Use one of the `remove*` verbs.
 - **An operation needs a complete rewrite** rather than piecemeal
   patching. Use `overrides.operations.<method>.replace`.
 
-The alternative — forking the spec, keeping the fork in sync as the
-upstream evolves, rebasing your patches on every update — is what
+The alternative (forking the spec, keeping the fork in sync as the
+upstream evolves, rebasing your patches on every update) is what
 overlays exist to avoid.
 
 ## Verb matrix
@@ -33,11 +33,11 @@ Every overlay verb falls into one of four categories.
 | Target                | add                | augment                  | replace                            | remove              |
 | --------------------- | ------------------ | ------------------------ | ---------------------------------- | ------------------- |
 | Paths                 | `addPaths`         | (via `overrides`)        | (via `overrides.replace`)          | `removePaths`       |
-| Component schemas     | —                  | `extendSchemas`          | `replaceSchemas`                   | `removeSchemas`     |
-| Operations            | —                  | (via additive op fields) | `overrides.operations.<m>.replace` | (via `removePaths`) |
-| Parameters (per op)   | `upsertParameters` | —                        | `upsertParameters`                 | `removeParameters`  |
-| Request body (per op) | —                  | —                        | `requestBody`                      | —                   |
-| Responses (per op)    | `responses`        | —                        | `responses`                        | `removeResponses`   |
+| Component schemas     |                    | `extendSchemas`          | `replaceSchemas`                   | `removeSchemas`     |
+| Operations            |                    | (via additive op fields) | `overrides.operations.<m>.replace` | (via `removePaths`) |
+| Parameters (per op)   | `upsertParameters` |                          | `upsertParameters`                 | `removeParameters`  |
+| Request body (per op) |                    |                          | `requestBody`                      |                     |
+| Responses (per op)    | `responses`        |                          | `responses`                        | `removeResponses`   |
 
 ## Applying an overlay
 
@@ -54,7 +54,7 @@ const validator = createValidator(patched);
 ```
 
 **`loadSpec`** resolves external `$ref`s and applies overlays in one
-pass — use this for multi-file specs or remote documents:
+pass; use this for multi-file specs or remote documents:
 
 ```ts
 import { loadSpec, composeReaders, createFileReader } from "@aahoughton/oav/spec";
@@ -69,7 +69,7 @@ const validator = createValidator(document);
 ```
 
 Overlays apply in order. Later overlays win on conflict. The base
-document is deep-cloned — the input is never mutated.
+document is deep-cloned; the input is never mutated.
 
 ## Shape
 
@@ -104,7 +104,7 @@ Each field is independent; use any subset.
 
 Add new routes or drop upstream ones. Both fail fast: `addPaths`
 throws if a target path already exists; `removePaths` throws if it
-doesn't. The fail-fast choice is deliberate — you want the overlay to
+doesn't. The fail-fast choice is deliberate: you want the overlay to
 notice when upstream shifts a path you've referenced instead of
 silently no-op'ing.
 
@@ -114,14 +114,14 @@ Patch the `components.schemas` map. `extend` wraps the original in
 `allOf`, keeping upstream constraints plus yours. `replace` swaps
 wholesale. `remove` drops the entry (throws if the name isn't
 present). Multiple overlays targeting the same schema via `extend`
-stack — each adds a new `allOf` branch.
+stack: each adds a new `allOf` branch.
 
 ### `overrides`
 
 Patches existing paths. Two things can be modified:
 
-- `operations` — per-method patches (see below).
-- `pathItem` — fields on the `PathItem` itself (e.g. path-level
+- `operations`: per-method patches (see below).
+- `pathItem`: fields on the `PathItem` itself (e.g. path-level
   `parameters`).
 
 Wildcards: use `"*"` as an operation key to apply the same override
@@ -130,18 +130,18 @@ to apply it to every path.
 
 #### Per-operation verbs
 
-- **`replace`** — wholesale swap of the `OperationObject`. Cannot be
+- **`replace`**: wholesale swap of the `OperationObject`. Cannot be
   combined with the additive / removal fields below in the same
   operation override; setting both throws at apply time.
-- **`upsertParameters`** — append new parameters or replace existing
+- **`upsertParameters`**: append new parameters or replace existing
   concrete entries by (`name`, `in`). `{ $ref: … }` parameters in the
   base can't be matched without resolution; new parameters with the
   same key append alongside refs rather than replacing them.
-- **`removeParameters`** — drop parameters by (`name`, `in`). Silent
+- **`removeParameters`**: drop parameters by (`name`, `in`). Silent
   no-op on missing entries (wildcards fan out to many operations).
-- **`requestBody`** — replace the request body entirely.
-- **`responses`** — merge by status code; override wins on clashes.
-- **`removeResponses`** — drop status codes. Silent no-op on missing.
+- **`requestBody`**: replace the request body entirely.
+- **`responses`**: merge by status code; override wins on clashes.
+- **`removeResponses`**: drop status codes. Silent no-op on missing.
 
 ### Full operation replacement
 
@@ -163,8 +163,8 @@ your deployment serves that patching it piecewise is noisier than
 starting fresh.
 
 Runnable demo:
-[`examples/overlay-petstore-endpoint.ts`](../examples/overlay-petstore-endpoint.ts)
-— adds a gateway-required `X-Tenant` header to `POST /pets`.
+[`examples/overlay-petstore-endpoint.ts`](../examples/overlay-petstore-endpoint.ts).
+Adds a gateway-required `X-Tenant` header to `POST /pets`.
 
 ## Things to know
 
@@ -175,7 +175,7 @@ Runnable demo:
 - **Internal `$ref`s stay internal.** `#/components/...` refs aren't
   inlined by the resolver, so editing an operation's response entry
   in place doesn't affect other operations that reference the same
-  component — a handy way to augment one endpoint's response shape
+  component: a handy way to augment one endpoint's response shape
   via `allOf` + the shared `$ref` without mutating the shared
   component for everyone else.
 - **Reference-object parameters.** `upsertParameters` can only match
@@ -196,5 +196,5 @@ Runnable demo:
 
 - [`examples/overlay-petstore-schema.ts`](../examples/overlay-petstore-schema.ts)
   and
-  [`examples/overlay-petstore-endpoint.ts`](../examples/overlay-petstore-endpoint.ts)
-  — runnable end-to-end demos.
+  [`examples/overlay-petstore-endpoint.ts`](../examples/overlay-petstore-endpoint.ts):
+  runnable end-to-end demos.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # oav (CLI)
 
-The `oav` binary — a thin wrapper around the oav library for shell
+The `oav` binary: a thin wrapper around the oav library for shell
 scripts, Makefiles, and CI.
 
 ## Install
@@ -14,7 +14,7 @@ oav --help
 npx @aahoughton/oav validate openapi.yaml --request req.http
 ```
 
-The CLI lives in the `oav` package, not `oav-core` — `oav-core`
+The CLI lives in the `oav` package, not `oav-core`. `oav-core`
 doesn't ship a `bin` or any CLI glue. `oav` carries `commander`
 (argv parsing) and `esbuild` (AOT bundling for `compile-schema` /
 `compile-spec`) as regular dependencies. Users who only need the
@@ -30,10 +30,10 @@ oav validate <spec> --request req.http                   # full HTTP request fro
 oav validate <spec> --path "POST /pets" --body body.json
 oav validate <spec> --path "GET /pets" --response --status 200 --body resp.json
 
-oav compile-schema <schema.json> -o v.mjs                # single JSON Schema → standalone validator
+oav compile-schema <schema.json> -o v.mjs                # single JSON Schema -> standalone validator
 oav compile-schema <schema.json> --dialect openapi-3.0
 
-oav compile-spec <openapi.yaml> -o v.mjs                 # OpenAPI spec → standalone HTTP validator
+oav compile-spec <openapi.yaml> -o v.mjs                 # OpenAPI spec -> standalone HTTP validator
 oav compile-spec <openapi.yaml> --requests-only -o v.mjs
 oav compile-spec <openapi.yaml> --only "POST /pets" -o v.mjs
 ```
@@ -44,7 +44,7 @@ Pass `-` as the file path to read from stdin (e.g. `--body -`).
 and `http://` / `https://` URLs (both JSON and YAML over HTTP). Relative
 `$ref`s inside a URL-hosted spec resolve against the URL's base.
 
-`--request` takes a `.http` file — see [`.http` file format](#http-file-format)
+`--request` takes a `.http` file; see [`.http` file format](#http-file-format)
 below for the expected shape.
 
 ## Flags
@@ -69,7 +69,7 @@ module has zero imports. Typical output is ~13 KB for a small schema,
 ~20–40 KB for a schema that touches every built-in format.
 
 Use for Lambda zips, Cloudflare Workers, Vercel Edge, single-file
-deployments — anywhere `new Function()` is forbidden or the runtime
+deployments: anywhere `new Function()` is forbidden or the runtime
 library footprint is unwanted.
 
 Constraints on the input schema:
@@ -78,7 +78,7 @@ Constraints on the input schema:
   names outside `oav/formats`, compile fails with exit
   code 3 and a listing of the unknown names. Custom formats aren't
   serialisable to standalone source.
-- **No custom keywords.** Same reason — the keyword's validator
+- **No custom keywords.** Same reason: the keyword's validator
   function can't be serialised.
 - **External `$ref`s must be pre-inlined.** Run `oav resolve` over
   a multi-file input first, or use `oav/spec.resolveSpec`
@@ -97,32 +97,32 @@ Consumers who were running `createValidator(await loadSpec(...))` at
 application boot get the same behaviour with no YAML parse, no
 `$ref` walk, no schema compilation at load time. Target use cases:
 
-- **Cloudflare Workers / Vercel Edge** — the runtime sandbox
+- **Cloudflare Workers / Vercel Edge**: the runtime sandbox
   forbids `new Function()`, which rules out `ajv.compile()` at
   runtime. Pre-compiled output sidesteps it.
-- **Lambda@Edge / viewer functions** — 1 MB zipped; the full
+- **Lambda@Edge / viewer functions**: 1 MB zipped; the full
   library + YAML parser graph doesn't fit. A compile-spec output for
   a small-to-medium spec does.
-- **Lambda + API Gateway** — shaves 5–50 ms off cold starts by
+- **Lambda + API Gateway**: shaves 5–50 ms off cold starts by
   removing spec parse + schema compile from the critical path.
 - **Single-file drops** (Deno subhosting, Val.town, `deno compile`,
-  `bun build --compile`) — one `.mjs`, no node_modules.
+  `bun build --compile`): one `.mjs`, no node_modules.
 
 ### Flags
 
-- **`--overlay <file>`** (repeatable) — applies overlays at build
+- **`--overlay <file>`** (repeatable): applies overlays at build
   time. Same semantics as `oav resolve`.
-- **`--dialect <name>`** — forces a specific schema dialect. Default
+- **`--dialect <name>`**: forces a specific schema dialect. Default
   is auto-detected from the spec's `openapi` field.
-- **`--requests-only`** — skips response-validator emit.
+- **`--requests-only`**: skips response-validator emit.
   `validateResponse` / `validateFetchResponse` are still exported
   but return `null`. Output shrinks significantly on response-heavy
   specs (rough rule of thumb: ~50% smaller on Stripe-shape, ~20–30%
   on petstore-shape).
-- **`--only "METHOD PATH"`** (repeatable) — restricts emit to
+- **`--only "METHOD PATH"`** (repeatable): restricts emit to
   specified operations. OR-combined across multiple flags. Paths not
   matching any `--only` are dropped from the router. Methods dropped
-  from a partially-filtered path return `code: "route"` (404) —
+  from a partially-filtered path return `code: "route"` (404),
   treating the filtered emit as "this deployment's surface" rather
   than "a partial view of the full spec". Gateway-routing layers
   that expect 405 (method not implemented here, try another
@@ -146,22 +146,22 @@ of ops. `--requests-only` and `--only` both shrink output materially.
 
 Same limits as `compile-schema`, plus:
 
-- **Custom formats / custom keywords** — the validator function
+- **Custom formats / custom keywords**: the validator function
   can't be serialised. Compile dynamically with `createValidator`
   if you need them.
-- **External `$ref`s** — internal refs within the document compile
+- **External `$ref`s**: internal refs within the document compile
   fine; multi-file external refs must be pre-inlined via `oav
 resolve` or `resolveSpec` before running `compile-spec`.
 
 ### Relationship to ajv's `standaloneCode`
 
-Ajv's `standaloneCode` covers the schema layer — it emits a compiled
+Ajv's `standaloneCode` covers the schema layer: it emits a compiled
 JSON Schema validator as module source. `compile-schema` does the
 same thing. `compile-spec` covers the HTTP layer on top: router
 matching, content-type dispatch, parameter deserialisation
 (style / explode), response status matching, and shape-only
 security checks. Rebuilding that layer on top of ajv's standalone
-output is essentially re-implementing `express-openapi-validator`
+output is re-implementing `express-openapi-validator`
 from scratch; `compile-spec` emits it directly.
 
 ## Exit codes

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -41,7 +41,7 @@ export interface BuildProgramOptions {
  * without spawning a child process; pass `{ io, exit }` to route all
  * side-effects through in-process collaborators. Commands write their
  * primary output through `io.stdout` (or the file sink when `-o` is
- * set) and their errors through `io.stderr` — this CLI layer only
+ * set) and their errors through `io.stderr`; this CLI layer only
  * handles argv-parsing usage errors + the final `exit` call.
  *
  * @public

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -199,7 +199,7 @@ export async function validateCommand(
     return { exitCode: 3 };
   }
 
-  // Silence on success — no bare-newline leak, matches Unix convention.
+  // Silence on success; no bare-newline leak, matches Unix convention.
   if (err === null) return { exitCode: 0 };
   const rendered = formatError(err, args.options.format, args.options.depth);
   await primarySink(io, args.options)(rendered + "\n");
@@ -232,7 +232,7 @@ export type ValidateMode =
  * `validate(data)` mirrors `compileSchema(schema).validate(data)`, then
  * bundles it via esbuild into a single file with zero imports.
  *
- * The output runs without `oav` installed at all — the
+ * The output runs without `oav` installed at all: the
  * Lambda / edge / single-file deployment case. `esbuild` is a required
  * peer dependency for this subcommand; a clear install hint prints on
  * stderr with exit code 3 if it's not resolvable.
@@ -331,9 +331,9 @@ async function bundleEmitted(source: string, resolveDir: string): Promise<string
  * Implement the `oav compile-spec <spec>` subcommand. Loads an OpenAPI
  * document (with optional overlays), compiles every operation's
  * schemas, and emits a standalone ES module exposing the full
- * `createValidator`-equivalent surface — `validateRequest`,
+ * `createValidator`-equivalent surface: `validateRequest`,
  * `validateResponse`, `validateFetchRequest`, `validateFetchResponse`,
- * `getOperation`, `detectedVersion`, `warnings` — with zero imports
+ * `getOperation`, `detectedVersion`, `warnings`, with zero imports
  * after bundling.
  *
  * @public

--- a/packages/cli/src/emit-spec.ts
+++ b/packages/cli/src/emit-spec.ts
@@ -1,9 +1,9 @@
 /**
  * Emit a standalone, AOT-compiled HTTP validator from an OpenAPI
  * document. The output is an ES module exporting the same surface as
- * `createValidator(document)` — `validateRequest`, `validateResponse`,
+ * `createValidator(document)`: `validateRequest`, `validateResponse`,
  * `validateFetchRequest`, `validateFetchResponse`, `getOperation`,
- * `detectedVersion`, `warnings` — but with every operation's schemas
+ * `detectedVersion`, `warnings`, but with every operation's schemas
  * already compiled into the module. After bundling through esbuild the
  * module has zero imports.
  *
@@ -11,7 +11,7 @@
  * runtime get the same behaviour with no YAML parse, no `$ref`
  * resolution, no schema compilation at load. Target use cases:
  * Cloudflare Workers, Vercel Edge, Lambda@Edge, Lambda cold-start
- * latency, deno compile, single-file bundles — anywhere runtime
+ * latency, deno compile, single-file bundles: anywhere runtime
  * compilation is either disallowed or too expensive.
  *
  * @packageDocumentation
@@ -57,7 +57,7 @@ export interface EmitSpecOptions {
   /**
    * Whitelist of `(method, path)` pairs to emit. Empty / undefined
    * means "emit every operation." Ops not matching any include are
-   * dropped from the router entirely — requests to them come back as
+   * dropped from the router entirely; requests to them come back as
    * `code: "route"` (404).
    */
   only?: Array<{ method: string; path: string }>;
@@ -89,7 +89,7 @@ export function emitSpec(document: OpenAPIDocument, options: EmitSpecOptions = {
   const refResolver: RefResolver = createRefResolver(graph);
 
   // Anything passed through resolveRef comes back with `{ $ref }`
-  // followed — the schema registry handles internal refs transparently.
+  // followed; the schema registry handles internal refs transparently.
   const resolveRef = <T>(v: T | ReferenceObject | undefined): T | undefined => {
     if (v === undefined) return undefined;
     if (typeof v !== "object" || v === null) return v as T;
@@ -118,7 +118,7 @@ export function emitSpec(document: OpenAPIDocument, options: EmitSpecOptions = {
   // - `pathMethods`: for each path that has ≥ 1 included op, the FULL
   //   set of spec-declared methods. Drives the router's paths table.
   //   A method declared in the spec but dropped by `--only` stays in
-  //   here — the router still sees it and reports method-not-allowed
+  //   here; the router still sees it and reports method-not-allowed
   //   only for methods the spec truly doesn't have. That preserves
   //   405 semantics for unfiltered deployments.
   // - `opsEmitted`: the FILTERED subset. Drives the ops table.
@@ -392,7 +392,7 @@ function buildEmittedOp(args: BuildEmittedOpArgs): EmittedOp {
   );
 
   // Introspection payload for `getOperation`. Matches the runtime's
-  // `match.pathItem` / `match.operation` references — the resolved
+  // `match.pathItem` / `match.operation` references: the resolved
   // top-level objects from the document. Nested `$ref`s (e.g. inside a
   // `requestBody` or `responses[status]`) are left intact, same as
   // runtime.
@@ -522,7 +522,7 @@ function resolveDialect(
   if (bucket === "3.1" || bucket === "3.2") return openapi31Dialect;
 
   // bucket === undefined: classify and warn. We still fall back to the
-  // 3.1 dialect rather than throwing — AOT is a build-time pipeline and
+  // 3.1 dialect rather than throwing; AOT is a build-time pipeline and
   // the consumer's `warnings` export is the appropriate signal.
   const rawOpenapi = (document as { openapi?: unknown }).openapi;
   const reason = classifyUnknownVersion(rawOpenapi);

--- a/packages/cli/src/emit-standalone.ts
+++ b/packages/cli/src/emit-standalone.ts
@@ -32,7 +32,7 @@ export interface EmitStandaloneOptions {
   dialect: StandaloneDialect;
   /**
    * Import-path prefix for runtime deps in the emitted module.
-   * Defaults to `"oav"` — the published name. Tests
+   * Defaults to `"oav"` (the published name). Tests
    * override to `"@oav"` so the output resolves against the
    * workspace aliases instead of a published tarball.
    */
@@ -51,7 +51,7 @@ export interface EmitStandaloneOptions {
  * Rejects schemas that use `format: "..."` values outside
  * {@link @aahoughton/oav/formats!builtInFormats}. Custom formats and
  * custom keywords aren't serialisable and require a more involved
- * emission path — out of scope for the CLI entry.
+ * emission path; out of scope for the CLI entry.
  *
  * @internal
  */
@@ -88,7 +88,7 @@ export function emitStandalone(schema: SchemaOrBoolean, options: EmitStandaloneO
     `import { builtInFormats } from "${importPrefix}/formats";`,
     "",
     "// Silence unused-import warnings when the schema doesn't reach a",
-    "// given helper — the compiler's output only references the ones it",
+    "// given helper. The compiler's output only references the ones it",
     "// needs, so some imports may appear unused at module scope.",
     "void createLeafError; void createBranchError; void createError;",
     "void deepEqual; void typeOf; void wrapErrors;",

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -66,7 +66,7 @@ const spec = {
   },
 };
 
-describe("buildProgram — argv-level", () => {
+describe("buildProgram: argv-level", () => {
   it("resolve prints the stitched document and exits 0", async () => {
     const mem = memoryIo([["spec.json", spec]]);
     const out = await runCli(["resolve", "spec.json"], mem);
@@ -246,7 +246,7 @@ describe("buildProgram — argv-level", () => {
     expect(out.exitCode).toBe(1);
     const lines = out.stdout.split("\n").filter((l) => l.length > 0);
     expect(lines.length).toBeGreaterThan(0);
-    // Flat format puts each leaf on its own line — no nested indentation.
+    // Flat format puts each leaf on its own line; no nested indentation.
     for (const line of lines) expect(line.startsWith(" ")).toBe(false);
   });
 });

--- a/packages/cli/test/commands.test.ts
+++ b/packages/cli/test/commands.test.ts
@@ -143,7 +143,7 @@ describe("validateCommand", () => {
       io,
     );
     expect(result.exitCode).toBe(0);
-    // Silence on success — no bare newline leak.
+    // Silence on success: no bare newline leak.
     expect(stdout.value).toBe("");
   });
 

--- a/packages/cli/test/compile-spec.test.ts
+++ b/packages/cli/test/compile-spec.test.ts
@@ -123,7 +123,7 @@ function collectLeafCodes(err: ValidationError): string[] {
   return err.children.flatMap(collectLeafCodes);
 }
 
-describe("compile-spec — equivalence vs createValidator", () => {
+describe("compile-spec: equivalence vs createValidator", () => {
   it("matches runtime output on the petstore matrix", async () => {
     const runtime = createValidator(petstore);
     const aot = await buildAot(petstore);

--- a/packages/cli/test/emit-standalone.test.ts
+++ b/packages/cli/test/emit-standalone.test.ts
@@ -56,7 +56,7 @@ describe("emitStandalone", () => {
     }
   });
 
-  it("includes built-in formats — emitted validator checks email", async () => {
+  it("includes built-in formats: emitted validator checks email", async () => {
     const schema: SchemaOrBoolean = {
       type: "object",
       properties: { contact: { type: "string", format: "email" } },
@@ -82,7 +82,7 @@ describe("emitStandalone", () => {
     ).toThrow(/not in the built-in set/);
   });
 
-  it("compiles under the OpenAPI 3.0 dialect — boolean exclusiveMaximum honoured", async () => {
+  it("compiles under the OpenAPI 3.0 dialect: boolean exclusiveMaximum honoured", async () => {
     const schema: SchemaOrBoolean = {
       type: "integer",
       maximum: 10,

--- a/packages/cli/test/fixtures.ts
+++ b/packages/cli/test/fixtures.ts
@@ -5,7 +5,7 @@ import type { CommandIo } from "../src/commands.js";
  * Shared helpers for the CLI test suite. The two callers
  * (`cli.test.ts` argv coverage, `commands.test.ts` in-process coverage)
  * both need a `CommandIo` wired to in-memory documents, text files, and
- * capture buffers for stdout / stderr / file writes — factored out
+ * capture buffers for stdout / stderr / file writes, factored out
  * here so the helpers can't drift.
  */
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,8 +1,8 @@
 # oav/core
 
 Error tree model, shared OpenAPI / HTTP types, and output formatters.
-Imported by every other module in the package and — because the error
-tree is what `validateRequest` / `validateResponse` return — the
+Imported by every other module in the package, and (because the error
+tree is what `validateRequest` / `validateResponse` return) the
 closest thing to a "read me first" for library consumers.
 
 This subpath is available from both `oav/core` and
@@ -23,14 +23,14 @@ import {
 ```ts
 interface ValidationError {
   code: string; // "type", "required", "oneOf", "content-type", ...
-  path: PathSegment[]; // (string | number)[] — rooted at the HTTP frame
+  path: PathSegment[]; // (string | number)[], rooted at the HTTP frame
   message: string; // human-readable
   params: Record<string, unknown>; // machine-readable; shape per code in BuiltInErrorParams
   children: ValidationError[]; // always an array; [] for leaves
 }
 ```
 
-Every node has a `children` array — leaves have `children: []`, branches
+Every node has a `children` array: leaves have `children: []`, branches
 have one child per relevant sub-failure (e.g. one per failing `oneOf`
 branch). Consumers can traverse without null checks.
 
@@ -72,34 +72,34 @@ Which one to reach for:
 | Want                                                                       | Use                                     |
 | -------------------------------------------------------------------------- | --------------------------------------- |
 | One-line summary for `response.message`, log lines, Sentry/NR group titles | `formatSummary(err)`                    |
-| Every leaf, one per line — flat enumeration (EOV-style, grep, CI diffs)    | `formatSummary(err, { select: "all" })` |
+| Every leaf, one per line: flat enumeration (EOV-style, grep, CI diffs)     | `formatSummary(err, { select: "all" })` |
 | Multi-line indented tree for stdout, log dumps, human reading              | `formatText(err)`                       |
 | Structured tree for programmatic consumption / JSON round-trip             | `toJsonObject(err)`                     |
 
 Detail:
 
-- **`formatText(err, { maxDepth?, indent? })`** — indented
+- **`formatText(err, { maxDepth?, indent? })`**: indented
   human-readable tree. One line per node.
 
-- **`formatSummary(err, { select? })`** — render the tree as a
+- **`formatSummary(err, { select? })`**: render the tree as a
   string. Default picks one leaf and renders it as
   `<dotted-path> <message>` (e.g. `"body.users[0].email must match
 format \"email\""`). Selection options:
-  - `select: "first"` (default) — first leaf in tree-traversal
+  - `select: "first"` (default): first leaf in tree-traversal
     order.
-  - `select: "deepest"` — leaf with the longest path; more
+  - `select: "deepest"`: leaf with the longest path; more
     informative on `oneOf` / composition trees.
-  - `select: "all"` — every leaf, one per line, each with path,
+  - `select: "all"`: every leaf, one per line, each with path,
     message, and `[code]`. The "every issue in a single message"
     shape; use this when migrating from validators that emit a
     flat enumeration by default.
-  - `select: { byCode: ["content-type", "required", ...] }` —
+  - `select: { byCode: ["content-type", "required", ...] }`:
     priority list. Returns the first leaf matching the
     highest-priority listed code; falls back to `"first"` if no
     match. Useful when the wire format wants to surface specific
     failure categories first.
 
-- **`toJsonObject(err)`** — deep copy that round-trips losslessly
+- **`toJsonObject(err)`**: deep copy that round-trips losslessly
   through `JSON.stringify` / `JSON.parse`.
 
 `countErrors(err)` returns the total number of nodes in the tree.
@@ -113,34 +113,34 @@ custom response shape (e.g. preserving an existing
 `{ message, errors: [...] }` envelope from a library you're
 migrating from).
 
-- `httpStatusFor(err, overrides?)` — maps a `ValidationError` tree to
+- `httpStatusFor(err, overrides?)`: maps a `ValidationError` tree to
   an HTTP status code. Defaults: `route` → 404, `method` → 405,
   `security` → 401, `content-type` → 415, `status` → 500, else 400.
   Correctly inspects the tree shape (some codes appear as leaves
   under a top-level `"request"` / `"response"` branch, not as
   `err.code`). Pass `{ default: 422 }` etc. to override a slot.
-- `allowHeaderFor(err)` — returns the comma-joined `Allow` header
+- `allowHeaderFor(err)`: returns the comma-joined `Allow` header
   value for a 405, or `undefined` otherwise (RFC 9110 §15.5.6).
-- `toProblemDetails(err, { type?, title?, status?, detail?, instance? })` —
+- `toProblemDetails(err, { type?, title?, status?, detail?, instance? })`:
   RFC 9457 `application/problem+json` envelope with a typed `issues`
   array as an extension member. Defaults: `about:blank` type,
   `"Validation failed"` title, status `400`, and `detail` = `formatSummary(err)`
   (first failing leaf). Pass `detail` explicitly for a structural
   summary like `` `${pd.issues.length} validation errors` `` or any
   other override.
-- `collectIssues(err)` — just the flat leaf list, if you're rolling
+- `collectIssues(err)`: just the flat leaf list, if you're rolling
   your own response shape. Each issue carries both a raw `path`
-  (`PathSegment[]`) and a `pointer` — the same path **pre-formatted
+  (`PathSegment[]`) and a `pointer`, the same path **pre-formatted
   as an [RFC 6901](https://www.rfc-editor.org/rfc/rfc6901) JSON
   Pointer** string (e.g. `/body/users/3/email`). Use `pointer`
   directly for response envelopes; `path` is the segments array if
-  you need programmatic access. Don't re-join `path` yourself —
+  you need programmatic access. Don't re-join `path` yourself;
   `pointer` already handles RFC 6901's `~` / `/` escaping.
 
 ### Common envelope shapes
 
 ```ts
-// RFC 9457 (default) — one call.
+// RFC 9457 (default), one call.
 res
   .status(httpStatusFor(err))
   .type("application/problem+json")
@@ -157,7 +157,7 @@ res.status(httpStatusFor(err)).json({
 });
 
 // Every-leaf "joined message" shape (some pre-existing wire formats
-// use this — e.g. eov under `validateRequests: { allErrors: true }`):
+// use this, e.g. eov under `validateRequests: { allErrors: true }`):
 formatSummary(err, { select: "all" }); // newline-joined
 // Or for a comma-joined variant:
 collectIssues(err)

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -8,7 +8,7 @@
 
 /**
  * A segment of a data or schema path. Property names are strings; array
- * indices are numbers. Paths are never pre-joined — consumers choose how
+ * indices are numbers. Paths are never pre-joined; consumers choose how
  * to render them.
  *
  * @public
@@ -27,7 +27,7 @@ export type PathSegment = string | number;
  * }
  * ```
  *
- * Extended via TypeScript interface declaration merging — a custom
+ * Extended via TypeScript interface declaration merging: a custom
  * consumer (or, internally, a new keyword) can augment the map by
  * re-declaring the interface in its own module:
  *
@@ -41,7 +41,7 @@ export type PathSegment = string | number;
  *
  * When adding a new built-in keyword, extend this interface with the
  * entry that describes its `params` shape. Contributors are asked to
- * keep this list in sync — the compiler cannot verify it because
+ * keep this list in sync; the compiler cannot verify it because
  * errors are emitted from generated JS source.
  *
  * @public
@@ -74,49 +74,49 @@ export interface BuiltInErrorParams {
   minItems: { minItems: number; actual: number };
   /** `maxItems` violation. */
   maxItems: { maxItems: number; actual: number };
-  /** `uniqueItems` violation — indices of the first duplicate pair. */
+  /** `uniqueItems` violation: indices of the first duplicate pair. */
   uniqueItems: { duplicates: [number, number] };
   /** `minProperties` violation. */
   minProperties: { minProperties: number; actual: number };
   /** `maxProperties` violation. */
   maxProperties: { maxProperties: number; actual: number };
-  /** `required` — a required property is missing. */
+  /** `required`: a required property is missing. */
   required: { missing: string };
-  /** `items: false` — no items allowed past the prefix. */
+  /** `items: false`: no items allowed past the prefix. */
   items: Record<string, never>;
   /** `contains` with `minContains` unmet. */
   contains: { minContains: number; actual: number };
   /** `contains` with `maxContains` exceeded. */
   maxContains: { maxContains: number; actual: number };
-  /** `additionalProperties: false` — an unexpected property was found. */
+  /** `additionalProperties: false`: an unexpected property was found. */
   additionalProperties: { unexpected: string };
-  /** `unevaluatedProperties` — a property isn't evaluated by the schema. */
+  /** `unevaluatedProperties`: a property isn't evaluated by the schema. */
   unevaluatedProperties: { unexpected: string };
-  /** `unevaluatedItems` — an index isn't evaluated by the schema. */
+  /** `unevaluatedItems`: an index isn't evaluated by the schema. */
   unevaluatedItems: { index: number };
-  /** `not` — the schema matched when it shouldn't. */
+  /** `not`: the schema matched when it shouldn't. */
   not: Record<string, never>;
-  /** `allOf` branch — failing conjuncts listed in `children`. */
+  /** `allOf` branch: failing conjuncts listed in `children`. */
   allOf: { total: number; failed: number };
-  /** `anyOf` branch — no branch matched. */
+  /** `anyOf` branch: no branch matched. */
   anyOf: { total: number };
-  /** `oneOf` branch — zero or >1 matched. */
+  /** `oneOf` branch: zero or >1 matched. */
   oneOf: { total: number; matchCount: number };
-  /** Inline multi-keyword subschema wrapper — matches a compiled function's `wrapErrors` shape. */
+  /** Inline multi-keyword subschema wrapper: matches a compiled function's `wrapErrors` shape. */
   schema: Record<string, never>;
-  /** `discriminator` — property absent/non-string, or value not in the mapping. */
+  /** `discriminator`: property absent/non-string, or value not in the mapping. */
   discriminator: { propertyName: string; value?: string };
-  /** `dependentRequired` — a sibling required by the trigger key is missing. */
+  /** `dependentRequired`: a sibling required by the trigger key is missing. */
   dependentRequired: { trigger: string; missing: string };
-  /** Draft-07 `dependencies` array form — same as dependentRequired. */
+  /** Draft-07 `dependencies` array form: same as dependentRequired. */
   dependencies: { trigger: string; missing: string };
 
   // --- HTTP-level wrappers (emitted by @oav/validator) ---
-  /** No path template matched `path` — semantically HTTP 404. */
+  /** No path template matched `path`: semantically HTTP 404. */
   route: { method: string; path: string };
   /**
    * Path template matched but the requested method isn't declared on
-   * it — semantically HTTP 405. `allowed` is the uppercase list of
+   * it; semantically HTTP 405. `allowed` is the uppercase list of
    * methods the matched path(s) do accept, suitable for an RFC 9110
    * `Allow` response header.
    */
@@ -125,12 +125,12 @@ export interface BuiltInErrorParams {
    * Request body, leaf-only. Emitted when a `required: true` body is
    * absent on the request. When a present body fails schema validation,
    * the schema's own error (with a keyword-specific code) bubbles up
-   * directly with path prefix `["body", ...]` — no `"body"` wrapper.
+   * directly with path prefix `["body", ...]`; no `"body"` wrapper.
    */
   body: Record<string, never>;
-  /** Request branch — children are parameter / body failures. */
+  /** Request branch: children are parameter / body failures. */
   request: { method: string; pathPattern: string };
-  /** Response branch — children are status / content-type / header / body failures. */
+  /** Response branch: children are status / content-type / header / body failures. */
   response: { status: number };
   /** Content-Type negotiation failed. */
   "content-type": { contentType: string | undefined; accepted?: string[]; declared?: string[] };
@@ -143,7 +143,7 @@ export interface BuiltInErrorParams {
   "cookie-param": { name: string; in: "cookie" };
   /**
    * No declared security requirement was satisfied by the request
-   * (shape-only check — presence / format of the declared credential
+   * (shape-only check: presence / format of the declared credential
    * location, not credential verification). `declared` lists the
    * alternatives tried: each inner array is a single requirement
    * (AND across its scheme names), the outer array is the OR set.
@@ -154,7 +154,7 @@ export interface BuiltInErrorParams {
 
 /**
  * Params shape for codes that aren't documented in
- * {@link BuiltInErrorParams} — custom keywords, consumer-defined
+ * {@link BuiltInErrorParams}: custom keywords, consumer-defined
  * HTTP-layer wrappers, or anything reached via a string variable the
  * compiler can't narrow.
  *
@@ -166,7 +166,7 @@ export type CustomErrorParams = Record<string, unknown>;
  * The params shape for an arbitrary error `code`. Built-in codes narrow
  * to the documented {@link BuiltInErrorParams} entry; any other code
  * widens to {@link CustomErrorParams}. Lets downstream code narrow
- * through a variable — `ErrorParams<typeof err.code>` — not just a
+ * through a variable (`ErrorParams<typeof err.code>`), not just a
  * string literal.
  *
  * @public
@@ -253,7 +253,7 @@ export type ErrorParamsFor<Code extends keyof BuiltInErrorParams> = BuiltInError
 /**
  * A single validation error, always a node in a {@link ValidationError} tree.
  *
- * Every error has a `children` array — leaf errors have `children: []`,
+ * Every error has a `children` array; leaf errors have `children: []`,
  * branch errors produced by applicator keywords have one child per relevant
  * subschema. Consumers can traverse without null checks.
  *
@@ -321,7 +321,7 @@ export interface CreateErrorParams {
  * @public
  */
 export function createError(params: CreateErrorParams): ValidationError {
-  // Snapshot path — generated validators reuse a single mutable path array
+  // Snapshot path: generated validators reuse a single mutable path array
   // across traversal (push/pop per depth), so freezing the segments here
   // protects the error from later mutations.
   return {
@@ -364,7 +364,7 @@ export function createLeafError(
   // every leaf. Saves one allocation per failure on hot invalid paths.
   // Leaves never accumulate children; the type is
   // `ValidationError[]` (mutable) for branch uses, but readers should
-  // treat a leaf's array as read-only — which is the existing contract.
+  // treat a leaf's array as read-only, which is the existing contract.
   //
   // The `extraSegment` / `extraSegment2` tail parameters let generated
   // validators append up to two path segments without allocating an
@@ -387,7 +387,7 @@ export function createLeafError(
 // Shared frozen empty array so leaf errors reuse one `children` value
 // instead of allocating a fresh `[]` per failure. `Object.freeze([])`
 // is typed `readonly never[]` which TS refuses to narrow to
-// `ValidationError[]` directly — the double cast expresses intent:
+// `ValidationError[]` directly; the double cast expresses intent:
 // readers treat a leaf's `children` as read-only already, and the
 // freeze is a runtime safety net against accidental mutation.
 const EMPTY_CHILDREN = Object.freeze([]) as unknown as ValidationError[];

--- a/packages/core/src/format-output.ts
+++ b/packages/core/src/format-output.ts
@@ -4,7 +4,7 @@ import type { ValidationError } from "./errors.js";
 /**
  * Single source of truth for the CLI's `--format` flag. The
  * {@link OutputFormat} union and the Commander parser validator both
- * derive from this tuple — add a new name here and extend
+ * derive from this tuple; add a new name here and extend
  * {@link formatError} to wire it up end-to-end.
  *
  * @public

--- a/packages/core/src/http-status.ts
+++ b/packages/core/src/http-status.ts
@@ -18,7 +18,7 @@ export interface HttpStatusMap {
   security: number;
   /** Response (response-side only): spec declares no entry for the received status. */
   status: number;
-  /** Anything else — schema violations, missing required fields, etc. */
+  /** Anything else: schema violations, missing required fields, etc. */
   default: number;
 }
 
@@ -49,7 +49,7 @@ export const DEFAULT_HTTP_STATUS_MAP: HttpStatusMap = {
  * a status from {@link DEFAULT_HTTP_STATUS_MAP} (or the caller's
  * overrides).
  *
- * Resolution order matches the HTTP gate semantics — 404 → 405 →
+ * Resolution order matches the HTTP gate semantics: 404 → 405 →
  * 415 → 401 → 500 → 400:
  *
  * ```ts
@@ -61,7 +61,7 @@ export const DEFAULT_HTTP_STATUS_MAP: HttpStatusMap = {
  * }
  * ```
  *
- * Override any slot — e.g. APIs that use 422 for schema errors:
+ * Override any slot, e.g. APIs that use 422 for schema errors:
  *
  * ```ts
  * httpStatusFor(err, { default: 422 });

--- a/packages/core/src/json-pointer.ts
+++ b/packages/core/src/json-pointer.ts
@@ -16,7 +16,7 @@ import type { JsonValue } from "./types.js";
  *     reference to optionally exist.
  *
  * Shared by `@oav/schema`'s internal `$ref` resolver and `@oav/spec`'s
- * document stitcher — having one implementation means a single place
+ * document stitcher; having one implementation means a single place
  * for any future RFC edge-case fix.
  *
  * @public

--- a/packages/core/src/problem-details.ts
+++ b/packages/core/src/problem-details.ts
@@ -5,7 +5,7 @@ import { formatSummary } from "./format.js";
  * A single validation issue flattened for client consumption. Produced
  * by {@link collectIssues} and embedded in {@link ProblemDetails.issues}.
  *
- * Maps 1:1 to a leaf in the {@link ValidationError} tree — you get the
+ * Maps 1:1 to a leaf in the {@link ValidationError} tree: you get the
  * same `code`, `message`, and `params`, plus the path in two forms:
  * the raw segments array (good for programmatic filtering) and an
  * RFC 6901 JSON Pointer (good for display and tools that follow the
@@ -67,7 +67,7 @@ export interface ProblemDetailsOptions {
   instance?: string;
   /**
    * Override the human-readable `detail`. Defaults to
-   * {@link formatSummary}(error) — a single line describing the first
+   * {@link formatSummary}(error): a single line describing the first
    * failing leaf (e.g. `"body.users[0].email must match format \"email\""`).
    * Pass an explicit string for a structural summary like
    * `` `${issues.length} validation error(s)` `` if you'd rather
@@ -81,7 +81,7 @@ export interface ProblemDetailsOptions {
  * with an RFC 6901 JSON Pointer. Useful when you want a client-friendly
  * issues array but don't need the {@link ProblemDetails} envelope.
  *
- * Leaf-only by design — branch-level `params` (e.g. `oneOf`'s `matchCount`)
+ * Leaf-only by design: branch-level `params` (e.g. `oneOf`'s `matchCount`)
  * are not in the result. Access the raw {@link ValidationError} if you
  * need the tree.
  *

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -190,7 +190,7 @@ export type SecurityRequirementObject = Record<string, string[]>;
  * {@link SecurityRequirementObject}.
  *
  * oav's validator performs shape-only checks on `http` (bearer / basic)
- * and `apiKey` schemes — it confirms the request carries the declared
+ * and `apiKey` schemes; it confirms the request carries the declared
  * credential location and format, but does not verify the credential
  * itself. `oauth2`, `openIdConnect`, and `mutualTLS` are accepted in
  * the spec but not shape-checked at the validator layer; credential
@@ -288,7 +288,7 @@ export interface PathItem {
 /**
  * The HTTP method names that can appear on a {@link PathItem}. `query`
  * is added in OpenAPI 3.2; earlier documents may not use it. Routing
- * is case-insensitive — validators lower-case the request's method
+ * is case-insensitive; validators lower-case the request's method
  * before lookup.
  *
  * @public

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -4,12 +4,12 @@
  * The OpenAPI Specification has two major variants that affect
  * validator behaviour:
  *
- * - **3.0.x** — uses a draft-Wright-00-based JSON Schema dialect with
+ * - **3.0.x**: uses a draft-Wright-00-based JSON Schema dialect with
  *   its own flavours of `type` (single string only), `nullable: true`,
  *   boolean `exclusiveMaximum`/`Minimum`, no sibling keys for `$ref`,
  *   and no `const` / `if`/`then`/`else` / `contains` /
  *   `unevaluatedProperties` / `patternProperties`.
- * - **3.1.x** and **3.2.x** — use JSON Schema 2020-12. 3.2 is largely
+ * - **3.1.x** and **3.2.x**: use JSON Schema 2020-12. 3.2 is largely
  *   additive over 3.1 (new methods like `QUERY`, tightened rules) and
  *   shares 3.1's dialect.
  *
@@ -84,7 +84,7 @@ export function classifyUnknownVersion(rawOpenapi: unknown): UnknownVersionReaso
     return {
       kind: "missing-openapi",
       message:
-        "expected an OpenAPI 3.x document — the `openapi` field must be a string " +
+        "expected an OpenAPI 3.x document; the `openapi` field must be a string " +
         `like "3.1.0" (got ${typeof rawOpenapi}). ` +
         'Swagger 2.0 documents use `swagger: "2.0"` instead and need to be converted ' +
         "first (e.g. `npx swagger2openapi input.json -o output.json`). " +

--- a/packages/core/test/http-status.test.ts
+++ b/packages/core/test/http-status.test.ts
@@ -45,7 +45,7 @@ describe("httpStatusFor", () => {
     expect(httpStatusFor(err)).toBe(500);
   });
 
-  it("returns 400 for anything else — schema violations, missing required, etc.", () => {
+  it("returns 400 for anything else: schema violations, missing required, etc.", () => {
     const err = createBranchError("request", [], "request validation failed", [
       createLeafError("required", ["body"], "missing name", { missing: "name" }),
       createLeafError("type", ["body", "age"], "must be number", {
@@ -71,7 +71,7 @@ describe("httpStatusFor", () => {
     // HTTP gate semantics: auth is the stricter gate ("we can't even tell
     // what you're asking for"), and 401 should surface ahead of 415. In
     // practice the validator short-circuits on security before checking
-    // content-type, so both rarely coexist — but the helper's priority
+    // content-type, so both rarely coexist, but the helper's priority
     // guarantees the behaviour regardless.
     const err = createBranchError("request", [], "request validation failed", [
       createLeafError("content-type", ["body"], "Content-Type not accepted", {

--- a/packages/formats/README.md
+++ b/packages/formats/README.md
@@ -18,7 +18,7 @@ validateUuid("not a uuid"); // false
 ```
 
 When the validator package is used via `createValidator`, the built-in
-formats are already included — pass `formats` to extend them, not
+formats are already included; pass `formats` to extend them, not
 replace them.
 
 ## Formats

--- a/packages/formats/src/email.ts
+++ b/packages/formats/src/email.ts
@@ -1,5 +1,5 @@
 /**
- * Email format validators. These are pragmatic — the full RFC 5321 grammar
+ * Email format validators. These are pragmatic; the full RFC 5321 grammar
  * is enormous and most real-world "email validators" reject too few
  * strings. We allow any ASCII local-part + a sensible domain.
  *

--- a/packages/formats/src/hostname.ts
+++ b/packages/formats/src/hostname.ts
@@ -21,7 +21,7 @@ export function validateHostname(value: string): boolean {
 
 /**
  * RFC 5890 internationalized `hostname`. Same rules as {@link validateHostname}
- * after punycoding each label — for v1 we accept any non-empty labels made
+ * after punycoding each label; for v1 we accept any non-empty labels made
  * of unicode letters, digits, and hyphens, 1-63 code points each.
  *
  * @public

--- a/packages/formats/src/index.ts
+++ b/packages/formats/src/index.ts
@@ -63,7 +63,7 @@ export const builtInFormats: Record<string, (value: string) => boolean> = {
 };
 
 /**
- * An Ajv-shaped format definition — `{ type, validate }`. oav's
+ * An Ajv-shaped format definition: `{ type, validate }`. oav's
  * `format` keyword only applies to string values (per JSON Schema
  * 2020-12 §6.3), so `type` is carried for shape compatibility but
  * not acted on; non-string values skip format validation regardless.
@@ -80,7 +80,7 @@ export interface AjvFormatDef {
 
 /**
  * Convert a map of Ajv-shaped format definitions to the plain
- * predicate shape oav's `formats` option expects. One-way — pass the
+ * predicate shape oav's `formats` option expects. One-way; pass the
  * result straight into `createValidator` / `compileSchema`.
  *
  * Main audience: migrants from `ajv-formats` or

--- a/packages/oav-express4/README.md
+++ b/packages/oav-express4/README.md
@@ -1,6 +1,6 @@
 # oav-express4
 
-Express 4 adapter for [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — a request-validator middleware factory plus standalone helpers (`httpRequestFromExpress`, `renderProblemDetails`) for callers composing their own middleware.
+Express 4 adapter for [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core): a request-validator middleware factory plus standalone helpers (`httpRequestFromExpress`, `renderProblemDetails`) for callers composing their own middleware.
 
 Thin: this package re-exports nothing from oav-core. You install both. The adapter declares oav-core as a regular dependency, so a single `npm install @aahoughton/oav-express4` pulls oav-core along; or install [`oav`](https://www.npmjs.com/package/@aahoughton/oav) instead if you want YAML readers and the CLI.
 
@@ -18,9 +18,9 @@ npm install @aahoughton/oav-core @aahoughton/oav-express4 express
 npm install @aahoughton/oav @aahoughton/oav-express4 express
 ```
 
-`express` is a peer dep — your app's existing install satisfies it.
+`express` is a peer dep; your app's existing install satisfies it.
 
-> **YAML specs.** `oav-core` is JSON-only by design (zero runtime deps). If your spec is YAML, either install [`oav`](https://www.npmjs.com/package/@aahoughton/oav) instead — it bundles the YAML readers and the CLI — or install `yaml` separately and parse the spec yourself before passing the parsed object to `createValidator`.
+> **YAML specs.** `oav-core` is JSON-only by design (zero runtime deps). If your spec is YAML, either install [`oav`](https://www.npmjs.com/package/@aahoughton/oav) instead (it bundles the YAML readers and the CLI), or install `yaml` separately and parse the spec yourself before passing the parsed object to `createValidator`.
 
 ## Quick start
 
@@ -40,9 +40,9 @@ app.post("/pets", (req, res) => res.json({ ok: true }));
 
 Invalid requests receive a `400 application/problem+json` response (status from `httpStatusFor`, body from `toProblemDetails`, `Allow` header on 405). Valid requests reach the route handlers.
 
-> **Body parser ordering matters.** `express.json()` (or your equivalent) must run **before** `validateRequests(...)`, otherwise `req.body` is `undefined` and the validator emits `body required` for every request — a misleading error that points at the schema, not at the missing parser. Same for `cookie-parser` if your spec validates cookies. Any middleware that populates `req.body` with a parsed object satisfies oav — `express.json()`, custom streaming parsers, `body-parser`, fastify's bridge, app-specific middleware all work the same way.
+> **Body parser ordering matters.** `express.json()` (or your equivalent) must run **before** `validateRequests(...)`, otherwise `req.body` is `undefined` and the validator emits `body required` for every request: a misleading error that points at the schema, not at the missing parser. Same for `cookie-parser` if your spec validates cookies. Any middleware that populates `req.body` with a parsed object satisfies oav: `express.json()`, custom streaming parsers, `body-parser`, fastify's bridge, app-specific middleware all work the same way.
 >
-> **Empty-body normalisation.** Some parsers (streaming variants, custom multi-format setups) leave `req.body === undefined` even after they run, for empty `{}`-equivalent payloads. When that happens, `required`-field checks short-circuit on the missing body — empty submissions pass validation. Normalise via `toHttpRequest`:
+> **Empty-body normalisation.** Some parsers (streaming variants, custom multi-format setups) leave `req.body === undefined` even after they run, for empty `{}`-equivalent payloads. When that happens, `required`-field checks short-circuit on the missing body, so empty submissions pass validation. Normalise via `toHttpRequest`:
 >
 > ```ts
 > import { httpRequestFromExpress, validateRequests } from "@aahoughton/oav-express4";
@@ -54,7 +54,7 @@ Invalid requests receive a `400 application/problem+json` response (status from 
 > );
 > ```
 >
-> Stock `express.json()` populates an empty body to `{}` and doesn't hit this — but migrators inheriting alternative parsers (e.g. `body-parser` streaming mode) often do.
+> Stock `express.json()` populates an empty body to `{}` and doesn't hit this, but migrators inheriting alternative parsers (e.g. `body-parser` streaming mode) often do.
 
 ## API
 
@@ -67,17 +67,17 @@ Returns an Express 4 `RequestHandler`.
 | `toHttpRequest` | `(req: Request) => HttpRequest`       | `httpRequestFromExpress` |
 | `onError`       | `(err, ctx) => void \| Promise<void>` | `renderProblemDetails`   |
 
-`onError` may be async — the middleware awaits it. If it throws or rejects, the error is forwarded via `next(err)` so the host's error middleware sees it. The middleware does **not** call `next()` after `onError` returns — your callback owns the response (write to `ctx.res`, or call `ctx.next(err)` to delegate).
+`onError` may be async; the middleware awaits it. If it throws or rejects, the error is forwarded via `next(err)` so the host's error middleware sees it. The middleware does **not** call `next()` after `onError` returns; your callback owns the response (write to `ctx.res`, or call `ctx.next(err)` to delegate).
 
-> **Validation failures don't traverse Express's error chain by default.** The default `onError` (`renderProblemDetails`) writes the response directly. If you're migrating from `express-openapi-validator` (which emits validation failures as `HttpError` through `next(err)`), your existing error middleware won't see oav's failures unless you forward them — see [Forward to Express's error middleware](#forward-to-expresss-error-middleware) below. Same goes for observability: see [Add observability without changing the response](#add-observability-without-changing-the-response).
+> **Validation failures don't traverse Express's error chain by default.** The default `onError` (`renderProblemDetails`) writes the response directly. If you're migrating from `express-openapi-validator` (which emits validation failures as `HttpError` through `next(err)`), your existing error middleware won't see oav's failures unless you forward them; see [Forward to Express's error middleware](#forward-to-expresss-error-middleware) below. Same goes for observability: see [Add observability without changing the response](#add-observability-without-changing-the-response).
 
 ### `httpRequestFromExpress(req)`
 
-Convert an Express 4 `Request` to oav's framework-agnostic `HttpRequest` shape. Read what's already on `req` — body parsing is the host app's responsibility.
+Convert an Express 4 `Request` to oav's framework-agnostic `HttpRequest` shape. Read what's already on `req`; body parsing is the host app's responsibility.
 
 Header keys lowercased, path stripped of query string, cookies read from `req.cookies` if present.
 
-**Returns a fresh `HttpRequest`.** Top-level fields can be reassigned freely without affecting the original Express `req` — safe to spread (`{ ...httpRequestFromExpress(req), body: {} }`) or mutate in place. The values it references (`req.body`, `req.headers`) are still the originals; deep mutation would still leak, but reassignment doesn't.
+**Returns a fresh `HttpRequest`.** Top-level fields can be reassigned freely without affecting the original Express `req`; safe to spread (`{ ...httpRequestFromExpress(req), body: {} }`) or mutate in place. The values it references (`req.body`, `req.headers`) are still the originals; deep mutation would still leak, but reassignment doesn't.
 
 Use this when you want to compose your own middleware (e.g. validate inside an existing custom wrapper) without re-implementing the extraction.
 
@@ -100,18 +100,18 @@ validateRequests(validator, {
 
 ### Enable shape-only security checks (no auth middleware yet)
 
-`ValidatorOptions.validateSecurity` is off by default — real apps run auth middleware upstream of the validator, so by the time `validateRequests` runs the credential has already been verified. During early dev (no auth wired yet) or with decorator-only auth that just attaches `req.user`, opt in:
+`ValidatorOptions.validateSecurity` is off by default; real apps run auth middleware upstream of the validator, so by the time `validateRequests` runs the credential has already been verified. During early dev (no auth wired yet) or with decorator-only auth that just attaches `req.user`, opt in:
 
 ```ts
 const validator = createValidator(spec, { validateSecurity: true });
 app.use(validateRequests(validator));
 ```
 
-The check is shape-only — it confirms the declared credential is _present_, not that it's _valid_. Don't treat it as a substitute for auth middleware.
+The check is shape-only: it confirms the declared credential is _present_, not that it's _valid_. Don't treat it as a substitute for auth middleware.
 
 ### Per-scheme auth dispatch (the eov `securityHandlers` shape)
 
-eov's `securityHandlers` is a per-scheme dispatch table — you supply an auth function per declared scheme and eov calls it. `oav-express4` doesn't ship this as a helper, but the recipe is small. Mount it as middleware _before_ `validateRequests`:
+eov's `securityHandlers` is a per-scheme dispatch table: you supply an auth function per declared scheme and eov calls it. `oav-express4` doesn't ship this as a helper, but the recipe is small. Mount it as middleware _before_ `validateRequests`:
 
 ```ts
 import type { Request } from "express";
@@ -158,11 +158,11 @@ app.use(validateRequests(validator)); // shape check off by default; redundant g
 
 OpenAPI semantics: each requirement object is AND across its scheme keys; the outer array is OR across requirements. The recipe walks them accordingly.
 
-If multiple projects end up copying this recipe, that's the signal to harvest into a `dispatchSecurity(...)` helper export — not yet.
+If multiple projects end up copying this recipe, that's the signal to harvest into a `dispatchSecurity(...)` helper export. Not yet.
 
 ### Skip validation for paths the spec doesn't declare
 
-The validator owns this — pass it `ignorePaths` or `ignoreUndocumented` at construction. See `ValidatorOptions` in `oav-core` for the contract.
+The validator owns this: pass it `ignorePaths` or `ignoreUndocumented` at construction. See `ValidatorOptions` in `oav-core` for the contract.
 
 ```ts
 const validator = createValidator(spec, {
@@ -238,7 +238,7 @@ The middleware awaits the returned promise; rejections route to `next(err)`.
 
 ### Per-route mounting
 
-`validateRequests(...)` is route-aware (it derives the operation from method+path). Mount it once at the app level — per-route mounting is redundant and may cause double-validation under nested routers.
+`validateRequests(...)` is route-aware (it derives the operation from method+path). Mount it once at the app level; per-route mounting is redundant and may cause double-validation under nested routers.
 
 ### Global validator + per-route multer (file uploads)
 
@@ -265,13 +265,13 @@ app.use(
 );
 ```
 
-`toHttpRequest` is the general "reshape what oav sees" seam — synthesizing body from files, normalizing empty bodies, merging headers from an upstream proxy, anything that lives above the extraction layer. The empty-body normalization recipe higher in this README and this multer recipe are two examples of the same pattern.
+`toHttpRequest` is the general "reshape what oav sees" seam: synthesizing body from files, normalizing empty bodies, merging headers from an upstream proxy, anything that lives above the extraction layer. The empty-body normalization recipe higher in this README and this multer recipe are two examples of the same pattern.
 
 For per-route inline multer (validator called from inside the route handler) and the full multer recipe with text-field reassembly, see the [integration.md file uploads section](https://github.com/aahoughton/oav/blob/main/docs/integration.md#file-uploads-with-multer).
 
 ## See also
 
-- [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — `createValidator`, `ValidatorOptions`, `formatSummary`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
-- [`oav`](https://www.npmjs.com/package/@aahoughton/oav) — batteries-included distribution of oav-core: YAML readers + the `oav` CLI.
-- The repo-root [`docs/integration.md`](../../docs/integration.md) — broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
-- The repo-root [`docs/migration-from-eov.md`](../../docs/migration-from-eov.md) — porting from `express-openapi-validator`.
+- [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core): `createValidator`, `ValidatorOptions`, `formatSummary`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
+- [`oav`](https://www.npmjs.com/package/@aahoughton/oav): batteries-included distribution of oav-core (YAML readers + the `oav` CLI).
+- The repo-root [`docs/integration.md`](../../docs/integration.md): broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
+- The repo-root [`docs/migration-from-eov.md`](../../docs/migration-from-eov.md): porting from `express-openapi-validator`.

--- a/packages/oav-express4/src/extract.ts
+++ b/packages/oav-express4/src/extract.ts
@@ -4,7 +4,7 @@ import type { HttpRequest } from "@oav/core";
 /**
  * Convert an Express 4 `Request` to oav's framework-agnostic
  * {@link HttpRequest} shape. Read what's already on `req`; do not
- * touch the body parser or any async source — bodies are assumed
+ * touch the body parser or any async source; bodies are assumed
  * already-parsed by `express.json()` (or equivalent) upstream of
  * the validator middleware.
  *
@@ -17,7 +17,7 @@ import type { HttpRequest } from "@oav/core";
  * them, otherwise omitted.
  *
  * Pairs with future `httpRequestFromExpress5`, `httpRequestFromFastify`,
- * etc. — same name pattern as oav's existing
+ * etc.: same name pattern as oav's existing
  * {@link httpRequestFromFetch}.
  *
  * @public

--- a/packages/oav-express4/src/index.ts
+++ b/packages/oav-express4/src/index.ts
@@ -1,11 +1,11 @@
 /**
- * The public `oav-express4` surface — three exports plus the type
+ * The public `oav-express4` surface: three exports plus the type
  * shape every adapter in the family shares.
  *
- * - {@link validateRequests} — middleware factory; the 80% case.
- * - {@link httpRequestFromExpress} — standalone extractor; for
+ * - {@link validateRequests}: middleware factory; the 80% case.
+ * - {@link httpRequestFromExpress}: standalone extractor; for
  *   callers composing their own middleware.
- * - {@link renderProblemDetails} — the default error renderer;
+ * - {@link renderProblemDetails}: the default error renderer;
  *   reusable from any custom middleware.
  *
  * Naming and option shapes are deliberately consistent with the
@@ -21,7 +21,7 @@ export { validateRequests, type ValidateRequestsOptions } from "./middleware.js"
 export type { ErrorHandler, ExpressContext } from "./types.js";
 
 // Re-export the types that appear in our own option signatures. Strictly
-// not duplication of oav-core's surface — these ARE the adapter's
+// not duplication of oav-core's surface; these ARE the adapter's
 // public contract, just borrowed for non-duplication reasons. Importing
 // them from this package means consumers don't have to know which
 // package owns them.

--- a/packages/oav-express4/src/middleware.ts
+++ b/packages/oav-express4/src/middleware.ts
@@ -9,7 +9,7 @@ import type { ErrorHandler, ExpressContext } from "./types.js";
  * Options for {@link validateRequests}. Names and semantics are
  * shared with future {@link validateResponses} and with the same
  * options on every other adapter in the family (`oav-express5`,
- * `oav-fastify`, ...) — only the framework-typed argument differs.
+ * `oav-fastify`, ...); only the framework-typed argument differs.
  *
  * @public
  */
@@ -24,11 +24,11 @@ export interface ValidateRequestsOptions {
   toHttpRequest?: (req: Request) => HttpRequest;
   /**
    * Called when {@link Validator.validateRequest} returns an error.
-   * Default: {@link renderProblemDetails} — RFC 9457
+   * Default: {@link renderProblemDetails}: RFC 9457
    * `application/problem+json` with status from `httpStatusFor`.
    * Pass your own to render a custom envelope, call `next(err)`,
    * map to a different status, etc. The middleware does not call
-   * `next()` after invoking `onError` — the callback is the response.
+   * `next()` after invoking `onError`; the callback is the response.
    */
   onError?: ErrorHandler<ExpressContext>;
 }
@@ -40,7 +40,7 @@ export interface ValidateRequestsOptions {
  * an RFC 9457 problem-details response.
  *
  * Plural (`validateRequests`, not `validateRequest`) because the
- * middleware intercepts every request — the singular form is the
+ * middleware intercepts every request; the singular form is the
  * Validator's own per-call method.
  *
  * Express 4 is sync at the framework level: thrown exceptions and

--- a/packages/oav-express4/src/render.ts
+++ b/packages/oav-express4/src/render.ts
@@ -12,9 +12,9 @@ import type { ExpressContext } from "./types.js";
  * Exported standalone for two cases:
  *
  * 1. You want oav's rendering as the fallback in your own
- *    middleware — call this directly when you don't want to handle
+ *    middleware: call this directly when you don't want to handle
  *    the error yourself.
- * 2. You want a slightly different renderer — use this as the
+ * 2. You want a slightly different renderer: use this as the
  *    starting point and adjust (e.g. swap the body, override the
  *    status, add headers).
  *

--- a/packages/oav-express4/src/types.ts
+++ b/packages/oav-express4/src/types.ts
@@ -6,7 +6,7 @@ import type { ValidationError } from "@oav/core";
  * `onError` callbacks so they can render their own response, call
  * `next(err)`, or whatever the host app's error contract requires.
  *
- * Identical in shape to what an inline middleware would close over —
+ * Identical in shape to what an inline middleware would close over;
  * the type is exported only so users can annotate their callbacks.
  *
  * @public
@@ -20,7 +20,7 @@ export interface ExpressContext {
 /**
  * Signature shared by `onError` on every adapter in the family
  * (`oav-express4`, future `oav-express5`, `oav-fastify`, ...). The
- * `Ctx` parameter is the only thing that varies — same name and shape
+ * `Ctx` parameter is the only thing that varies; same name and shape
  * everywhere.
  *
  * Returning a Promise is supported on every adapter. `oav-express4`

--- a/packages/oav-express4/test/extract.test.ts
+++ b/packages/oav-express4/test/extract.test.ts
@@ -28,7 +28,7 @@ describe("httpRequestFromExpress", () => {
 
   it("lowercases header keys defensively", () => {
     // Express already lowercases, but downstream middleware can mutate
-    // req.headers — defensive pass keeps the contract regardless.
+    // req.headers; defensive pass keeps the contract regardless.
     const got = httpRequestFromExpress(
       fakeReq({
         method: "GET",

--- a/packages/oav-express4/test/integration.test.ts
+++ b/packages/oav-express4/test/integration.test.ts
@@ -13,7 +13,7 @@ import { validateRequests } from "../src/middleware.js";
  * round-trip via native fetch, close the server when done.
  *
  * Same `it()` names as future oav-express5 / oav-fastify integration
- * suites — adapter implementations differ, scenarios stay identical.
+ * suites; adapter implementations differ, scenarios stay identical.
  */
 
 function petSpec(): OpenAPIDocument {
@@ -218,7 +218,7 @@ describe("oav-express4 integration: custom toHttpRequest", () => {
     const validator = createValidator(petSpec());
     const app = express();
     app.use(express.json());
-    // Inject a synthetic verifiedBody for every request — must run
+    // Inject a synthetic verifiedBody for every request; must run
     // BEFORE validateRequests so the extractor sees it.
     app.use((req, _res, next) => {
       (req as Request & { verifiedBody?: unknown }).verifiedBody = { name: "Fido" };
@@ -244,7 +244,7 @@ describe("oav-express4 integration: custom toHttpRequest", () => {
   });
 
   it("custom toHttpRequest extractor reaches the validator", async () => {
-    // Real body is empty, but verifiedBody contains a valid body — the
+    // Real body is empty, but verifiedBody contains a valid body; the
     // custom extractor should surface it to the validator and validation
     // should pass.
     const r = await fetch(`${baseUrl}/pets`, {
@@ -268,7 +268,7 @@ describe("oav-express4 integration: Express 4 specifics", () => {
     app.use(
       validateRequests(validator, {
         toHttpRequest: () => {
-          // Simulate a sync extractor failure — Express 4 requires
+          // Simulate a sync extractor failure; Express 4 requires
           // try/catch + next(err) since it doesn't await middleware
           // promises. The adapter handles this for us.
           throw new Error("extractor exploded");

--- a/packages/oav-express4/test/middleware.test.ts
+++ b/packages/oav-express4/test/middleware.test.ts
@@ -183,7 +183,7 @@ describe("validateRequests", () => {
       res,
       next,
     );
-    // Microtask drain — the await inside onError needs the event loop to tick.
+    // Microtask drain; the await inside onError needs the event loop to tick.
     await new Promise((resolve) => setTimeout(resolve, 20));
     expect(asyncWorkComplete).toBe(true);
     expect(res.status).toHaveBeenCalledWith(422);

--- a/packages/oav-express4/test/render.test.ts
+++ b/packages/oav-express4/test/render.test.ts
@@ -41,7 +41,7 @@ describe("renderProblemDetails", () => {
       status: 400,
       instance: "/pets",
     });
-    // detail comes from formatSummary() — first leaf, "<path> <message>".
+    // detail comes from formatSummary(): first leaf, "<path> <message>".
     expect(body.detail).toBe("body.age must be number");
     expect(body.issues).toHaveLength(1);
   });

--- a/packages/oav-express4/tsup.config.ts
+++ b/packages/oav-express4/tsup.config.ts
@@ -3,7 +3,7 @@ import type { Plugin } from "esbuild";
 import { defineConfig } from "tsup";
 
 /**
- * Build config for `oav-express4` — the Express 4 adapter.
+ * Build config for `oav-express4`, the Express 4 adapter.
  *
  * Thin tarball: nothing from `oav-core` is bundled. The adapter
  * imports `@oav/core` / `@oav/validator` (workspace aliases) in
@@ -12,7 +12,7 @@ import { defineConfig } from "tsup";
  * from the consumer's install of `@aahoughton/oav-core` (or
  * `@aahoughton/oav`, which transitively provides it).
  *
- * `express` is a peer dep — never bundled. `@types/express` is a
+ * `express` is a peer dep, never bundled. `@types/express` is a
  * dev dep and only contributes to the .d.ts emit.
  */
 const oavCoreRewrite: Record<string, string> = {

--- a/packages/oav-express5/README.md
+++ b/packages/oav-express5/README.md
@@ -1,8 +1,8 @@
 # oav-express5
 
-Express 5 adapter for [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — a promise-native middleware factory plus standalone helpers (`httpRequestFromExpress`, `renderProblemDetails`) for callers composing their own middleware.
+Express 5 adapter for [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core): a promise-native middleware factory plus standalone helpers (`httpRequestFromExpress`, `renderProblemDetails`) for callers composing their own middleware.
 
-Same shape as the [`oav-express4`](../oav-express4/README.md) sibling — only the framework-typed argument and the async semantics differ. Express 5's promise-native middleware means thrown errors and rejected promises propagate to the host's error middleware automatically, with no `try/catch` wrapper.
+Same shape as the [`oav-express4`](../oav-express4/README.md) sibling; only the framework-typed argument and the async semantics differ. Express 5's promise-native middleware means thrown errors and rejected promises propagate to the host's error middleware automatically, with no `try/catch` wrapper.
 
 Sibling packages: [`oav-express4`](../oav-express4/README.md), [`oav-fastify`](../oav-fastify/README.md). Same export names, option shapes, and defaults; only the framework-typed argument differs.
 
@@ -18,9 +18,9 @@ npm install @aahoughton/oav-core @aahoughton/oav-express5 express
 npm install @aahoughton/oav @aahoughton/oav-express5 express
 ```
 
-`express` is a peer dep — your app's existing install satisfies it.
+`express` is a peer dep; your app's existing install satisfies it.
 
-> **YAML specs.** `oav-core` is JSON-only by design (zero runtime deps). If your spec is YAML, either install [`oav`](https://www.npmjs.com/package/@aahoughton/oav) instead — it bundles the YAML readers and the CLI — or install `yaml` separately and parse the spec yourself before passing the parsed object to `createValidator`.
+> **YAML specs.** `oav-core` is JSON-only by design (zero runtime deps). If your spec is YAML, either install [`oav`](https://www.npmjs.com/package/@aahoughton/oav) instead (it bundles the YAML readers and the CLI), or install `yaml` separately and parse the spec yourself before passing the parsed object to `createValidator`.
 
 ## Quick start
 
@@ -40,7 +40,7 @@ app.post("/pets", (req, res) => res.json({ ok: true }));
 
 Invalid requests receive a `400 application/problem+json` response (status from `httpStatusFor`, body from `toProblemDetails`, `Allow` header on 405). Valid requests reach the route handlers.
 
-> **Body parser ordering matters.** `express.json()` (or any equivalent that populates `req.body` with a parsed object) must run **before** `validateRequests(...)`. Same for `cookie-parser` if your spec validates cookies. Any middleware that populates `req.body` works — `express.json()`, `body-parser`, custom streaming parsers, app-specific middleware all work the same way.
+> **Body parser ordering matters.** `express.json()` (or any equivalent that populates `req.body` with a parsed object) must run **before** `validateRequests(...)`. Same for `cookie-parser` if your spec validates cookies. Any middleware that populates `req.body` works: `express.json()`, `body-parser`, custom streaming parsers, app-specific middleware all work the same way.
 >
 > **Empty-body normalisation.** Some parsers leave `req.body === undefined` for empty `{}`-equivalent payloads. When that happens, `required`-field checks short-circuit on the missing body. Normalise via `toHttpRequest`:
 >
@@ -65,17 +65,17 @@ Returns an Express 5 promise-returning `RequestHandler`.
 | `toHttpRequest` | `(req: Request) => HttpRequest`       | `httpRequestFromExpress` |
 | `onError`       | `(err, ctx) => void \| Promise<void>` | `renderProblemDetails`   |
 
-`onError` may be async — the middleware awaits it. Express 5 awaits the returned promise, so thrown extractor errors and rejected `onError` promises propagate to the host's error middleware automatically, no `try/catch` needed. The middleware does **not** call `next()` after `onError` returns — your callback owns the response (write to `ctx.res`, or call `ctx.next(err)` to delegate).
+`onError` may be async; the middleware awaits it. Express 5 awaits the returned promise, so thrown extractor errors and rejected `onError` promises propagate to the host's error middleware automatically, no `try/catch` needed. The middleware does **not** call `next()` after `onError` returns; your callback owns the response (write to `ctx.res`, or call `ctx.next(err)` to delegate).
 
-> **Validation failures don't traverse Express's error chain by default.** The default `onError` (`renderProblemDetails`) writes the response directly. If you're migrating from `express-openapi-validator` (which emits validation failures as `HttpError` through `next(err)`), your existing error middleware won't see oav's failures unless you forward them — see [Forward to Express's error middleware](#forward-to-expresss-error-middleware) below. Same goes for observability: see [Add observability without changing the response](#add-observability-without-changing-the-response).
+> **Validation failures don't traverse Express's error chain by default.** The default `onError` (`renderProblemDetails`) writes the response directly. If you're migrating from `express-openapi-validator` (which emits validation failures as `HttpError` through `next(err)`), your existing error middleware won't see oav's failures unless you forward them; see [Forward to Express's error middleware](#forward-to-expresss-error-middleware) below. Same goes for observability: see [Add observability without changing the response](#add-observability-without-changing-the-response).
 
 ### `httpRequestFromExpress(req)`
 
-Convert an Express 5 `Request` to oav's framework-agnostic `HttpRequest` shape. Read what's already on `req` — body parsing is the host app's responsibility.
+Convert an Express 5 `Request` to oav's framework-agnostic `HttpRequest` shape. Read what's already on `req`; body parsing is the host app's responsibility.
 
 Header keys lowercased, path stripped of query string, cookies read from `req.cookies` if present.
 
-**Returns a fresh `HttpRequest`.** Top-level fields can be reassigned freely without affecting the original Express `req` — safe to spread (`{ ...httpRequestFromExpress(req), body: {} }`) or mutate in place. The values it references (`req.body`, `req.headers`) are still the originals; deep mutation would still leak, but reassignment doesn't.
+**Returns a fresh `HttpRequest`.** Top-level fields can be reassigned freely without affecting the original Express `req`; safe to spread (`{ ...httpRequestFromExpress(req), body: {} }`) or mutate in place. The values it references (`req.body`, `req.headers`) are still the originals; deep mutation would still leak, but reassignment doesn't.
 
 Use this when you want to compose your own middleware (e.g. validate inside an existing custom wrapper) without re-implementing the extraction.
 
@@ -98,18 +98,18 @@ validateRequests(validator, {
 
 ### Enable shape-only security checks (no auth middleware yet)
 
-`ValidatorOptions.validateSecurity` is off by default — real apps run auth middleware upstream of the validator, so by the time `validateRequests` runs the credential has already been verified. During early dev (no auth wired yet) or with decorator-only auth that just attaches `req.user`, opt in:
+`ValidatorOptions.validateSecurity` is off by default; real apps run auth middleware upstream of the validator, so by the time `validateRequests` runs the credential has already been verified. During early dev (no auth wired yet) or with decorator-only auth that just attaches `req.user`, opt in:
 
 ```ts
 const validator = createValidator(spec, { validateSecurity: true });
 app.use(validateRequests(validator));
 ```
 
-The check is shape-only — it confirms the declared credential is _present_, not that it's _valid_. Don't treat it as a substitute for auth middleware.
+The check is shape-only: it confirms the declared credential is _present_, not that it's _valid_. Don't treat it as a substitute for auth middleware.
 
 ### Skip validation for paths the spec doesn't declare
 
-The validator owns this — pass it `ignorePaths` or `ignoreUndocumented` at construction. See `ValidatorOptions` in `oav-core` for the contract.
+The validator owns this: pass it `ignorePaths` or `ignoreUndocumented` at construction. See `ValidatorOptions` in `oav-core` for the contract.
 
 ```ts
 const validator = createValidator(spec, {
@@ -185,7 +185,7 @@ The middleware awaits the returned promise. Express 5 awaits the middleware itse
 
 ### Per-route mounting
 
-`validateRequests(...)` is route-aware (it derives the operation from method+path). Mount it once at the app level — per-route mounting is redundant and may cause double-validation under nested routers.
+`validateRequests(...)` is route-aware (it derives the operation from method+path). Mount it once at the app level; per-route mounting is redundant and may cause double-validation under nested routers.
 
 ### Global validator + per-route multer (file uploads)
 
@@ -196,14 +196,14 @@ When the validator is mounted globally and one or a few routes accept file uploa
 Same package shape, same exports, same defaults. The only differences:
 
 - The middleware returned by `validateRequests` is `async` (Express 5 awaits returned promises).
-- No `try/catch` wrapper around the extractor — Express 5 routes thrown errors and rejected promises to the error chain via the promise itself.
+- No `try/catch` wrapper around the extractor; Express 5 routes thrown errors and rejected promises to the error chain via the promise itself.
 - `peerDependencies` requires `express ^5.0.0` (oav-express4 requires `^4.0.0`).
 
 A migrating consumer's `import { validateRequests } from "@aahoughton/oav-express5"` is the only line that changes after upgrading from oav-express4.
 
 ## See also
 
-- [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — `createValidator`, `ValidatorOptions`, `formatSummary`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
-- [`oav`](https://www.npmjs.com/package/@aahoughton/oav) — batteries-included distribution of oav-core: YAML readers + the `oav` CLI.
-- The repo-root [`docs/integration.md`](../../docs/integration.md) — broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
-- The repo-root [`docs/migration-from-eov.md`](../../docs/migration-from-eov.md) — porting from `express-openapi-validator`.
+- [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core): `createValidator`, `ValidatorOptions`, `formatSummary`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
+- [`oav`](https://www.npmjs.com/package/@aahoughton/oav): batteries-included distribution of oav-core (YAML readers + the `oav` CLI).
+- The repo-root [`docs/integration.md`](../../docs/integration.md): broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
+- The repo-root [`docs/migration-from-eov.md`](../../docs/migration-from-eov.md): porting from `express-openapi-validator`.

--- a/packages/oav-express5/src/extract.ts
+++ b/packages/oav-express5/src/extract.ts
@@ -4,7 +4,7 @@ import type { HttpRequest } from "@oav/core";
 /**
  * Convert an Express 5 `Request` to oav's framework-agnostic
  * {@link HttpRequest} shape. Read what's already on `req`; do not
- * touch the body parser or any async source — bodies are assumed
+ * touch the body parser or any async source; bodies are assumed
  * already-parsed by `express.json()` (or equivalent) upstream of
  * the validator middleware.
  *
@@ -17,7 +17,7 @@ import type { HttpRequest } from "@oav/core";
  * them, otherwise omitted.
  *
  * Pairs with sibling `httpRequestFromExpress` in `oav-express4`,
- * `httpRequestFromFastify` in `oav-fastify`, etc. — same name pattern
+ * `httpRequestFromFastify` in `oav-fastify`, etc.: same name pattern
  * as oav's existing {@link httpRequestFromFetch}.
  *
  * @public

--- a/packages/oav-express5/src/index.ts
+++ b/packages/oav-express5/src/index.ts
@@ -1,11 +1,11 @@
 /**
- * The public `oav-express5` surface — three exports plus the type
+ * The public `oav-express5` surface: three exports plus the type
  * shape every adapter in the family shares.
  *
- * - {@link validateRequests} — middleware factory; the 80% case.
- * - {@link httpRequestFromExpress} — standalone extractor; for
+ * - {@link validateRequests}: middleware factory; the 80% case.
+ * - {@link httpRequestFromExpress}: standalone extractor; for
  *   callers composing their own middleware.
- * - {@link renderProblemDetails} — the default error renderer;
+ * - {@link renderProblemDetails}: the default error renderer;
  *   reusable from any custom middleware.
  *
  * Naming and option shapes are deliberately consistent with the
@@ -26,7 +26,7 @@ export { validateRequests, type ValidateRequestsOptions } from "./middleware.js"
 export type { ErrorHandler, ExpressContext } from "./types.js";
 
 // Re-export the types that appear in our own option signatures. Strictly
-// not duplication of oav-core's surface — these ARE the adapter's
+// not duplication of oav-core's surface; these ARE the adapter's
 // public contract, just borrowed for non-duplication reasons. Importing
 // them from this package means consumers don't have to know which
 // package owns them.

--- a/packages/oav-express5/src/middleware.ts
+++ b/packages/oav-express5/src/middleware.ts
@@ -9,7 +9,7 @@ import type { ErrorHandler, ExpressContext } from "./types.js";
  * Options for {@link validateRequests}. Names and semantics are
  * shared with future {@link validateResponses} and with the same
  * options on every other adapter in the family (`oav-express4`,
- * `oav-fastify`, ...) — only the framework-typed argument differs.
+ * `oav-fastify`, ...); only the framework-typed argument differs.
  *
  * @public
  */
@@ -24,11 +24,11 @@ export interface ValidateRequestsOptions {
   toHttpRequest?: (req: Request) => HttpRequest;
   /**
    * Called when {@link Validator.validateRequest} returns an error.
-   * Default: {@link renderProblemDetails} — RFC 9457
+   * Default: {@link renderProblemDetails}: RFC 9457
    * `application/problem+json` with status from `httpStatusFor`.
    * Pass your own to render a custom envelope, call `next(err)`,
    * map to a different status, etc. The middleware does not call
-   * `next()` after invoking `onError` — the callback is the response.
+   * `next()` after invoking `onError`; the callback is the response.
    */
   onError?: ErrorHandler<ExpressContext>;
 }
@@ -40,7 +40,7 @@ export interface ValidateRequestsOptions {
  * an RFC 9457 problem-details response.
  *
  * Plural (`validateRequests`, not `validateRequest`) because the
- * middleware intercepts every request — the singular form is the
+ * middleware intercepts every request; the singular form is the
  * Validator's own per-call method.
  *
  * Express 5 is promise-native: this middleware is `async`, and

--- a/packages/oav-express5/src/render.ts
+++ b/packages/oav-express5/src/render.ts
@@ -12,9 +12,9 @@ import type { ExpressContext } from "./types.js";
  * Exported standalone for two cases:
  *
  * 1. You want oav's rendering as the fallback in your own
- *    middleware — call this directly when you don't want to handle
+ *    middleware: call this directly when you don't want to handle
  *    the error yourself.
- * 2. You want a slightly different renderer — use this as the
+ * 2. You want a slightly different renderer: use this as the
  *    starting point and adjust (e.g. swap the body, override the
  *    status, add headers).
  *

--- a/packages/oav-express5/src/types.ts
+++ b/packages/oav-express5/src/types.ts
@@ -6,7 +6,7 @@ import type { ValidationError } from "@oav/core";
  * `onError` callbacks so they can render their own response, call
  * `next(err)`, or whatever the host app's error contract requires.
  *
- * Identical in shape to what an inline middleware would close over —
+ * Identical in shape to what an inline middleware would close over;
  * the type is exported only so users can annotate their callbacks.
  *
  * @public
@@ -20,7 +20,7 @@ export interface ExpressContext {
 /**
  * Signature shared by `onError` on every adapter in the family
  * (`oav-express4`, `oav-express5`, future `oav-fastify`, ...). The
- * `Ctx` parameter is the only thing that varies — same name and shape
+ * `Ctx` parameter is the only thing that varies; same name and shape
  * everywhere.
  *
  * Returning a Promise is supported on every adapter. `oav-express5`

--- a/packages/oav-express5/test/middleware.test.ts
+++ b/packages/oav-express5/test/middleware.test.ts
@@ -149,7 +149,7 @@ describe("validateRequests", () => {
     const next = vi.fn() as unknown as NextFunction;
     // Express 5 awaits the returned promise; thrown errors reach the
     // error chain via the promise rejection. The middleware itself
-    // doesn't try/catch — Express does.
+    // doesn't try/catch; Express does.
     await expect(
       mw(fakeReq({ method: "GET", path: "/pets", headers: {} }), res, next),
     ).rejects.toBe(boom);

--- a/packages/oav-express5/tsup.config.ts
+++ b/packages/oav-express5/tsup.config.ts
@@ -3,7 +3,7 @@ import type { Plugin } from "esbuild";
 import { defineConfig } from "tsup";
 
 /**
- * Build config for `oav-express5` — the Express 5 adapter.
+ * Build config for `oav-express5`, the Express 5 adapter.
  * Same shape as oav-express4: thin tarball, oav-core externalized,
  * express marked external (peer dep).
  */

--- a/packages/oav-fastify/README.md
+++ b/packages/oav-fastify/README.md
@@ -1,8 +1,8 @@
 # oav-fastify
 
-Fastify adapter for [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — a `preValidation` hook factory plus standalone helpers (`httpRequestFromFastify`, `renderProblemDetails`) for callers composing their own hooks.
+Fastify adapter for [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core): a `preValidation` hook factory plus standalone helpers (`httpRequestFromFastify`, `renderProblemDetails`) for callers composing their own hooks.
 
-Same shape as the Express siblings ([`oav-express4`](../oav-express4/README.md), [`oav-express5`](../oav-express5/README.md)) — only the framework-typed argument and Fastify's hook-vs-middleware distinction differ. Fastify is async-native, so thrown errors and rejected promises propagate to Fastify's error handler automatically, with no `try/catch` wrapper.
+Same shape as the Express siblings ([`oav-express4`](../oav-express4/README.md), [`oav-express5`](../oav-express5/README.md)); only the framework-typed argument and Fastify's hook-vs-middleware distinction differ. Fastify is async-native, so thrown errors and rejected promises propagate to Fastify's error handler automatically, with no `try/catch` wrapper.
 
 Sibling packages: [`oav-express4`](../oav-express4/README.md), [`oav-express5`](../oav-express5/README.md). Same export names, option shapes, and defaults; only the framework-typed argument differs.
 
@@ -16,9 +16,9 @@ npm install @aahoughton/oav-core @aahoughton/oav-fastify fastify
 npm install @aahoughton/oav @aahoughton/oav-fastify fastify
 ```
 
-`fastify` is a peer dep — your app's existing install satisfies it.
+`fastify` is a peer dep; your app's existing install satisfies it.
 
-> **YAML specs.** `oav-core` is JSON-only by design (zero runtime deps). If your spec is YAML, either install [`oav`](https://www.npmjs.com/package/@aahoughton/oav) instead — it bundles the YAML readers and the CLI — or install `yaml` separately and parse the spec yourself before passing the parsed object to `createValidator`.
+> **YAML specs.** `oav-core` is JSON-only by design (zero runtime deps). If your spec is YAML, either install [`oav`](https://www.npmjs.com/package/@aahoughton/oav) instead (it bundles the YAML readers and the CLI), or install `yaml` separately and parse the spec yourself before passing the parsed object to `createValidator`.
 
 ## Quick start
 
@@ -41,14 +41,14 @@ Invalid requests receive a `400 application/problem+json` response (status from 
 
 Fastify runs hooks in a fixed order:
 
-1. `onRequest` — request parsing not yet done
-2. `preParsing` — about to parse the body
-3. `preValidation` — body parsed; **this is where oav runs**
-4. `validation` — Fastify's per-route schema validation
-5. `preHandler` — about to call the route handler
+1. `onRequest`: request parsing not yet done
+2. `preParsing`: about to parse the body
+3. `preValidation`: body parsed; **this is where oav runs**
+4. `validation`: Fastify's per-route schema validation
+5. `preHandler`: about to call the route handler
 6. `handler`
 
-Mount on `preValidation` so oav sees the parsed body. If you also have per-route Fastify schemas declared, Fastify's own validation runs in step 4 (after this hook). Both can coexist — if oav rejects, Fastify's own validation never runs; if oav passes, Fastify's runs as usual. Authoring the same constraints in both places isn't recommended, but mixing them (oav for spec-driven validation, Fastify schemas for app-internal types) works.
+Mount on `preValidation` so oav sees the parsed body. If you also have per-route Fastify schemas declared, Fastify's own validation runs in step 4 (after this hook). Both can coexist: if oav rejects, Fastify's own validation never runs; if oav passes, Fastify's runs as usual. Authoring the same constraints in both places isn't recommended, but mixing them (oav for spec-driven validation, Fastify schemas for app-internal types) works.
 
 ## API
 
@@ -61,17 +61,17 @@ Returns a Fastify `preValidationHookHandler`.
 | `toHttpRequest` | `(request: FastifyRequest) => HttpRequest` | `httpRequestFromFastify` |
 | `onError`       | `(err, ctx) => void \| Promise<void>`      | `renderProblemDetails`   |
 
-`onError` may be async — the hook awaits it. Fastify awaits the returned promise, so thrown extractor errors and rejected `onError` promises propagate to Fastify's `setErrorHandler` automatically, no `try/catch` needed. The hook does **not** call `reply.send()` after `onError` returns — your callback owns the response (write to `ctx.reply`, or throw to delegate to Fastify's error handler).
+`onError` may be async; the hook awaits it. Fastify awaits the returned promise, so thrown extractor errors and rejected `onError` promises propagate to Fastify's `setErrorHandler` automatically, no `try/catch` needed. The hook does **not** call `reply.send()` after `onError` returns; your callback owns the response (write to `ctx.reply`, or throw to delegate to Fastify's error handler).
 
-> **Validation failures don't traverse Fastify's `setErrorHandler` by default.** The default `onError` (`renderProblemDetails`) writes the response directly. If you want validation failures in your existing error pipeline, throw from `onError` (Fastify routes throws to `setErrorHandler`) or compose a logger before `renderProblemDetails` — see [Add observability without changing the response](#add-observability-without-changing-the-response).
+> **Validation failures don't traverse Fastify's `setErrorHandler` by default.** The default `onError` (`renderProblemDetails`) writes the response directly. If you want validation failures in your existing error pipeline, throw from `onError` (Fastify routes throws to `setErrorHandler`) or compose a logger before `renderProblemDetails`; see [Add observability without changing the response](#add-observability-without-changing-the-response).
 
 ### `httpRequestFromFastify(request)`
 
-Convert a `FastifyRequest` to oav's framework-agnostic `HttpRequest` shape. Read what's already on the request — body parsing is Fastify's responsibility (handled by content-type parsers before `preValidation`).
+Convert a `FastifyRequest` to oav's framework-agnostic `HttpRequest` shape. Read what's already on the request; body parsing is Fastify's responsibility (handled by content-type parsers before `preValidation`).
 
 Header keys passed through (Fastify already lowercases per HTTP spec), path stripped of query string from `request.url`, query taken from `request.query` (Fastify parses it into an object), cookies read from `request.cookies` if `@fastify/cookie` populated them.
 
-**Returns a fresh `HttpRequest`.** Top-level fields can be reassigned freely without affecting the original `FastifyRequest` — safe to spread (`{ ...httpRequestFromFastify(req), body: {} }`) or mutate in place.
+**Returns a fresh `HttpRequest`.** Top-level fields can be reassigned freely without affecting the original `FastifyRequest`; safe to spread (`{ ...httpRequestFromFastify(req), body: {} }`) or mutate in place.
 
 Use this when you want to compose your own hook (e.g. validate inside a custom plugin) without re-implementing the extraction.
 
@@ -94,14 +94,14 @@ validateRequests(validator, {
 
 ### Enable shape-only security checks (no auth middleware yet)
 
-`ValidatorOptions.validateSecurity` is off by default — real apps run auth middleware (or hooks) upstream of the validator. During early dev (no auth wired yet) or with decorator-only auth that just attaches `request.user`, opt in:
+`ValidatorOptions.validateSecurity` is off by default; real apps run auth middleware (or hooks) upstream of the validator. During early dev (no auth wired yet) or with decorator-only auth that just attaches `request.user`, opt in:
 
 ```ts
 const validator = createValidator(spec, { validateSecurity: true });
 app.addHook("preValidation", validateRequests(validator));
 ```
 
-The check is shape-only — it confirms the declared credential is _present_, not that it's _valid_. Don't treat it as a substitute for auth middleware.
+The check is shape-only: it confirms the declared credential is _present_, not that it's _valid_. Don't treat it as a substitute for auth middleware.
 
 ### Custom error envelope
 
@@ -121,7 +121,7 @@ app.addHook(
 
 ### Forward to Fastify's `setErrorHandler`
 
-Throw from `onError` — Fastify routes thrown errors to `setErrorHandler`:
+Throw from `onError`; Fastify routes thrown errors to `setErrorHandler`:
 
 ```ts
 app.addHook(
@@ -180,7 +180,7 @@ The hook awaits the returned promise; rejections propagate to Fastify's `setErro
 
 Fastify's idiomatic per-route-schema pattern is independent of oav. The two can coexist in the same app:
 
-- Use **oav-fastify** when the OpenAPI spec is the source of truth — for endpoints whose contract is published / contract-tested / shared with other languages or services.
+- Use **oav-fastify** when the OpenAPI spec is the source of truth, for endpoints whose contract is published / contract-tested / shared with other languages or services.
 - Use **Fastify per-route schemas** for app-internal types where you'd rather author the schema inline.
 
 If both fire on the same route, oav's `preValidation` hook runs first; if it passes, Fastify's `validation` step runs next. Don't author the same constraints in both places.
@@ -191,7 +191,7 @@ If both fire on the same route, oav's `preValidation` hook runs first; if it pas
 
 ## See also
 
-- [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core) — `createValidator`, `ValidatorOptions`, `formatSummary`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
-- [`oav`](https://www.npmjs.com/package/@aahoughton/oav) — batteries-included distribution of oav-core: YAML readers + the `oav` CLI.
-- The repo-root `docs/integration.md` — broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
-- The repo-root `docs/migration-from-eov.md` — porting from `express-openapi-validator`.
+- [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core): `createValidator`, `ValidatorOptions`, `formatSummary`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
+- [`oav`](https://www.npmjs.com/package/@aahoughton/oav): batteries-included distribution of oav-core (YAML readers + the `oav` CLI).
+- The repo-root `docs/integration.md`: broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
+- The repo-root `docs/migration-from-eov.md`: porting from `express-openapi-validator`.

--- a/packages/oav-fastify/src/extract.ts
+++ b/packages/oav-fastify/src/extract.ts
@@ -4,26 +4,26 @@ import type { HttpRequest } from "@oav/core";
 /**
  * Convert a Fastify `FastifyRequest` to oav's framework-agnostic
  * {@link HttpRequest} shape. Read what's already on the request;
- * do not touch the body parser or any async source — bodies are
+ * do not touch the body parser or any async source; bodies are
  * assumed already-parsed by Fastify's content-type parsers
  * (which run before `preValidation`).
  *
  * Header keys are already lowercased by Fastify (per HTTP spec); we
  * pass them through. The path is extracted from `request.url` (which
- * includes the query string) — query string is dropped from the
+ * includes the query string); query string is dropped from the
  * `path` field and routed to `query` separately.
  *
  * Cookies are read from `request.cookies` if `@fastify/cookie` has
  * populated them, otherwise omitted.
  *
  * Pairs with sibling `httpRequestFromExpress` in `oav-express4` /
- * `oav-express5`, future `httpRequestFromHono`, etc. — same name
+ * `oav-express5`, future `httpRequestFromHono`, etc.; same name
  * pattern as oav's existing {@link httpRequestFromFetch}.
  *
  * @public
  */
 export function httpRequestFromFastify(request: FastifyRequest): HttpRequest {
-  // request.url is /path?query — extract pathname.
+  // request.url is /path?query; extract pathname.
   const url = new URL(request.url, "http://localhost");
   const headers: Record<string, string | string[]> = {};
   for (const [key, value] of Object.entries(request.headers)) {

--- a/packages/oav-fastify/src/index.ts
+++ b/packages/oav-fastify/src/index.ts
@@ -1,12 +1,12 @@
 /**
- * The public `oav-fastify` surface — three exports plus the type
+ * The public `oav-fastify` surface: three exports plus the type
  * shape every adapter in the family shares.
  *
- * - {@link validateRequests} — preValidation hook factory; the
+ * - {@link validateRequests}: preValidation hook factory; the
  *   80% case.
- * - {@link httpRequestFromFastify} — standalone extractor; for
+ * - {@link httpRequestFromFastify}: standalone extractor; for
  *   callers composing their own hooks.
- * - {@link renderProblemDetails} — the default error renderer;
+ * - {@link renderProblemDetails}: the default error renderer;
  *   reusable from any custom hook.
  *
  * Naming and option shapes are deliberately consistent with the
@@ -27,7 +27,7 @@ export { validateRequests, type ValidateRequestsOptions } from "./middleware.js"
 export type { ErrorHandler, FastifyContext } from "./types.js";
 
 // Re-export the types that appear in our own option signatures. Strictly
-// not duplication of oav-core's surface — these ARE the adapter's
+// not duplication of oav-core's surface; these ARE the adapter's
 // public contract, just borrowed for non-duplication reasons. Importing
 // them from this package means consumers don't have to know which
 // package owns them.

--- a/packages/oav-fastify/src/middleware.ts
+++ b/packages/oav-fastify/src/middleware.ts
@@ -9,7 +9,7 @@ import type { ErrorHandler, FastifyContext } from "./types.js";
  * Options for {@link validateRequests}. Names and semantics are
  * shared with future {@link validateResponses} and with the same
  * options on every other adapter in the family (`oav-express4`,
- * `oav-express5`, future `oav-hono`, ...) — only the
+ * `oav-express5`, future `oav-hono`, ...); only the
  * framework-typed argument differs.
  *
  * @public
@@ -25,11 +25,11 @@ export interface ValidateRequestsOptions {
   toHttpRequest?: (request: FastifyRequest) => HttpRequest;
   /**
    * Called when {@link Validator.validateRequest} returns an error.
-   * Default: {@link renderProblemDetails} — RFC 9457
+   * Default: {@link renderProblemDetails}: RFC 9457
    * `application/problem+json` with status from `httpStatusFor`.
    * Pass your own to render a custom envelope, throw (handed to
    * Fastify's error handler), map to a different status, etc. The
-   * hook does not call `reply.send()` after invoking `onError` —
+   * hook does not call `reply.send()` after invoking `onError`;
    * the callback is the response.
    */
   onError?: ErrorHandler<FastifyContext>;
@@ -42,13 +42,13 @@ export interface ValidateRequestsOptions {
  * `onError` writes an RFC 9457 problem-details response.
  *
  * Plural (`validateRequests`, not `validateRequest`) because the
- * hook intercepts every request — the singular form is the
+ * hook intercepts every request; the singular form is the
  * Validator's own per-call method.
  *
  * Mount on `preValidation` so it runs after Fastify's content-type
  * parsers (which populate `request.body`) but before route
  * handlers and Fastify's own per-route schema validation (which
- * runs in the `validation` step). Both can coexist — Fastify's own
+ * runs in the `validation` step). Both can coexist; Fastify's own
  * per-route schemas run after this hook; oav's failures are
  * surfaced first.
  *
@@ -80,7 +80,7 @@ export function validateRequests(
     if (err === null) return;
     // Fastify awaits the returned promise; thrown errors / rejected
     // promises propagate to Fastify's error handler. The hook
-    // returns once onError settles — Fastify treats a sent reply
+    // returns once onError settles; Fastify treats a sent reply
     // as "we handled it, skip the route handler."
     await onError(err, { request, reply });
   };

--- a/packages/oav-fastify/src/render.ts
+++ b/packages/oav-fastify/src/render.ts
@@ -14,7 +14,7 @@ import type { FastifyContext } from "./types.js";
  * 1. You want oav's rendering as the fallback in your own hook —
  *    call this directly when you don't want to handle the error
  *    yourself.
- * 2. You want a slightly different renderer — use this as the
+ * 2. You want a slightly different renderer: use this as the
  *    starting point and adjust (e.g. swap the body, override the
  *    status, add headers).
  *

--- a/packages/oav-fastify/src/types.ts
+++ b/packages/oav-fastify/src/types.ts
@@ -6,7 +6,7 @@ import type { ValidationError } from "@oav/core";
  * `onError` callbacks so they can render their own response or
  * delegate to Fastify's error handler.
  *
- * Identical in shape to what an inline hook would close over —
+ * Identical in shape to what an inline hook would close over;
  * the type is exported only so users can annotate their callbacks.
  *
  * Pairs with `ExpressContext` from `oav-express4` / `oav-express5`.
@@ -25,7 +25,7 @@ export interface FastifyContext {
  * Signature shared by `onError` on every adapter in the family
  * (`oav-express4`, `oav-express5`, `oav-fastify`, future
  * `oav-hono`, ...). The `Ctx` parameter is the only thing that
- * varies — same name and shape everywhere.
+ * varies; same name and shape everywhere.
  *
  * Returning a Promise is supported on every adapter. `oav-fastify`
  * awaits the return; rejected promises propagate through Fastify's

--- a/packages/oav-fastify/test/integration.test.ts
+++ b/packages/oav-fastify/test/integration.test.ts
@@ -9,7 +9,7 @@ import { validateRequests } from "../src/middleware.js";
 /**
  * Real-server integration tests against Fastify. Uses
  * `fastify.inject()` (Fastify-native synthetic-request API) instead
- * of `app.listen(0)` + native fetch — `inject` is so idiomatic in
+ * of `app.listen(0)` + native fetch; `inject` is so idiomatic in
  * Fastify-land that bending the cross-adapter native-fetch
  * convention here earns its keep. Same `it()` names as the Express
  * adapters' integration suites; the implementations differ only

--- a/packages/oav-fastify/tsup.config.ts
+++ b/packages/oav-fastify/tsup.config.ts
@@ -3,7 +3,7 @@ import type { Plugin } from "esbuild";
 import { defineConfig } from "tsup";
 
 /**
- * Build config for `oav-fastify` — the Fastify adapter.
+ * Build config for `oav-fastify`, the Fastify adapter.
  * Same shape as oav-express4 / oav-express5: thin tarball,
  * oav-core externalized, fastify marked external (peer dep).
  */

--- a/packages/oav/README.md
+++ b/packages/oav/README.md
@@ -26,18 +26,18 @@ const validator = createValidator(document);
 (`oav/schema`, `oav/spec`, `oav/formats`, `oav/core`,
 `oav/schema/internals`, `oav/validator/internals`). Code written
 against one swaps to the other by changing the package name in
-imports — no surface changes.
+imports; no surface changes.
 
 ## What this package adds
 
-- **`createYamlFileReader()`** — file reader for `.yaml` / `.yml`
+- **`createYamlFileReader()`**: file reader for `.yaml` / `.yml`
   paths. Calling `oav-core`'s `createFileReader()` on a YAML path
   throws an install-hint pointing here.
-- **`createSmartHttpReader()`** — HTTP reader that parses both JSON
+- **`createSmartHttpReader()`**: HTTP reader that parses both JSON
   and YAML by inspecting `Content-Type` / file extension.
-- **`parseYamlString(source)`** — exposed for callers loading YAML
+- **`parseYamlString(source)`**: exposed for callers loading YAML
   out-of-band (e.g. fetched from a config service).
-- **The `oav` CLI binary** — `oav resolve`, `oav validate`,
+- **The `oav` CLI binary**: `oav resolve`, `oav validate`,
   `oav compile-schema`, `oav compile-spec`. See
   [`packages/cli/README.md`](../cli/README.md) for commands and
   flags.
@@ -46,15 +46,15 @@ Everything else (`createValidator`, `compileSchema`, error helpers,
 formatters, `formatSummary`, `toProblemDetails`, HTTP-status helpers, …)
 is re-exported from `oav-core`. Documentation for those lives in:
 
-- [`packages/core/README.md`](../core/README.md) — error tree,
+- [`packages/core/README.md`](../core/README.md): error tree,
   formatters, HTTP helpers.
-- [`packages/validator/README.md`](../validator/README.md) — the
+- [`packages/validator/README.md`](../validator/README.md): the
   HTTP validator.
-- [`packages/schema/README.md`](../schema/README.md) — the JSON
+- [`packages/schema/README.md`](../schema/README.md): the JSON
   Schema compiler.
-- [`packages/spec/README.md`](../spec/README.md) — multi-file
+- [`packages/spec/README.md`](../spec/README.md): multi-file
   loader, resolver, overlays.
-- [`packages/formats/README.md`](../formats/README.md) — built-in
+- [`packages/formats/README.md`](../formats/README.md): built-in
   string format validators.
 
 ## Framework integration
@@ -70,10 +70,10 @@ the Web Standards adapter.
 
 ## See also
 
-- [Top-level `README.md`](../../README.md) — full rationale, install
+- [Top-level `README.md`](../../README.md): full rationale, install
   matrix, comparison.
-- [`docs/integration.md`](../../docs/integration.md) — adapter recipes,
+- [`docs/integration.md`](../../docs/integration.md): adapter recipes,
   security wiring, response validation, file uploads, migration.
-- [`docs/overlays.md`](../../docs/overlays.md) — extending an externally-owned
+- [`docs/overlays.md`](../../docs/overlays.md): extending an externally-owned
   base spec at load time.
-- [`docs/comparison.md`](../../docs/comparison.md) — feature comparison vs Ajv.
+- [`docs/comparison.md`](../../docs/comparison.md): feature comparison vs Ajv.

--- a/packages/oav/src/cli.ts
+++ b/packages/oav/src/cli.ts
@@ -3,7 +3,7 @@ export {};
 
 // `commander` and `esbuild` are regular dependencies of
 // `oav`, so a normal install puts them in node_modules.
-// If they're missing, the install is corrupted — catch the dynamic
+// If they're missing, the install is corrupted; catch the dynamic
 // import up front and print a clearer message than the default
 // ERR_MODULE_NOT_FOUND trace.
 for (const { name, purpose } of [
@@ -34,7 +34,7 @@ const { createSmartHttpReader, createYamlFileReader } = await import("./yaml.js"
 // front of the JSON-only readers baked into @oav/cli's defaultCommandIo,
 // so `oav resolve spec.yaml` and `oav resolve https://host/openapi`
 // work out of the box. createSmartHttpReader handles both JSON and
-// YAML over HTTP by inspecting Content-Type — it replaces the core
+// YAML over HTTP by inspecting Content-Type; it replaces the core
 // createHttpReader in the chain for any http(s) URI.
 const baseIo = defaultCommandIo();
 const io = {

--- a/packages/oav/src/index.ts
+++ b/packages/oav/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * `oav` — batteries-included distribution. Re-exports the
+ * `oav`: batteries-included distribution. Re-exports the
  * full surface of `oav-core` and adds YAML readers so
  * `loadSpec` works against hand-authored `.yaml` specs out of the
  * box. Also ships the `oav` CLI binary.

--- a/packages/oav/src/spec.ts
+++ b/packages/oav/src/spec.ts
@@ -1,7 +1,7 @@
 // Re-export of `oav-core/spec`. JSON-only readers; the
 // batteries-included readers (`createYamlFileReader`,
 // `createSmartHttpReader`, `parseYamlString`) live at the root of
-// `oav` — compose them ahead of the readers in this
+// `oav`. Compose them ahead of the readers in this
 // subpath when loading YAML specs or fetching over HTTP with
 // Content-Type dispatch.
 export * from "@oav/spec";

--- a/packages/oav/src/yaml.ts
+++ b/packages/oav/src/yaml.ts
@@ -3,7 +3,7 @@
  * `oav` distribution. Each implements
  * {@link @aahoughton/oav/spec!DocumentReader} and is designed to be
  * composed via
- * {@link @aahoughton/oav/spec!composeReaders} — order YAML readers
+ * {@link @aahoughton/oav/spec!composeReaders}: order YAML readers
  * first so the JSON-only readers in `oav-core/spec` act
  * as the fallback for `.json` paths.
  *
@@ -130,7 +130,7 @@ export function createSmartHttpReader(): DocumentReader {
       // Ambiguous Content-Type: use URL extension as the tiebreaker,
       // defaulting to JSON for extensionless URLs. A misconfigured
       // server that returns YAML with `text/plain` and a URL like
-      // `/openapi` will fail with a JSON parse error — escape hatch is
+      // `/openapi` will fail with a JSON parse error; escape hatch is
       // to supply a `.yaml` suffix or plug in a custom reader.
       if (hasYamlExtension(uri)) return parseYaml(text);
       return JSON.parse(text);

--- a/packages/oav/test/readers.test.ts
+++ b/packages/oav/test/readers.test.ts
@@ -82,7 +82,7 @@ describe("createSmartHttpReader", () => {
     ]) {
       stubFetch("openapi: 3.1.0\ninfo: { title: X, version: '1' }", ct);
       const r = createSmartHttpReader();
-      // URL has no yaml extension on purpose — Content-Type drives the pick.
+      // URL has no yaml extension on purpose; Content-Type drives the pick.
       expect(await r.read("https://api.example.com/openapi"), `ct=${ct}`).toEqual({
         openapi: "3.1.0",
         info: { title: "X", version: "1" },

--- a/packages/oav/tsup.config.ts
+++ b/packages/oav/tsup.config.ts
@@ -3,14 +3,14 @@ import type { Plugin } from "esbuild";
 import { defineConfig } from "tsup";
 
 /**
- * Build config for `oav` — the batteries-included tarball.
+ * Build config for `oav`, the batteries-included tarball.
  * Emits subpath shims that re-export `oav-core/*`, adds
  * the YAML readers at the root entry, and bundles the `oav` CLI.
  *
  * Dependency shape:
  * - `oav-core` and `yaml` are external runtime deps the
  *   consumer's install already provides.
- * - `commander` is an external optional-peer — resolved at CLI run
+ * - `commander` is an external optional-peer, resolved at CLI run
  *   time with a clear error when missing.
  * - `@oav/cli` (the workspace package that owns the CLI logic) is
  *   bundled in, along with everything it transitively imports from
@@ -23,7 +23,7 @@ import { defineConfig } from "tsup";
  * Two configs are exported: the library entries emit both ESM and
  * CJS, while the CLI emits ESM only (top-level `await` in cli.ts
  * isn't legal in a CJS output, and the `bin` field points at
- * `./dist/cli.js` — Node picks up the ESM build regardless of
+ * `./dist/cli.js`. Node picks up the ESM build regardless of
  * consumers' package type).
  */
 const repoRoot = resolve(__dirname, "..", "..");

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -1,6 +1,6 @@
 # @oav/router
 
-> **Internal package — not published.** `@oav/router` is a workspace-private
+> **Internal package, not published.** `@oav/router` is a workspace-private
 > dependency of `oav`; it does not appear on npm and has no
 > published subpath. This README documents the internal surface for
 > contributors navigating the monorepo. Third-party consumers get the
@@ -33,5 +33,5 @@ case-insensitive. Path segments are percent-decoded.
 `RouteMatch.operation` is the same reference that was supplied to
 `createRouter`. The validator keys per-operation caches on this
 identity via `WeakMap`, so the router must not clone, merge, or
-otherwise reconstruct operations — if you write a custom router,
+otherwise reconstruct operations. If you write a custom router,
 preserve the spec-provided reference.

--- a/packages/router/src/matcher.ts
+++ b/packages/router/src/matcher.ts
@@ -3,10 +3,10 @@ import type { HttpMethod, OperationObject, PathItem } from "@oav/core";
 /**
  * Segments of a parsed OpenAPI path template. Three kinds:
  *
- * - `literal` — a fixed substring (`pets`).
- * - `template` — a single `{name}` parameter occupying the whole
+ * - `literal`: a fixed substring (`pets`).
+ * - `template`: a single `{name}` parameter occupying the whole
  *   segment (`{petId}`).
- * - `compound` — multiple `{name}` parameters interleaved with literal
+ * - `compound`: multiple `{name}` parameters interleaved with literal
  *   text inside one segment (`{sha}.{diffType}`,
  *   `{year}-{month}.json`). Carries a pre-compiled regex with one
  *   non-greedy capture group per template part so the matcher stays a
@@ -32,7 +32,7 @@ export type Segment =
  * `operation` and `pathItem` are the identical references supplied to
  * {@link createRouter}. Downstream consumers (notably `@oav/validator`)
  * key per-operation caches on `operation`'s object identity via
- * `WeakMap`, so any future router change must preserve that identity —
+ * `WeakMap`, so any future router change must preserve that identity:
  * do not clone, merge, or otherwise reconstruct these references.
  *
  * @public
@@ -49,8 +49,8 @@ export interface RouteMatch {
  * Result returned when the path template matched but the requested
  * method isn't declared on it. Semantically a 405 Method Not Allowed
  * rather than a 404. `allowed` is the union of HTTP methods declared
- * across every path template that matched the request path, uppercased
- * — suitable for an RFC 9110 `Allow` response header.
+ * across every path template that matched the request path, uppercased,
+ * suitable for an RFC 9110 `Allow` response header.
  *
  * @public
  */
@@ -65,10 +65,10 @@ export interface MethodNotAllowed {
 /**
  * The router interface. `match` returns:
  *
- * - `RouteMatch` — the path matched and the method is declared on it.
- * - `MethodNotAllowed` — the path matched but no declared method
+ * - `RouteMatch`: the path matched and the method is declared on it.
+ * - `MethodNotAllowed`: the path matched but no declared method
  *   handles the request's verb. Callers map this to HTTP 405.
- * - `undefined` — no path template matched at all. Callers map this
+ * - `undefined`: no path template matched at all. Callers map this
  *   to HTTP 404.
  *
  * @public
@@ -104,7 +104,7 @@ interface Route {
  * declared (RFC 9110 §9.3.2: GET implicitly answers HEAD via the
  * runtime fallback below). Used by the per-(method, structure)
  * ambiguity check so a pattern declaring GET reserves the HEAD slot
- * too — a structurally-identical sibling declaring explicit HEAD would
+ * too; a structurally-identical sibling declaring explicit HEAD would
  * otherwise slip past the check and silently win at match time.
  */
 function methodsDeclaredOn(item: PathItem): Set<HttpMethod> {
@@ -138,16 +138,16 @@ export function parseTemplate(template: string): Segment[] {
 }
 
 function parseSegment(seg: string): Segment {
-  // Pure literal — no template syntax at all. Common case; skip parsing.
+  // Pure literal: no template syntax at all. Common case; skip parsing.
   if (!seg.includes("{")) {
     return { kind: "literal", value: decodeURIComponent(seg) };
   }
-  // Pure template — the whole segment is one `{name}`.
+  // Pure template: the whole segment is one `{name}`.
   const pure = /^\{([^{}]+)\}$/.exec(seg);
   if (pure !== null) {
     return { kind: "template", name: pure[1]! };
   }
-  // Compound — alternating literal and `{name}` parts. Build a regex
+  // Compound: alternating literal and `{name}` parts. Build a regex
   // with one non-greedy `[^/]+?` capture per template part; the trailing
   // `$` anchor + lazy capture resolves multi-param ambiguity left-to-right
   // (e.g. `{x}.{y}` against `a.b.c` captures `x="a"`, `y="b.c"`), matching
@@ -161,7 +161,7 @@ function parseSegment(seg: string): Segment {
     if (ch === "{") {
       const end = seg.indexOf("}", i);
       if (end === -1) {
-        // Unterminated `{` — treat the rest as literal so we don't throw
+        // Unterminated `{`: treat the rest as literal so we don't throw
         // on a malformed template; match `path-to-regexp`'s tolerance.
         pendingLiteral += seg.slice(i);
         break;
@@ -183,7 +183,7 @@ function parseSegment(seg: string): Segment {
     regexSrc += escapeRegex(pendingLiteral);
   }
   regexSrc += "$";
-  // No template parts ended up in the segment despite a `{` — degenerate.
+  // No template parts ended up in the segment despite a `{`; degenerate.
   // Fall back to literal so behaviour matches the !includes("{") branch.
   if (names.length === 0) {
     return { kind: "literal", value: decodeURIComponent(seg) };
@@ -214,7 +214,7 @@ function segmentSignature(s: Segment): string {
  * Build a router from a map of `pathTemplate → PathItem`. Paths with more
  * literal (non-template) segments win over more template-heavy siblings;
  * the route list is sorted once at construction, then each `match` call is
- * a linear scan — O(routes × segments). That is cheap for the route counts
+ * a linear scan: O(routes × segments). That is cheap for the route counts
  * typical in OpenAPI specs (tens to low hundreds); swap in a proper radix
  * tree here if you're routing thousands of paths.
  *
@@ -237,7 +237,7 @@ export function createRouter(paths: Record<string, PathItem>): Router {
   const routes: Route[] = [];
   // Per-(method, structure) ambiguity index. Two patterns that differ
   // only in parameter names are an ill-formed document only when they
-  // also overlap on at least one HTTP method — disjoint-method siblings
+  // also overlap on at least one HTTP method; disjoint-method siblings
   // (e.g. `/items/{id}` GET and `/items/{slug}` POST) describe disjoint
   // routing cells and would never collide at match time. Real-world
   // specs (GitHub, Jira, Gmail, several AWS APIs) declare such pairs.

--- a/packages/router/test/router.test.ts
+++ b/packages/router/test/router.test.ts
@@ -161,7 +161,7 @@ describe("router", () => {
   it("flags GET-vs-explicit-HEAD as ambiguous on identical structure", () => {
     // GET implicitly answers HEAD via the runtime fallback (RFC 9110).
     // A sibling pattern declaring explicit HEAD on the same structure
-    // would silently win at match time depending on sort order — surface
+    // would silently win at match time depending on sort order; surface
     // it at construction.
     expect(() =>
       createRouter({

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -1,12 +1,12 @@
 # oav/schema
 
 JSON Schema 2020-12 compiler. Walks the schema once at construction
-time and emits a JavaScript function via code generation — no
+time and emits a JavaScript function via code generation, with no
 schema-walking on the hot path. Compiled validators return
 `{ valid, error? }` where `error` is a `ValidationError` tree.
 
 Use this module directly when you want schema validation without the
-HTTP layer — REST-less RPC bodies, config files, test fixtures, etc.
+HTTP layer (REST-less RPC bodies, config files, test fixtures, etc.).
 For OpenAPI request/response validation, use `createValidator` from
 the root entrypoint instead.
 
@@ -32,12 +32,12 @@ to every error's `path` (used by the HTTP validator to prefix `"body"`,
 
 ## Dialects
 
-Every compile picks exactly one `Dialect` — a vocabulary stack plus
+Every compile picks exactly one `Dialect`: a vocabulary stack plus
 the keyword-dispatcher rules that make it coherent. Three built-ins:
 
 | Dialect             | Spec                | `format`   | Extras                                                               |
 | ------------------- | ------------------- | ---------- | -------------------------------------------------------------------- |
-| `jsonSchemaDialect` | JSON Schema 2020-12 | annotation | —                                                                    |
+| `jsonSchemaDialect` | JSON Schema 2020-12 | annotation |                                                                      |
 | `openapi31Dialect`  | OpenAPI 3.1 / 3.2   | assertion  | Adds `formatAssertionVocabulary`                                     |
 | `oas30Dialect`      | OpenAPI 3.0         | assertion  | `nullable`, boolean `exclusive{Min,Max}`, `$ref`-suppresses-siblings |
 
@@ -61,14 +61,14 @@ const minimalDialect: Dialect = {
 
 Built-in vocabularies available to compose:
 
-- `coreVocabulary` — `$ref`, `$dynamicRef`, `$id`, `$defs`, anchors.
-- `validationVocabulary` — `type`, `enum`, `const`, numeric / string /
+- `coreVocabulary`: `$ref`, `$dynamicRef`, `$id`, `$defs`, anchors.
+- `validationVocabulary`: `type`, `enum`, `const`, numeric / string /
   array / object bounds, `required`.
-- `applicatorVocabulary` — composition keywords (`allOf`, `anyOf`,
+- `applicatorVocabulary`: composition keywords (`allOf`, `anyOf`,
   `oneOf`, `not`), nested schemas (`properties`, `items`, …),
   `if`/`then`/`else`, `discriminator`.
-- `unevaluatedVocabulary` — `unevaluatedProperties`, `unevaluatedItems`.
-- `formatVocabulary` / `formatAssertionVocabulary` — `format` as
+- `unevaluatedVocabulary`: `unevaluatedProperties`, `unevaluatedItems`.
+- `formatVocabulary` / `formatAssertionVocabulary`: `format` as
   annotation / assertion.
 
 ## Registering a custom keyword
@@ -100,7 +100,7 @@ with a built-in keyword throw at construction.
 
 The function form above covers most custom keywords. For applicator
 keywords (ones that descend into subschemas), evaluation-key tracking,
-or custom emit shapes, pass a full `KeywordDefinition` instead — the
+or custom emit shapes, pass a full `KeywordDefinition` instead. The
 `compile(ctx)` function receives a `KeywordCompileContext` that lets
 you emit generated code directly.
 
@@ -113,7 +113,7 @@ flag reference live in [`CLAUDE.md`](../../CLAUDE.md#how-to-add-a-new-keyword).
 short-circuits hot loops once the budget is exhausted. `maxErrors: 1`
 is classic fast-fail; larger values bound CPU/memory on huge invalid
 payloads. Results carry `truncated: true` when the tree was capped.
-Omit the option for zero-overhead unlimited collection — codegen is
+Omit the option for zero-overhead unlimited collection: codegen is
 specialised so uncapped callers emit plain `errors.push` with no
 budget checks.
 

--- a/packages/schema/src/codegen/codegen.ts
+++ b/packages/schema/src/codegen/codegen.ts
@@ -18,7 +18,7 @@ export interface NameGenerator {
  * implementation.
  *
  * If you find yourself wanting a method that isn't here (e.g. `forIn`,
- * `forRange`), open an issue — the interface is intentionally small so
+ * `forRange`), open an issue; the interface is intentionally small so
  * it's stable.
  *
  * @public

--- a/packages/schema/src/compiler/compiler.ts
+++ b/packages/schema/src/compiler/compiler.ts
@@ -20,7 +20,7 @@ import { createDeps, type ValidatorDeps } from "./runtime.js";
 
 // Token scan fed into CompileStats.emittedTreeRuntime. Word-boundaried
 // so stray mentions inside string literals (e.g. an error message that
-// happens to contain "wrapErrors") don't count — every real emission
+// happens to contain "wrapErrors") don't count; every real emission
 // spells the helper as a bare identifier.
 const TREE_RUNTIME_HELPERS = /\b(?:createLeafError|createBranchError|wrapErrors)\b/;
 
@@ -113,7 +113,7 @@ export interface CompileStats {
   /**
    * `true` iff the compiler actually emitted `evalProps` / `evalItems`
    * Set machinery anywhere in the generated source. When `false`, the
-   * unevaluated-keys-gating optimisation is taking effect — the schema
+   * unevaluated-keys-gating optimisation is taking effect: the schema
    * doesn't use `unevaluatedProperties` / `unevaluatedItems`, so the
    * compiler suppressed the per-function Set allocation and merge loop.
    * Surfaced so tests can assert on the optimisation directly instead
@@ -123,7 +123,7 @@ export interface CompileStats {
   /**
    * `true` iff the generated source references any tree-mode runtime
    * helper (`createLeafError`, `createBranchError`, `wrapErrors`). In
-   * predicate mode this MUST be `false` — the whole point of the mode
+   * predicate mode this MUST be `false`: the whole point of the mode
    * is to avoid allocating an error tree. Surfaced so the predicate-
    * mode contract can be asserted without grepping the generated JS.
    */
@@ -131,7 +131,7 @@ export interface CompileStats {
   /**
    * Warnings produced by {@link CompileOptions.strict}. Empty unless
    * strict mode is active and found something to flag. Never contains
-   * compile-blocking issues — strict mode only reports; the caller
+   * compile-blocking issues; strict mode only reports; the caller
    * decides whether to treat any entry as fatal.
    */
   strictIssues: readonly StrictIssue[];
@@ -165,7 +165,7 @@ export interface StrictIssue {
 /**
  * The function returned by {@link compileSchema}. Call it with any JSON value
  * to validate against the original schema. An optional `startPath`
- * is prepended to every error's `path` — useful when the compiled
+ * is prepended to every error's `path`, useful when the compiled
  * validator is embedded inside a larger traversal (e.g. the HTTP
  * validator prepends `["body"]`, `["query", name]`, etc.). The array
  * is cloned before use and never mutated.
@@ -183,7 +183,7 @@ export type CompiledSchema = {
 /**
  * The shape returned by {@link compileSchema} when `predicate: true` is
  * set. The validator collects no errors, allocates no tree, and
- * returns a boolean — a true yes/no predicate. Use when consumers only
+ * returns a boolean: a true yes/no predicate. Use when consumers only
  * need to know whether the value conforms (e.g. routing, gating), not
  * why it doesn't.
  *
@@ -204,10 +204,10 @@ export type CompiledPredicate = {
  * Ordering convention (shared with
  * {@link @aahoughton/oav!ValidatorOptions}):
  *
- *   1. Compile essentials — `dialect`.
- *   2. Shared extension points — `formats`, `keywords`.
- *   3. Error-collection policy — `maxErrors`.
- *   4. Surface-specific extras last — here, `external`, `refResolver`,
+ *   1. Compile essentials: `dialect`.
+ *   2. Shared extension points: `formats`, `keywords`.
+ *   3. Error-collection policy: `maxErrors`.
+ *   4. Surface-specific extras last: here, `external`, `refResolver`,
  *      `predicate`.
  *
  * Options common to both surfaces share names and positions so a
@@ -267,7 +267,7 @@ export interface CompileOptions {
    *
    * Must be a positive integer (>= 1) when supplied. A cap of 0 is
    * effectively predicate mode (no errors collected, validation
-   * collapses to yes/no) — for that, prefer
+   * collapses to yes/no); for that, prefer
    * {@link CompileOptions.predicate} which compiles a fully
    * specialised function with no error infrastructure at all.
    * `compileSchema` throws on `maxErrors <= 0`.
@@ -279,7 +279,7 @@ export interface CompileOptions {
    *
    * - `"off"`: silence on everything (pre-v-strict behaviour).
    * - `"warn-partial"` (default): warn on keywords flagged as
-   *   partially-implemented (currently `$dynamicRef` — its runtime
+   *   partially-implemented (currently `$dynamicRef`; its runtime
    *   dynamic-scope rebinding is not emitted).
    * - `"strict"`: warn on partial features AND unknown keys (keys not
    *   in the active dialect, not `x-*` extensions, not standard
@@ -291,12 +291,12 @@ export interface CompileOptions {
 
   /** Additional external named schemas that `$ref` can resolve to. */
   external?: Map<string, SchemaOrBoolean>;
-  /** Custom ref resolver — overrides the default (which resolves fragments within the root). */
+  /** Custom ref resolver; overrides the default (which resolves fragments within the root). */
   refResolver?: RefResolver;
   /**
    * When `true`, compile a boolean predicate rather than an
    * error-collecting validator. The returned {@link CompiledPredicate}'s
-   * `validate(data)` returns `boolean` — no {@link ValidationError}
+   * `validate(data)` returns `boolean`: no {@link ValidationError}
    * tree is ever constructed, so consumers who only need a yes/no
    * answer pay nothing for error-reporting machinery (leaf allocation,
    * path snapshot, params object, message string).
@@ -330,7 +330,7 @@ export interface CompileState {
   readonly compileValidator: (schema: SchemaOrBoolean) => string;
   /**
    * `true` when a finite `maxErrors` was configured. Codegen uses this
-   * to emit the extra budget checks — when errors are uncapped we emit
+   * to emit the extra budget checks; when errors are uncapped we emit
    * plain `errors.push` with no runtime overhead.
    */
   readonly gated: boolean;
@@ -351,7 +351,7 @@ export interface CompileState {
    * anywhere in the root schema or any registered external schema. When
    * `false`, the compiler suppresses allocation of per-function
    * `evalProps` / `evalItems` Sets and the merge loop that threads them
-   * back to the caller — machinery that's inert unless
+   * back to the caller: machinery that's inert unless
    * `unevaluated*` actually consumes it. OpenAPI specs essentially
    * never use these keywords, so the false path is the common case.
    */
@@ -370,7 +370,7 @@ export interface CompileState {
  * Return `true` iff `schema` (or any schema reachable from it through
  * subschema-valued positions) contains the `unevaluatedProperties` or
  * `unevaluatedItems` keyword. The detector is the gate for the
- * evaluated-keys-Set machinery — when it's `false`, the compiler emits
+ * evaluated-keys-Set machinery: when it's `false`, the compiler emits
  * a form that skips the per-function Set allocation entirely.
  */
 function schemaUsesUnevaluated(schema: SchemaOrBoolean): boolean {
@@ -465,7 +465,7 @@ export function compileSchema(
     // data; non-integers are likely a typo. Predicate mode is the
     // explicit way to skip error collection entirely. `Infinity` is
     // degenerate (equivalent to omitting the option) but harmless,
-    // and existing callers may pass it explicitly — accept it.
+    // and existing callers may pass it explicitly; accept it.
     throw new Error(
       `compileSchema: \`maxErrors\` must be a positive integer (got ${String(options.maxErrors)}). ` +
         "Use `predicate: true` if you want a yes/no validator with no error tree.",
@@ -477,8 +477,8 @@ export function compileSchema(
     // a finite maxErrors cap would be shadowed and callers would be
     // misled into thinking errors were being counted. Fail loudly.
     throw new Error(
-      "compileSchema: `predicate: true` is mutually exclusive with a finite `maxErrors` — " +
-        "predicate mode short-circuits on the first failure, so there is nothing to count.",
+      "compileSchema: `predicate: true` is mutually exclusive with a finite `maxErrors`. " +
+        "Predicate mode short-circuits on the first failure, so there is nothing to count.",
     );
   }
   const deps = createDeps(maxErrors);
@@ -586,7 +586,7 @@ function compileValidator(schema: SchemaOrBoolean, state: CompileState): string 
   // Pure-`$ref` elision: a schema whose only non-annotation keyword is
   // `$ref` compiles to a pass-through wrapper today (allocates a
   // scratch errors array, calls the target, propagates the result).
-  // Nothing structural comes out of the wrapper — inlining it away
+  // Nothing structural comes out of the wrapper; inlining it away
   // saves one function call per descent on every composition branch /
   // items call / properties subschema that uses `$ref`. When the ref
   // resolves back to this schema (self-recursion), alias returns the
@@ -656,7 +656,7 @@ function resolvePureRefTarget(schema: SchemaObject, state: CompileState): string
  * whether a generated function needs to allocate evaluated-key sets.
  *
  * Short-circuits to `false` when {@link CompileState.unevaluatedTracking}
- * is off — a compile unit that never uses `unevaluatedProperties` has
+ * is off: a compile unit that never uses `unevaluatedProperties` has
  * nothing to consume the Sets, so allocating + merging them is pure
  * overhead.
  *
@@ -709,7 +709,7 @@ function buildFunctionBody(schema: SchemaOrBoolean, state: CompileState): string
   gen.indent();
   if (!state.predicate) {
     // Start null; lazily allocate on first push. Valid inputs never
-    // touch this — the function returns null directly without
+    // touch this; the function returns null directly without
     // allocating anything.
     gen.let(NAMES.ERRORS, "null");
   }
@@ -740,7 +740,7 @@ function buildFunctionBody(schema: SchemaOrBoolean, state: CompileState): string
     }
     compileSchemaKeywords(schema, gen, state, evaluatedPropertiesVar, evaluatedItemsVar);
     // Merge evaluated-key sets into the caller's out-parameters when the
-    // caller is tracking. Runs regardless of errors — a keyword that
+    // caller is tracking. Runs regardless of errors; a keyword that
     // evaluated a key evaluated it, even if other keywords flagged the
     // data invalid. In predicate mode any failure has already returned
     // `false` by this point, so the merge only runs for passing data;

--- a/packages/schema/src/compiler/runtime.ts
+++ b/packages/schema/src/compiler/runtime.ts
@@ -20,8 +20,8 @@ export interface ValidatorDeps {
   ) => ValidationError | null;
   patterns: Map<string, RegExp>;
   /**
-   * Compile a user-supplied regex. Tries the `u` (Unicode) flag first —
-   * JSON Schema 2020-12 recommends it — and falls back to no-flag when
+   * Compile a user-supplied regex. Tries the `u` (Unicode) flag first
+   * (JSON Schema 2020-12 recommends it) and falls back to no-flag when
    * the pattern trips strict `u`-mode rules (stray `\-`, `\:`, `\/` etc.,
    * common in real-world OpenAPI specs). Results are memoized in
    * `patterns`. Throws `SyntaxError` only when the pattern is malformed
@@ -37,7 +37,7 @@ export interface ValidatorDeps {
    * The obvious `[...s].length` expression builds a one-string-per-code-point
    * array just to read its length; on a 10 MB payload that allocates far
    * more than the `maxLength` check can refuse. This helper walks the
-   * string's iterator and counts — O(1) memory.
+   * string's iterator and counts; O(1) memory.
    */
   countCodePoints: (s: string) => number;
   /**
@@ -114,7 +114,7 @@ export function typeOf(value: unknown): string {
 }
 
 /**
- * Structural equality for JSON values — honours array ordering, object key
+ * Structural equality for JSON values: honours array ordering, object key
  * sets (not ordering), and NaN-as-not-equal. Used by `enum`, `const`, and
  * `uniqueItems`.
  *
@@ -271,7 +271,7 @@ export function createDeps(maxErrors: number = Number.POSITIVE_INFINITY): Valida
         try {
           re = new RegExp(pattern);
         } catch {
-          // Surface the stricter (`u`-mode) error — it's more informative
+          // Surface the stricter (`u`-mode) error; it's more informative
           // when both modes reject the pattern.
           throw errU;
         }

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,10 +1,10 @@
 /**
  * The public `oav/schema` surface. Two audiences:
  *
- *   1. Compiler consumers — `compileSchema`, `CompiledSchema`,
+ *   1. Compiler consumers: `compileSchema`, `CompiledSchema`,
  *      `CompileOptions`, dialects. The minimum needed to turn a schema
  *      into a validator.
- *   2. Keyword authors — `KeywordDefinition`, `KeywordCompileContext`,
+ *   2. Keyword authors: `KeywordDefinition`, `KeywordCompileContext`,
  *      vocabulary URIs + vocab objects, the built-in keyword constants
  *      (useful for reusing or composing them into a custom dialect),
  *      the OAS 3.0 overrides.
@@ -18,7 +18,7 @@
  * @packageDocumentation
  */
 
-// Compiler — turning schemas into validators.
+// Compiler: turning schemas into validators.
 export {
   compileSchema,
   type CompileOptions,
@@ -30,7 +30,7 @@ export {
   type ValidationResult,
 } from "./compiler/index.js";
 
-// Keyword authoring — types + context seen inside `compile(ctx)`.
+// Keyword authoring: types + context seen inside `compile(ctx)`.
 export {
   createCustomKeywordDefinition,
   customKeywordVocabulary,
@@ -77,7 +77,7 @@ export {
   validationVocabulary,
 } from "./keywords/vocabulary.js";
 
-// Built-in keyword constants — reusable when composing a custom dialect.
+// Built-in keyword constants: reusable when composing a custom dialect.
 export {
   maxItemsKeyword,
   minItemsKeyword,
@@ -157,7 +157,7 @@ export { typeKeyword } from "./keywords/type.js";
 export { discriminatorKeyword } from "./keywords/discriminator.js";
 export { unevaluatedItemsKeyword, unevaluatedPropertiesKeyword } from "./keywords/unevaluated.js";
 
-// Ref resolution — needed by `@oav/validator` and any consumer wiring
+// Ref resolution: needed by `@oav/validator` and any consumer wiring
 // up a custom spec loader. The lower-level `SchemaRegistry` /
 // `collectDynamicAnchors` primitives are in `./internals`.
 export {
@@ -168,7 +168,7 @@ export {
   type ResolveOptions,
 } from "./resolve/index.js";
 
-// Generic subschema walk — intended for linters / introspection /
+// Generic subschema walk: intended for linters / introspection /
 // tooling. For rewriting use cases, the raw `SUBSCHEMA_*_POSITIONS`
 // constants are in `./internals`.
 export { walkSubschemas, type SubschemaVisitor } from "./subschema-positions.js";

--- a/packages/schema/src/internals.ts
+++ b/packages/schema/src/internals.ts
@@ -2,8 +2,8 @@
  * Internal re-exports for `oav/schema/internals`. Exposes
  * the codegen mechanics, runtime helpers, resolve internals, and
  * subschema-position constants that sit below the public extension
- * recipe. Reachable when you really need them — tests, advanced
- * plugins, tooling that walks or rewrites schemas — but deliberately
+ * recipe. Reachable when you really need them (tests, advanced
+ * plugins, tooling that walks or rewrites schemas) but deliberately
  * separated from the main `oav/schema` barrel so the
  * public surface matches what keyword authors actually need.
  *
@@ -13,7 +13,7 @@
  * @packageDocumentation
  */
 
-// Codegen mechanics — used by keyword authors that need to emit
+// Codegen mechanics: used by keyword authors that need to emit
 // non-boilerplate JS (path joining, string quoting, raw JS injection).
 export {
   CodeGen,
@@ -28,7 +28,7 @@ export {
   type RawExpression,
 } from "./codegen/index.js";
 
-// Runtime helpers — the objects bundled into `deps` and fed to every
+// Runtime helpers: the objects bundled into `deps` and fed to every
 // generated validator. Callers building custom compilers or dialect
 // harnesses can reach for these; normal consumers don't.
 export {
@@ -49,7 +49,7 @@ export { SchemaRegistry, collectDynamicAnchors } from "./resolve/index.js";
 // keyword in isolation) need to build one.
 export { createKeywordContext, type KeywordContextInputs } from "./keywords/context.js";
 
-// Subschema-position constants — the raw sets of schema-valued keys.
+// Subschema-position constants: the raw sets of schema-valued keys.
 // Prefer the public `walkSubschemas` helper when a read-walk suffices;
 // reach for these only when you need to transform / rewrite.
 export {

--- a/packages/schema/src/keywords/composition.ts
+++ b/packages/schema/src/keywords/composition.ts
@@ -224,7 +224,7 @@ export const notKeyword: KeywordDefinition = {
     const sub = ctx.schema as SchemaOrBoolean;
     const fn = ctx.compileSubschema(sub);
     if (ctx.predicate) {
-      // If the sub validates, `not` fails — short-circuit.
+      // If the sub validates, `not` fails; short-circuit.
       ctx.gen.line(`if (${fn}(${ctx.data})) return false;`);
       return;
     }

--- a/packages/schema/src/keywords/context.ts
+++ b/packages/schema/src/keywords/context.ts
@@ -12,7 +12,7 @@ const EMPTY_PATH_SEGMENTS: readonly string[] = Object.freeze([]);
 
 /**
  * Inputs accepted by {@link createKeywordContext}. The compiler assembles
- * these from its own state — keyword authors never construct them directly.
+ * these from its own state; keyword authors never construct them directly.
  *
  * @public
  */
@@ -36,7 +36,7 @@ export interface KeywordContextInputs {
   /**
    * When `true`, a finite `maxErrors` was configured and push / loop
    * sites should emit the extra budget checks. When `false`, emit plain
-   * `errors.push(x)` / unchecked loops — zero runtime overhead.
+   * `errors.push(x)` / unchecked loops; zero runtime overhead.
    */
   gated?: boolean;
   /**
@@ -56,7 +56,7 @@ export interface KeywordContextInputs {
   byKeyword?: ReadonlyMap<string, KeywordDefinition>;
   /**
    * Depth counter for recursive multi-keyword inlining. Callers never
-   * set this directly — the context threads it through
+   * set this directly; the context threads it through
    * {@link KeywordCompileContext.validateSubschema} so deeply-nested
    * inline chains eventually fall back to the function-call path
    * rather than blowing up the compiled source.
@@ -89,7 +89,7 @@ export interface KeywordContextInputs {
  * nested subschemas. When a subschema contains exactly one of these
  * keywords and nothing else that can emit errors, we can emit its
  * validation code inline in the enclosing function instead of
- * compiling it to a separate function — saving the per-call dispatch
+ * compiling it to a separate function, saving the per-call dispatch
  * cost and, more importantly, the eager `[...path, seg]` allocation
  * that function boundaries force.
  *
@@ -128,7 +128,7 @@ const INLINEABLE_SINGLE_KEYWORDS = new Set([
  * The unevaluated-keys keywords (`unevaluatedProperties`,
  * `unevaluatedItems`) also need per-function state, but they are
  * already tagged `applicator: true` so the applicator check below
- * catches them — no need to list them here.
+ * catches them; no need to list them here.
  */
 const INLINE_DISQUALIFIERS = new Set(["$ref", "$dynamicRef"]);
 
@@ -180,7 +180,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
   // Fall back to a local-scope const when no compiler-provided hoist sink
   // is threaded in (for tests or out-of-tree callers that build a
   // context directly). In that case the "hoisted" value just lives in
-  // the current validator body — correct but not optimized.
+  // the current validator body; correct but not optimized.
   let localHoistCounter = 0;
   const hoistConstant =
     inputs.hoistConstant ??
@@ -195,7 +195,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     if (predicate) {
       // Predicate mode: we don't construct an error tree, so any
       // error-emission site just short-circuits. The `errExpr` is
-      // intentionally discarded — its `ctx.path` / `createLeafError`
+      // intentionally discarded; its `ctx.path` / `createLeafError`
       // references never reach the generated source.
       void kind;
       void errExpr;
@@ -304,7 +304,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     const validationKeys: string[] = [];
     for (const k of allKeys) {
       // Annotation keywords (title, description, $comment, etc.) are
-      // registered with `annotation: true` and emit no code — safe to
+      // registered with `annotation: true` and emit no code; safe to
       // skip. Unknown keys fall through to `validationKeys` so the
       // inliner conservatively refuses to inline them, which matches
       // the old behaviour for pre-`annotation`-flag unknowns.
@@ -312,9 +312,9 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
       if (INLINE_DISQUALIFIERS.has(k)) return false;
       validationKeys.push(k);
     }
-    if (validationKeys.length === 0) return true; // empty-ish schema — nothing to emit
+    if (validationKeys.length === 0) return true; // empty-ish schema; nothing to emit
 
-    // Single-keyword: simplest case — whitelist match, no wrapping needed.
+    // Single-keyword: simplest case, whitelist match, no wrapping needed.
     if (validationKeys.length === 1) {
       const k = validationKeys[0]!;
       if (!INLINEABLE_SINGLE_KEYWORDS.has(k)) return false;
@@ -344,7 +344,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
 
     // Multi-keyword inline is limited to pure-leaf combinations
     // (type + required + bounds, etc.). Schemas that contain any
-    // applicator are left to the function-call path — the per-call
+    // applicator are left to the function-call path; the per-call
     // dispatch pays for itself on hot loops because V8 monomorphises
     // the function better than it can optimise a massive inlined
     // loop body.
@@ -355,7 +355,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     // Snapshot the errors array length; if >1 new error fires, wrap
     // the new ones in a "schema" branch so the tree shape matches a
     // named function's `wrapErrors` output. Predicate mode skips the
-    // snapshot/wrap entirely — inlined keywords return `false` on
+    // snapshot/wrap entirely; inlined keywords return `false` on
     // failure so there's nothing to wrap.
     const startVar = predicate ? null : inputs.gen.scope.name("_start");
     // errors may be null (lazy allocation). Treat null as length-0 for
@@ -365,7 +365,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
 
     // Keyword ordering mirrors the compiler's top-level dispatch: run
     // validation keywords first (leaf checks) in their defined vocab
-    // order, then applicators, then unevaluated — this matches what
+    // order, then applicators, then unevaluated; this matches what
     // `compileSchemaKeywords` does for function-compiled subschemas.
     const present = new Set(validationKeys);
     const runOrder: string[] = [];
@@ -403,14 +403,14 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
       kw.compile(innerCtx);
     }
 
-    // Wrap if >1 new error actually fired — error-tree mode only.
+    // Wrap if >1 new error actually fired; error-tree mode only.
     // errors may still be null here if no keyword pushed anything (or
     // only the budget got exhausted without pushing); the null-check
     // short-circuits the wrap.
     if (startVar !== null) {
       const wrappedVar = inputs.gen.scope.name("_wrapped");
       // The wrap expression lives at the same extended path as its
-      // leaf children — use the inner-scope segments directly (not
+      // leaf children; use the inner-scope segments directly (not
       // the outer ctx's `pathSegments`, which is what the public
       // helpers would concat).
       // Always include the empty `params` slot so the runtime
@@ -441,7 +441,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
   ): void => {
     const segment = options?.segment;
     // Inline path threads `pathSegments` through the inner keyword
-    // contexts — leaves splice the segments as trailing
+    // contexts: leaves splice the segments as trailing
     // createLeafError args, avoiding the pre-materialized
     // `[...path, seg]` double-allocation. Function-call fallback
     // keeps the classic push/pop-then-call shape because the callee
@@ -470,7 +470,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
           ? [segment]
           : [...pathSegments, segment];
     if (tryInline(schema, dataExpr, innerSegments)) return;
-    // Function-call fallback — push/pop around the call so the callee
+    // Function-call fallback: push/pop around the call so the callee
     // sees the extended path via the shared array (no per-call
     // allocation just to pass a path).
     const fn = inputs.compileSubschema(schema);
@@ -499,7 +499,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     // When the enclosing scope tracks evaluated props or items, each
     // call gets its own branch-local Set so annotations from a failing
     // branch don't leak into the caller. When tracking is off for both,
-    // we can skip the branch vars entirely — the sub-validator's trailing
+    // we can skip the branch vars entirely; the sub-validator's trailing
     // params default to `undefined`.
     const needBranchVars = evaluatedPropertiesVar !== null || evaluatedItemsVar !== null;
     const branchProps = needBranchVars ? inputs.gen.scope.name("bProps") : null;

--- a/packages/schema/src/keywords/custom.ts
+++ b/packages/schema/src/keywords/custom.ts
@@ -3,7 +3,7 @@ import type { KeywordCompileContext, KeywordDefinition } from "./types.js";
 
 /**
  * Vocabulary URI for user-registered keywords. Not a published JSON
- * Schema vocabulary — just a local tag that keeps custom entries
+ * Schema vocabulary; just a local tag that keeps custom entries
  * alongside the built-in ones in the keyword registry.
  *
  * @public
@@ -34,7 +34,7 @@ export interface CustomKeywordFailure {
  *
  * The `schemaValue` argument is the JSON value the keyword carries in
  * the schema. Since schemas are JSON, `schemaValue` is always
- * JSON-serialisable — callers may close over precomputed values (e.g. a
+ * JSON-serialisable; callers may close over precomputed values (e.g. a
  * compiled regex) at registration time if per-validation work should be
  * avoided.
  *

--- a/packages/schema/src/keywords/discriminator.ts
+++ b/packages/schema/src/keywords/discriminator.ts
@@ -5,7 +5,7 @@ import { APPLICATOR_VOCAB } from "./vocabulary-uris.js";
 /**
  * The OpenAPI 3.1 `discriminator` object. When present alongside `oneOf`,
  * the validator reads the named property, looks it up in `mapping`, and
- * validates the data against ONLY the selected branch — producing a
+ * validates the data against ONLY the selected branch, producing a
  * single-branch failure tree rather than N branches.
  *
  * @remarks
@@ -96,9 +96,9 @@ export const discriminatorKeyword: KeywordDefinition = {
               return;
             }
             // Discriminator routes to ONE branch. If it returns an error,
-            // that's already a counted leaf from the sub-validator — lift
+            // that's already a counted leaf from the sub-validator; lift
             // it (don't re-count). If the discriminator value matches no
-            // branch, THAT error is a fresh leaf — gate it.
+            // branch, THAT error is a fresh leaf; gate it.
             const switchLines = discFns
               .map(
                 ({ value, fn }) =>

--- a/packages/schema/src/keywords/items.ts
+++ b/packages/schema/src/keywords/items.ts
@@ -75,7 +75,7 @@ export const itemsKeyword: KeywordDefinition = {
  * The `contains` keyword. The array must have at least `minContains`
  * (default 1) and at most `maxContains` items matching the subschema.
  *
- * Dispatches for `minContains` and `maxContains` are suppressed — this
+ * Dispatches for `minContains` and `maxContains` are suppressed; this
  * keyword handles them.
  *
  * @public

--- a/packages/schema/src/keywords/meta-data.ts
+++ b/packages/schema/src/keywords/meta-data.ts
@@ -1,6 +1,6 @@
 /**
  * The JSON Schema 2020-12 Meta-Data vocabulary. These keywords are
- * annotation-only — they carry human- or tool-facing metadata and emit
+ * annotation-only: they carry human- or tool-facing metadata and emit
  * no runtime validation code. Registering them as first-class keyword
  * definitions (rather than tolerating them as unknown keys) gives the
  * compiler a single source of truth for the set, which the subschema
@@ -17,13 +17,13 @@ function annotationKeyword(name: string, vocabulary: string = META_DATA_VOCAB): 
     vocabulary,
     annotation: true,
     compile(): void {
-      // intentionally empty — pure annotation
+      // intentionally empty: pure annotation
     },
   };
 }
 
 /**
- * `title` — a short human-readable label for the schema. Annotation-
+ * `title`: a short human-readable label for the schema. Annotation-
  * only; emits no validation code. Bundled into
  * {@link metaDataVocabulary} and reachable alongside it from
  * `oav/schema`.
@@ -33,7 +33,7 @@ function annotationKeyword(name: string, vocabulary: string = META_DATA_VOCAB): 
 export const titleKeyword = annotationKeyword("title");
 
 /**
- * `description` — a longer human-readable explanation of the schema.
+ * `description`: a longer human-readable explanation of the schema.
  * Annotation-only; emits no validation code. Pair with
  * {@link titleKeyword} for tooling that displays a label plus details.
  *
@@ -42,7 +42,7 @@ export const titleKeyword = annotationKeyword("title");
 export const descriptionKeyword = annotationKeyword("description");
 
 /**
- * `default` — a suggested default value for the schema. Preserved as
+ * `default`: a suggested default value for the schema. Preserved as
  * metadata only; oav never injects defaults into request bodies or
  * response bodies (see the `useDefaults` discussion in
  * [`docs/comparison.md`](../../../docs/comparison.md) if you need that behaviour).
@@ -52,7 +52,7 @@ export const descriptionKeyword = annotationKeyword("description");
 export const defaultKeyword = annotationKeyword("default");
 
 /**
- * `deprecated` — marks a schema (most often a single property) as
+ * `deprecated`: marks a schema (most often a single property) as
  * deprecated. Annotation-only: deprecated values are not rejected at
  * runtime. Tooling and generated clients use it to surface warnings.
  *
@@ -61,7 +61,7 @@ export const defaultKeyword = annotationKeyword("default");
 export const deprecatedKeyword = annotationKeyword("deprecated");
 
 /**
- * `readOnly` — flags a property the client MUST NOT send on request
+ * `readOnly`: flags a property the client MUST NOT send on request
  * bodies. Annotation-only inside the schema compiler; the validator's
  * request-side body transform consults it and rewrites such properties
  * to `false` on request-direction schemas. Companion to
@@ -72,7 +72,7 @@ export const deprecatedKeyword = annotationKeyword("deprecated");
 export const readOnlyKeyword = annotationKeyword("readOnly");
 
 /**
- * `writeOnly` — flags a property the server MUST NOT send on response
+ * `writeOnly`: flags a property the server MUST NOT send on response
  * bodies. Annotation-only inside the schema compiler; the validator's
  * response-side body transform consults it and rewrites such properties
  * to `false` on response-direction schemas. Companion to
@@ -83,7 +83,7 @@ export const readOnlyKeyword = annotationKeyword("readOnly");
 export const writeOnlyKeyword = annotationKeyword("writeOnly");
 
 /**
- * `examples` — an array of example values the schema author supplies
+ * `examples`: an array of example values the schema author supplies
  * for documentation and tooling. Annotation-only; emits no validation
  * code. Supersedes OpenAPI 3.0's singular {@link exampleKeyword}.
  *
@@ -110,7 +110,7 @@ export const exampleKeyword = annotationKeyword("example", OPENAPI_META_DATA_VOC
 export const xmlKeyword = annotationKeyword("xml", OPENAPI_META_DATA_VOCAB);
 
 /**
- * OpenAPI Schema Object's `externalDocs` annotation — pointer to
+ * OpenAPI Schema Object's `externalDocs` annotation: pointer to
  * additional external documentation for this schema. Annotation-only.
  * Spec-defined fixed field on the Schema Object across 3.0 / 3.1 / 3.2.
  *
@@ -119,7 +119,7 @@ export const xmlKeyword = annotationKeyword("xml", OPENAPI_META_DATA_VOCAB);
 export const externalDocsKeyword = annotationKeyword("externalDocs", OPENAPI_META_DATA_VOCAB);
 
 /**
- * JSON Schema 2020-12 `contentEncoding` — declares the encoding (e.g.
+ * JSON Schema 2020-12 `contentEncoding`: declares the encoding (e.g.
  * `base64`) used for a string value. The spec marks the content
  * vocabulary as not required to validate; oav treats it as
  * annotation-only.
@@ -129,7 +129,7 @@ export const externalDocsKeyword = annotationKeyword("externalDocs", OPENAPI_MET
 export const contentEncodingKeyword = annotationKeyword("contentEncoding", CONTENT_VOCAB);
 
 /**
- * JSON Schema 2020-12 `contentMediaType` — declares the media type
+ * JSON Schema 2020-12 `contentMediaType`: declares the media type
  * (e.g. `application/jwt`) of a string value's content. Annotation-only
  * companion to {@link contentEncodingKeyword}.
  *
@@ -138,9 +138,9 @@ export const contentEncodingKeyword = annotationKeyword("contentEncoding", CONTE
 export const contentMediaTypeKeyword = annotationKeyword("contentMediaType", CONTENT_VOCAB);
 
 /**
- * JSON Schema 2020-12 `contentSchema` — schema describing the structure
+ * JSON Schema 2020-12 `contentSchema`: schema describing the structure
  * of decoded content (after applying `contentEncoding` and parsing
- * `contentMediaType`). Annotation-only — oav doesn't decode + re-validate.
+ * `contentMediaType`). Annotation-only; oav doesn't decode + re-validate.
  *
  * @public
  */

--- a/packages/schema/src/keywords/number.ts
+++ b/packages/schema/src/keywords/number.ts
@@ -23,7 +23,7 @@ function emitNumericError(
  * relative epsilon so valid multiples aren't rejected when the division
  * produces a non-terminating binary fraction. IEEE-754 rounding error
  * grows roughly with magnitude, so a flat tolerance is wrong at both
- * ends — a value like `143.48 / 0.01` drifts by about `1.82e-12`, while
+ * ends: a value like `143.48 / 0.01` drifts by about `1.82e-12`, while
  * values near `1` stay within `1e-14`. Scaling by `Number.EPSILON *
  * max(1, |q|, |divisor|)` gives each multiple of `divisor` the same
  * proportional slack without letting true non-multiples sneak through.

--- a/packages/schema/src/keywords/oas30.ts
+++ b/packages/schema/src/keywords/oas30.ts
@@ -76,7 +76,7 @@ export const oas30NullableKeyword: KeywordDefinition = {
   vocabulary: OAS30_VOCAB,
   annotation: true,
   compile(): void {
-    // intentionally empty — consumed by oas30TypeKeyword
+    // intentionally empty: consumed by oas30TypeKeyword
   },
 };
 

--- a/packages/schema/src/keywords/ref.ts
+++ b/packages/schema/src/keywords/ref.ts
@@ -38,7 +38,7 @@ export const refKeyword: KeywordDefinition = {
 
 /**
  * The JSON Schema 2020-12 `$dynamicRef` keyword. For schemas that do not use
- * `$dynamicAnchor` extension points this behaves exactly like `$ref` — the
+ * `$dynamicAnchor` extension points this behaves exactly like `$ref`: the
  * anchor is resolved statically against the schema tree.
  *
  * @public
@@ -65,7 +65,7 @@ export const dynamicAnchorKeyword: KeywordDefinition = {
   vocabulary: CORE_VOCAB,
   annotation: true,
   compile(): void {
-    // intentionally empty — anchor is consumed at resolve time
+    // intentionally empty: anchor is consumed at resolve time
   },
 };
 
@@ -80,7 +80,7 @@ export const anchorKeyword: KeywordDefinition = {
   vocabulary: CORE_VOCAB,
   annotation: true,
   compile(): void {
-    // intentionally empty — anchor is consumed at resolve time
+    // intentionally empty: anchor is consumed at resolve time
   },
 };
 
@@ -110,7 +110,7 @@ export const defsKeyword: KeywordDefinition = {
   vocabulary: CORE_VOCAB,
   annotation: true,
   compile(): void {
-    // intentionally empty — resolved on demand via $ref
+    // intentionally empty: resolved on demand via $ref
   },
 };
 

--- a/packages/schema/src/keywords/string.ts
+++ b/packages/schema/src/keywords/string.ts
@@ -132,7 +132,7 @@ export const formatAssertionKeyword: KeywordDefinition = {
  * JSON Schema 2020-12 §6.3 specifies that `minLength` / `maxLength` count
  * code points, so surrogate pairs (emoji, astral CJK, ...) count as one.
  * Delegates to the `countCodePoints` runtime helper, which iterates without
- * allocating an intermediate array — `[...s].length` would spike memory on
+ * allocating an intermediate array; `[...s].length` would spike memory on
  * large strings before the length check could reject them.
  */
 function codePointLengthExpr(dataExpr: string): string {

--- a/packages/schema/src/keywords/types.ts
+++ b/packages/schema/src/keywords/types.ts
@@ -17,8 +17,8 @@ export interface CompileRuntime {
  * Which budget semantics to apply when pushing an error expression
  * onto the errors accumulator. See {@link KeywordCompileContext.emitError}.
  *
- * - `"leaf"` — fresh leaf error, counts against `maxErrors`.
- * - `"lift"` — already-counted error being propagated (unconditional push).
+ * - `"leaf"`: fresh leaf error, counts against `maxErrors`.
+ * - `"lift"`: already-counted error being propagated (unconditional push).
  *
  * @public
  */
@@ -33,7 +33,7 @@ export interface ValidateSubschemaOptions {
   /**
    * Extra path segment to push onto `path` for the duration of this
    * subschema's traversal (e.g. an array index or property name).
-   * Pass a JS expression — literal strings must be quoted.
+   * Pass a JS expression; literal strings must be quoted.
    */
   segment?: string;
 }
@@ -51,7 +51,7 @@ export interface CompileAndCallOptions {
    * Emitted into the "sub passed" branch. Receives the per-branch
    * evaluated-keys var names when the enclosing scope tracks either;
    * `null` otherwise. Merge into the caller's `outProps` / `outItems`
-   * here — annotations from failing branches are not merged per the
+   * here; annotations from failing branches are not merged per the
    * 2020-12 spec, so the helper only exposes them on the pass side.
    */
   onPass: (gen: CodeEmitter, branchProps: string | null, branchItems: string | null) => void;
@@ -73,7 +73,7 @@ export interface CompileAndCallOptions {
 
 /**
  * The narrow context passed to each keyword's `compile()` function. Keyword
- * authors see only these names — no reference to the compiler, the full
+ * authors see only these names: no reference to the compiler, the full
  * vocabulary, or the validator instance.
  *
  * @public
@@ -95,7 +95,7 @@ export interface KeywordCompileContext {
    * Compile a nested subschema to its own function and return the
    * function's identifier. The returned name is callable with
    * `(data, path)` inside generated code. Use this when a keyword
-   * needs direct access to the function name — most composition-style
+   * needs direct access to the function name; most composition-style
    * keywords are better served by
    * {@link KeywordCompileContext.compileAndCallSubschema}, which also
    * hides the predicate-vs-tree call-signature split.
@@ -116,7 +116,7 @@ export interface KeywordCompileContext {
    * `null` for the branch variables.
    *
    * The sub-validator is called once; what each branch does is
-   * keyword-specific — composition keywords push the error into a
+   * keyword-specific: composition keywords push the error into a
    * per-keyword errors array on fail, `not` emits a leaf on pass,
    * etc. The abstraction deliberately stops at the call shape.
    */
@@ -132,13 +132,13 @@ export interface KeywordCompileContext {
   readonly evaluatedItemsVar: string | null;
   /**
    * `true` when a finite `maxErrors` cap was configured. Keyword
-   * authors usually don't need to read this directly — prefer
+   * authors usually don't need to read this directly; prefer
    * {@link KeywordCompileContext.emitError} /
    * {@link KeywordCompileContext.emitBudgetBreak} which inspect it.
    */
   readonly gated: boolean;
   /**
-   * `true` when predicate mode is active — the compiled validator
+   * `true` when predicate mode is active: the compiled validator
    * returns `boolean` and constructs no error tree. Most keywords
    * don't need to read this directly: `emitError`,
    * `errorStatement`, `leafErrorExpr`, and `validateSubschema` all
@@ -146,7 +146,7 @@ export interface KeywordCompileContext {
    * that inspect a sub-validator's return value for their own
    * control flow (`allOf`, `anyOf`, `oneOf`, `not`, `if/then/else`,
    * `$ref`, `contains`, `discriminator`, `dependentSchemas`) must
-   * branch on this flag — sub-validators in predicate mode return
+   * branch on this flag; sub-validators in predicate mode return
    * `boolean`, not `ValidationError | null`, and don't take a
    * `path` argument.
    */
@@ -156,13 +156,13 @@ export interface KeywordCompileContext {
    * generator. Pick the right `kind` based on where the error
    * expression came from:
    *
-   * - `"leaf"` — freshly-minted leaf error, created in this call.
+   * - `"leaf"`: freshly-minted leaf error, created in this call.
    *   Counts against the `maxErrors` budget when one is configured;
    *   short-circuits cleanly when the cap has been hit.
-   * - `"lift"` — an already-counted error being propagated up the
+   * - `"lift"`: an already-counted error being propagated up the
    *   tree (a sub-validator's return value) or a branch wrapper
    *   around already-counted children (`createBranchError`). Always
-   *   unconditional — never touches the budget counter.
+   *   unconditional, never touches the budget counter.
    *
    * Using the wrong kind silently miscounts errors against the
    * budget, so think about it each time. TypeScript enforces that you
@@ -170,7 +170,7 @@ export interface KeywordCompileContext {
    */
   emitError(kind: ErrorKind, errExpr: string): void;
   /**
-   * String form of {@link KeywordCompileContext.emitError} — returns
+   * String form of {@link KeywordCompileContext.emitError}: returns
    * the statement instead of emitting it. Useful inside compound
    * source like a `switch` body, where the push appears inline in a
    * larger `gen.line(...)` call.
@@ -196,15 +196,15 @@ export interface KeywordCompileContext {
    * pair so the shared-mutable `path` array carries the extra segment
    * only for the duration of this subschema's traversal.
    *
-   * When the subschema is simple enough — a boolean, or a single
-   * validation keyword from a safe whitelist — the keyword's code is
+   * When the subschema is simple enough (a boolean, or a single
+   * validation keyword from a safe whitelist) the keyword's code is
    * inlined directly, avoiding the per-call function dispatch. For
    * anything more complex, it falls back to compiling the subschema
    * into a named function and emitting the usual call + lift. Either
    * way the path is reused, not re-allocated.
    *
    * This is the right helper for the common "descend into a
-   * subschema and emit any errors" pattern — used by `properties`,
+   * subschema and emit any errors" pattern, used by `properties`,
    * `items`, `additionalProperties`, etc. Composition keywords that
    * need the sub-validator's return value for their own logic
    * (`allOf`, `anyOf`, `oneOf`, …) should call
@@ -219,7 +219,7 @@ export interface KeywordCompileContext {
    * Pending path segments to splice as trailing args into
    * `createLeafError` / `createBranchError`. Populated by the
    * subschema inliner when it flattens a segmented
-   * `validateSubschema` call into the enclosing function body —
+   * `validateSubschema` call into the enclosing function body:
    * instead of pre-materializing `[...path, seg]` for the inner
    * keyword contexts (which the runtime then re-snapshots, doubling
    * allocation), we leave `path` unchanged and let leaf keywords
@@ -232,7 +232,7 @@ export interface KeywordCompileContext {
    */
   readonly pathSegments: readonly string[];
   /**
-   * JS expression producing the effective path at runtime —
+   * JS expression producing the effective path at runtime,
    * equivalent to `ctx.path` when `pathSegments` is empty, and to
    * `[...path, seg1, seg2, …]` otherwise. Prefer the error helpers
    * for error construction; reach for this only when a keyword
@@ -247,7 +247,7 @@ export interface KeywordCompileContext {
    * caller's own `extraSegments` as trailing args. Up to two total
    * extras embed as explicit parameters (matching the runtime
    * signature); three or more fall back to eagerly materializing the
-   * extended path at the call site (rare — pathologically nested
+   * extended path at the call site (rare; pathologically nested
    * inlined subschemas).
    *
    * @param codeExpr - Pre-quoted JS expression for the error code
@@ -284,7 +284,7 @@ export interface KeywordCompileContext {
    * their validator body.
    *
    * Use this for schema-derived constants that would otherwise be
-   * allocated on every validate call — Sets of known property names,
+   * allocated on every validate call: Sets of known property names,
    * required-name arrays, enum candidates. The hoisted value must be
    * immutable from the validator's perspective (the validator reads it;
    * nothing in the generated code mutates it).
@@ -318,7 +318,7 @@ export interface KeywordDefinition {
   /** When `true`, indicates the keyword takes subschemas (applicator). */
   applicator?: boolean;
   /**
-   * When `true`, declares this keyword to be pure annotation/metadata —
+   * When `true`, declares this keyword to be pure annotation/metadata:
    * it emits no runtime validation code. Annotation keywords can coexist
    * with inlineable keywords without disqualifying the schema. Used by
    * the subschema inliner to decide which keys to skip when counting
@@ -327,7 +327,7 @@ export interface KeywordDefinition {
    */
   annotation?: boolean;
   /**
-   * Short explanation when this keyword is only partially supported —
+   * Short explanation when this keyword is only partially supported:
    * the compiler accepts and dispatches it, but the emitted validation
    * doesn't fully match the spec. Surfaced via the compile-time strict
    * mode (see {@link CompileOptions.strict}) so users know they're

--- a/packages/schema/src/keywords/vocabulary.ts
+++ b/packages/schema/src/keywords/vocabulary.ts
@@ -190,7 +190,7 @@ export const unevaluatedVocabulary: Vocabulary = {
 
 /**
  * The built-in format-annotation vocabulary. Non-assertive per the spec
- * default — use {@link formatAssertionVocabulary} to make `format`
+ * default; use {@link formatAssertionVocabulary} to make `format`
  * actually reject data.
  *
  * @public
@@ -213,7 +213,7 @@ export const formatAssertionVocabulary: Vocabulary = {
 };
 
 /**
- * The JSON Schema 2020-12 Meta-Data vocabulary. Pure annotations — these
+ * The JSON Schema 2020-12 Meta-Data vocabulary. Pure annotations: these
  * keywords carry human- and tool-facing metadata and never reject data.
  * Registering them explicitly gives the compiler's inliner a single,
  * dialect-scoped source of truth for "which keys are safe to ignore".
@@ -263,7 +263,7 @@ export const contentVocabulary: Vocabulary = {
 /**
  * The three default vocabularies (validation + applicator +
  * format-annotation) in the order the compiler expects. Consumers
- * normally pick a full {@link Dialect} instead — see
+ * normally pick a full {@link Dialect} instead; see
  * {@link jsonSchemaDialect}, {@link openapi31Dialect}, and
  * {@link oas30Dialect}.
  *

--- a/packages/schema/src/resolve/refs.ts
+++ b/packages/schema/src/resolve/refs.ts
@@ -30,13 +30,13 @@ export interface RefResolver {
  *
  * @remarks
  * Supported forms:
- * - `#` — the root of the enclosing `$id` scope (or the graph root if
+ * - `#`: the root of the enclosing `$id` scope (or the graph root if
  *   the `$ref` appears at the root).
- * - `#/a/b/c` — JSON Pointer into the enclosing scope's root schema.
- * - `#name` — lookup in the enclosing scope's anchor map; falls back to
+ * - `#/a/b/c`: JSON Pointer into the enclosing scope's root schema.
+ * - `#name`: lookup in the enclosing scope's anchor map; falls back to
  *   the flat anchor map for cross-scope references.
- * - absolute URI — lookup in `byId` or the external registry.
- * - absolute URI + fragment — resolve the URI, then the fragment.
+ * - absolute URI: lookup in `byId` or the external registry.
+ * - absolute URI + fragment: resolve the URI, then the fragment.
  *
  * @param graph - Output of {@link resolve}.
  * @returns A resolver ready to hand to the compiler.
@@ -97,7 +97,7 @@ function resolveFragment(
     graph.anchorScopes.get(baseUri)?.get(fragment) ??
     graph.dynamicAnchorScopes.get(baseUri)?.get(fragment);
   if (scoped !== undefined) return scoped;
-  // Fall back to the flat union — lets #anchor refs resolve against
+  // Fall back to the flat union; lets #anchor refs resolve against
   // cousin scopes when the enclosing scope doesn't own the anchor.
   const flat = graph.byAnchor.get(fragment) ?? graph.byDynamicAnchor.get(fragment);
   if (flat !== undefined) return flat;
@@ -110,7 +110,7 @@ function resolveJsonPointer(root: SchemaOrBoolean, pointer: string): SchemaOrBoo
 
 /**
  * Find every distinct schema object reachable via `$dynamicAnchor` from an
- * ancestor chain — used when the compiler needs to decide which dynamic
+ * ancestor chain, used when the compiler needs to decide which dynamic
  * anchor the current `$dynamicRef` should bind to.
  *
  * @remarks

--- a/packages/schema/src/resolve/registry.ts
+++ b/packages/schema/src/resolve/registry.ts
@@ -2,7 +2,7 @@ import type { SchemaOrBoolean } from "@oav/core";
 
 /**
  * A URI-keyed registry of schemas. A single `Map` provides `add` / `get` /
- * `remove` — there is deliberately no separate `schemas` vs `refs` vs `cache`
+ * `remove`; there is deliberately no separate `schemas` vs `refs` vs `cache`
  * distinction because that distinction always leaks.
  *
  * @public

--- a/packages/schema/src/resolve/resolver.ts
+++ b/packages/schema/src/resolve/resolver.ts
@@ -16,7 +16,7 @@ export interface ResolvedGraph {
   /** Every `$id` discovered, mapped to the schema it labels (keyed by absolute URI). */
   byId: Map<string, SchemaOrBoolean>;
   /**
-   * Flat union of every `$anchor` discovered — last-writer-wins when two
+   * Flat union of every `$anchor` discovered: last-writer-wins when two
    * anchors share a name across scopes. Prefer {@link anchorScopes} when
    * scope-local lookup matters; this map exists for compatibility.
    */
@@ -32,7 +32,7 @@ export interface ResolvedGraph {
    * maps for the anchors declared within that scope.
    */
   anchorScopes: Map<string, Map<string, SchemaOrBoolean>>;
-  /** Per-base-URI `$dynamicAnchor` maps — same shape as {@link anchorScopes}. */
+  /** Per-base-URI `$dynamicAnchor` maps; same shape as {@link anchorScopes}. */
   dynamicAnchorScopes: Map<string, Map<string, SchemaOrBoolean>>;
   /** Identity-keyed map from every schema object to its enclosing base URI. */
   schemaBaseUri: WeakMap<object, string>;
@@ -60,7 +60,7 @@ export interface ResolveOptions {
  * too, using their registry key as the starting base URI.
  *
  * @remarks
- * This function does not yet inline `$ref` — references are left in place
+ * This function does not yet inline `$ref`; references are left in place
  * and resolved lazily at compile time. The schemas remain the original
  * values (not cloned).
  *

--- a/packages/schema/src/subschema-positions.ts
+++ b/packages/schema/src/subschema-positions.ts
@@ -31,7 +31,7 @@ export const SUBSCHEMA_ARRAY_POSITIONS = ["allOf", "anyOf", "oneOf", "prefixItem
 /**
  * Known JSON Schema 2020-12 positions that hold a `string -> subschema`
  * map. Callers that treat `properties` specially (e.g. validator's
- * direction transform) should filter it out themselves — it's included
+ * direction transform) should filter it out themselves; it's included
  * here so generic walkers see the complete set of schema positions.
  *
  * @internal
@@ -47,7 +47,7 @@ export const SUBSCHEMA_MAP_POSITIONS = [
 /**
  * Visitor callback shape for {@link walkSubschemas}. Receives each
  * visited subschema plus the dotted-path string leading to it (relative
- * to the walk root — empty string for the root itself). Returning
+ * to the walk root; empty string for the root itself). Returning
  * `false` from the visitor prunes the subtree; any other value (or
  * `void`) continues the walk.
  *
@@ -61,7 +61,7 @@ export type SubschemaVisitor = (schema: SchemaOrBoolean, path: string) => void |
  * (plus the keys OpenAPI adds on top) declares. Boolean schemas and
  * `$ref` nodes are visited but not descended.
  *
- * Intended for tooling — linters, introspection, tree rewriters — that
+ * Intended for tooling (linters, introspection, tree rewriters) that
  * would otherwise re-derive the set of schema-valued keys and risk
  * drifting from the vocabulary. Callers that need to *rewrite* schemas
  * in place can instead reach for the underlying

--- a/packages/schema/test/external-schemas.test.ts
+++ b/packages/schema/test/external-schemas.test.ts
@@ -62,7 +62,7 @@ describe("compileSchema with external schemas", () => {
     expect(v.validate(1).valid).toBe(false);
   });
 
-  it("scopes $anchor by enclosing $id — same anchor name in different scopes", () => {
+  it("scopes $anchor by enclosing $id: same anchor name in different scopes", () => {
     // Two subschemas both declare `$anchor: "x"` under different $ids; refs
     // must resolve to the scope-local anchor, not the last one written.
     const schema = {

--- a/packages/schema/test/inlining.test.ts
+++ b/packages/schema/test/inlining.test.ts
@@ -1,7 +1,7 @@
 /**
  * Behavioural tests for the subschema-inlining optimisation. We assert
- * on `v.stats.functionCount` — the compiler's own tally of
- * `validate_N` helper functions emitted — so the shape of the
+ * on `v.stats.functionCount` (the compiler's own tally of
+ * `validate_N` helper functions emitted), so the shape of the
  * generated source can change without breaking these tests.
  */
 
@@ -30,7 +30,7 @@ describe("subschema inlining", () => {
       type: "array",
       items: { type: "integer", minimum: 1, maximum: 100 },
     });
-    // Only the root validator — items' schema has three leaf keywords
+    // Only the root validator; items' schema has three leaf keywords
     // (no applicators), so it inlines.
     expect(v.stats.functionCount).toBe(1);
   });
@@ -41,7 +41,7 @@ describe("subschema inlining", () => {
       items: { type: "object", required: ["x"], properties: { x: { type: "number" } } },
     });
     // items' schema has `properties` (applicator), so it stays a
-    // function — V8 monomorphises the hot-loop call better that way
+    // function; V8 monomorphises the hot-loop call better that way
     // than inlining would.
     expect(v.stats.functionCount).toBe(2);
   });
@@ -60,7 +60,7 @@ describe("subschema inlining", () => {
   });
 
   it("falls back to a named function past the inline-depth ceiling", () => {
-    // 8 levels of nesting — exceeds MAX_INLINE_DEPTH=6.
+    // 8 levels of nesting; exceeds MAX_INLINE_DEPTH=6.
     let inner: unknown = { type: "number" };
     for (let i = 0; i < 8; i += 1) {
       inner = { type: "object", properties: { nested: inner } };
@@ -71,7 +71,7 @@ describe("subschema inlining", () => {
     expect(v.stats.functionCount).toBeGreaterThanOrEqual(2);
   });
 
-  it("inlining preserves validation behaviour — tree form", () => {
+  it("inlining preserves validation behaviour: tree form", () => {
     const v = compile({ type: "array", items: { type: "number" } });
     expect(v.validate([1, 2, 3]).valid).toBe(true);
     const r = v.validate([1, "two", 3]);
@@ -80,7 +80,7 @@ describe("subschema inlining", () => {
     expect(r.error?.path).toEqual([1]);
   });
 
-  it("inlining preserves validation behaviour — property form", () => {
+  it("inlining preserves validation behaviour: property form", () => {
     const v = compile({ type: "object", properties: { age: { type: "integer" } } });
     expect(v.validate({ age: 5 }).valid).toBe(true);
     const r = v.validate({ age: "x" });
@@ -88,7 +88,7 @@ describe("subschema inlining", () => {
     expect(r.error?.path).toEqual(["age"]);
   });
 
-  it("inlining respects maxErrors — allocated paths still wear the budget cap", () => {
+  it("inlining respects maxErrors: allocated paths still wear the budget cap", () => {
     const v = compileSchema(
       { type: "array", items: { type: "number" } },
       { dialect: jsonSchemaDialect, maxErrors: 3 },

--- a/packages/schema/test/keyword-array.test.ts
+++ b/packages/schema/test/keyword-array.test.ts
@@ -28,7 +28,7 @@ describe("array validation keywords", () => {
   });
 
   it("uniqueItems spots mixed-type collisions via the primitive fast path", () => {
-    // Regression for #142 — the Map-backed lookup must treat each
+    // Regression for #142: the Map-backed lookup must treat each
     // primitive identity (number, string, boolean, null) correctly.
     const v = compile({ uniqueItems: true });
     expect(v.validate([1, "1"]).valid).toBe(true); // different types, not equal

--- a/packages/schema/test/keyword-composition.test.ts
+++ b/packages/schema/test/keyword-composition.test.ts
@@ -101,7 +101,7 @@ describe("if/then/else keyword", () => {
   it("an `if` whose property is missing is vacuously true (applies `then`)", () => {
     // ajv #2439 / #2299. A `properties` subschema is vacuously satisfied
     // when the named key isn't present in the data, so the `if` passes
-    // and `then` fires — distinct from the case where the key IS present
+    // and `then` fires, distinct from the case where the key IS present
     // but fails the constraint.
     const schema = {
       type: "object",

--- a/packages/schema/test/keyword-custom.test.ts
+++ b/packages/schema/test/keyword-custom.test.ts
@@ -114,7 +114,7 @@ describe("custom keywords", () => {
     expect(leaves).toBe(2);
   });
 
-  it("is optional — omitting keywords has zero impact", () => {
+  it("is optional: omitting keywords has zero impact", () => {
     const compiled = compileSchema({ type: "number" }, { dialect: baseDialect });
     expect(compiled.validate(1).valid).toBe(true);
     expect(compiled.validate("x").valid).toBe(false);

--- a/packages/schema/test/keyword-meta-data.test.ts
+++ b/packages/schema/test/keyword-meta-data.test.ts
@@ -65,7 +65,7 @@ describe("meta-data vocabulary", () => {
     expect(jsHas("externalDocs")).toBe(false);
   });
 
-  it("is a no-op at runtime — annotation-only schemas accept any input", () => {
+  it("is a no-op at runtime: annotation-only schemas accept any input", () => {
     const v = compile({
       title: "X",
       description: "anything",
@@ -130,7 +130,7 @@ describe("content vocabulary", () => {
     }
   });
 
-  it("is a no-op at runtime — content keywords accept any string", () => {
+  it("is a no-op at runtime: content keywords accept any string", () => {
     const v = compile({
       type: "string",
       contentEncoding: "base64",

--- a/packages/schema/test/keyword-properties.test.ts
+++ b/packages/schema/test/keyword-properties.test.ts
@@ -26,7 +26,7 @@ describe("properties keyword", () => {
 
   it("property names and pattern sources with JS-hostile chars don't break codegen", () => {
     // Property names and regex patterns end up embedded in generated
-    // JavaScript — quoteString + escapeMessage must escape every code
+    // JavaScript; quoteString + escapeMessage must escape every code
     // point that could terminate a literal or inject new source.
     const evilName = 'bad"name\nwith`backticks`${1+1}';
     const evilPattern = "^hi\\${injected}$";

--- a/packages/schema/test/keyword-string.test.ts
+++ b/packages/schema/test/keyword-string.test.ts
@@ -15,7 +15,7 @@ describe("string keywords", () => {
   });
 
   it("maxLength treats a single surrogate-pair code point as length 1", () => {
-    // Regression for #12 — str.length would return 2 for this.
+    // Regression for #12: str.length would return 2 for this.
     const v = compile({ maxLength: 1 });
     expect(v.validate("👨").valid).toBe(true);
     expect(v.validate("ab").valid).toBe(false);
@@ -24,7 +24,7 @@ describe("string keywords", () => {
   it("maxLength rejects a large string without allocating a code-point array", () => {
     // Regression for #143. The legacy `[...s].length` implementation
     // materialised one string-per-code-point for the whole input before
-    // the length check could refuse it — trivially OOM-able. Validate
+    // the length check could refuse it (trivially OOM-able). Validate
     // the fix: a multi-megabyte string against a 10-char cap returns a
     // failure quickly and without crashing.
     const big = "a".repeat(5_000_000);
@@ -33,7 +33,7 @@ describe("string keywords", () => {
     const res = v.validate(big);
     const elapsed = Date.now() - start;
     expect(res.valid).toBe(false);
-    // Generous ceiling — the for...of walk is O(N) in time but O(1) in
+    // Generous ceiling: the for...of walk is O(N) in time but O(1) in
     // memory. 2 s is orders of magnitude above the expected runtime
     // (~50 ms on modern hardware) and still catches a regression to
     // the allocating implementation.
@@ -63,7 +63,7 @@ describe("string keywords", () => {
   });
 
   it("pattern keeps Unicode-only features when `u` does parse", () => {
-    // \p{L} is only meaningful under the `u` flag — without it, the
+    // \p{L} is only meaningful under the `u` flag; without it, the
     // regex would match literal 'p{L}'. Verifies we try `u` first.
     const v = compile({ pattern: "^\\p{L}+$" });
     expect(v.validate("héllo").valid).toBe(true);

--- a/packages/schema/test/keyword-unevaluated.test.ts
+++ b/packages/schema/test/keyword-unevaluated.test.ts
@@ -134,7 +134,7 @@ describe("discriminator keyword", () => {
 
   it("accepts multiple mapping keys that point to the same branch", () => {
     // eov #1088: two mapping entries targeting the same schema should
-    // not collide — each key routes to the shared branch deterministically.
+    // not collide; each key routes to the shared branch deterministically.
     const v = compile({
       $defs: {
         Pet: { type: "object", required: ["name"], properties: { name: { type: "string" } } },

--- a/packages/schema/test/max-errors.test.ts
+++ b/packages/schema/test/max-errors.test.ts
@@ -95,7 +95,7 @@ describe("maxErrors option", () => {
 
   it("rejects maxErrors: 0 at compile time", () => {
     // A cap of 0 collects no errors and would silently return
-    // `valid: true` for invalid data — a correctness trap. Predicate
+    // `valid: true` for invalid data, a correctness trap. Predicate
     // mode is the explicit way to skip error collection entirely.
     expect(() => compile({ type: "number" }, 0)).toThrow(
       /must be a positive integer.*Use `predicate: true`/,

--- a/packages/schema/test/path-leak-probe.test.ts
+++ b/packages/schema/test/path-leak-probe.test.ts
@@ -36,7 +36,7 @@ describe("error paths survive path-array reuse", () => {
 
   // Regression probe for the inline-pathSegments optimisation (#50).
   // A single-keyword leaf inlined with a pending segment must place
-  // the segment in its error's .path — the inliner no longer
+  // the segment in its error's .path; the inliner no longer
   // pre-materializes `[...path, seg]` for the inner ctx, so a leaf
   // that forgets to splice its pending segment would drop it.
   it("inlined const under properties reports path ['kind']", () => {
@@ -56,7 +56,7 @@ describe("error paths survive path-array reuse", () => {
 
   // Regression probe for the multi-keyword inline wrap. When an
   // inlined subschema has 2+ keywords that both fail, the wrap
-  // branch error should live at the extended path too — not at the
+  // branch error should live at the extended path too, not at the
   // caller's unextended path.
   it("inlined multi-keyword wrap reports path ['fins']", () => {
     const { validate } = compileSchema(
@@ -69,7 +69,7 @@ describe("error paths survive path-array reuse", () => {
     const r = validate({ fins: -1.5 });
     if (r.valid) throw new Error("unexpected valid");
     // Two inlined leaves (type + minimum) wrapped in a "schema"
-    // branch — `wrapErrors` unwraps single-child, so the root error
+    // branch; `wrapErrors` unwraps single-child, so the root error
     // IS that "schema" branch.
     const root = r.error! as Err;
     expect(root.code).toBe("schema");

--- a/packages/schema/test/path-sharing.test.ts
+++ b/packages/schema/test/path-sharing.test.ts
@@ -76,7 +76,7 @@ describe("path sharing: correctness under stress", () => {
     // First call: error at ["x"]
     const r1 = v.validate({ x: "not a number" });
     expect(r1.error?.path).toEqual(["x"]);
-    // Second call: same error, same path — not ["x", "x"] from shared leak
+    // Second call: same error, same path, not ["x", "x"] from shared leak
     const r2 = v.validate({ x: "still not a number" });
     expect(r2.error?.path).toEqual(["x"]);
     // Third call, a different shape

--- a/packages/schema/test/predicate-mode.test.ts
+++ b/packages/schema/test/predicate-mode.test.ts
@@ -15,7 +15,7 @@ const tree = (schema: SchemaOrBoolean) =>
  * Every test in this file checks two things:
  *   1. predicate-mode returns the right boolean.
  *   2. predicate's boolean matches tree-mode's `valid` on the same input.
- * That parity check is the main safety net — if the two modes disagree
+ * That parity check is the main safety net: if the two modes disagree
  * on any fixture, we broke something.
  */
 function parity(schema: SchemaOrBoolean, samples: { valid: unknown[]; invalid: unknown[] }) {
@@ -51,7 +51,7 @@ describe("predicate mode: return type", () => {
   });
 });
 
-describe("predicate mode: leaf keywords (bucket A — via emitError)", () => {
+describe("predicate mode: leaf keywords (bucket A, via emitError)", () => {
   it("type", () => {
     parity({ type: "number" }, { valid: [1, 1.5, -0], invalid: ["x", null, [], {}] });
   });
@@ -140,7 +140,7 @@ describe("predicate mode: applicator keywords", () => {
     parity(
       {
         type: "object",
-        // Pattern admits lowercase letters, digits, and underscore —
+        // Pattern admits lowercase letters, digits, and underscore,
         // so `x_1` / `y` are valid keys.
         propertyNames: { pattern: "^[a-z_0-9]+$" },
         patternProperties: { "^x_": { type: "number" } },
@@ -153,7 +153,7 @@ describe("predicate mode: applicator keywords", () => {
   });
 });
 
-describe("predicate mode: composition (bucket B — rewritten)", () => {
+describe("predicate mode: composition (bucket B, rewritten)", () => {
   it("allOf", () => {
     parity(
       { allOf: [{ type: "number" }, { minimum: 0 }, { maximum: 10 }] },
@@ -168,13 +168,13 @@ describe("predicate mode: composition (bucket B — rewritten)", () => {
     );
   });
 
-  it("oneOf — exactly-one semantics", () => {
+  it("oneOf: exactly-one semantics", () => {
     parity({ oneOf: [{ type: "number" }, { minimum: 5 }] }, { valid: ["x", 3], invalid: [7] });
     // 7 matches both branches ({type: number} AND {minimum: 5}), so oneOf fails.
     // 3 matches only {type: number}.
     // "x" matches neither (well, minimum: 5 is vacuously true for non-numbers).
-    // Wait — minimum: 5 with non-number data is vacuously valid. So "x"
-    // passes {minimum: 5} but not {type: number} — single match → oneOf valid.
+    // Wait: minimum: 5 with non-number data is vacuously valid. So "x"
+    // passes {minimum: 5} but not {type: number}; single match → oneOf valid.
   });
 
   it("not", () => {
@@ -369,7 +369,7 @@ describe("predicate mode: discriminator (OAS 3.1)", () => {
     expect(p.validate({ kind: "cat", meow: "not-a-bool" })).toBe(false);
     expect(p.validate({ kind: "fish" })).toBe(false);
     expect(p.validate({ kind: 42 })).toBe(false);
-    // Non-object data is vacuously valid — discriminator only activates
+    // Non-object data is vacuously valid; discriminator only activates
     // on objects; the schema has no sibling `type: "object"` constraint,
     // so that matches tree-mode semantics.
   });
@@ -411,7 +411,7 @@ describe("predicate mode: generated source sanity", () => {
       required: ["a"],
     });
     // The compiler sets `emittedTreeRuntime` iff the source references
-    // `createLeafError` / `createBranchError` / `wrapErrors` — all
+    // `createLeafError` / `createBranchError` / `wrapErrors`, all
     // tree-mode only. Asserting on the stat keeps the invariant stable
     // under codegen renames (compare the `functionCount` precedent in
     // inlining.test.ts).
@@ -420,7 +420,7 @@ describe("predicate mode: generated source sanity", () => {
 
   it("tree mode does emit tree-runtime helpers (control)", () => {
     // Guards the complement: make sure emittedTreeRuntime isn't stuck
-    // at false — a non-predicate schema that actually reports errors
+    // at false; a non-predicate schema that actually reports errors
     // should flip it.
     const v = compileSchema({ type: "string", minLength: 3 }, { dialect: jsonSchemaDialect });
     expect(v.stats.emittedTreeRuntime).toBe(true);

--- a/packages/schema/test/strict-mode.test.ts
+++ b/packages/schema/test/strict-mode.test.ts
@@ -16,7 +16,7 @@ describe("strict mode", () => {
     minimumx: 5, // also a typo
   } as unknown as SchemaOrBoolean;
 
-  it("defaults to warn-partial — flags $dynamicRef but not unknown keywords", () => {
+  it("defaults to warn-partial: flags $dynamicRef but not unknown keywords", () => {
     const issues = compileSchema(dynamicSchema, { dialect: jsonSchemaDialect }).stats.strictIssues;
     expect(issues).toHaveLength(1);
     expect(issues[0]).toMatchObject({
@@ -67,8 +67,8 @@ describe("strict mode", () => {
       xml: { name: "Msg" },
       externalDocs: { url: "https://example.com/docs" },
     } as unknown as SchemaOrBoolean;
-    // Base JSON Schema dialect does NOT recognise `xml` / `externalDocs`
-    // — they're OpenAPI extensions, not core JSON Schema keywords.
+    // Base JSON Schema dialect does NOT recognise `xml` / `externalDocs`;
+    // they're OpenAPI extensions, not core JSON Schema keywords.
     const baseIssues = compileSchema(schema, {
       dialect: jsonSchemaDialect,
       strict: "strict",

--- a/packages/schema/test/unevaluated-composition.test.ts
+++ b/packages/schema/test/unevaluated-composition.test.ts
@@ -162,7 +162,7 @@ describe("unevaluatedProperties across composition", () => {
     expect(v.validate(["a", "a"]).valid).toBe(true);
     expect(v.validate(["a", "b", "a"]).valid).toBe(true);
     expect(v.validate(["c", "a", "b", "c"]).valid).toBe(true);
-    // Missing `a` — the outer `if` fails, no annotations flow in, so
+    // Missing `a`: the outer `if` fails, no annotations flow in, so
     // every item becomes unevaluated.
     expect(v.validate(["b", "b"]).valid).toBe(false);
   });

--- a/packages/schema/test/unevaluated-gating.test.ts
+++ b/packages/schema/test/unevaluated-gating.test.ts
@@ -41,7 +41,7 @@ describe("unevaluated-tracking compile-time gating", () => {
   });
 
   it("keeps evaluated-keys Sets when the trigger is deep inside $defs", () => {
-    // A schema that doesn't mention unevaluated* at its root — but
+    // A schema that doesn't mention unevaluated* at its root, but
     // does through a $def reachable via $ref. The walker descends the
     // full tree so tracking stays on.
     const v = compile({

--- a/packages/schema/test/walk-subschemas.test.ts
+++ b/packages/schema/test/walk-subschemas.test.ts
@@ -16,8 +16,8 @@ describe("walkSubschemas", () => {
     walkSubschemas(schema, (_node, path) => {
       paths.push(path);
     });
-    // Order: single-valued keys first, then array keys, then map keys —
-    // matches the SUBSCHEMA_{SINGLE,ARRAY,MAP}_POSITIONS iteration.
+    // Order: single-valued keys first, then array keys, then map keys.
+    // Matches the SUBSCHEMA_{SINGLE,ARRAY,MAP}_POSITIONS iteration.
     expect(paths).toEqual([
       "",
       "allOf[0]",

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -18,8 +18,8 @@ if you're on the lean package.
 ## Loading a spec
 
 `loadSpec` is the recommended entrypoint. It reads the entry document,
-resolves external `$ref`s, and applies any overlays — in the right
-order — in a single call:
+resolves external `$ref`s, and applies any overlays (in the right
+order) in a single call:
 
 ```ts
 import { composeReaders, createFileReader, loadSpec } from "@aahoughton/oav/spec";
@@ -50,19 +50,19 @@ interface DocumentReader {
 }
 ```
 
-Built-ins (JSON only — YAML support lives in `oav`):
+Built-ins (JSON only; YAML support lives in `oav`):
 
-- `createFileReader(cwd?)` — filesystem JSON. `.yaml` / `.yml` paths
+- `createFileReader(cwd?)`: filesystem JSON. `.yaml` / `.yml` paths
   throw an install-hint error; compose with `createYamlFileReader` from
   `oav` to cover YAML.
-- `createHttpReader()` — HTTP / HTTPS JSON. Same YAML policy.
-- `createMemoryReader(entries)` — in-memory JSON or pre-parsed objects.
-- `composeReaders([...])` — layers readers, dispatching by `canRead`.
+- `createHttpReader()`: HTTP / HTTPS JSON. Same YAML policy.
+- `createMemoryReader(entries)`: in-memory JSON or pre-parsed objects.
+- `composeReaders([...])`: layers readers, dispatching by `canRead`.
 
 `oav` additionally exports `createYamlFileReader`,
 `createSmartHttpReader`, and `parseYamlString` for YAML-backed specs.
 `createSmartHttpReader` supersedes the JSON-only `createHttpReader`
-when composed — it claims every `http(s)` URI and dispatches by
+when composed: it claims every `http(s)` URI and dispatches by
 response `Content-Type` (falling back to URL extension), so JSON and
 YAML endpoints work through the same reader:
 
@@ -119,8 +119,8 @@ errors on duplicates. `extendSchemas` wraps in `allOf`.
 
 ## `$ref` semantics
 
-`resolveSpec` inlines external `$ref`s — references to separate files
-or HTTP URIs. Internal references (`#/components/...`) are left alone;
+`resolveSpec` inlines external `$ref`s (references to separate files
+or HTTP URIs). Internal references (`#/components/...`) are left alone;
 the validator and schema compiler follow them at runtime via a
 ref-resolution cache keyed on schema identity, so self-recursive
 schemas compile to normal recursive calls.

--- a/packages/spec/src/overlay.ts
+++ b/packages/spec/src/overlay.ts
@@ -31,7 +31,7 @@ export interface PathOverride {
  * - `replace` is wholesale and cannot be combined with the additive /
  *   removal fields below. Setting both throws at apply time.
  * - `removeParameters` / `removeResponses` silently no-op when the
- *   target isn't present — wildcard overrides (`"*"`) fan out to many
+ *   target isn't present; wildcard overrides (`"*"`) fan out to many
  *   operations and can't assume every target has the same surface.
  *
  * @public

--- a/packages/spec/src/reader.ts
+++ b/packages/spec/src/reader.ts
@@ -25,7 +25,7 @@ const YAML_HINT =
   "createSmartHttpReader() ahead of the JSON-only readers from @aahoughton/oav-core/spec.";
 
 /**
- * Read files from the local filesystem. JSON only — `.yaml` / `.yml`
+ * Read files from the local filesystem. JSON only; `.yaml` / `.yml`
  * paths throw with a clear install hint. Pair with
  * `oav`' `createYamlFileReader` via
  * {@link composeReaders} for YAML support.
@@ -70,7 +70,7 @@ export function createFileReader(cwd: string = process.cwd()): DocumentReader {
  * Read documents over HTTP/HTTPS. JSON only; pair with
  * `oav`'s `createSmartHttpReader` for YAML (it claims all
  * `http(s)` URIs and dispatches by `Content-Type`, so it shadows this
- * reader in a compose chain — that's fine; JSON endpoints still parse
+ * reader in a compose chain; that's fine; JSON endpoints still parse
  * as JSON there).
  *
  * @returns A {@link DocumentReader}.

--- a/packages/spec/src/resolver.ts
+++ b/packages/spec/src/resolver.ts
@@ -86,7 +86,7 @@ export async function resolveSpec(options: ResolveSpecOptions): Promise<Resolved
         $ref: `#/$defs/__ext__/${encodeUri(targetUri)}${fragment ? `/${encodeFragment(fragment)}` : ""}`,
       };
       if (stitchingUri !== null && stitchingUri === targetUri) {
-        // Self-ref inside the subtree we're currently stitching — keep as
+        // Self-ref inside the subtree we're currently stitching; keep as
         // internal ref (the stitched copy serves as the target).
         return stitchRef;
       }

--- a/packages/spec/test/load.test.ts
+++ b/packages/spec/test/load.test.ts
@@ -100,7 +100,7 @@ describe("loadSpec", () => {
 
     expect(sources.sort()).toEqual(["main.json", "schemas.json"]);
     // External ref inlined into components.schemas.Pet, then wrapped in
-    // allOf by extendSchemas — proves resolveSpec ran first.
+    // allOf by extendSchemas; proves resolveSpec ran first.
     const pet = document.components?.schemas?.["Pet"];
     expect(pet).toMatchObject({ allOf: expect.any(Array) });
   });

--- a/packages/spec/test/reader.test.ts
+++ b/packages/spec/test/reader.test.ts
@@ -150,7 +150,7 @@ describe("composeReaders", () => {
   it("first reader to claim a URI wins (later readers are shadowed)", async () => {
     // Documented composition contract: composeReaders walks the array and
     // returns the first reader where canRead() is true. A second reader
-    // that also claims the same URI must be shadowed — this is the
+    // that also claims the same URI must be shadowed; this is the
     // mechanism for layering (e.g. a project-specific reader in front of
     // a generic file reader).
     const front = createMemoryReader(new Map([["shared.json", '{"from":"front"}']]));

--- a/packages/spec/test/resolver.test.ts
+++ b/packages/spec/test/resolver.test.ts
@@ -123,7 +123,7 @@ describe("resolveSpec", () => {
     }
   });
 
-  it("only stitches circular externals — non-circular refs are inlined", async () => {
+  it("only stitches circular externals; non-circular refs are inlined", async () => {
     const reader = createMemoryReader(
       new Map<string, unknown>([
         [
@@ -349,7 +349,7 @@ describe("resolveSpec", () => {
       );
       const { document } = await resolveSpec({ reader, entry: "root.json" });
       const refs = collectInternalRefs(document);
-      // No raw root-level #/components/... refs should survive —
+      // No raw root-level #/components/... refs should survive;
       // everything got rewritten into the external namespace.
       expect(refs.filter((r) => r.startsWith("#/components/"))).toEqual([]);
       // Both external files got stitched.

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -1,7 +1,7 @@
 # oav (validator)
 
 HTTP request/response validator for OpenAPI 3.0, 3.1, and 3.2. This is
-the headline surface of the package — `createValidator` is re-exported
+the headline surface of the package; `createValidator` is re-exported
 from the package root.
 
 ```ts
@@ -32,7 +32,7 @@ can group by location. The top-level node's `code` (`"request"` vs
 
 `validator.detectedVersion` reflects the `openapi` string that was
 detected on construction (or `undefined` if the field was missing or
-unsupported and a fallback was used — see `onUnknownVersion` below).
+unsupported and a fallback was used; see `onUnknownVersion` below).
 
 Companion adapter packages wrap the validator as middleware /
 hooks: [`oav-express4`](../oav-express4/README.md),
@@ -68,7 +68,7 @@ the upstream test suites live in
   `deepObject`, `spaceDelimited`, `pipeDelimited` with `explode`.
 - **Content-type negotiation**: against the request / response
   `Content-Type`, including wildcards (`application/*`, `*/*`).
-- **Response status matching**: exact → `NXX` class → `default`.
+- **Response status matching**: exact, then `NXX` class, then `default`.
 - **Format validators**: the `oav/formats` built-ins merged
   with any extras passed via `options.formats`.
 
@@ -82,7 +82,7 @@ the upstream test suites live in
 | `validateFetchResponse<T>(request, response)` | Symmetric Web Standards `Response` check. Useful for contract-testing an upstream.                                                                                        |
 | `getOperation({ method, path })`              | Startup-time introspection: returns the resolved, overlay-applied `OperationObject` + matched template for a (method, path) pair.                                         |
 | `detectedVersion`                             | The `openapi` string detected on construction, or `undefined` for an unrecognised / missing version (see `onUnknownVersion`).                                             |
-| `warnings`                                    | `readonly string[]` — warnings accumulated at construction time (`onUnknownVersion: "warn"` or `dialect`-suppressed category error). Empty when neither path fires.       |
+| `warnings`                                    | `readonly string[]`: warnings accumulated at construction time (`onUnknownVersion: "warn"` or `dialect`-suppressed category error). Empty when neither path fires.        |
 
 ## Options
 
@@ -141,16 +141,16 @@ true` when the tree was capped.
 
 Two kinds of "unknown":
 
-- **Category errors** — missing / non-string `openapi`, non-semver
+- **Category errors**: missing / non-string `openapi`, non-semver
   string, or a major version that isn't `3`. These **throw** at
   construction by default. Set `dialect` to force a specific
   compiler; that suppresses the throw and adds an entry to
   `validator.warnings` so the override is still visible.
-- **Unknown minor within 3.x** — e.g. `"3.7.0"` if a future minor
+- **Unknown minor within 3.x**: e.g. `"3.7.0"` if a future minor
   ships before oav is updated. Governed by `onUnknownVersion`:
 
   ```ts
-  createValidator(spec); // fallback31 default — silent, uses 3.1 dialect
+  createValidator(spec); // fallback31 default (silent, uses 3.1 dialect)
   createValidator(spec, { onUnknownVersion: "throw" }); // refuse to build
   createValidator(spec, { onUnknownVersion: "warn" }); // populates validator.warnings, uses 3.1 dialect
   createValidator(spec, { onUnknownVersion: "warn", warn: (m) => log.info(m) }); // plus live callback

--- a/packages/validator/src/body-schema-transform.ts
+++ b/packages/validator/src/body-schema-transform.ts
@@ -2,12 +2,12 @@
  * Body schema pre-transforms applied before the JSON Schema compiler
  * sees the operation's body schema. Two concerns live here:
  *
- *   1. Direction (readOnly / writeOnly) — properties forbidden in the
+ *   1. Direction (readOnly / writeOnly): properties forbidden in the
  *      current leg of the HTTP exchange are rewritten to `false` and
  *      stripped from `required`. See
  *      {@link transformBodySchemaForDirection}.
  *
- *   2. Opaque bodies — `format: "binary"` fields arrive as Buffers or
+ *   2. Opaque bodies: `format: "binary"` fields arrive as Buffers or
  *      framework-specific objects, not strings, so the transform
  *      replaces them with `{}` (an "accept anything" schema) in both
  *      directions. See {@link isBinaryStringSchema}.
@@ -38,9 +38,9 @@ export type BodyDirection = "request" | "response";
  *
  * OpenAPI `readOnly` / `writeOnly` constrain the direction of travel for
  * a property:
- * - `readOnly: true` — server-generated; clients MUST NOT include it in
+ * - `readOnly: true`: server-generated; clients MUST NOT include it in
  *   request bodies, and it's exempt from `required` on the request side.
- * - `writeOnly: true` — client-only; servers MUST NOT include it in
+ * - `writeOnly: true`: client-only; servers MUST NOT include it in
  *   response bodies, and it's exempt from `required` on the response side.
  *
  * The JSON Schema compiler is direction-agnostic, so we pre-transform
@@ -48,7 +48,7 @@ export type BodyDirection = "request" | "response";
  * replaced with `false` (rejecting their presence) and stripped from
  * `required` (exempting their absence).
  *
- * The transform is a local rewrite only — `$ref` nodes are preserved as
+ * The transform is a local rewrite only; `$ref` nodes are preserved as
  * they are. To make composition-via-ref work (e.g.
  * `allOf: [{ $ref: "#/Timestamps" }, ...]` where `Timestamps` owns the
  * readOnly field), pair this with {@link createDirectionResolver}:
@@ -127,7 +127,7 @@ function transformInner(
   const cached = cache.get(schema);
   if (cached !== undefined) return cached;
 
-  // OAS `format: "binary"` marks opaque bytes — the field arrives as a
+  // OAS `format: "binary"` marks opaque bytes: the field arrives as a
   // Buffer, Uint8Array, or framework-specific object (multer etc.), not
   // a JS string. Stripping all constraints so the validator accepts
   // whatever the HTTP layer decoded avoids false positives on every
@@ -196,12 +196,12 @@ function isBinaryStringSchema(schema: SchemaOrBoolean): boolean {
   if (typeof schema !== "object" || schema === null || Array.isArray(schema)) return false;
   const s = schema as Record<string, unknown>;
   if (s.format !== "binary") return false;
-  // Either `type: "string"` or an array containing "string" — accept
+  // Either `type: "string"` or an array containing "string"; accept
   // both, including the 3.1 shorthand `type: ["string", "null"]`.
   if (s.type === "string") return true;
   if (Array.isArray(s.type) && (s.type as unknown[]).includes("string")) return true;
   // Author declared `format: binary` without a type. Still not a
-  // validatable JSON value — bypass.
+  // validatable JSON value; bypass.
   if (s.type === undefined) return true;
   return false;
 }

--- a/packages/validator/src/from-fetch.ts
+++ b/packages/validator/src/from-fetch.ts
@@ -8,7 +8,7 @@
  *
  * The content-type dispatcher recognises JSON (`application/json` and
  * `*+json`), URL-encoded forms, multipart/form-data, and text/*. For
- * anything else, the raw bytes come through as a `Uint8Array` — the
+ * anything else, the raw bytes come through as a `Uint8Array`; the
  * validator's `format: "binary"` opaque-body bypass accepts any value
  * when the body schema declares it that way.
  *
@@ -34,7 +34,7 @@ export interface FetchRequestOptions {
    *
    * The callback receives the original `Request` with its body stream
    * intact. Return whatever shape the spec's `requestBody` schema
-   * expects — `format: "binary"` fields pass through the validator
+   * expects; `format: "binary"` fields pass through the validator
    * unchanged, so opaque placeholders (a temp-file path, a Buffer
    * handle, etc.) are valid.
    *
@@ -63,7 +63,7 @@ export interface FetchRequestOptions {
  * framework-agnostic {@link HttpRequest} shape the validator expects,
  * plus the parsed body for the caller to consume.
  *
- * The request body is a one-shot stream — after this helper returns,
+ * The request body is a one-shot stream; after this helper returns,
  * `request.body` is exhausted. Callers that need to re-read the body
  * should use `request.clone()` before calling.
  *
@@ -131,7 +131,7 @@ export async function httpResponseFromFetch(response: Response): Promise<{
   const headers = headersToRecord(response.headers);
   const contentType = response.headers.get("content-type") ?? undefined;
   // Response body parsing: reuse the same media-type dispatch as
-  // requests. Method is irrelevant — there's no GET/HEAD skip; a
+  // requests. Method is irrelevant; there's no GET/HEAD skip; a
   // spec-declared response body is readable regardless.
   const body = await readBody(response, contentType, "POST");
 

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * The public `oav/validator` surface. One audience: callers
  * building a request/response validator from a resolved OpenAPI
- * document — `createValidator`, the `Validator` instance it returns,
+ * document: `createValidator`, the `Validator` instance it returns,
  * the options, and the Fetch-API adapters for consumers plugging the
  * validator into Next.js / Hono / Bun / Deno handlers.
  *

--- a/packages/validator/src/internals.ts
+++ b/packages/validator/src/internals.ts
@@ -2,9 +2,9 @@
  * Internal re-exports for `oav/validator/internals`. Exposes
  * the parameter-deserialisation and query-assembly primitives that the
  * validator uses to prepare values before schema compilation, plus the
- * operation-level `$ref` resolver. Reachable when you need them —
- * tests, advanced plugins, tooling that reuses the same style /
- * explode rules outside the normal validator flow — but deliberately
+ * operation-level `$ref` resolver. Reachable when you need them
+ * (tests, advanced plugins, tooling that reuses the same style /
+ * explode rules outside the normal validator flow) but deliberately
  * separated from the main `oav/validator` barrel so the
  * public surface matches what request/response-validation consumers
  * actually need.
@@ -30,7 +30,7 @@ export {
   coerceQueryScalar,
 } from "./query-assembly.js";
 
-// Operation-level `$ref` resolver — used internally by the cache
+// Operation-level `$ref` resolver: used internally by the cache
 // builder; exposed so tests can exercise it without constructing a
 // full validator.
 export { resolveOperationRef } from "./operation-cache.js";

--- a/packages/validator/src/operation-cache.ts
+++ b/packages/validator/src/operation-cache.ts
@@ -185,7 +185,7 @@ export function buildOperationCache(
     bodyValidators,
     responses,
     // Security is populated by `createValidator` after this call
-    // returns — `buildOperationCache` deliberately doesn't see the full
+    // returns; `buildOperationCache` deliberately doesn't see the full
     // document (it only needs the `RouteMatch` subtree) so the field
     // starts out undefined.
     security: undefined,
@@ -195,7 +195,7 @@ export function buildOperationCache(
 /**
  * Resolve an operation-level `$ref` (requestBody / response / parameter /
  * header) against the spec. Returns the target object with any siblings
- * on the reference itself dropped — per OAS, siblings of a Reference
+ * on the reference itself dropped: per OAS, siblings of a Reference
  * are ignored. Follows chains with a depth guard to catch cycles.
  * External refs must be inlined upstream by `@oav/spec.resolveSpec()`.
  *

--- a/packages/validator/src/query-assembly.ts
+++ b/packages/validator/src/query-assembly.ts
@@ -6,7 +6,7 @@
  * parameter, the pieces have to be re-assembled into a single object.
  *
  * Extracted from validator.ts so the rules are unit-testable in
- * isolation — the end-to-end validator tests only ever see the
+ * isolation; the end-to-end validator tests only ever see the
  * reassembled value through the schema error leaves, so edge cases
  * in the assembly logic were invisible to structural assertions.
  *
@@ -71,7 +71,7 @@ export function coerceQueryScalar(value: string | undefined, schema: SchemaOrBoo
 
 /**
  * Gather `name[key]=value` pairs from the top-level query into an
- * object — the `style: deepObject` assembly. Single-level only:
+ * object: the `style: deepObject` assembly. Single-level only:
  * OpenAPI 3.0–3.2 do not define nested semantics, so `obj[a][b]=v`
  * yields a property literally named `a][b`.
  *
@@ -95,7 +95,7 @@ export function assembleDeepObject(
 }
 
 /**
- * Reassemble a `style: form + explode: true` object query param —
+ * Reassemble a `style: form + explode: true` object query param:
  * each declared property appears as its own top-level key.
  *
  * @internal
@@ -121,7 +121,7 @@ export function assembleFormExplodedObject(
 /**
  * Dispatch an object-typed query parameter to the appropriate
  * assembler (`deepObject` or `form+explode`). Returns `undefined`
- * when the parameter isn't object-typed — caller should fall through
+ * when the parameter isn't object-typed; caller should fall through
  * to the standard scalar/array deserialization path.
  *
  * When the parameter IS object-typed but no matching query keys are

--- a/packages/validator/src/security.ts
+++ b/packages/validator/src/security.ts
@@ -36,7 +36,7 @@ export interface CompiledSecurityRequirement {
 
 /**
  * A pre-compiled, operation-level security check. An OR across one or
- * more `CompiledSecurityRequirement`s — at least one must fully satisfy
+ * more `CompiledSecurityRequirement`s; at least one must fully satisfy
  * for the request to pass. `null` (stored as `undefined` on
  * `OperationCache`) means "no security required" and skips the check.
  *
@@ -52,7 +52,7 @@ export type CompiledSecurity = CompiledSecurityRequirement[];
  * than silently passing.
  *
  * Returns `undefined` when no requirement applies (no check emitted at
- * request time) — distinct from an empty array, which is never returned
+ * request time): distinct from an empty array, which is never returned
  * here: empty means "no security" and we fold that into `undefined`.
  *
  * @internal
@@ -185,7 +185,7 @@ function pickApiKey(
 function tryBase64Decode(s: string): string | undefined {
   try {
     // `atob` is available in Node 16+ and in every modern browser /
-    // runtime — avoid a `Buffer` import to keep this file portable.
+    // runtime; avoid a `Buffer` import to keep this file portable.
     return atob(s);
   } catch {
     return undefined;

--- a/packages/validator/src/validate-step.ts
+++ b/packages/validator/src/validate-step.ts
@@ -40,7 +40,7 @@ function isJsonMediaType(mediaType: string): boolean {
  * Validate a single parameter against the operation cache: fetch the
  * raw value from the appropriate HTTP frame (path / query / header /
  * cookie), deserialise per `style` + `explode`, and run the pre-
- * compiled schema validator. Pure — no closure over createValidator
+ * compiled schema validator. Pure: no closure over createValidator
  * state; the cache carries everything it needs.
  *
  * @internal
@@ -116,7 +116,7 @@ export function validateParameter(
     }
     return null;
   }
-  // Empty-string is a legitimate value — `minLength`/`pattern` on the
+  // Empty-string is a legitimate value; `minLength`/`pattern` on the
   // parameter schema handles rejection where needed. OpenAPI 3.1 §4.8.12.1
   // explicitly permits `?flag=` on query parameters declaring
   // `allowEmptyValue: true`; exempt those from validation.
@@ -164,9 +164,9 @@ export function validateParameter(
  * unrelated parameter diagnostics.
  *
  * Fires whenever the client declared a `Content-Type` that doesn't
- * match — including the body-absent case, where the wrong header is
+ * match, including the body-absent case, where the wrong header is
  * the more actionable signal than the downstream "body required" leaf.
- * Returns `null` — deliberately not a content-type error — when:
+ * Returns `null` (deliberately not a content-type error) when:
  * - the operation declares no `requestBody`,
  * - the operation's `requestBody.content` map is empty (nothing to
  *   match against),

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -114,7 +114,7 @@ export interface Validator {
   /**
    * Validate a Web Standards {@link Response} against the operation
    * the {@link Request} resolves to. Mirrors
-   * {@link validateFetchRequest} for the response side — useful when
+   * {@link validateFetchRequest} for the response side; useful when
    * you're calling an upstream API and want to confirm its response
    * matches the spec, or when you're testing your own handler's
    * output against its OpenAPI contract.
@@ -181,7 +181,7 @@ export interface Validator {
    * hatch suppresses a category error that would otherwise throw
    * (missing `openapi` field, wrong major). Empty when neither applies.
    *
-   * The library never writes to `process.stderr` or `console` — this
+   * The library never writes to `process.stderr` or `console`; this
    * array is the library's only record of such events. Callers that
    * want live output pass {@link ValidatorOptions.warn}; the CLI
    * wrapper does this.
@@ -221,7 +221,7 @@ export interface ValidatorStats {
    * or when the linter found nothing to flag.
    *
    * Schema paths are the full path inside each compiled schema, not
-   * HTTP-frame-prefixed — the linter runs over raw JSON Schema, not
+   * HTTP-frame-prefixed; the linter runs over raw JSON Schema, not
    * OpenAPI.
    */
   strictIssues: readonly StrictIssue[];
@@ -233,26 +233,26 @@ export interface ValidatorStats {
  * the canonical contract for each one. The integration guide carries
  * worked examples; this type carries the API.
  *
- * - **Dialect override** — {@link ValidatorOptions.dialect}.
- * - **Schema extension** — {@link ValidatorOptions.formats},
+ * - **Dialect override**: {@link ValidatorOptions.dialect}.
+ * - **Schema extension**: {@link ValidatorOptions.formats},
  *   {@link ValidatorOptions.keywords}.
- * - **Error budget** — {@link ValidatorOptions.maxErrors}.
- * - **Strict-mode linting** — {@link ValidatorOptions.strict}.
- * - **Security gating** — {@link ValidatorOptions.validateSecurity}.
- * - **Path filtering** — {@link ValidatorOptions.ignoreUndocumented},
+ * - **Error budget**: {@link ValidatorOptions.maxErrors}.
+ * - **Strict-mode linting**: {@link ValidatorOptions.strict}.
+ * - **Security gating**: {@link ValidatorOptions.validateSecurity}.
+ * - **Path filtering**: {@link ValidatorOptions.ignoreUndocumented},
  *   {@link ValidatorOptions.ignorePaths}.
- * - **Query strictness** — {@link ValidatorOptions.strictQueryParameters}.
- * - **Version mismatch** — {@link ValidatorOptions.onUnknownVersion}.
- * - **Warn sink** — {@link ValidatorOptions.warn}.
+ * - **Query strictness**: {@link ValidatorOptions.strictQueryParameters}.
+ * - **Version mismatch**: {@link ValidatorOptions.onUnknownVersion}.
+ * - **Warn sink**: {@link ValidatorOptions.warn}.
  *
  * @remarks
  * Ordering convention (shared with
  * {@link @aahoughton/oav/schema!CompileOptions}):
  *
- *   1. Compile essentials — `dialect`.
- *   2. Shared extension points — `formats`, `keywords`.
- *   3. Error-collection policy — `maxErrors`.
- *   4. Surface-specific extras last — here, `strictQueryParameters`,
+ *   1. Compile essentials: `dialect`.
+ *   2. Shared extension points: `formats`, `keywords`.
+ *   3. Error-collection policy: `maxErrors`.
+ *   4. Surface-specific extras last: here, `strictQueryParameters`,
  *      `onUnknownVersion`, `warn`.
  *
  * Options common to both surfaces share names and positions so a
@@ -345,7 +345,7 @@ export interface ValidatorOptions {
    * {@link OpenAPIDocument.security} when the operation doesn't override).
    * **Shape-only**: the check confirms the request carries the declared
    * credential (e.g. a `Bearer` token in `Authorization`, the declared
-   * apiKey header) — it does not verify the credential itself. Credential
+   * apiKey header); it does not verify the credential itself. Credential
    * verification stays with the app's auth middleware.
    *
    * Supported schemes: `http` with `scheme: "bearer"` or `"basic"`, and
@@ -353,8 +353,8 @@ export interface ValidatorOptions {
    * `mutualTLS` are accepted in the spec but not shape-checked at the
    * validator layer.
    *
-   * Defaults to `false`. Real apps gate security upstream of validation
-   * — by the time the validator runs, the auth middleware has already
+   * Defaults to `false`. Real apps gate security upstream of validation:
+   * by the time the validator runs, the auth middleware has already
    * verified (or rejected) the credential. Opt in with `true` when
    * there's no auth middleware (early dev / prototyping) or when the
    * auth layer only decorates `req` without rejecting unauthenticated
@@ -365,7 +365,7 @@ export interface ValidatorOptions {
   /** When `true`, reject unknown query parameters (default: `false`). */
   strictQueryParameters?: boolean;
   /**
-   * When `true`, an unmatched path no longer produces a `route` error —
+   * When `true`, an unmatched path no longer produces a `route` error;
    * `validateRequest` / `validateResponse` return `null`. Mirrors
    * `express-openapi-validator`'s `ignoreUndocumented`. Does not affect
    * the `method` code: a path that matched but whose verb wasn't
@@ -387,23 +387,23 @@ export interface ValidatorOptions {
   ignorePaths?: (path: string) => boolean;
   /**
    * How to handle a spec with an unknown **minor** version inside the
-   * OpenAPI 3.x line — e.g. `openapi: "3.7.0"` if a future minor ships
+   * OpenAPI 3.x line; e.g. `openapi: "3.7.0"` if a future minor ships
    * before oav is updated. Pure forward-compat control; does not govern
    * category errors (missing `openapi` field, wrong major), which
    * always throw unless `dialect` is set.
    *
-   * - `"fallback31"` (default) — accept silently; use the 3.1 dialect.
-   * - `"warn"` — add an entry to {@link Validator.warnings} (and
+   * - `"fallback31"` (default): accept silently; use the 3.1 dialect.
+   * - `"warn"`: add an entry to {@link Validator.warnings} (and
    *   call {@link ValidatorOptions.warn} if provided) and use the 3.1
    *   dialect.
-   * - `"throw"` — throw an `Error`.
+   * - `"throw"`: throw an `Error`.
    *
    * Regardless of the choice, `Validator.detectedVersion` is set to
    * `undefined` so callers can introspect after the fact.
    */
   onUnknownVersion?: "fallback31" | "warn" | "throw";
   /**
-   * Optional live-output sink for warnings — called synchronously
+   * Optional live-output sink for warnings, called synchronously
    * during {@link createValidator} whenever a warning is emitted
    * (currently: `onUnknownVersion: "warn"` path, and the single
    * category-error-overridden-by-`dialect` case). Every warning is
@@ -470,10 +470,10 @@ export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions
   // per request.
   //
   // Three categories of input:
-  //   (1) valid 3.x spec (3.0 / 3.1 / 3.2)  — pick dialect, compile
-  //   (2) missing openapi field / wrong major — category error, throw
+  //   (1) valid 3.x spec (3.0 / 3.1 / 3.2): pick dialect, compile
+  //   (2) missing openapi field / wrong major: category error, throw
   //       (unless `dialect` is set, which is the universal override)
-  //   (3) valid 3.x major but unknown minor (e.g. "3.7.0") — forward
+  //   (3) valid 3.x major but unknown minor (e.g. "3.7.0"): forward
   //       compat, governed by `onUnknownVersion`
   const detectedVersion = detectOpenAPIVersion(spec);
   const dialect: Dialect = (() => {
@@ -826,7 +826,7 @@ export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions
     response: Response,
   ): Promise<{ ok: true; body: T } | { ok: false; error: ValidationError }> => {
     // Build an HttpRequest from the fetch Request without reading its
-    // body — we only need method + path to match the operation.
+    // body; we only need method + path to match the operation.
     const url = new URL(request.url);
     const method = request.method.toUpperCase();
     const httpRequest: HttpRequest = { method, path: url.pathname };

--- a/packages/validator/test/deserialize.test.ts
+++ b/packages/validator/test/deserialize.test.ts
@@ -28,7 +28,7 @@ describe("deserialize", () => {
       explode: false,
       schema: { type: "array", items: { type: "integer" } },
     });
-    // Array items keep their string form — coercion uses the
+    // Array items keep their string form; coercion uses the
     // container's schema, not the items' schema.
     expect(out).toEqual(["1", "2", "3"]);
   });

--- a/packages/validator/test/error-codes.test.ts
+++ b/packages/validator/test/error-codes.test.ts
@@ -18,7 +18,7 @@ import { createValidator } from "../src/index.js";
  *   - every HTTP-layer named code is observed at least once
  *
  * Adding a new keyword or HTTP-layer wrapper should force a PR update
- * here — otherwise the `BuiltInErrorParams` contract silently drifts.
+ * here; otherwise the `BuiltInErrorParams` contract silently drifts.
  */
 
 function collectCodes(err: ValidationError | null): Set<string> {
@@ -149,7 +149,7 @@ describe("BuiltInErrorParams registry cross-check", () => {
     // requests. Bidirectional coverage across rarer codes
     // (path-param / cookie-param, which only fire on content-JSON
     // parameter deserialisation failures) is intentionally not
-    // enforced — the forward check above already catches undocumented
+    // enforced; the forward check above already catches undocumented
     // emissions, which is the drift mode that actually bites consumers.
     const v = createValidator(sampleSpec());
     const observed = new Set<string>();
@@ -211,7 +211,7 @@ describe("BuiltInErrorParams registry cross-check", () => {
       body: { name: "x" },
     });
     expect(e).not.toBeNull();
-    // `request` branch must carry method + pathPattern — the documented
+    // `request` branch must carry method + pathPattern, the documented
     // shape that drifted previously.
     expect(e?.code).toBe("request");
     expect(e?.params).toEqual({ method: "POST", pathPattern: "/items/{id}" });
@@ -221,7 +221,7 @@ describe("BuiltInErrorParams registry cross-check", () => {
     // Declared required keys per HTTP-layer code. Runtime assertion
     // that the validator's emitted params include every documented key.
     // Errors are emitted imperatively (not through generated JS), so
-    // TypeScript can't enforce the contract — this test is the backstop.
+    // TypeScript can't enforce the contract; this test is the backstop.
     const requiredKeys: Record<string, readonly string[]> = {
       route: ["method", "path"],
       method: ["method", "pathPattern", "allowed"],
@@ -308,7 +308,7 @@ describe("BuiltInErrorParams registry cross-check", () => {
     // `*-param` wrapper. Declared shape trusted by construction
     // (same `{ name, in }` builder as the reachable siblings).
     check(v.validateRequest({ method: "GET", path: "/items/1" }), "header-param");
-    // Strict query parameters — unknown key triggers query-param.
+    // Strict query parameters: unknown key triggers query-param.
     check(
       v.validateRequest({
         method: "GET",
@@ -320,7 +320,7 @@ describe("BuiltInErrorParams registry cross-check", () => {
     );
     check(v.validateResponse({ method: "GET", path: "/items/1" }, { status: 500 }), "response");
     check(v.validateResponse({ method: "GET", path: "/items/1" }, { status: 500 }), "status");
-    // Response-side missing required header — must carry name + in.
+    // Response-side missing required header; must carry name + in.
     check(
       vWithResponseHeader.validateResponse(
         { method: "GET", path: "/r" },

--- a/packages/validator/test/fetch-validators.test.ts
+++ b/packages/validator/test/fetch-validators.test.ts
@@ -272,7 +272,7 @@ describe("validator.validateFetchRequest", () => {
         body: JSON.stringify({ name: "FromWire", age: 1 }),
       });
       // …but the override returns a different body shape instead. The
-      // Request stream isn't consumed by our default parser — the
+      // Request stream isn't consumed by our default parser; the
       // callback owns it.
       const result = await v.validateFetchRequest<{ name: string; age: number }>(req, {
         readBody: async () => ({ name: "FromOverride", age: 2 }),
@@ -315,7 +315,7 @@ describe("validator.validateFetchRequest", () => {
       // The sureify / puddle-rest-proxy shape: a multipart endpoint
       // declared in the spec as `{ documents: string, format: binary }`
       // (or an array of same). A user's streaming parser pulls bytes off
-      // the request and assembles whatever body the spec expects —
+      // the request and assembles whatever body the spec expects;
       // placeholders for file fields (paths, buffer handles) pass through
       // the validator's format:binary bypass.
       const spec: OpenAPIDocument = {
@@ -440,7 +440,7 @@ describe("validator.validateFetchResponse", () => {
   });
 
   it("doesn't read the request body", async () => {
-    // Request body present but validateFetchResponse shouldn't consume it —
+    // Request body present but validateFetchResponse shouldn't consume it;
     // a caller that wants the request body after validating the response
     // should still be able to read it.
     const req = new Request("https://example.com/pets", {

--- a/packages/validator/test/fixtures.ts
+++ b/packages/validator/test/fixtures.ts
@@ -21,7 +21,7 @@ export function leafAt(
 
 /**
  * Minimal 3.1 Pet Store covering GET /pets, POST /pets, and
- * GET /pets/{petId} — enough surface area for tests that need a
+ * GET /pets/{petId}, enough surface area for tests that need a
  * realistic multi-operation spec without inlining a large literal.
  */
 export function petSpec(): OpenAPIDocument {

--- a/packages/validator/test/request.test.ts
+++ b/packages/validator/test/request.test.ts
@@ -102,7 +102,7 @@ describe("validateRequest", () => {
       },
     };
     const vi = createValidator(spec, { strict: "strict" });
-    // Schemas compile lazily — first touch to the route triggers it.
+    // Schemas compile lazily; first touch to the route triggers it.
     vi.validateRequest({ method: "POST", path: "/p", contentType: "application/json", body: "x" });
     const unknown = vi.stats.strictIssues.find((i) => i.code === "unknown-keyword");
     expect(unknown).toBeDefined();
@@ -124,7 +124,7 @@ describe("validateRequest", () => {
     // Spec accepts only multipart/form-data. Client says text/plain and
     // sends no body. Today's bug: the gate skipped body-absent requests
     // entirely, so validateBody fired "missing required request body"
-    // (400) — true but downstream of the actual cause. Now the gate
+    // (400), true but downstream of the actual cause. Now the gate
     // sees the unmatched header and surfaces a content-type leaf (415),
     // which is the actionable signal.
     const spec: OpenAPIDocument = {
@@ -185,7 +185,7 @@ describe("validateRequest", () => {
 
   it("content-type gate short-circuits before parameter validation", () => {
     // Wrong Content-Type AND missing required X-Tenant header. The gate
-    // fires first, so the tree is a single content-type leaf — no
+    // fires first, so the tree is a single content-type leaf, no
     // paired header-param diagnostic. Motivation: a client who fixes
     // the content-type can't act on a header-param complaint anyway;
     // surface the upstream problem unambiguously.
@@ -415,7 +415,7 @@ describe("validateRequest", () => {
     const leaves = collectLeaves(err ?? undefined!).filter((l) => l.code === "required");
     const paths = leaves.map((l) => l.path.join("."));
     // Each error's path carries the parent property's slot (weight vs
-    // temperature) — not a single shared location derived from the
+    // temperature), not a single shared location derived from the
     // $ref site.
     expect(paths.sort()).toEqual(["body.temperature.value", "body.weight.value"]);
   });
@@ -439,7 +439,7 @@ describe("validateRequest", () => {
 
   it("optional requestBody:required=false passes when the body is omitted", () => {
     // openapi-backend #817 / #292. Distinct from the bareboss no-body
-    // case — here the spec declares content but explicitly marks it
+    // case; here the spec declares content but explicitly marks it
     // non-required.
     const spec: OpenAPIDocument = {
       openapi: "3.1.0",
@@ -556,7 +556,7 @@ describe("validateRequest", () => {
   it("operation-level parameters replace path-level ones with the same name+in", () => {
     // openapi-backend #46. Path-level param: minLength 1; op-level
     // override: minLength 10. Per OAS 3.x the op-level fully replaces
-    // the path-level — a single error with the op-level constraint.
+    // the path-level: a single error with the op-level constraint.
     const spec: OpenAPIDocument = {
       openapi: "3.1.0",
       info: { title: "t", version: "1" },
@@ -672,7 +672,7 @@ describe("validateRequest", () => {
 
   it("accepts an optional-body POST with no body and no content-type", () => {
     // eov #397 / #646 / #655: when requestBody is not required and the
-    // caller sends nothing, there's nothing to validate — don't error
+    // caller sends nothing, there's nothing to validate; don't error
     // on the missing content-type.
     const spec: OpenAPIDocument = {
       openapi: "3.1.0",
@@ -695,7 +695,7 @@ describe("validateRequest", () => {
 
   it("format validators let null pass through on nullable OAS 3.0 fields", () => {
     // eov #382 / #108: format checks should not fire for null values on
-    // nullable properties — the format predicate only applies to strings.
+    // nullable properties; the format predicate only applies to strings.
     const spec: OpenAPIDocument = {
       openapi: "3.0.3",
       info: { title: "t", version: "1" },
@@ -841,7 +841,7 @@ describe("validateRequest", () => {
   });
 
   it("readOnly inside an allOf-referenced subschema is enforced on request bodies", () => {
-    // eov #149 / #389: the classic OpenAPI composition pattern — a
+    // eov #149 / #389: the classic OpenAPI composition pattern, a
     // per-entity schema extends a shared "timestamps" fragment via
     // allOf + $ref. The shared fragment's readOnly fields (and their
     // required-ness) must be transformed on the request side.
@@ -882,7 +882,7 @@ describe("validateRequest", () => {
       },
     };
     const sv = createValidator(spec);
-    // Omitting createdAt should pass — the readOnly field is exempt
+    // Omitting createdAt should pass; the readOnly field is exempt
     // from required on the request side.
     expect(
       sv.validateRequest({
@@ -892,7 +892,7 @@ describe("validateRequest", () => {
         body: { name: "n" },
       }),
     ).toBeNull();
-    // Sending createdAt should fail — clients must not supply it.
+    // Sending createdAt should fail; clients must not supply it.
     const err = sv.validateRequest({
       method: "POST",
       path: "/users",
@@ -945,7 +945,7 @@ describe("validateRequest", () => {
 
   it("parameter.content parses JSON and validates its schema", () => {
     // OpenAPI 3.1 §4.8.12.1 lets a parameter carry `content` instead of
-    // `schema` — standard pattern for structured-JSON query params.
+    // `schema`: standard pattern for structured-JSON query params.
     const spec: OpenAPIDocument = {
       openapi: "3.1.0",
       info: { title: "t", version: "1" },
@@ -1020,7 +1020,7 @@ describe("validateRequest", () => {
                 in: "query",
                 required: false,
                 allowEmptyValue: true,
-                // A schema that would normally reject "" — allowEmptyValue skips it.
+                // A schema that would normally reject "" (allowEmptyValue skips it).
                 schema: { type: "string", minLength: 4 },
               },
             ],

--- a/packages/validator/test/response.test.ts
+++ b/packages/validator/test/response.test.ts
@@ -170,14 +170,14 @@ describe("validateResponse", () => {
       },
     };
     const sv = createValidator(spec);
-    // Response omits writeOnly password — should pass.
+    // Response omits writeOnly password; should pass.
     expect(
       sv.validateResponse(
         { method: "GET", path: "/users" },
         { status: 200, contentType: "application/json", body: { id: "u1" } },
       ),
     ).toBeNull();
-    // Response includes writeOnly password — rejected.
+    // Response includes writeOnly password; rejected.
     const err = sv.validateResponse(
       { method: "GET", path: "/users" },
       {

--- a/packages/validator/test/security.test.ts
+++ b/packages/validator/test/security.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { createValidator } from "../src/validator.js";
 
 /**
- * Shape-only security validation coverage — bearer / basic / apiKey.
+ * Shape-only security validation coverage: bearer / basic / apiKey.
  * Credential verification is explicitly out of scope; these tests only
  * exercise presence + structural shape of the declared credential
  * location.
@@ -222,7 +222,7 @@ describe("security validation: OR across alternatives, AND within", () => {
     );
     const andV = createValidator(andSpec, { validateSecurity: true });
 
-    // Only the bearer is present — AND fails.
+    // Only the bearer is present; AND fails.
     const err = andV.validateRequest({
       method: "GET",
       path: "/ping",
@@ -230,7 +230,7 @@ describe("security validation: OR across alternatives, AND within", () => {
     });
     expect(firstLeaf(err)?.code).toBe("security");
 
-    // Both present — passes.
+    // Both present; passes.
     expect(
       andV.validateRequest({
         method: "GET",
@@ -264,7 +264,7 @@ describe("security validation: top-level vs operation-level", () => {
 });
 
 describe("security validation: configuration", () => {
-  it("defaults to off — security is not enforced unless validateSecurity: true is set", () => {
+  it("defaults to off: security is not enforced unless validateSecurity: true is set", () => {
     // The default reflects the "auth middleware runs upstream" reality:
     // by the time the validator sees a request, the credential has
     // already been verified (or rejected) by the host app's auth layer.
@@ -282,7 +282,7 @@ describe("security validation: configuration", () => {
     expect(firstLeaf(err)?.code).toBe("security");
   });
 
-  it("short-circuits before parameter / body checks — only a security error surfaces", () => {
+  it("short-circuits before parameter / body checks: only a security error surfaces", () => {
     const doc: OpenAPIDocument = {
       openapi: "3.1.0",
       info: { title: "t", version: "1" },
@@ -311,7 +311,7 @@ describe("security validation: configuration", () => {
       method: "POST",
       path: "/echo",
       contentType: "application/json",
-      body: {}, // missing `name` — normally a second error
+      body: {}, // missing `name`, normally a second error
     });
     // Only one child error (security); body violation is suppressed.
     expect(err?.code).toBe("request");
@@ -330,7 +330,7 @@ describe("security validation: configuration", () => {
       [{ oauth: ["read"] }],
     );
     const v = createValidator(spec, { validateSecurity: true });
-    // No headers / query — oauth2 isn't shape-checked, so pass.
+    // No headers / query; oauth2 isn't shape-checked, so pass.
     expect(v.validateRequest({ method: "GET", path: "/ping" })).toBeNull();
   });
 });

--- a/packages/validator/test/versioning.test.ts
+++ b/packages/validator/test/versioning.test.ts
@@ -205,7 +205,7 @@ describe("3.0 support", () => {
     const v = createValidator(spec);
     // If siblings weren't suppressed, "hi" (a string) would fail the
     // type:number sibling check. Under 3.0 semantics, only the
-    // referenced type:string applies — "hi" is valid.
+    // referenced type:string applies; "hi" is valid.
     expect(
       v.validateRequest({
         method: "POST",
@@ -218,7 +218,7 @@ describe("3.0 support", () => {
 
   it("drops nullable when it sits beside a $ref (3.0 sibling suppression)", () => {
     // eov #839: `{ $ref: X, nullable: true }` does NOT make the
-    // referenced schema nullable — 3.0 suppresses siblings of $ref.
+    // referenced schema nullable; 3.0 suppresses siblings of $ref.
     const spec: OpenAPIDocument = {
       openapi: "3.0.3",
       info: { title: "t", version: "1" },
@@ -259,7 +259,7 @@ describe("3.0 support", () => {
     expect(err).not.toBeNull();
   });
 
-  it("nullable combines with string constraints — null ok, short strings fail", () => {
+  it("nullable combines with string constraints: null ok, short strings fail", () => {
     // eov #912: nullable + minLength should treat null as a valid value
     // (bypassing length entirely) and still enforce minLength on strings.
     const spec: OpenAPIDocument = {
@@ -409,7 +409,7 @@ describe("category errors", () => {
   });
 
   it("message for missing openapi mentions the `swagger` sibling-field convention as a hint", () => {
-    // We don't *sniff* the `swagger` field — the check is just
+    // We don't *sniff* the `swagger` field; the check is just
     // "openapi must be a string." But the error text points the user
     // at the common sibling-format convention so they know where to
     // go next.
@@ -448,7 +448,7 @@ describe("category errors", () => {
   });
 
   it("warnings accumulate onto validator.warnings even without a warn callback", () => {
-    // The library never writes to stderr on its own — instead, every
+    // The library never writes to stderr on its own; instead, every
     // would-warn event lands on validator.warnings so the caller can
     // inspect post-construction.
     const v = createValidator(specWith(undefined), { dialect: jsonSchemaDialect });
@@ -469,7 +469,7 @@ describe("category errors", () => {
 });
 
 describe("unknown minor version (forward-compat within 3.x)", () => {
-  // Valid 3.x major with an unknown minor — e.g. 3.7.0. Not a
+  // Valid 3.x major with an unknown minor (e.g. 3.7.0). Not a
   // category error; this is the one case `onUnknownVersion` governs.
 
   function specWith(openapi: string): OpenAPIDocument {
@@ -518,7 +518,7 @@ describe("unknown minor version (forward-compat within 3.x)", () => {
       warn: (msg) => chunks.push(msg),
     });
     expect(v.detectedVersion).toBeUndefined();
-    // No warn here — `dialect` on a valid-shaped 3.x spec is just a
+    // No warn here; `dialect` on a valid-shaped 3.x spec is just a
     // normal override, not a category-error suppression.
     expect(chunks).toHaveLength(0);
   });


### PR DESCRIPTION
Closes #240.

## Summary

- New **Prose Style** subsection in CLAUDE.md under Contribution principles. A brief rule against four LLM-writing tells (em-dash, contrastive negation, filler/hedging, over-promising vocabulary) plus an ASCII-only constraint on generated output (error messages, log lines).
- Repo-wide em-dash scrub. ~700 occurrences of ` -- ` across 131 files replaced with context-appropriate punctuation.
- Three em-dashes inside string literals (Error messages, one generated-output comment) also scrubbed to satisfy the new ASCII-only output rule.
- A separate judgment pass over markdown for the other three tells found one line worth editing (`packages/cli/README.md:164`, dropped a filler ``essentially``). The prose was already careful.

## Framing

The Prose Style section frames the rule as reader flow, not detection:

> LLM-like writing breaks reader flow. Readers familiar with the patterns notice them, snap out of whatever they were absorbing, and have to reset. Avoid the patterns for the reader's sake, not for camouflage.

## Scope notes

- CLAUDE.md still contains one em-dash in the rule itself (referencing the literal character).
- CHANGELOG.md left alone (auto-generated by release-please).
- conformance/ test fixtures left alone (upstream JSON Schema Test Suite + spec corpora; not our prose).
- No behavior change. No API change.

## Test plan

- [x] ``pnpm fmt`` clean
- [x] ``pnpm lint`` clean (0 warnings, 0 errors)
- [x] ``pnpm typecheck`` clean
- [x] ``pnpm test`` 792 / 792 passing
- [ ] CI green