### PR TITLE
feat(spec): spec-hygiene lint (resolveSpec / createValidator / oav resolve --lint)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,6 +25,9 @@ programmatic API install `oav-core` instead.
 ```bash
 oav resolve <spec>                                       # stitch a multi-file spec
 oav resolve <spec> --overlay overlay1.json --overlay overlay2.json
+oav resolve <spec> --lint                                # spec-hygiene check; findings to stderr
+oav resolve <spec> --lint --fail-on warning              # CI gate: exit 1 on any finding
+oav resolve <spec> --lint --envelope json                # findings folded into JSON envelope
 
 oav validate <spec> --request req.http                   # full HTTP request from a .http file
 oav validate <spec> --path "POST /pets" --body body.json
@@ -54,6 +57,9 @@ below for the expected shape.
 | `--format text\|json\|flat`                   | validate                          | Error rendering. Default `text`.                                                                     |
 | `--depth <n>`                                 | validate                          | Truncate error tree depth (text format).                                                             |
 | `--overlay <file>`                            | resolve / validate / compile-spec | Repeatable; applies overlays in order.                                                               |
+| `--lint`                                      | resolve                           | Run spec-hygiene checks; findings to stderr (or JSON envelope with `--envelope json`).               |
+| `--fail-on <level>`                           | resolve                           | Non-zero exit on any finding at or above `<level>`. Requires `--lint`. Currently only `warning`.     |
+| `--envelope text\|json`                       | resolve                           | `text` (default; document on stdout, findings on stderr) or `json` (single payload).                 |
 | `--dialect 2020-12\|openapi-3.1\|openapi-3.0` | compile-schema / compile-spec     | Schema dialect. Defaults: 2020-12 (compile-schema), auto-detect from `openapi` field (compile-spec). |
 | `--requests-only`                             | compile-spec                      | Skip response-validator emit. Smaller output.                                                        |
 | `--only <method-path...>`                     | compile-spec                      | Repeatable; restrict emit to given ops, e.g. `--only "POST /pets"`.                                  |

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -57,23 +57,64 @@ export function buildProgram(options: BuildProgramOptions = {}): Command {
     .command("resolve <spec>")
     .description("Resolve a (possibly multi-file) OpenAPI document and print the stitched result.")
     .option("--overlay <file...>", "apply one or more overlays in order", collectOverlays, [])
+    .option(
+      "--lint",
+      "run spec-hygiene checks; findings go to stderr (or the json envelope when --envelope json)",
+      false,
+    )
+    .option(
+      "--fail-on <level>",
+      "non-zero exit when any finding at or above <level> appears (only 'warning' for now); requires --lint",
+      (value: string): "warning" => {
+        if (value !== "warning") {
+          throw new Error(`unknown level: ${value} (expected "warning")`);
+        }
+        return value;
+      },
+    )
+    .option(
+      "--envelope <shape>",
+      "'text' (default; document on stdout, findings on stderr) or 'json' ({ document, specHygieneIssues } single payload)",
+      (value: string): "text" | "json" => {
+        if (value !== "text" && value !== "json") {
+          throw new Error(`unknown envelope: ${value} (expected "text" or "json")`);
+        }
+        return value;
+      },
+      "text",
+    )
     .option("-o, --output <file>", "write output to a file instead of stdout")
     .option("--quiet", "print nothing; exit code only", false)
-    .action(async (spec: string, opts: { overlay: string[]; output?: string; quiet: boolean }) => {
-      const res = await resolveCommand(
-        {
-          spec,
-          overlays: opts.overlay ?? [],
-          options: {
-            format: "text",
-            output: opts.output,
-            quiet: opts.quiet,
-          },
+    .action(
+      async (
+        spec: string,
+        opts: {
+          overlay: string[];
+          lint: boolean;
+          failOn?: "warning";
+          envelope: "text" | "json";
+          output?: string;
+          quiet: boolean;
         },
-        io,
-      );
-      exit(res.exitCode);
-    });
+      ) => {
+        const res = await resolveCommand(
+          {
+            spec,
+            overlays: opts.overlay ?? [],
+            lint: opts.lint,
+            ...(opts.failOn !== undefined && { failOn: opts.failOn }),
+            envelope: opts.envelope,
+            options: {
+              format: "text",
+              output: opts.output,
+              quiet: opts.quiet,
+            },
+          },
+          io,
+        );
+        exit(res.exitCode);
+      },
+    );
 
   program
     .command("validate <spec>")

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -119,8 +119,11 @@ function primarySink(
 /**
  * Implement the `oav resolve <spec>` subcommand.
  *
- * @param args - Entry spec path + overlay files + base CLI options.
- * @returns The stitched document (as a CommandResult).
+ * @param args - Entry spec path, overlay files, optional lint flags, and
+ *   base CLI options.
+ * @returns Exit code 0 on success, 1 when `--lint --fail-on warning`
+ *   surfaces any findings, 3 on usage errors (`--fail-on` without
+ *   `--lint`).
  *
  * @public
  */
@@ -128,20 +131,49 @@ export async function resolveCommand(
   args: {
     spec: string;
     overlays: string[];
+    /** Run spec-hygiene lint passes and surface findings. Defaults to false. */
+    lint?: boolean;
+    /** Exit non-zero when any finding at or above <level> appears. Requires `lint`. */
+    failOn?: "warning";
+    /** `"text"` (default; document on stdout, findings on stderr) or `"json"` (one envelope). */
+    envelope?: "text" | "json";
     options: CommandOptions;
   },
   io: CommandIo = defaultCommandIo(),
 ): Promise<CommandResult> {
+  if (args.failOn !== undefined && args.lint !== true) {
+    io.stderr("error: --fail-on requires --lint\n");
+    return { exitCode: 3 };
+  }
+
   const overlayDocs = await Promise.all(
     args.overlays.map(async (path) => (await io.reader.read(path)) as SpecOverlay),
   );
-  const { document } = await loadSpec({
+  const { document, specHygieneIssues } = await loadSpec({
     reader: io.reader,
     entry: args.spec,
     overlays: overlayDocs,
+    lint: args.lint === true,
   });
-  const out = JSON.stringify(document, null, 2);
-  await primarySink(io, args.options)(out + "\n");
+
+  const sink = primarySink(io, args.options);
+  if (args.envelope === "json") {
+    // Single envelope: keeps the findings alongside the document for
+    // machine consumers without splitting across stdout/stderr.
+    const out = args.lint ? { document, specHygieneIssues } : { document };
+    await sink(JSON.stringify(out, null, 2) + "\n");
+  } else {
+    await sink(JSON.stringify(document, null, 2) + "\n");
+    if (args.lint && specHygieneIssues.length > 0) {
+      for (const w of specHygieneIssues) {
+        io.stderr(`warning [${w.code}] ${w.pointer}: ${w.message}\n`);
+      }
+    }
+  }
+
+  if (args.lint && args.failOn === "warning" && specHygieneIssues.length > 0) {
+    return { exitCode: 1 };
+  }
   return { exitCode: 0 };
 }
 

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -85,6 +85,38 @@ describe("buildProgram: argv-level", () => {
     expect(mem.writes[0]?.[1]).toContain('"openapi"');
   });
 
+  it("resolve --lint --fail-on warning exits 1 when the spec has hygiene issues", async () => {
+    const dirty = {
+      ...spec,
+      components: { schemas: { Orphan: { type: "object" } } },
+    };
+    const mem = memoryIo([["spec.json", dirty]]);
+    const out = await runCli(["resolve", "spec.json", "--lint", "--fail-on", "warning"], mem);
+    expect(out.exitCode).toBe(1);
+    expect(out.stderr).toContain("warning [unused-component]");
+  });
+
+  it("resolve --lint --envelope json folds findings into the envelope", async () => {
+    const dirty = {
+      ...spec,
+      components: { schemas: { Orphan: { type: "object" } } },
+    };
+    const mem = memoryIo([["spec.json", dirty]]);
+    const out = await runCli(["resolve", "spec.json", "--lint", "--envelope", "json"], mem);
+    expect(out.exitCode).toBe(0);
+    expect(out.stderr).toBe("");
+    const env = JSON.parse(out.stdout);
+    expect(env.specHygieneIssues).toHaveLength(1);
+    expect(env.specHygieneIssues[0].code).toBe("unused-component");
+  });
+
+  it("resolve --fail-on without --lint is a usage error", async () => {
+    const mem = memoryIo([["spec.json", spec]]);
+    const out = await runCli(["resolve", "spec.json", "--fail-on", "warning"], mem);
+    expect(out.exitCode).toBe(3);
+    expect(out.stderr).toContain("--fail-on requires --lint");
+  });
+
   it("validate --path/--body happy path exits 0 and stays silent", async () => {
     const mem = memoryIo([["spec.json", spec]], [["body.json", JSON.stringify({ name: "Fido" })]]);
     const out = await runCli(

--- a/packages/cli/test/commands.test.ts
+++ b/packages/cli/test/commands.test.ts
@@ -103,6 +103,97 @@ describe("resolveCommand", () => {
     expect(result.exitCode).toBe(0);
     expect(stdout.value).toBe("");
   });
+
+  function dirtySpec(): unknown {
+    return {
+      openapi: "3.1.0",
+      info: { title: "X", version: "1" },
+      paths: { "/pets": { get: { responses: { "200": { description: "ok" } } } } },
+      components: { schemas: { Orphan: { type: "object" } } },
+    };
+  }
+
+  it("--lint emits warnings to stderr, document still on stdout, exit 0", async () => {
+    const { io, stdout, stderr } = memoryIo([["spec.json", dirtySpec()]]);
+    const result = await resolveCommand(
+      { spec: "spec.json", overlays: [], lint: true, options: textOpts },
+      io,
+    );
+    expect(result.exitCode).toBe(0);
+    expect(stderr.value).toContain("warning [unused-component]");
+    expect(stderr.value).toContain("/components/schemas/Orphan");
+    expect(stdout.value).toContain('"openapi"');
+  });
+
+  it("--lint --fail-on warning bumps exit code to 1 when findings exist", async () => {
+    const { io } = memoryIo([["spec.json", dirtySpec()]]);
+    const result = await resolveCommand(
+      {
+        spec: "spec.json",
+        overlays: [],
+        lint: true,
+        failOn: "warning",
+        options: textOpts,
+      },
+      io,
+    );
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("--lint --fail-on warning stays at 0 when the spec is clean", async () => {
+    const cleanSpec = {
+      openapi: "3.1.0",
+      info: { title: "X", version: "1" },
+      paths: { "/pets": { get: { responses: { "200": { description: "ok" } } } } },
+    };
+    const { io } = memoryIo([["spec.json", cleanSpec]]);
+    const result = await resolveCommand(
+      {
+        spec: "spec.json",
+        overlays: [],
+        lint: true,
+        failOn: "warning",
+        options: textOpts,
+      },
+      io,
+    );
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("--envelope json folds findings into the envelope (no stderr split)", async () => {
+    const { io, stdout, stderr } = memoryIo([["spec.json", dirtySpec()]]);
+    const result = await resolveCommand(
+      {
+        spec: "spec.json",
+        overlays: [],
+        lint: true,
+        envelope: "json",
+        options: textOpts,
+      },
+      io,
+    );
+    expect(result.exitCode).toBe(0);
+    expect(stderr.value).toBe("");
+    const envelope = JSON.parse(stdout.value);
+    expect(envelope).toHaveProperty("document");
+    expect(envelope.specHygieneIssues).toHaveLength(1);
+    expect(envelope.specHygieneIssues[0].code).toBe("unused-component");
+  });
+
+  it("--fail-on without --lint is a usage error (exit 3)", async () => {
+    const { io, stderr } = memoryIo([["spec.json", dirtySpec()]]);
+    const result = await resolveCommand(
+      {
+        spec: "spec.json",
+        overlays: [],
+        failOn: "warning",
+        options: textOpts,
+      },
+      io,
+    );
+    expect(result.exitCode).toBe(3);
+    expect(stderr.value).toContain("--fail-on requires --lint");
+  });
 });
 
 describe("validateCommand", () => {

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -127,3 +127,37 @@ schemas compile to normal recursive calls.
 
 Circular external references are rewritten to internal anchors
 during resolution, so the final document is always self-contained.
+
+## Spec hygiene lint
+
+`loadSpec` and `resolveSpec` accept `lint: true`. When set, the
+returned `ResolvedSpec.specHygieneIssues` carries findings about
+authoring mistakes the structural validation can't catch:
+
+- `unused-component`: a `components.{schemas,parameters,...}` entry
+  with no `$ref` reaching it.
+- `unused-tag`: a `tags[]` entry no operation references.
+- `unreachable-defs`: a per-schema `$defs/<name>` no sibling `$ref`
+  points at.
+- `path-param-undeclared` / `path-param-unused`: mismatch between the
+  `{name}` placeholders in a path template and the path-parameter
+  declarations on the operation or its path-item.
+
+```ts
+const { document, specHygieneIssues } = await loadSpec({ reader, entry, lint: true });
+for (const w of specHygieneIssues) {
+  console.warn(`[${w.code}] ${w.pointer}: ${w.message}`);
+}
+```
+
+The same engine is reachable directly via `lintResolvedSpec(document)`
+for callers that already have a resolved document and just want the
+findings. The validator surfaces it too: `createValidator(spec,
+{ lint: true })` exposes `validator.specHygieneIssues`. Pick whichever
+layer is natural for the flow; running `lint: true` in two places lints
+twice.
+
+`oav resolve --lint` exposes the same checks at the CLI; pair with
+`--fail-on warning` for a CI gate.
+
+See `SpecHygieneIssue` for the per-finding shape.

--- a/packages/spec/src/index.ts
+++ b/packages/spec/src/index.ts
@@ -18,3 +18,4 @@ export {
   type SpecOverlay,
 } from "./overlay.js";
 export { loadSpec, type LoadSpecOptions } from "./load.js";
+export { lintResolvedSpec, type SpecHygieneIssue } from "./lint.js";

--- a/packages/spec/src/lint.ts
+++ b/packages/spec/src/lint.ts
@@ -1,0 +1,489 @@
+import {
+  resolveJsonPointer,
+  type ComponentsObject,
+  type OpenAPIDocument,
+  type OperationObject,
+  type ParameterObject,
+  type PathItem,
+  type ReferenceObject,
+  type TagObject,
+} from "@oav/core";
+
+/**
+ * A single spec-hygiene finding from {@link lintResolvedSpec}.
+ *
+ * Findings are reported, never fatal: the spec is structurally valid, the
+ * shape just looks like an authoring mistake (declared but unused,
+ * referenced but undeclared).
+ *
+ * @public
+ */
+export interface SpecHygieneIssue {
+  /**
+   * - `"unused-component"`: a `components.{schemas,parameters,requestBodies,responses,headers,securitySchemes}`
+   *   entry that no operation reaches.
+   * - `"unused-tag"`: a `tags[]` entry whose name doesn't appear in any
+   *   operation's `tags` array.
+   * - `"unreachable-defs"`: a `$defs/<name>` entry inside a schema that no
+   *   `$ref` in the same schema points to.
+   * - `"path-param-undeclared"`: a `{name}` placeholder in a path template
+   *   with no matching `parameters: [{ in: "path", name }]` declaration on
+   *   the operation or its path-item.
+   * - `"path-param-unused"`: a `parameters: [{ in: "path", name }]`
+   *   declaration whose name doesn't appear as a placeholder in the path
+   *   template.
+   */
+  code:
+    | "unused-component"
+    | "unused-tag"
+    | "unreachable-defs"
+    | "path-param-undeclared"
+    | "path-param-unused";
+  /** RFC 6901 JSON Pointer to the offending node in the resolved document. */
+  pointer: string;
+  /** Human-readable explanation. */
+  message: string;
+}
+
+const COMPONENT_CATEGORIES = [
+  "schemas",
+  "parameters",
+  "requestBodies",
+  "responses",
+  "headers",
+  "securitySchemes",
+] as const satisfies readonly (keyof ComponentsObject)[];
+
+const HTTP_METHODS = [
+  "get",
+  "put",
+  "post",
+  "delete",
+  "options",
+  "head",
+  "patch",
+  "trace",
+  "query",
+] as const;
+
+const PATH_TEMPLATE_RE = /\{([^{}]+)\}/g;
+
+/**
+ * Lint a resolved OpenAPI document for spec-hygiene issues.
+ *
+ * Pure: the document is not mutated. Run after
+ * {@link resolveSpec | resolveSpec} so external `$ref`s are inlined and
+ * circular ones live under `$defs.__ext__/<encoded-uri>` (the lint skips
+ * these resolver-inserted entries).
+ *
+ * The four checks:
+ *
+ * - **unused-component**: components defined but not reached from any
+ *   operation, security requirement, or `discriminator.mapping`.
+ * - **unused-tag**: top-level `tags[]` entry with no operation referring to
+ *   it.
+ * - **unreachable-defs**: per-schema `$defs/<name>` that no sibling `$ref`
+ *   in the same schema points to.
+ * - **path-param-undeclared / path-param-unused**: mismatch between the
+ *   `{name}` placeholders in a path template and the path-parameter
+ *   declarations on the operation + its path-item.
+ *
+ * @returns Findings, ordered by category then by pointer for stable
+ *   output. Empty array means clean spec.
+ *
+ * @public
+ */
+export function lintResolvedSpec(document: OpenAPIDocument): SpecHygieneIssue[] {
+  const issues: SpecHygieneIssue[] = [];
+  issues.push(...findUnusedComponents(document));
+  issues.push(...findUnusedTags(document));
+  issues.push(...findUnreachableDefs(document));
+  issues.push(...findPathParamMismatches(document));
+  return issues;
+}
+
+// ---------------------------------------------------------------------------
+// unused-component
+// ---------------------------------------------------------------------------
+
+function findUnusedComponents(document: OpenAPIDocument): SpecHygieneIssue[] {
+  const components = document.components;
+  if (!components) return [];
+
+  const declared = new Set<string>();
+  for (const category of COMPONENT_CATEGORIES) {
+    const bucket = components[category];
+    if (!bucket) continue;
+    for (const name of Object.keys(bucket)) {
+      declared.add(`${category}/${name}`);
+    }
+  }
+  if (declared.size === 0) return [];
+
+  const reached = collectReachableComponents(document);
+
+  const issues: SpecHygieneIssue[] = [];
+  for (const category of COMPONENT_CATEGORIES) {
+    const bucket = components[category];
+    if (!bucket) continue;
+    for (const name of Object.keys(bucket)) {
+      const key = `${category}/${name}`;
+      if (reached.has(key)) continue;
+      issues.push({
+        code: "unused-component",
+        pointer: `/components/${category}/${encodePointerSegment(name)}`,
+        message: `components.${category}.${name} is declared but no operation reaches it`,
+      });
+    }
+  }
+  return issues;
+}
+
+/**
+ * Walk roots (operations, top-level + per-op `security`,
+ * `discriminator.mapping`), collect every `$ref` target into
+ * `components/*` and every `securitySchemes` name referenced. Iterates
+ * to a fixed point so component-to-component refs propagate.
+ */
+function collectReachableComponents(document: OpenAPIDocument): Set<string> {
+  // Direct refs collected from non-component roots.
+  const fromRoots = new Set<string>();
+  // Map from a component key (e.g. "schemas/Pet") to refs it makes.
+  const componentEdges = new Map<string, Set<string>>();
+
+  // Index: every $ref / security-scheme reference in the document, paired
+  // with a "source" path so we can attribute it to a containing component
+  // (for transitive-closure) or to a non-component root.
+  collectAllRefs(document, fromRoots, componentEdges);
+
+  // Closure: anything reached from roots, plus anything reached from
+  // already-reached components.
+  const reached = new Set<string>(fromRoots);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const key of reached) {
+      const edges = componentEdges.get(key);
+      if (!edges) continue;
+      for (const target of edges) {
+        if (!reached.has(target)) {
+          reached.add(target);
+          changed = true;
+        }
+      }
+    }
+  }
+  return reached;
+}
+
+function collectAllRefs(
+  document: OpenAPIDocument,
+  fromRoots: Set<string>,
+  componentEdges: Map<string, Set<string>>,
+): void {
+  // Top-level security scheme references.
+  for (const req of document.security ?? []) {
+    for (const schemeName of Object.keys(req)) {
+      fromRoots.add(`securitySchemes/${schemeName}`);
+    }
+  }
+
+  // Operations under paths.
+  for (const [pathTemplate, pathItem] of Object.entries(document.paths ?? {})) {
+    if (!pathItem) continue;
+    walkPathItem(pathItem, fromRoots);
+    walkAnyRefs(pathItem, fromRoots);
+    void pathTemplate;
+  }
+  // Operations under webhooks (3.1+).
+  for (const [, webhook] of Object.entries(document.webhooks ?? {})) {
+    if (!webhook || isReference(webhook)) continue;
+    walkPathItem(webhook, fromRoots);
+    walkAnyRefs(webhook, fromRoots);
+  }
+  // Operations under components.pathItems would belong here too, but the
+  // type doesn't expose pathItems; the generic walkAnyRefs over the whole
+  // document below catches every $ref regardless.
+
+  // Components: edges from each component to whatever it refs.
+  const components = document.components;
+  if (!components) return;
+  for (const category of COMPONENT_CATEGORIES) {
+    const bucket = components[category];
+    if (!bucket) continue;
+    for (const [name, value] of Object.entries(bucket)) {
+      const key = `${category}/${name}`;
+      const edges = new Set<string>();
+      walkAnyRefs(value, edges);
+      if (edges.size > 0) componentEdges.set(key, edges);
+    }
+  }
+}
+
+function walkPathItem(pathItem: PathItem, sink: Set<string>): void {
+  for (const method of HTTP_METHODS) {
+    const op = pathItem[method];
+    if (!op) continue;
+    for (const req of op.security ?? []) {
+      for (const schemeName of Object.keys(req)) {
+        sink.add(`securitySchemes/${schemeName}`);
+      }
+    }
+  }
+}
+
+/**
+ * Recursive walk that captures every `$ref` whose target is
+ * `#/components/<category>/<name>` and every `discriminator.mapping`
+ * value pointing at the same shape. Adds to `sink` as
+ * `<category>/<name>`.
+ */
+function walkAnyRefs(value: unknown, sink: Set<string>): void {
+  if (value === null || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    for (const item of value) walkAnyRefs(item, sink);
+    return;
+  }
+  const obj = value as Record<string, unknown>;
+  const ref = obj.$ref;
+  if (typeof ref === "string") {
+    const key = parseComponentRef(ref);
+    if (key) sink.add(key);
+  }
+  const discriminator = obj.discriminator;
+  if (discriminator && typeof discriminator === "object") {
+    const mapping = (discriminator as { mapping?: unknown }).mapping;
+    if (mapping && typeof mapping === "object") {
+      for (const target of Object.values(mapping as Record<string, unknown>)) {
+        if (typeof target === "string") {
+          const key = parseComponentRef(target);
+          if (key) sink.add(key);
+        }
+      }
+    }
+  }
+  for (const v of Object.values(obj)) walkAnyRefs(v, sink);
+}
+
+function parseComponentRef(ref: string): string | null {
+  // Match `#/components/<category>/<name>` exactly. Reject deeper
+  // pointers (e.g. `#/components/schemas/Pet/properties/id`); those
+  // still mark the component as reached, so accept the prefix too.
+  const m = /^#\/components\/([^/]+)\/([^/]+)/.exec(ref);
+  if (!m) return null;
+  const category = decodePointerSegment(m[1]!);
+  const name = decodePointerSegment(m[2]!);
+  if (!(COMPONENT_CATEGORIES as readonly string[]).includes(category)) return null;
+  return `${category}/${name}`;
+}
+
+// ---------------------------------------------------------------------------
+// unused-tag
+// ---------------------------------------------------------------------------
+
+function findUnusedTags(document: OpenAPIDocument): SpecHygieneIssue[] {
+  const declared: TagObject[] = document.tags ?? [];
+  if (declared.length === 0) return [];
+  const used = new Set<string>();
+  const collect = (op: OperationObject | undefined): void => {
+    if (!op) return;
+    for (const tag of op.tags ?? []) used.add(tag);
+  };
+  for (const pathItem of Object.values(document.paths ?? {})) {
+    if (!pathItem) continue;
+    for (const method of HTTP_METHODS) collect(pathItem[method]);
+  }
+  for (const webhook of Object.values(document.webhooks ?? {})) {
+    if (!webhook || isReference(webhook)) continue;
+    for (const method of HTTP_METHODS) collect(webhook[method]);
+  }
+
+  const issues: SpecHygieneIssue[] = [];
+  for (let i = 0; i < declared.length; i += 1) {
+    const tag = declared[i]!;
+    if (used.has(tag.name)) continue;
+    issues.push({
+      code: "unused-tag",
+      pointer: `/tags/${i}`,
+      message: `tag "${tag.name}" is declared but no operation references it`,
+    });
+  }
+  return issues;
+}
+
+// ---------------------------------------------------------------------------
+// unreachable-defs
+// ---------------------------------------------------------------------------
+
+function findUnreachableDefs(document: OpenAPIDocument): SpecHygieneIssue[] {
+  // Find every $defs container with its location, then for each entry
+  // see whether any $ref in the document points at that location.
+  // Conservative: a ref from outside the containing schema also counts as
+  // "reached", which avoids false positives when a $defs entry is genuinely
+  // shared across schemas via absolute pointers.
+  const allRefs = new Set<string>();
+  collectEveryRefValue(document, allRefs);
+
+  const issues: SpecHygieneIssue[] = [];
+  walkForDefs(document, "", (defsPointer, name) => {
+    if (name.startsWith("__ext__/")) return; // resolver-injected; always referenced
+    const target = `${defsPointer}/${encodePointerSegment(name)}`;
+    if (refsHit(allRefs, target)) return;
+    issues.push({
+      code: "unreachable-defs",
+      pointer: target,
+      message: `$defs entry "${name}" at ${defsPointer.slice(0, -"/$defs".length) || "/"} is not referenced by any $ref`,
+    });
+  });
+  return issues;
+}
+
+function collectEveryRefValue(value: unknown, sink: Set<string>): void {
+  if (value === null || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    for (const item of value) collectEveryRefValue(item, sink);
+    return;
+  }
+  const obj = value as Record<string, unknown>;
+  const ref = obj.$ref;
+  if (typeof ref === "string" && ref.startsWith("#")) {
+    sink.add(ref);
+  }
+  for (const v of Object.values(obj)) collectEveryRefValue(v, sink);
+}
+
+function walkForDefs(
+  value: unknown,
+  pointer: string,
+  visit: (defsPointer: string, name: string) => void,
+): void {
+  if (value === null || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i += 1) {
+      walkForDefs(value[i], `${pointer}/${i}`, visit);
+    }
+    return;
+  }
+  const obj = value as Record<string, unknown>;
+  for (const [key, child] of Object.entries(obj)) {
+    const childPointer = `${pointer}/${encodePointerSegment(key)}`;
+    if (key === "$defs" && child && typeof child === "object" && !Array.isArray(child)) {
+      for (const name of Object.keys(child as Record<string, unknown>)) {
+        visit(childPointer, name);
+      }
+    }
+    walkForDefs(child, childPointer, visit);
+  }
+}
+
+function refsHit(allRefs: Set<string>, targetPointer: string): boolean {
+  // `targetPointer` is like `/components/schemas/Pet/$defs/Inner`.
+  // A ref hits if some `#`-prefixed value matches `#<targetPointer>` or
+  // extends it (`#<targetPointer>/...`).
+  const exact = `#${targetPointer}`;
+  if (allRefs.has(exact)) return true;
+  const prefix = `${exact}/`;
+  for (const ref of allRefs) {
+    if (ref.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// path-param-undeclared / path-param-unused
+// ---------------------------------------------------------------------------
+
+function findPathParamMismatches(document: OpenAPIDocument): SpecHygieneIssue[] {
+  const issues: SpecHygieneIssue[] = [];
+  for (const [pathTemplate, pathItem] of Object.entries(document.paths ?? {})) {
+    if (!pathItem) continue;
+    const inTemplate = extractPathTemplateNames(pathTemplate);
+    const pathItemPointer = `/paths/${encodePointerSegment(pathTemplate)}`;
+    const itemLevelDeclared = collectPathParams(pathItem.parameters ?? [], document);
+    for (const method of HTTP_METHODS) {
+      const op = pathItem[method];
+      if (!op) continue;
+      const opPointer = `${pathItemPointer}/${method}`;
+      const opLevelDeclared = collectPathParams(op.parameters ?? [], document);
+
+      // OpenAPI: operation-level parameters with same (name, in) override
+      // path-item-level. Compute the effective set by name.
+      const effective = new Map<string, "item" | "op">();
+      for (const name of itemLevelDeclared) effective.set(name, "item");
+      for (const name of opLevelDeclared) effective.set(name, "op");
+
+      for (const name of inTemplate) {
+        if (effective.has(name)) continue;
+        issues.push({
+          code: "path-param-undeclared",
+          pointer: opPointer,
+          message: `path template "${pathTemplate}" references "{${name}}" but neither the operation nor its path item declares a path parameter named "${name}"`,
+        });
+      }
+      for (const [name, source] of effective) {
+        if (inTemplate.has(name)) continue;
+        issues.push({
+          code: "path-param-unused",
+          pointer: source === "op" ? `${opPointer}/parameters` : `${pathItemPointer}/parameters`,
+          message: `path parameter "${name}" is declared on ${source === "op" ? "the operation" : "the path item"} but does not appear in the path template "${pathTemplate}"`,
+        });
+      }
+    }
+  }
+  return issues;
+}
+
+function extractPathTemplateNames(template: string): Set<string> {
+  const names = new Set<string>();
+  for (const match of template.matchAll(PATH_TEMPLATE_RE)) {
+    names.add(match[1]!);
+  }
+  return names;
+}
+
+function collectPathParams(
+  parameters: readonly (ParameterObject | ReferenceObject)[],
+  document: OpenAPIDocument,
+): Set<string> {
+  const names = new Set<string>();
+  for (const entry of parameters) {
+    const param = isReference(entry) ? resolveParamRef(entry, document) : entry;
+    if (!param) continue;
+    if (param.in === "path") names.add(param.name);
+  }
+  return names;
+}
+
+function resolveParamRef(ref: ReferenceObject, document: OpenAPIDocument): ParameterObject | null {
+  // resolveJsonPointer takes the fragment after the leading `#`.
+  const pointer = ref.$ref.startsWith("#") ? ref.$ref.slice(1) : ref.$ref;
+  try {
+    const target = resolveJsonPointer(document, pointer);
+    if (target && typeof target === "object" && "in" in target && "name" in target) {
+      return target as unknown as ParameterObject;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function isReference(value: unknown): value is ReferenceObject {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    typeof (value as { $ref?: unknown }).$ref === "string"
+  );
+}
+
+function encodePointerSegment(segment: string): string {
+  return segment.replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
+function decodePointerSegment(segment: string): string {
+  return segment.replace(/~1/g, "/").replace(/~0/g, "~");
+}

--- a/packages/spec/src/load.ts
+++ b/packages/spec/src/load.ts
@@ -1,6 +1,7 @@
 import type { DocumentReader } from "./reader.js";
 import { applyOverlays, type SpecOverlay } from "./overlay.js";
 import { resolveSpec, type ResolvedSpec } from "./resolver.js";
+import { lintResolvedSpec } from "./lint.js";
 
 /**
  * Options accepted by {@link loadSpec}.
@@ -16,6 +17,12 @@ export interface LoadSpecOptions {
   baseUri?: string;
   /** Overlays to apply in order after resolution. */
   overlays?: SpecOverlay[];
+  /**
+   * Run spec-hygiene lint passes against the post-overlay document.
+   * Findings land in {@link ResolvedSpec.specHygieneIssues}. Defaults
+   * to `false`.
+   */
+  lint?: boolean;
 }
 
 /**
@@ -37,14 +44,19 @@ export interface LoadSpecOptions {
  * @public
  */
 export async function loadSpec(options: LoadSpecOptions): Promise<ResolvedSpec> {
+  // resolveSpec lints the pre-overlay document if asked, but the overlay
+  // pass below can change reachability (add or remove operations,
+  // components, refs). Defer the lint to after overlays are applied so
+  // the findings reflect the document the consumer will actually use.
   const resolved = await resolveSpec({
     reader: options.reader,
     entry: options.entry,
     ...(options.baseUri !== undefined && { baseUri: options.baseUri }),
   });
-  if (!options.overlays || options.overlays.length === 0) return resolved;
-  return {
-    document: applyOverlays(resolved.document, options.overlays),
-    sources: resolved.sources,
-  };
+  const overlaid =
+    options.overlays && options.overlays.length > 0
+      ? applyOverlays(resolved.document, options.overlays)
+      : resolved.document;
+  const specHygieneIssues = options.lint ? lintResolvedSpec(overlaid) : [];
+  return { document: overlaid, sources: resolved.sources, specHygieneIssues };
 }

--- a/packages/spec/src/resolver.ts
+++ b/packages/spec/src/resolver.ts
@@ -1,6 +1,7 @@
 import { dirname, isAbsolute, posix, resolve as resolvePath } from "node:path";
 import { resolveJsonPointer, type OpenAPIDocument } from "@oav/core";
 import type { DocumentReader } from "./reader.js";
+import { lintResolvedSpec, type SpecHygieneIssue } from "./lint.js";
 
 // Re-export the canonical implementation so @oav/spec consumers who
 // imported `resolveJsonPointer` keep working.
@@ -18,6 +19,12 @@ export interface ResolveSpecOptions {
   entry: string;
   /** Base directory/URI for resolving relative refs. Defaults to the entry's directory. */
   baseUri?: string;
+  /**
+   * Run spec-hygiene lint passes against the resolved document.
+   * Findings land in {@link ResolvedSpec.specHygieneIssues}. Defaults
+   * to `false`. See {@link lintResolvedSpec}.
+   */
+  lint?: boolean;
 }
 
 /**
@@ -30,6 +37,12 @@ export interface ResolvedSpec {
   document: OpenAPIDocument;
   /** URIs of every external file that was loaded during resolution. */
   sources: string[];
+  /**
+   * Spec-hygiene findings from {@link lintResolvedSpec}. Empty unless
+   * {@link ResolveSpecOptions.lint} was set. Same name and shape as
+   * {@link Validator.specHygieneIssues} on the validator side.
+   */
+  specHygieneIssues: readonly SpecHygieneIssue[];
 }
 
 type Mutable = Record<string, unknown>;
@@ -182,7 +195,8 @@ export async function resolveSpec(options: ResolveSpecOptions): Promise<Resolved
     rootObj.$defs = { ...prevDefs, __ext__: { ...prevExt, ...stitched } };
   }
 
-  return { document: resolved, sources: [...sources] };
+  const specHygieneIssues = options.lint ? lintResolvedSpec(resolved) : [];
+  return { document: resolved, sources: [...sources], specHygieneIssues };
 }
 
 function resolveRelative(base: string, rel: string): string {

--- a/packages/spec/test/lint.test.ts
+++ b/packages/spec/test/lint.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, it } from "vitest";
+import type { OpenAPIDocument } from "@oav/core";
+import { lintResolvedSpec } from "../src/lint.js";
+
+function minimalSpec(overrides: Partial<OpenAPIDocument> = {}): OpenAPIDocument {
+  return {
+    openapi: "3.1.0",
+    info: { title: "T", version: "1" },
+    paths: {},
+    ...overrides,
+  };
+}
+
+describe("lintResolvedSpec: clean specs", () => {
+  it("returns no findings for a minimal valid spec", () => {
+    expect(lintResolvedSpec(minimalSpec())).toEqual([]);
+  });
+
+  it("returns no findings for a spec where every component is reached", () => {
+    const spec = minimalSpec({
+      paths: {
+        "/pets/{id}": {
+          parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+          get: {
+            responses: {
+              "200": { $ref: "#/components/responses/PetResponse" },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Pet: { type: "object", properties: { id: { type: "string" } } },
+        },
+        responses: {
+          PetResponse: {
+            description: "ok",
+            content: {
+              "application/json": { schema: { $ref: "#/components/schemas/Pet" } },
+            },
+          },
+        },
+      },
+    });
+    expect(lintResolvedSpec(spec)).toEqual([]);
+  });
+});
+
+describe("lintResolvedSpec: unused-component", () => {
+  it("flags a schema declared in components.schemas but not reached", () => {
+    const spec = minimalSpec({
+      paths: { "/pets": { get: { responses: { "200": { description: "ok" } } } } },
+      components: {
+        schemas: { Orphan: { type: "object" } },
+      },
+    });
+    const issues = lintResolvedSpec(spec);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      code: "unused-component",
+      pointer: "/components/schemas/Orphan",
+    });
+  });
+
+  it("does not flag a schema that's reached transitively via another component", () => {
+    const spec = minimalSpec({
+      paths: {
+        "/pets": {
+          get: {
+            responses: {
+              "200": {
+                description: "ok",
+                content: {
+                  "application/json": { schema: { $ref: "#/components/schemas/Pet" } },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Pet: { type: "object", properties: { tag: { $ref: "#/components/schemas/Tag" } } },
+          Tag: { type: "object", properties: { name: { type: "string" } } },
+        },
+      },
+    });
+    expect(lintResolvedSpec(spec)).toEqual([]);
+  });
+
+  it("flags an unused securityScheme (no security: clause references it)", () => {
+    const spec = minimalSpec({
+      components: {
+        securitySchemes: { bearerAuth: { type: "http", scheme: "bearer" } },
+      },
+    });
+    const issues = lintResolvedSpec(spec);
+    expect(
+      issues.some((i) => i.code === "unused-component" && i.pointer.endsWith("/bearerAuth")),
+    ).toBe(true);
+  });
+
+  it("does not flag a securityScheme reached via top-level security", () => {
+    const spec = minimalSpec({
+      security: [{ bearerAuth: [] }],
+      components: {
+        securitySchemes: { bearerAuth: { type: "http", scheme: "bearer" } },
+      },
+    });
+    expect(lintResolvedSpec(spec)).toEqual([]);
+  });
+
+  it("treats a discriminator.mapping target as reached", () => {
+    const spec = minimalSpec({
+      paths: {
+        "/animals": {
+          get: {
+            responses: {
+              "200": {
+                description: "ok",
+                content: {
+                  "application/json": {
+                    schema: {
+                      discriminator: {
+                        propertyName: "kind",
+                        mapping: { cat: "#/components/schemas/Cat" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: { Cat: { type: "object" } },
+      },
+    });
+    expect(lintResolvedSpec(spec)).toEqual([]);
+  });
+});
+
+describe("lintResolvedSpec: unused-tag", () => {
+  it("flags a top-level tag that no operation uses", () => {
+    const spec = minimalSpec({
+      tags: [{ name: "Internal" }, { name: "Pets" }],
+      paths: {
+        "/pets": { get: { tags: ["Pets"], responses: { "200": { description: "ok" } } } },
+      },
+    });
+    const issues = lintResolvedSpec(spec);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ code: "unused-tag", pointer: "/tags/0" });
+  });
+
+  it("returns nothing when every tag has at least one user", () => {
+    const spec = minimalSpec({
+      tags: [{ name: "Pets" }],
+      paths: {
+        "/pets": { get: { tags: ["Pets"], responses: { "200": { description: "ok" } } } },
+      },
+    });
+    expect(lintResolvedSpec(spec)).toEqual([]);
+  });
+});
+
+describe("lintResolvedSpec: unreachable-defs", () => {
+  it("flags a $defs entry that no $ref points at", () => {
+    const spec = minimalSpec({
+      components: {
+        schemas: {
+          Pet: {
+            type: "object",
+            $defs: {
+              Used: { type: "string" },
+              Dead: { type: "number" },
+            },
+            properties: {
+              tag: { $ref: "#/components/schemas/Pet/$defs/Used" },
+            },
+          },
+        },
+      },
+      paths: {
+        "/pets": {
+          get: {
+            responses: {
+              "200": {
+                description: "ok",
+                content: {
+                  "application/json": { schema: { $ref: "#/components/schemas/Pet" } },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const issues = lintResolvedSpec(spec);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      code: "unreachable-defs",
+      pointer: "/components/schemas/Pet/$defs/Dead",
+    });
+  });
+
+  it("does not flag $defs/__ext__/<uri> entries (resolver-injected)", () => {
+    const spec: OpenAPIDocument = {
+      openapi: "3.1.0",
+      info: { title: "T", version: "1" },
+      paths: {
+        "/pets": {
+          get: {
+            responses: {
+              "200": {
+                description: "ok",
+                content: { "application/json": { schema: { $ref: "#/$defs/__ext__/foo" } } },
+              },
+            },
+          },
+        },
+      },
+      $defs: {
+        __ext__: {
+          foo: { type: "object" },
+        },
+      },
+    } as OpenAPIDocument;
+    expect(lintResolvedSpec(spec).filter((i) => i.code === "unreachable-defs")).toEqual([]);
+  });
+});
+
+describe("lintResolvedSpec: path-param-undeclared / path-param-unused", () => {
+  it("flags a {placeholder} in the path with no matching declaration", () => {
+    const spec = minimalSpec({
+      paths: {
+        "/pets/{id}": {
+          get: { responses: { "200": { description: "ok" } } },
+        },
+      },
+    });
+    const issues = lintResolvedSpec(spec);
+    expect(issues).toContainEqual(
+      expect.objectContaining({
+        code: "path-param-undeclared",
+        pointer: "/paths/~1pets~1{id}/get",
+      }),
+    );
+  });
+
+  it("flags a declared in:path parameter that's not in the path template", () => {
+    const spec = minimalSpec({
+      paths: {
+        "/pets": {
+          get: {
+            parameters: [{ name: "ghost", in: "path", required: true, schema: { type: "string" } }],
+            responses: { "200": { description: "ok" } },
+          },
+        },
+      },
+    });
+    const issues = lintResolvedSpec(spec);
+    expect(issues).toContainEqual(
+      expect.objectContaining({
+        code: "path-param-unused",
+      }),
+    );
+  });
+
+  it("accepts a parameter declared at the path-item level", () => {
+    const spec = minimalSpec({
+      paths: {
+        "/pets/{id}": {
+          parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+          get: { responses: { "200": { description: "ok" } } },
+        },
+      },
+    });
+    expect(lintResolvedSpec(spec)).toEqual([]);
+  });
+
+  it("accepts a parameter declared via $ref to components.parameters", () => {
+    const spec = minimalSpec({
+      paths: {
+        "/pets/{id}": {
+          parameters: [{ $ref: "#/components/parameters/PetId" }],
+          get: { responses: { "200": { description: "ok" } } },
+        },
+      },
+      components: {
+        parameters: {
+          PetId: { name: "id", in: "path", required: true, schema: { type: "string" } },
+        },
+      },
+    });
+    expect(lintResolvedSpec(spec)).toEqual([]);
+  });
+});

--- a/packages/spec/test/load.test.ts
+++ b/packages/spec/test/load.test.ts
@@ -51,6 +51,47 @@ describe("loadSpec", () => {
     expect(Object.keys(document.paths ?? {})).toEqual(["/pets"]);
   });
 
+  it("returns an empty specHygieneIssues array when lint is not requested", async () => {
+    const { specHygieneIssues } = await loadSpec({ reader: baseReader(), entry: "main.json" });
+    expect(specHygieneIssues).toEqual([]);
+  });
+
+  it("populates specHygieneIssues when lint: true and the spec has hygiene issues", async () => {
+    const reader = createMemoryReader(
+      new Map<string, unknown>([
+        [
+          "main.json",
+          {
+            openapi: "3.1.0",
+            info: { title: "X", version: "1" },
+            paths: { "/pets": { get: { responses: { "200": { description: "ok" } } } } },
+            components: { schemas: { Orphan: { type: "object" } } },
+          },
+        ],
+      ]),
+    );
+    const { specHygieneIssues } = await loadSpec({ reader, entry: "main.json", lint: true });
+    expect(specHygieneIssues).toHaveLength(1);
+    expect(specHygieneIssues[0]?.code).toBe("unused-component");
+    expect(specHygieneIssues[0]?.pointer).toBe("/components/schemas/Orphan");
+  });
+
+  it("lints the post-overlay document, not the pre-overlay one", async () => {
+    // Pre-overlay the spec is clean. The overlay adds an unused component
+    // so the lint reflects what the consumer will actually use.
+    const reader = baseReader();
+    const overlays: SpecOverlay[] = [
+      { addPaths: { "/health": { get: { responses: { "200": { description: "ok" } } } } } },
+    ];
+    const { specHygieneIssues } = await loadSpec({
+      reader,
+      entry: "main.json",
+      overlays,
+      lint: true,
+    });
+    expect(specHygieneIssues).toEqual([]);
+  });
+
   it("inlines external $refs first, then applies overlays to the resolved document", async () => {
     // Integration: confirms `loadSpec` runs `resolveSpec` before
     // `applyOverlays`, so an overlay extending `components.schemas.Pet`

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -15,6 +15,7 @@ import {
 } from "@oav/core";
 import { builtInFormats } from "@oav/formats";
 import { createRouter, type RouteMatch, type Router } from "@oav/router";
+import { lintResolvedSpec, type SpecHygieneIssue } from "@oav/spec";
 import {
   compileSchema,
   createRefResolver,
@@ -190,6 +191,16 @@ export interface Validator {
    * writes happen.
    */
   readonly warnings: readonly string[];
+  /**
+   * Spec-hygiene findings from {@link lintResolvedSpec}, populated when
+   * {@link ValidatorOptions.lint} is `true`. Empty otherwise. Frozen
+   * after `createValidator` returns.
+   *
+   * Different from {@link ValidatorStats.strictIssues}, which lints
+   * compiled schemas; this one lints the OpenAPI document itself
+   * (unused components, dead path parameters, unreachable `$defs`).
+   */
+  readonly specHygieneIssues: readonly SpecHygieneIssue[];
   /**
    * Runtime observability for compile-time-specialisation optimisations.
    * The counters live on the validator, not inside a ValidationError
@@ -416,6 +427,18 @@ export interface ValidatorOptions {
    * stderr.
    */
   warn?: (message: string) => void;
+  /**
+   * Run spec-hygiene lint passes against the document at construction.
+   * Findings land in {@link Validator.specHygieneIssues}; nothing is
+   * thrown. Defaults to `false`.
+   *
+   * The same engine runs from
+   * {@link @aahoughton/oav/spec!resolveSpec} and
+   * {@link @aahoughton/oav/spec!loadSpec}; pick whichever layer is
+   * natural for your flow. Running it in both places lints twice for
+   * no benefit.
+   */
+  lint?: boolean;
 }
 
 /**
@@ -853,6 +876,10 @@ export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions
     };
   };
 
+  const specHygieneIssues: readonly SpecHygieneIssue[] = options.lint
+    ? Object.freeze(lintResolvedSpec(spec))
+    : [];
+
   return {
     validateRequest,
     validateResponse,
@@ -861,6 +888,7 @@ export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions
     getOperation,
     detectedVersion,
     warnings,
+    specHygieneIssues,
     stats,
   };
 }

--- a/packages/validator/test/request.test.ts
+++ b/packages/validator/test/request.test.ts
@@ -1059,4 +1059,24 @@ describe("createValidator option validation", () => {
     expect(() => createValidator(petSpec(), { maxErrors: 1 })).not.toThrow();
     expect(() => createValidator(petSpec(), { maxErrors: 100 })).not.toThrow();
   });
+
+  it("specHygieneIssues is empty by default (lint not requested)", () => {
+    const v = createValidator(petSpec());
+    expect(v.specHygieneIssues).toEqual([]);
+  });
+
+  it("populates specHygieneIssues when lint: true and the spec has hygiene issues", () => {
+    const spec = petSpec();
+    spec.components = {
+      ...spec.components,
+      schemas: { ...spec.components?.schemas, Orphan: { type: "object" } },
+    };
+    const v = createValidator(spec, { lint: true });
+    expect(v.specHygieneIssues.some((i) => i.code === "unused-component")).toBe(true);
+  });
+
+  it("specHygieneIssues is frozen (callers can't mutate it)", () => {
+    const v = createValidator(petSpec(), { lint: true });
+    expect(Object.isFrozen(v.specHygieneIssues)).toBe(true);
+  });
 });


### PR DESCRIPTION
Closes #236.

## Summary

New ``lintResolvedSpec(document)`` engine in ``@oav/spec``, four checks. Reports authoring mistakes the structural validation can't catch.

## Checks

- ``unused-component``: ``components.{schemas,parameters,requestBodies,responses,headers,securitySchemes}`` entries no operation reaches. Transitive closure across components; ``discriminator.mapping`` and top-level / per-op ``security`` references count as reachability roots.
- ``unused-tag``: top-level ``tags[]`` entries no operation references.
- ``unreachable-defs``: per-schema ``$defs/<name>`` no sibling ``$ref`` points at. Skips resolver-injected ``$defs/__ext__/*`` entries.
- ``path-param-undeclared`` / ``path-param-unused``: mismatch between ``{name}`` placeholders in path templates and ``parameters: [{ in: "path", name }]`` declarations on the operation + path-item.

## Surfaces

Three opt-in surfaces, one engine:

| Layer | Opt-in | Findings |
| ----- | ------ | -------- |
| ``resolveSpec`` / ``loadSpec`` | ``{ lint: true }`` | ``ResolvedSpec.specHygieneIssues`` |
| ``createValidator`` | ``{ lint: true }`` | ``Validator.specHygieneIssues`` |
| Direct | ``import { lintResolvedSpec }`` | return value |

CLI:

```
oav resolve <spec> --lint                    # findings to stderr
oav resolve <spec> --lint --fail-on warning  # CI gate; exit 1 on findings
oav resolve <spec> --lint --envelope json    # { document, specHygieneIssues }
```

## API design notes

After the implementation pass, did a review for ergonomic issues:

- **``--envelope``, not ``--format``** on ``resolve``. The ``validate`` command already has ``--format text|json|flat`` for *error rendering*. Using ``--format`` on ``resolve`` for *output envelope shape* would have been the same flag name with a different axis. Renamed to avoid the collision.
- **``--fail-on`` requires ``--lint``.** Setting it without ``--lint`` errors with exit code 3 instead of silently being a no-op.
- **``ResolvedSpec.specHygieneIssues``, not ``warnings``.** Symmetric with ``Validator.specHygieneIssues``. Same name, same shape across both packages.
- **Both layers running ``lint: true`` lints twice.** Acceptable (each layer serves a different audience); doc guides callers to pick one.

## Test plan

- [x] ``pnpm test`` (821 passing; up from 819)
- [x] ``pnpm typecheck`` clean
- [x] ``pnpm lint`` clean
- [ ] CI green