### PR TITLE
feat(schema): silent-rewrite/* lint family with three checks

### DIFF
--- a/packages/schema/src/compiler/compiler.ts
+++ b/packages/schema/src/compiler/compiler.ts
@@ -32,10 +32,74 @@ const TREE_RUNTIME_HELPERS = /\b(?:createLeafError|createBranchError|wrapErrors)
  */
 const DEFAULT_STRICT_MODE = "warn-partial" as const;
 
+/**
+ * Sibling keys explicitly permitted alongside `$ref` under OAS 3.0
+ * (Schema Object §4.7.24.2): metadata-only, no validation effect.
+ * Anything else gets silently dropped under
+ * `refSuppressesSiblings: true`.
+ */
+const OAS30_REF_SIBLINGS_ALLOWED = new Set(["$ref", "description", "summary"]);
+
+/** Composition keys that can introduce a `required` key from elsewhere. */
+const COMPOSITION_KEYS = ["$ref", "allOf", "oneOf", "anyOf"] as const;
+
+/**
+ * Annotation-only keys that don't affect validation. Stripped before
+ * structural-equality compares so a "two branches differ only in
+ * description" case still surfaces as redundant.
+ */
+const ANNOTATION_KEYS = new Set([
+  "title",
+  "description",
+  "summary",
+  "examples",
+  "example",
+  "default",
+  "deprecated",
+  "$comment",
+  "$id",
+  "$schema",
+  "$anchor",
+  "$dynamicAnchor",
+]);
+
+/** Compose-style keys whose duplicate branches signal silent collapse. */
+const COMPOSITION_BRANCH_KEYS = ["oneOf", "anyOf"] as const;
+
+function structuralEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return false;
+  if (typeof a !== "object") return false;
+  const aArr = Array.isArray(a);
+  const bArr = Array.isArray(b);
+  if (aArr !== bArr) return false;
+  if (aArr) {
+    const al = a as unknown[];
+    const bl = b as unknown[];
+    if (al.length !== bl.length) return false;
+    for (let i = 0; i < al.length; i += 1) {
+      if (!structuralEqual(al[i], bl[i])) return false;
+    }
+    return true;
+  }
+  const ao = a as Record<string, unknown>;
+  const bo = b as Record<string, unknown>;
+  const ak = Object.keys(ao).filter((k) => !ANNOTATION_KEYS.has(k));
+  const bk = Object.keys(bo).filter((k) => !ANNOTATION_KEYS.has(k));
+  if (ak.length !== bk.length) return false;
+  for (const k of ak) {
+    if (!Object.prototype.hasOwnProperty.call(bo, k)) return false;
+    if (!structuralEqual(ao[k], bo[k])) return false;
+  }
+  return true;
+}
+
 function runStrictLint(
   schema: SchemaOrBoolean,
   byKeyword: Map<string, KeywordDefinition>,
   mode: "warn-partial" | "strict",
+  rules: { refSuppressesSiblings: boolean },
 ): StrictIssue[] {
   // The full set of names the active dialect recognises, including
   // `implements` entries on existing definitions (e.g. `if` implements
@@ -49,7 +113,9 @@ function runStrictLint(
   const issues: StrictIssue[] = [];
   walkSubschemas(schema, (node, path) => {
     if (typeof node !== "object" || node === null || Array.isArray(node)) return;
-    for (const key of Object.keys(node)) {
+    const obj = node as Record<string, unknown>;
+
+    for (const key of Object.keys(obj)) {
       const def = byKeyword.get(key);
       if (def?.partial !== undefined) {
         issues.push({
@@ -74,6 +140,69 @@ function runStrictLint(
             ? `unknown keyword "${key}" at <root>`
             : `unknown keyword "${key}" at "${path}"`,
       });
+    }
+
+    // silent-rewrite/* checks are always-on (any non-"off" mode).
+    if (rules.refSuppressesSiblings && typeof obj.$ref === "string") {
+      for (const key of Object.keys(obj)) {
+        if (OAS30_REF_SIBLINGS_ALLOWED.has(key)) continue;
+        issues.push({
+          code: "silent-rewrite/ref-siblings-oas30",
+          keyword: key,
+          path,
+          message:
+            path.length === 0
+              ? `OAS 3.0: "${key}" sibling of $ref at <root> is silently dropped (only description/summary survive)`
+              : `OAS 3.0: "${key}" sibling of $ref at "${path}" is silently dropped (only description/summary survive)`,
+        });
+      }
+    }
+
+    if (Array.isArray(obj.required)) {
+      const hasComposition = COMPOSITION_KEYS.some((k) => k in obj);
+      if (!hasComposition) {
+        const props = obj.properties;
+        const propKeys =
+          typeof props === "object" && props !== null && !Array.isArray(props)
+            ? new Set(Object.keys(props as Record<string, unknown>))
+            : new Set<string>();
+        for (const name of obj.required) {
+          if (typeof name !== "string") continue;
+          if (propKeys.has(name)) continue;
+          issues.push({
+            code: "silent-rewrite/required-not-in-properties",
+            keyword: "required",
+            path,
+            message:
+              path.length === 0
+                ? `required: "${name}" at <root> not declared in properties (likely a typo)`
+                : `required: "${name}" at "${path}" not declared in properties (likely a typo)`,
+          });
+        }
+      }
+    }
+
+    for (const key of COMPOSITION_BRANCH_KEYS) {
+      const branches = obj[key];
+      if (!Array.isArray(branches) || branches.length < 2) continue;
+      // O(n^2) pairwise compare; n is small in real specs (oneOf with
+      // 2-5 branches is the common shape). For each branch, flag if any
+      // earlier branch is structurally equal to it (skip the first
+      // occurrence to avoid N findings for N identical branches).
+      for (let i = 1; i < branches.length; i += 1) {
+        for (let j = 0; j < i; j += 1) {
+          if (structuralEqual(branches[i], branches[j])) {
+            const branchPath = path.length === 0 ? `${key}[${i}]` : `${path}.${key}[${i}]`;
+            issues.push({
+              code: "silent-rewrite/redundant-composition-branches",
+              keyword: key,
+              path: branchPath,
+              message: `${key}[${i}] is structurally identical to ${key}[${j}] (annotation-only differences ignored); branches collapse and the validator's match-count behavior diverges from the source spec`,
+            });
+            break;
+          }
+        }
+      }
     }
   });
   return issues;
@@ -152,8 +281,30 @@ export interface StrictIssue {
    * - `"unknown-keyword"`: the schema declares a key that's not in the
    *   active dialect, not an `x-*` extension, and not a standard
    *   `$`-prefixed metadata key. Likely a typo.
+   * - `"silent-rewrite/ref-siblings-oas30"`: under OAS 3.0
+   *   (`refSuppressesSiblings: true`), a schema with `$ref` plus
+   *   sibling keywords other than `description` / `summary`. The
+   *   siblings are silently dropped; the validator runs the `$ref`
+   *   target only.
+   * - `"silent-rewrite/required-not-in-properties"`: a `required`
+   *   array names a key that doesn't appear in the same schema's
+   *   `properties`. Almost always a typo. Conservative: skipped on
+   *   schemas that mix `required` with `$ref` / `allOf` / `oneOf` /
+   *   `anyOf` (the named key could be contributed by a composed
+   *   branch).
+   * - `"silent-rewrite/redundant-composition-branches"`: an `oneOf` /
+   *   `anyOf` array where two or more branches are structurally
+   *   identical after compile-time rewrites (notably the validator's
+   *   `format: binary` opaque-body bypass). The compiled validator's
+   *   semantics differ from the source spec: identical branches
+   *   collapse, changing the match-count behavior.
    */
-  code: "partial-feature" | "unknown-keyword";
+  code:
+    | "partial-feature"
+    | "unknown-keyword"
+    | "silent-rewrite/ref-siblings-oas30"
+    | "silent-rewrite/required-not-in-properties"
+    | "silent-rewrite/redundant-composition-branches";
   /** The offending keyword / key name as written in the schema. */
   keyword: string;
   /** Dotted path from the root schema to the subschema holding the key. */
@@ -544,7 +695,11 @@ export function compileSchema(
   const wholeSource = assembleSource(state, rootName);
   const strictMode = options.strict ?? DEFAULT_STRICT_MODE;
   const strictIssues: readonly StrictIssue[] =
-    strictMode === "off" ? [] : runStrictLint(schema, byKeyword, strictMode);
+    strictMode === "off"
+      ? []
+      : runStrictLint(schema, byKeyword, strictMode, {
+          refSuppressesSiblings: state.refSuppressesSiblings,
+        });
   const stats: CompileStats = {
     functionCount: state.nextFn,
     unevaluatedTrackingEmitted: state.unevaluatedEmitted,

--- a/packages/schema/test/strict-mode.test.ts
+++ b/packages/schema/test/strict-mode.test.ts
@@ -134,3 +134,167 @@ describe("strict mode", () => {
     expect(issues).toEqual([]);
   });
 });
+
+describe("strict mode: silent-rewrite/ref-siblings-oas30", () => {
+  // The compiler resolves $refs eagerly, so test fixtures need a real
+  // target for each ref. A self-contained $defs/Pet works for every
+  // dialect (the linter looks at the sibling shape, not the target).
+  const withTarget = (overrides: Record<string, unknown>) =>
+    ({
+      $defs: { Pet: { type: "object", properties: { name: { type: "string" } } } },
+      ...overrides,
+    }) as unknown as SchemaOrBoolean;
+
+  const oas30Lint = (schema: SchemaOrBoolean) =>
+    compileSchema(schema, { dialect: oas30Dialect }).stats.strictIssues;
+
+  it("flags non-metadata siblings of $ref under OAS 3.0", () => {
+    const schema = withTarget({
+      properties: {
+        wrapper: { $ref: "#/$defs/Pet", required: ["name"] },
+      },
+    });
+    const issues = oas30Lint(schema);
+    const sib = issues.filter((i) => i.code === "silent-rewrite/ref-siblings-oas30");
+    expect(sib).toHaveLength(1);
+    expect(sib[0]?.keyword).toBe("required");
+  });
+
+  it("tolerates `description` and `summary` siblings of $ref under OAS 3.0", () => {
+    const schema = withTarget({
+      properties: {
+        wrapper: { $ref: "#/$defs/Pet", description: "A pet", summary: "Pet ref" },
+      },
+    });
+    const issues = oas30Lint(schema).filter((i) => i.code === "silent-rewrite/ref-siblings-oas30");
+    expect(issues).toEqual([]);
+  });
+
+  it("does NOT fire under JSON Schema 2020-12 / OpenAPI 3.1 (refs allow siblings)", () => {
+    const schema = withTarget({
+      properties: {
+        wrapper: { $ref: "#/$defs/Pet", required: ["name"] },
+      },
+    });
+    for (const dialect of [jsonSchemaDialect, openapi31Dialect]) {
+      const issues = compileSchema(schema, { dialect }).stats.strictIssues.filter(
+        (i) => i.code === "silent-rewrite/ref-siblings-oas30",
+      );
+      expect(issues).toEqual([]);
+    }
+  });
+});
+
+describe("strict mode: silent-rewrite/required-not-in-properties", () => {
+  const lint = (schema: SchemaOrBoolean) =>
+    compileSchema(schema, { dialect: jsonSchemaDialect }).stats.strictIssues;
+
+  it("flags a required key not in properties (typo case)", () => {
+    const schema = {
+      type: "object",
+      properties: { name: { type: "string" } },
+      required: ["nam"],
+    } as unknown as SchemaOrBoolean;
+    const issues = lint(schema).filter(
+      (i) => i.code === "silent-rewrite/required-not-in-properties",
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.keyword).toBe("required");
+    expect(issues[0]?.message).toContain('"nam"');
+  });
+
+  it("does not flag when every required key appears in properties", () => {
+    const schema = {
+      type: "object",
+      properties: { name: { type: "string" }, age: { type: "number" } },
+      required: ["name", "age"],
+    } as unknown as SchemaOrBoolean;
+    const issues = lint(schema).filter(
+      (i) => i.code === "silent-rewrite/required-not-in-properties",
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it("skips the check when schema mixes required with $ref / allOf / oneOf / anyOf", () => {
+    // Conservative: a composed schema may contribute the required key
+    // from elsewhere, so we don't flag false-positively.
+    const named = { type: "object", properties: { name: { type: "string" } } };
+    const schemas: SchemaOrBoolean[] = [
+      { allOf: [named], required: ["name"] },
+      {
+        $defs: { Named: named },
+        properties: { wrap: { $ref: "#/$defs/Named", required: ["name"] } },
+      },
+      { oneOf: [named], required: ["name"] },
+      { anyOf: [named], required: ["name"] },
+    ] as unknown as SchemaOrBoolean[];
+    for (const schema of schemas) {
+      const issues = lint(schema).filter(
+        (i) => i.code === "silent-rewrite/required-not-in-properties",
+      );
+      expect(issues).toEqual([]);
+    }
+  });
+});
+
+describe("strict mode: silent-rewrite/redundant-composition-branches", () => {
+  const lint = (schema: SchemaOrBoolean) =>
+    compileSchema(schema, { dialect: jsonSchemaDialect }).stats.strictIssues;
+
+  it("flags literally identical oneOf branches", () => {
+    const schema = {
+      oneOf: [{ type: "string" }, { type: "string" }],
+    } as unknown as SchemaOrBoolean;
+    const issues = lint(schema).filter(
+      (i) => i.code === "silent-rewrite/redundant-composition-branches",
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.path).toBe("oneOf[1]");
+  });
+
+  it("flags branches that differ only in description / title (annotation-only)", () => {
+    const schema = {
+      anyOf: [
+        { type: "string", description: "first" },
+        { type: "string", title: "second" },
+      ],
+    } as unknown as SchemaOrBoolean;
+    const issues = lint(schema).filter(
+      (i) => i.code === "silent-rewrite/redundant-composition-branches",
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.keyword).toBe("anyOf");
+  });
+
+  it("does not flag branches that genuinely differ", () => {
+    const schema = {
+      oneOf: [{ type: "string" }, { type: "number" }],
+    } as unknown as SchemaOrBoolean;
+    const issues = lint(schema).filter(
+      (i) => i.code === "silent-rewrite/redundant-composition-branches",
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it("emits one finding per duplicate group, not N for N copies", () => {
+    const schema = {
+      oneOf: [{ type: "string" }, { type: "string" }, { type: "string" }],
+    } as unknown as SchemaOrBoolean;
+    const issues = lint(schema).filter(
+      (i) => i.code === "silent-rewrite/redundant-composition-branches",
+    );
+    // Each later branch flags once against the first; 3 copies → 2 findings.
+    expect(issues).toHaveLength(2);
+    expect(issues.map((i) => i.path)).toEqual(["oneOf[1]", "oneOf[2]"]);
+  });
+
+  it("does not flag allOf duplicates (intersection, not branch collapse)", () => {
+    const schema = {
+      allOf: [{ type: "string" }, { type: "string" }],
+    } as unknown as SchemaOrBoolean;
+    const issues = lint(schema).filter(
+      (i) => i.code === "silent-rewrite/redundant-composition-branches",
+    );
+    expect(issues).toEqual([]);
+  });
+});

--- a/packages/validator/test/request.test.ts
+++ b/packages/validator/test/request.test.ts
@@ -109,6 +109,55 @@ describe("validateRequest", () => {
     expect(unknown?.keyword).toBe("minLenght");
   });
 
+  it("strict mode surfaces silent-rewrite/redundant-composition-branches after binary-bypass collapse", () => {
+    // Two branches that look distinct in the source spec ({string +
+    // format:binary} vs {string + format:binary + description}) collapse
+    // to identical empty schemas after the validator's binary bypass.
+    // The lint surfaces from the post-transform shape.
+    const spec: OpenAPIDocument = {
+      openapi: "3.1.0",
+      info: { title: "t", version: "1" },
+      paths: {
+        "/upload": {
+          post: {
+            requestBody: {
+              required: true,
+              content: {
+                "multipart/form-data": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      file: {
+                        oneOf: [
+                          { type: "string", format: "binary" },
+                          { type: "string", format: "binary", description: "the upload" },
+                        ],
+                      },
+                    },
+                  } as unknown as OpenAPIDocument["components"],
+                },
+              },
+            },
+            responses: { "200": { description: "ok" } },
+          },
+        },
+      },
+    };
+    const vi = createValidator(spec);
+    // Lazy compile: trigger the request-side schema compile.
+    vi.validateRequest({
+      method: "POST",
+      path: "/upload",
+      contentType: "multipart/form-data",
+      body: { file: Buffer.from("x") },
+    });
+    const redundant = vi.stats.strictIssues.find(
+      (i) => i.code === "silent-rewrite/redundant-composition-branches",
+    );
+    expect(redundant).toBeDefined();
+    expect(redundant?.keyword).toBe("oneOf");
+  });
+
   it("errors for wrong Content-Type", () => {
     const err = v.validateRequest({
       method: "POST",


### PR DESCRIPTION
Closes #235. Out-of-scope candidates parked in #244.

## Summary

New ``StrictIssue.code`` family ``silent-rewrite/*`` for cases where the compiled validator's behavior diverges silently from the schema as written. Three checks:

| Code | What it catches |
| ---- | --------------- |
| ``silent-rewrite/ref-siblings-oas30`` | Under OAS 3.0, ``{ $ref, ...siblings }``: siblings other than ``description`` / ``summary`` are silently dropped. Spec is structurally valid; intent is almost certainly violated. |
| ``silent-rewrite/required-not-in-properties`` | ``required: ["foo"]`` where ``foo`` is not declared in ``properties``. Conservative: skipped when the schema mixes ``required`` with ``$ref`` / ``allOf`` / ``oneOf`` / ``anyOf`` (composed branch could contribute the key). Catches the typo case with zero false-positive risk. |
| ``silent-rewrite/redundant-composition-branches`` | ``oneOf`` / ``anyOf`` where two or more branches are structurally identical (annotation-only differences ignored). Catches the literal ``oneOf: [{}, {}]`` case, the ""branches differ only in description"" case, and (via the validator's pre-compile transform) the ``format: binary`` collapse case from #232. |

## Always-on

All three fire under any non-``"off"`` strict mode (default ``warn-partial`` and ``strict``). The whole point of these checks is that the divergence is invisible from the source spec, so emitting only under ``strict`` would defeat them.

## No new surface

Findings flow through the existing ``validator.stats.strictIssues`` live array, same as ``partial-feature`` / ``unknown-keyword``. ``StrictIssue.code`` is a union; this PR widens it. No new option, no new field, no new entry point.

## Validator-side integration

The validator compiles each operation's body schema via ``compile(transformBodySchemaForDirection(schema, direction))``, so the compiler's strict-lint sees the post-transform shape. The redundant-composition-branches check catches the binary-bypass collapse case for free, without a separate post-transform hook.

## Out of scope (parked in #244)

- ``readOnly`` / ``writeOnly`` direction stripping (documented OpenAPI behavior; the keyword name is the disclosure).
- Missing ``additionalProperties`` (famous JSON Schema gotcha; not oav-specific; prescriptive).
- ``required-not-in-properties`` with ``$ref`` / ``allOf`` resolution (current check is conservative; deferring resolution-aware version pending a real false-negative report).

## Test plan

- [x] ``pnpm test``: 833 passing (up from 821).
- [x] ``pnpm typecheck`` clean.
- [x] ``pnpm lint`` clean.
- [ ] CI green.