### PR TITLE
chore(release): link package versions for in-concert releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,13 @@
   "separate-pull-requests": false,
   "include-v-in-tag": true,
   "include-component-in-tag": true,
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "oav",
+      "components": ["oav-core", "oav", "oav-express4", "oav-express5", "oav-fastify"]
+    }
+  ],
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary

Add release-please's ``linked-versions`` plugin. After this lands, all five published packages share a single version number on every release.

Group members: ``oav-core``, ``oav``, ``oav-express4``, ``oav-express5``, ``oav-fastify``.

## Why

Per-component versioning has drifted. ``.release-please-manifest.json`` currently:

| Package | Version |
| ------- | ------- |
| oav-core (root) | 1.1.2 |
| oav | 1.1.1 |
| oav-express4 | 1.1.1 |
| oav-express5 | 1.1.1 |
| oav-fastify | 1.1.1 |

When oav-core ships breaking changes, the adapters don't republish unless a commit touched their package path. Anyone installing the adapter at 1.1.1 gets a stale ``@aahoughton/oav-core`` resolution through ``workspace:*``. With linked-versions, every release moves all five together, so an adapter at version X always pairs with oav-core at version X.

## Effect on the pending release PR (#238)

#238 currently wants oav-core → 2.0.0 (driven by the breaking change in #241) and the others → 1.1.2 (docs-only bumps).

Once this PR lands, release-please will recompute. The refreshed release PR will bump **all five packages to 2.0.0** in lockstep. The 2.x line starts with everyone aligned, no synthetic bump-everyone-to-1.1.2 commit needed.

## Test plan

- [x] JSON validates against the release-please schema (no editor errors).
- [ ] Confirm release-please picks it up after merge: PR #238 either updates or closes-and-reopens with all five packages bumping to 2.0.0.

## After merge

1. Verify the refreshed release PR (#238 or its successor) bumps all five packages to 2.0.0.
2. Merge the release PR. ``pnpm -r publish`` should publish all five at 2.0.0.