### PR TITLE
fix(schema): close codegen-injection vectors in keyword compilation

### DIFF
--- a/packages/schema/src/codegen/codegen.ts
+++ b/packages/schema/src/codegen/codegen.ts
@@ -191,8 +191,8 @@ export class CodeGen implements CodeEmitter {
   }
 
   /**
-   * Enter an indentation level without emitting a brace pair. Rarely used —
-   * prefer {@link CodeGen.if} / {@link CodeGen.forRange} / etc.
+   * Enter an indentation level without emitting a brace pair. Rarely
+   * used; prefer {@link CodeGen.if} / {@link CodeGen.forRange} / etc.
    *
    * @returns `this`, for chaining.
    */
@@ -237,6 +237,100 @@ export class CodeGen implements CodeEmitter {
  */
 export function quoteString(value: string): string {
   return JSON.stringify(value);
+}
+
+/**
+ * Coerce a schema-supplied finite number into a JavaScript numeric
+ * literal that is safe to interpolate directly into generated source.
+ * Throws at compile time on non-numbers, NaN, and infinities.
+ *
+ * Use this for any keyword whose value lands raw in a generated JS
+ * expression (e.g. `${data} > ${limit}`). Interpolating
+ * `ctx.schema` directly is a codegen-injection vector when the
+ * schema is attacker-supplied; this helper closes that path by
+ * validating the value first and returning a known-safe `String(n)`.
+ *
+ * @param value - The schema-supplied value (untrusted).
+ * @param keyword - The schema keyword being compiled. Surfaced in the
+ *   error message so callers know which schema position to fix.
+ * @returns The value rendered as a numeric literal, e.g. `"5"` or `"-1.5"`.
+ * @throws Error when `value` is not a finite number.
+ *
+ * @public
+ */
+export function numberLiteral(value: unknown, keyword: string): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`keyword "${keyword}" requires a finite number; got ${describeValue(value)}`);
+  }
+  return String(value);
+}
+
+/**
+ * Like {@link numberLiteral}, but additionally requires a non-negative
+ * integer. Used for `maxLength`, `minItems`, `maxProperties`, etc.
+ *
+ * @param value - The schema-supplied value (untrusted).
+ * @param keyword - The schema keyword being compiled.
+ * @returns The value rendered as a numeric literal.
+ * @throws Error if `value` is not an integer >= 0.
+ *
+ * @public
+ */
+export function nonNegativeIntegerLiteral(value: unknown, keyword: string): string {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw new Error(
+      `keyword "${keyword}" requires a non-negative integer; got ${describeValue(value)}`,
+    );
+  }
+  return String(value);
+}
+
+/**
+ * Like {@link numberLiteral}, but additionally requires a strictly positive
+ * value. Used for `multipleOf`, where zero would mean "every number is a
+ * multiple of zero" (vacuous, and triggers a division by zero in the
+ * generated check).
+ *
+ * @param value - The schema-supplied value (untrusted).
+ * @param keyword - The schema keyword being compiled.
+ * @returns The value rendered as a numeric literal.
+ * @throws Error if `value` is not a finite number > 0.
+ *
+ * @public
+ */
+export function positiveNumberLiteral(value: unknown, keyword: string): string {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new Error(
+      `keyword "${keyword}" requires a finite positive number; got ${describeValue(value)}`,
+    );
+  }
+  return String(value);
+}
+
+/**
+ * Coerce a schema-supplied boolean into a JavaScript boolean literal
+ * (`"true"` or `"false"`) safe to interpolate into generated source.
+ *
+ * @param value - The schema-supplied value (untrusted).
+ * @param keyword - The schema keyword being compiled.
+ * @returns `"true"` or `"false"`.
+ * @throws Error if `value` is not a boolean.
+ *
+ * @public
+ */
+export function booleanLiteral(value: unknown, keyword: string): string {
+  if (typeof value !== "boolean") {
+    throw new Error(`keyword "${keyword}" requires a boolean; got ${describeValue(value)}`);
+  }
+  return value ? "true" : "false";
+}
+
+function describeValue(value: unknown): string {
+  if (typeof value === "string") return `string ${JSON.stringify(value)}`;
+  if (typeof value === "number") return `number ${String(value)}`;
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
 }
 
 /**

--- a/packages/schema/src/codegen/index.ts
+++ b/packages/schema/src/codegen/index.ts
@@ -1,4 +1,13 @@
-export { CodeGen, pathJoinExpr, quoteString, rawExpr } from "./codegen.js";
+export {
+  booleanLiteral,
+  CodeGen,
+  nonNegativeIntegerLiteral,
+  numberLiteral,
+  pathJoinExpr,
+  positiveNumberLiteral,
+  quoteString,
+  rawExpr,
+} from "./codegen.js";
 export type { CodeEmitter, NameGenerator, PathSegmentLike, RawExpression } from "./codegen.js";
 export { NAMES } from "./names.js";
 export { Scope } from "./scope.js";

--- a/packages/schema/src/internals.ts
+++ b/packages/schema/src/internals.ts
@@ -14,12 +14,18 @@
  */
 
 // Codegen mechanics: used by keyword authors that need to emit
-// non-boilerplate JS (path joining, string quoting, raw JS injection).
+// non-boilerplate JS (path joining, string quoting, raw JS injection,
+// and the safe-literal helpers that coerce schema-supplied values
+// before interpolating them into generated source).
 export {
+  booleanLiteral,
   CodeGen,
   NAMES,
   Scope,
+  nonNegativeIntegerLiteral,
+  numberLiteral,
   pathJoinExpr,
+  positiveNumberLiteral,
   quoteString,
   rawExpr,
   type CodeEmitter,

--- a/packages/schema/src/keywords/array-validation.ts
+++ b/packages/schema/src/keywords/array-validation.ts
@@ -1,4 +1,4 @@
-import { NAMES, quoteString } from "../codegen/index.js";
+import { NAMES, nonNegativeIntegerLiteral, quoteString } from "../codegen/index.js";
 import type { KeywordCompileContext, KeywordDefinition } from "./types.js";
 import { CORE_VALIDATION_VOCAB } from "./vocabulary-uris.js";
 
@@ -11,7 +11,7 @@ export const maxItemsKeyword: KeywordDefinition = {
   keyword: "maxItems",
   vocabulary: CORE_VALIDATION_VOCAB,
   compile(ctx: KeywordCompileContext): void {
-    const limit = ctx.schema as number;
+    const limit = nonNegativeIntegerLiteral(ctx.schema, "maxItems");
     ctx.gen.if(`Array.isArray(${ctx.data}) && ${ctx.data}.length > ${limit}`, () => {
       ctx.emitError(
         "leaf",
@@ -34,7 +34,7 @@ export const minItemsKeyword: KeywordDefinition = {
   keyword: "minItems",
   vocabulary: CORE_VALIDATION_VOCAB,
   compile(ctx: KeywordCompileContext): void {
-    const limit = ctx.schema as number;
+    const limit = nonNegativeIntegerLiteral(ctx.schema, "minItems");
     ctx.gen.if(`Array.isArray(${ctx.data}) && ${ctx.data}.length < ${limit}`, () => {
       ctx.emitError(
         "leaf",

--- a/packages/schema/src/keywords/composition.ts
+++ b/packages/schema/src/keywords/composition.ts
@@ -385,7 +385,7 @@ export const dependenciesKeyword: KeywordDefinition = {
                     "leaf",
                     ctx.leafErrorExpr(
                       quoteString("dependencies"),
-                      `\`property "${prop}" is required when "${trigger}" is present\``,
+                      quoteString(`property "${prop}" is required when "${trigger}" is present`),
                       `{ trigger: ${triggerLit}, missing: ${propLit} }`,
                       [propLit],
                     ),
@@ -438,7 +438,7 @@ export const dependentRequiredKeyword: KeywordDefinition = {
                   "leaf",
                   ctx.leafErrorExpr(
                     quoteString("dependentRequired"),
-                    `\`property "${prop}" is required when "${trigger}" is present\``,
+                    quoteString(`property "${prop}" is required when "${trigger}" is present`),
                     `{ trigger: ${triggerLit}, missing: ${propLit} }`,
                     [propLit],
                   ),

--- a/packages/schema/src/keywords/discriminator.ts
+++ b/packages/schema/src/keywords/discriminator.ts
@@ -75,7 +75,7 @@ export const discriminatorKeyword: KeywordDefinition = {
               "leaf",
               ctx.leafErrorExpr(
                 quoteString("discriminator"),
-                `\`discriminator property "${propertyName}" must be a string\``,
+                quoteString(`discriminator property "${propertyName}" must be a string`),
                 `{ propertyName: ${propLit} }`,
                 [propLit],
               ),

--- a/packages/schema/src/keywords/items.ts
+++ b/packages/schema/src/keywords/items.ts
@@ -1,4 +1,4 @@
-import { quoteString } from "../codegen/index.js";
+import { nonNegativeIntegerLiteral, quoteString } from "../codegen/index.js";
 import type { SchemaOrBoolean } from "@oav/core";
 import type { KeywordCompileContext, KeywordDefinition } from "./types.js";
 import { APPLICATOR_VOCAB } from "./vocabulary-uris.js";
@@ -88,8 +88,15 @@ export const containsKeyword: KeywordDefinition = {
   compile(ctx: KeywordCompileContext): void {
     const subSchema = ctx.schema as SchemaOrBoolean;
     const fn = ctx.compileSubschema(subSchema);
-    const min = ctx.parentSchema.minContains ?? 1;
-    const max = ctx.parentSchema.maxContains;
+    const minLit =
+      ctx.parentSchema.minContains === undefined
+        ? "1"
+        : nonNegativeIntegerLiteral(ctx.parentSchema.minContains, "minContains");
+    const min = Number(minLit);
+    const maxLit =
+      ctx.parentSchema.maxContains === undefined
+        ? null
+        : nonNegativeIntegerLiteral(ctx.parentSchema.maxContains, "maxContains");
     ctx.gen.if(`Array.isArray(${ctx.data})`, (g) => {
       const count = g.scope.name("count");
       g.let(count, "0");
@@ -107,8 +114,8 @@ export const containsKeyword: KeywordDefinition = {
             }
           });
         });
-        if (min > 0) g.line(`if (${count} < ${min}) return false;`);
-        if (max !== undefined) g.line(`if (${count} > ${max}) return false;`);
+        if (min > 0) g.line(`if (${count} < ${minLit}) return false;`);
+        if (maxLit !== null) g.line(`if (${count} > ${maxLit}) return false;`);
         return;
       }
       const matchedIdx = g.scope.name("matched");
@@ -130,27 +137,27 @@ export const containsKeyword: KeywordDefinition = {
         });
       });
       if (min > 0) {
-        g.if(`${count} < ${min}`, () => {
+        g.if(`${count} < ${minLit}`, () => {
           // actual count lives in params.actual; dropping it from the
           // message turns the emitted string into a constant literal.
           ctx.emitError(
             "leaf",
             ctx.leafErrorExpr(
               quoteString("contains"),
-              `\`must contain at least ${min} matching item(s)\``,
-              `{ minContains: ${min}, actual: ${count} }`,
+              `\`must contain at least ${minLit} matching item(s)\``,
+              `{ minContains: ${minLit}, actual: ${count} }`,
             ),
           );
         });
       }
-      if (max !== undefined) {
-        g.if(`${count} > ${max}`, () => {
+      if (maxLit !== null) {
+        g.if(`${count} > ${maxLit}`, () => {
           ctx.emitError(
             "leaf",
             ctx.leafErrorExpr(
               quoteString("maxContains"),
-              `\`must contain at most ${max} matching item(s)\``,
-              `{ maxContains: ${max}, actual: ${count} }`,
+              `\`must contain at most ${maxLit} matching item(s)\``,
+              `{ maxContains: ${maxLit}, actual: ${count} }`,
             ),
           );
         });

--- a/packages/schema/src/keywords/number.ts
+++ b/packages/schema/src/keywords/number.ts
@@ -1,4 +1,4 @@
-import { quoteString } from "../codegen/index.js";
+import { numberLiteral, positiveNumberLiteral, quoteString } from "../codegen/index.js";
 import type { KeywordCompileContext, KeywordDefinition } from "./types.js";
 import { CORE_VALIDATION_VOCAB } from "./vocabulary-uris.js";
 
@@ -34,7 +34,7 @@ export const multipleOfKeyword: KeywordDefinition = {
   keyword: "multipleOf",
   vocabulary: CORE_VALIDATION_VOCAB,
   compile(ctx: KeywordCompileContext): void {
-    const divisor = ctx.schema as number;
+    const divisor = positiveNumberLiteral(ctx.schema, "multipleOf");
     const q = ctx.gen.scope.name("q");
     const tol = ctx.gen.scope.name("tol");
     // 16 * Number.EPSILON ≈ 3.55e-15; at |q| = 1e15 that admits ~3.55
@@ -68,7 +68,7 @@ export const maximumKeyword: KeywordDefinition = {
   keyword: "maximum",
   vocabulary: CORE_VALIDATION_VOCAB,
   compile(ctx: KeywordCompileContext): void {
-    const limit = ctx.schema as number;
+    const limit = numberLiteral(ctx.schema, "maximum");
     ctx.gen.if(`${numberGuard(ctx.data)} && ${ctx.data} > ${limit}`, () => {
       emitNumericError(
         ctx,
@@ -89,7 +89,7 @@ export const exclusiveMaximumKeyword: KeywordDefinition = {
   keyword: "exclusiveMaximum",
   vocabulary: CORE_VALIDATION_VOCAB,
   compile(ctx: KeywordCompileContext): void {
-    const limit = ctx.schema as number;
+    const limit = numberLiteral(ctx.schema, "exclusiveMaximum");
     ctx.gen.if(`${numberGuard(ctx.data)} && ${ctx.data} >= ${limit}`, () => {
       emitNumericError(
         ctx,
@@ -110,7 +110,7 @@ export const minimumKeyword: KeywordDefinition = {
   keyword: "minimum",
   vocabulary: CORE_VALIDATION_VOCAB,
   compile(ctx: KeywordCompileContext): void {
-    const limit = ctx.schema as number;
+    const limit = numberLiteral(ctx.schema, "minimum");
     ctx.gen.if(`${numberGuard(ctx.data)} && ${ctx.data} < ${limit}`, () => {
       emitNumericError(
         ctx,
@@ -131,7 +131,7 @@ export const exclusiveMinimumKeyword: KeywordDefinition = {
   keyword: "exclusiveMinimum",
   vocabulary: CORE_VALIDATION_VOCAB,
   compile(ctx: KeywordCompileContext): void {
-    const limit = ctx.schema as number;
+    const limit = numberLiteral(ctx.schema, "exclusiveMinimum");
     ctx.gen.if(`${numberGuard(ctx.data)} && ${ctx.data} <= ${limit}`, () => {
       emitNumericError(
         ctx,

--- a/packages/schema/src/keywords/oas30.ts
+++ b/packages/schema/src/keywords/oas30.ts
@@ -21,7 +21,7 @@
  * @packageDocumentation
  */
 
-import { NAMES, quoteString } from "../codegen/index.js";
+import { NAMES, numberLiteral, quoteString } from "../codegen/index.js";
 import { buildTypeMismatchCondition } from "./type-predicates.js";
 import type { KeywordCompileContext, KeywordDefinition } from "./types.js";
 import { OAS30_VOCAB } from "./vocabulary-uris.js";
@@ -91,9 +91,10 @@ export const oas30MaximumKeyword: KeywordDefinition = {
   keyword: "maximum",
   vocabulary: OAS30_VOCAB,
   compile(ctx: KeywordCompileContext): void {
-    const limit = ctx.schema as number;
+    const limit = numberLiteral(ctx.schema, "maximum");
     const exclusive = ctx.parentSchema.exclusiveMaximum === true;
     const op = exclusive ? ">=" : ">";
+    const exclusiveLit = exclusive ? "true" : "false";
     ctx.gen.if(
       `typeof ${ctx.data} === "number" && Number.isFinite(${ctx.data}) && ${ctx.data} ${op} ${limit}`,
       () => {
@@ -102,7 +103,7 @@ export const oas30MaximumKeyword: KeywordDefinition = {
           ctx.leafErrorExpr(
             quoteString("maximum"),
             `\`must be ${exclusive ? "<" : "<="} ${limit}\``,
-            `{ maximum: ${limit}, exclusive: ${exclusive}, actual: ${ctx.data} }`,
+            `{ maximum: ${limit}, exclusive: ${exclusiveLit}, actual: ${ctx.data} }`,
           ),
         );
       },
@@ -120,9 +121,10 @@ export const oas30MinimumKeyword: KeywordDefinition = {
   keyword: "minimum",
   vocabulary: OAS30_VOCAB,
   compile(ctx: KeywordCompileContext): void {
-    const limit = ctx.schema as number;
+    const limit = numberLiteral(ctx.schema, "minimum");
     const exclusive = ctx.parentSchema.exclusiveMinimum === true;
     const op = exclusive ? "<=" : "<";
+    const exclusiveLit = exclusive ? "true" : "false";
     ctx.gen.if(
       `typeof ${ctx.data} === "number" && Number.isFinite(${ctx.data}) && ${ctx.data} ${op} ${limit}`,
       () => {
@@ -131,7 +133,7 @@ export const oas30MinimumKeyword: KeywordDefinition = {
           ctx.leafErrorExpr(
             quoteString("minimum"),
             `\`must be ${exclusive ? ">" : ">="} ${limit}\``,
-            `{ minimum: ${limit}, exclusive: ${exclusive}, actual: ${ctx.data} }`,
+            `{ minimum: ${limit}, exclusive: ${exclusiveLit}, actual: ${ctx.data} }`,
           ),
         );
       },

--- a/packages/schema/src/keywords/object-validation.ts
+++ b/packages/schema/src/keywords/object-validation.ts
@@ -1,4 +1,4 @@
-import { quoteString } from "../codegen/index.js";
+import { nonNegativeIntegerLiteral, quoteString } from "../codegen/index.js";
 import type { KeywordCompileContext, KeywordDefinition } from "./types.js";
 import { CORE_VALIDATION_VOCAB } from "./vocabulary-uris.js";
 
@@ -19,7 +19,7 @@ export const maxPropertiesKeyword: KeywordDefinition = {
   keyword: "maxProperties",
   vocabulary: CORE_VALIDATION_VOCAB,
   compile(ctx: KeywordCompileContext): void {
-    const limit = ctx.schema as number;
+    const limit = nonNegativeIntegerLiteral(ctx.schema, "maxProperties");
     const count = ctx.gen.scope.name("count");
     ctx.gen.if(isObjectGuard(ctx.data), (g) => {
       g.const(count, keyCountExpr(ctx.data));
@@ -46,7 +46,7 @@ export const minPropertiesKeyword: KeywordDefinition = {
   keyword: "minProperties",
   vocabulary: CORE_VALIDATION_VOCAB,
   compile(ctx: KeywordCompileContext): void {
-    const limit = ctx.schema as number;
+    const limit = nonNegativeIntegerLiteral(ctx.schema, "minProperties");
     const count = ctx.gen.scope.name("count");
     ctx.gen.if(isObjectGuard(ctx.data), (g) => {
       g.const(count, keyCountExpr(ctx.data));

--- a/packages/schema/src/keywords/string.ts
+++ b/packages/schema/src/keywords/string.ts
@@ -1,4 +1,4 @@
-import { NAMES, quoteString } from "../codegen/index.js";
+import { NAMES, nonNegativeIntegerLiteral, quoteString } from "../codegen/index.js";
 import type { KeywordCompileContext, KeywordDefinition } from "./types.js";
 import { CORE_VALIDATION_VOCAB, FORMAT_ASSERTION_VOCAB, FORMAT_VOCAB } from "./vocabulary-uris.js";
 
@@ -12,7 +12,7 @@ export const maxLengthKeyword: KeywordDefinition = {
   keyword: "maxLength",
   vocabulary: CORE_VALIDATION_VOCAB,
   compile(ctx: KeywordCompileContext): void {
-    const limit = ctx.schema as number;
+    const limit = nonNegativeIntegerLiteral(ctx.schema, "maxLength");
     const lenExpr = codePointLengthExpr(ctx.data);
     ctx.gen.if(`typeof ${ctx.data} === "string" && ${lenExpr} > ${limit}`, () => {
       ctx.emitError(
@@ -37,7 +37,7 @@ export const minLengthKeyword: KeywordDefinition = {
   keyword: "minLength",
   vocabulary: CORE_VALIDATION_VOCAB,
   compile(ctx: KeywordCompileContext): void {
-    const limit = ctx.schema as number;
+    const limit = nonNegativeIntegerLiteral(ctx.schema, "minLength");
     const lenExpr = codePointLengthExpr(ctx.data);
     ctx.gen.if(`typeof ${ctx.data} === "string" && ${lenExpr} < ${limit}`, () => {
       ctx.emitError(

--- a/packages/schema/test/codegen-injection.test.ts
+++ b/packages/schema/test/codegen-injection.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Codegen-injection regression tests.
+ *
+ * The compiler builds validator source by string-interpolating schema
+ * values into generated JavaScript. Untrusted schemas can therefore
+ * smuggle code through any keyword whose value lands raw in a JS
+ * expression context (numerics) or in a generated template literal
+ * (a few string fields). These tests exercise both classes:
+ *
+ *   1. Numeric keywords reject non-finite, non-integer, or string
+ *      values at compile time with a clear `keyword "..."` error.
+ *   2. String-bearing keywords whose value reaches a generated
+ *      template literal (`discriminator.propertyName`,
+ *      `dependencies` / `dependentRequired` keys) cannot inject by
+ *      embedding ``${...}`` or backticks; the message is a quoted
+ *      literal in the generated source.
+ *   3. Negative space: schemas with adversarial strings in
+ *      `pattern`, `format`, `enum`, `const`, and property names
+ *      compile and run normally because those values flow through
+ *      `quoteString` / `JSON.stringify`.
+ *
+ * The canary every numeric case checks: a payload that, if executed,
+ * sets `globalThis.__oavInjection`. Compile must throw before the
+ * generated function is ever built; the canary must remain unset.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { compile } from "./helpers.js";
+import { compileSchema } from "../src/index.js";
+import { oas30Dialect } from "../src/keywords/vocabulary.js";
+
+const G = globalThis as unknown as Record<string, unknown>;
+const CANARY = "__oavInjection";
+
+beforeEach(() => {
+  delete G[CANARY];
+});
+afterEach(() => {
+  delete G[CANARY];
+});
+
+function expectNoCanary(): void {
+  expect(G[CANARY]).toBeUndefined();
+}
+
+// A side-effecting expression that, if reached, sets the canary.
+// Wrapped so it returns a number / boolean for whichever slot it lands in.
+const EXPR_NUMBER = `(globalThis.${CANARY} = "x", 5)`;
+const EXPR_BOOLEAN = `(globalThis.${CANARY} = "x", true)`;
+
+describe("codegen injection: numeric keywords reject non-numbers", () => {
+  const numericKeywords: ReadonlyArray<{
+    name: string;
+    schema: (val: unknown) => Record<string, unknown>;
+    /** "non-negative integer" or "finite number" - controls which payloads we expect to fail. */
+    kind: "nonNegativeInteger" | "finite" | "positiveFinite";
+  }> = [
+    {
+      name: "maxLength",
+      schema: (v) => ({ type: "string", maxLength: v }),
+      kind: "nonNegativeInteger",
+    },
+    {
+      name: "minLength",
+      schema: (v) => ({ type: "string", minLength: v }),
+      kind: "nonNegativeInteger",
+    },
+    { name: "maximum", schema: (v) => ({ type: "number", maximum: v }), kind: "finite" },
+    { name: "minimum", schema: (v) => ({ type: "number", minimum: v }), kind: "finite" },
+    {
+      name: "exclusiveMaximum",
+      schema: (v) => ({ type: "number", exclusiveMaximum: v }),
+      kind: "finite",
+    },
+    {
+      name: "exclusiveMinimum",
+      schema: (v) => ({ type: "number", exclusiveMinimum: v }),
+      kind: "finite",
+    },
+    {
+      name: "multipleOf",
+      schema: (v) => ({ type: "number", multipleOf: v }),
+      kind: "positiveFinite",
+    },
+    {
+      name: "maxItems",
+      schema: (v) => ({ type: "array", maxItems: v }),
+      kind: "nonNegativeInteger",
+    },
+    {
+      name: "minItems",
+      schema: (v) => ({ type: "array", minItems: v }),
+      kind: "nonNegativeInteger",
+    },
+    {
+      name: "maxProperties",
+      schema: (v) => ({ type: "object", maxProperties: v }),
+      kind: "nonNegativeInteger",
+    },
+    {
+      name: "minProperties",
+      schema: (v) => ({ type: "object", minProperties: v }),
+      kind: "nonNegativeInteger",
+    },
+    {
+      name: "minContains",
+      schema: (v) => ({ type: "array", contains: { type: "string" }, minContains: v }),
+      kind: "nonNegativeInteger",
+    },
+    {
+      name: "maxContains",
+      schema: (v) => ({ type: "array", contains: { type: "string" }, maxContains: v }),
+      kind: "nonNegativeInteger",
+    },
+  ];
+
+  for (const { name, schema, kind } of numericKeywords) {
+    describe(name, () => {
+      it("rejects a syntactically-valid expression that sets a canary", () => {
+        expect(() => compile(schema(EXPR_NUMBER) as never)).toThrow(
+          new RegExp(`keyword "${name}"`),
+        );
+        expectNoCanary();
+      });
+
+      it("rejects a string masquerading as a number", () => {
+        expect(() => compile(schema("5") as never)).toThrow(new RegExp(`keyword "${name}"`));
+        expectNoCanary();
+      });
+
+      it("rejects NaN", () => {
+        expect(() => compile(schema(Number.NaN) as never)).toThrow(new RegExp(`keyword "${name}"`));
+      });
+
+      it("rejects Infinity", () => {
+        expect(() => compile(schema(Number.POSITIVE_INFINITY) as never)).toThrow(
+          new RegExp(`keyword "${name}"`),
+        );
+      });
+
+      it("rejects null", () => {
+        expect(() => compile(schema(null) as never)).toThrow(new RegExp(`keyword "${name}"`));
+      });
+
+      it("rejects an object", () => {
+        expect(() => compile(schema({ malicious: true }) as never)).toThrow(
+          new RegExp(`keyword "${name}"`),
+        );
+      });
+
+      if (kind === "nonNegativeInteger") {
+        it("rejects negative integers", () => {
+          expect(() => compile(schema(-1) as never)).toThrow(new RegExp(`keyword "${name}"`));
+        });
+        it("rejects fractional values", () => {
+          expect(() => compile(schema(1.5) as never)).toThrow(new RegExp(`keyword "${name}"`));
+        });
+        it("accepts a valid non-negative integer", () => {
+          expect(() => compile(schema(0) as never)).not.toThrow();
+          expect(() => compile(schema(5) as never)).not.toThrow();
+        });
+      } else if (kind === "finite") {
+        it("accepts finite numbers (including negatives and fractions)", () => {
+          expect(() => compile(schema(-1.5) as never)).not.toThrow();
+          expect(() => compile(schema(0) as never)).not.toThrow();
+          expect(() => compile(schema(1e6) as never)).not.toThrow();
+        });
+      } else {
+        it("rejects zero (positive finite required)", () => {
+          expect(() => compile(schema(0) as never)).toThrow(new RegExp(`keyword "${name}"`));
+        });
+        it("rejects negative numbers (positive finite required)", () => {
+          expect(() => compile(schema(-1) as never)).toThrow(new RegExp(`keyword "${name}"`));
+        });
+        it("accepts positive finite numbers", () => {
+          expect(() => compile(schema(0.5) as never)).not.toThrow();
+          expect(() => compile(schema(1e-7) as never)).not.toThrow();
+        });
+      }
+    });
+  }
+});
+
+describe("codegen injection: OAS 3.0 numeric keywords reject non-numbers", () => {
+  it("oas30 maximum rejects expression payload", () => {
+    expect(() =>
+      compileSchema({ type: "number", maximum: EXPR_NUMBER } as never, {
+        dialect: oas30Dialect,
+      }),
+    ).toThrow(/keyword "maximum"/);
+    expectNoCanary();
+  });
+
+  it("oas30 minimum rejects expression payload", () => {
+    expect(() =>
+      compileSchema({ type: "number", minimum: EXPR_NUMBER } as never, {
+        dialect: oas30Dialect,
+      }),
+    ).toThrow(/keyword "minimum"/);
+    expectNoCanary();
+  });
+
+  it("oas30 maximum with exclusiveMaximum=true compiles normally", () => {
+    expect(() =>
+      compileSchema({ type: "number", maximum: 5, exclusiveMaximum: true } as never, {
+        dialect: oas30Dialect,
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("codegen injection: backtick-template fields cannot smuggle ${...}", () => {
+  // Schemas where a string field flows into a generated template-literal
+  // message. The fix routes the message through `quoteString`, which
+  // produces a "..." JS string literal in generated source, so any ${...}
+  // in the user value becomes literal characters - no runtime evaluation.
+  it("discriminator.propertyName containing a runtime template expression", () => {
+    const schema = {
+      oneOf: [{ $ref: "#/$defs/A" }, { $ref: "#/$defs/B" }],
+      discriminator: {
+        propertyName: `\${(globalThis.${CANARY} = "discriminator")}`,
+        mapping: { a: "#/$defs/A", b: "#/$defs/B" },
+      },
+      $defs: {
+        A: { type: "object" },
+        B: { type: "object" },
+      },
+    } as never;
+    const v = compile(schema);
+    // Trigger the message path: data is an object whose discriminator
+    // property is not a string. The generated message includes the
+    // adversarial propertyName as literal text, NOT as evaluated code.
+    const result = v.validate({ [`\${(globalThis.${CANARY} = "discriminator")}`]: 42 });
+    expect(result.valid).toBe(false);
+    expectNoCanary();
+  });
+
+  it("dependencies (array form) keys/values cannot inject", () => {
+    const adversarialKey = `key\${(globalThis.${CANARY} = "deps-key")}`;
+    const adversarialDep = `dep\${(globalThis.${CANARY} = "deps-dep")}`;
+    const schema = {
+      type: "object",
+      dependencies: {
+        [adversarialKey]: [adversarialDep],
+      },
+    } as never;
+    const v = compile(schema);
+    const result = v.validate({ [adversarialKey]: 1 });
+    expect(result.valid).toBe(false);
+    expectNoCanary();
+  });
+
+  it("dependentRequired keys/values cannot inject", () => {
+    const adversarialKey = `key\${(globalThis.${CANARY} = "depReq-key")}`;
+    const adversarialDep = `dep\${(globalThis.${CANARY} = "depReq-dep")}`;
+    const schema = {
+      type: "object",
+      dependentRequired: {
+        [adversarialKey]: [adversarialDep],
+      },
+    } as never;
+    const v = compile(schema);
+    const result = v.validate({ [adversarialKey]: 1 });
+    expect(result.valid).toBe(false);
+    expectNoCanary();
+  });
+});
+
+describe("codegen injection: boolean OAS 3.0 exclusive flag must be a boolean", () => {
+  // The codegen now hardcodes `"true"` / `"false"` strings based on a
+  // === true comparison. Any non-true value collapses to false, so an
+  // adversarial expression-as-string in `exclusiveMaximum` is treated
+  // as "not exclusive" rather than executed.
+  it("exclusiveMaximum: <expression string> behaves as non-exclusive (no execution)", () => {
+    const v = compileSchema(
+      {
+        type: "number",
+        maximum: 5,
+        exclusiveMaximum: EXPR_BOOLEAN as never,
+      } as never,
+      { dialect: oas30Dialect },
+    );
+    // Compile succeeded without executing the expression.
+    expectNoCanary();
+    // Behaves as non-exclusive (boundary is allowed).
+    expect(v.validate(5).valid).toBe(true);
+    expect(v.validate(6).valid).toBe(false);
+  });
+});
+
+describe("negative space: string-encoded fields tolerate adversarial input", () => {
+  // These fields all flow through `quoteString` / `JSON.stringify`. The
+  // schema validator's behavior is unaffected by adversarial strings;
+  // crucially, the canary is never set.
+
+  it("pattern with adversarial regex source", () => {
+    const adversarial = "abc`; (globalThis.__oavInjection = 1); //";
+    // Most chars are regex-literal; the test only asserts no execution.
+    expect(() => compile({ type: "string", pattern: adversarial } as never)).not.toThrow();
+    expectNoCanary();
+  });
+
+  it("format name containing template-literal syntax", () => {
+    const v = compile({
+      type: "string",
+      format: `\${(globalThis.${CANARY} = "format")}`,
+    } as never);
+    // Unknown format → no validation, no error.
+    expect(v.validate("anything").valid).toBe(true);
+    expectNoCanary();
+  });
+
+  it("property names containing template-literal syntax", () => {
+    const adversarialKey = `key\${(globalThis.${CANARY} = "prop")}`;
+    const v = compile({
+      type: "object",
+      properties: { [adversarialKey]: { type: "string" } },
+      required: [adversarialKey],
+    } as never);
+    expect(v.validate({}).valid).toBe(false);
+    expect(v.validate({ [adversarialKey]: "ok" }).valid).toBe(true);
+    expect(v.validate({ [adversarialKey]: 42 }).valid).toBe(false);
+    expectNoCanary();
+  });
+
+  it("enum / const carrying objects with adversarial strings", () => {
+    const adversarial = `\${(globalThis.${CANARY} = "enum")}`;
+    const v = compile({ enum: [adversarial, "ok"] } as never);
+    expect(v.validate("ok").valid).toBe(true);
+    expect(v.validate("nope").valid).toBe(false);
+    expectNoCanary();
+
+    const v2 = compile({ const: adversarial } as never);
+    expect(v2.validate(adversarial).valid).toBe(true);
+    expect(v2.validate("other").valid).toBe(false);
+    expectNoCanary();
+  });
+});


### PR DESCRIPTION
## Summary

- Two confirmed RCE vectors in the schema compiler. Numeric keyword values (`maxLength`, `minimum`, `multipleOf`, `maxItems`, `minContains`, etc.) were interpolated raw into JS expression contexts; a payload like `5 || (sideEffect(), 5)` parsed, landed in the generated function body, and ran on every `validate()` call. Separately, string values flowing into generated *template literals* (`discriminator.propertyName`, `dependencies` / `dependentRequired` keys) reached a runtime `${...}` slot in the compiled error message.
- Fix: per-call coercion at every interpolation site. Four new helpers in `@oav/schema` codegen (`numberLiteral`, `nonNegativeIntegerLiteral`, `positiveNumberLiteral`, `booleanLiteral`) validate type and range, then return a known-safe `String(value)`; throw at compile time on malformed input. Template-literal sites now route their messages through `quoteString` so the runtime sees a quoted `"..."` literal instead of a backtick template that would re-evaluate `${...}`.
- Helpers exported from `oav/schema/internals` alongside `quoteString`. Future keywords interpolating schema values into generated JS should use them; raw `String(ctx.schema)` is the pattern to avoid.

## Behavior change

Schemas with malformed keyword values now throw at compile time instead of producing best-effort or undefined-behavior validators. Two cases worth flagging:

- `{ maxLength: "5" }` (string instead of number): previously lying-cast and worked by coercion luck; now throws with a clear keyword-name error.
- `{ minContains: null }`: previously coerced to the default `1` via `??`; now throws (consistent with `maxContains`, which never accepted null).

Schemas valid per JSON Schema 2020-12 / OpenAPI 3.0 / 3.1 / 3.2 are unaffected.

## Coverage

`packages/schema/test/codegen-injection.test.ts` — 120-case regression suite.

- Each numeric/boolean keyword is exercised with six payload classes: canary expression, string-as-number, NaN, Infinity, null, object. Plus per-kind shape constraints (non-negative integer, finite, finite positive).
- The three template-literal sites (`discriminator.propertyName`, `dependencies`, `dependentRequired`) get adversarial-string tests.
- A "negative space" suite proves `pattern`, `format`, property names, `enum`, and `const` accept adversarial strings without execution (those already routed through `quoteString` / `JSON.stringify`).
- A global canary catches any future regression where a schema value executes during compile or validate.

Follow-up: #252 tracks a typed codegen layer (branded `Literal` / `Expr` / `Identifier` so misuse is a TypeScript error) plus an optional meta-schema gate, for defense in depth.

## Test plan

- [ ] CI green (lint, typecheck, full test suite)
- [ ] Verify the new injection regression suite runs (`pnpm vitest run packages/schema/test/codegen-injection.test.ts`)
- [ ] Spot-check `gh pr checks` reports the same as local