### PR TITLE
docs: cleanup pass, spelling normalization, TSDoc tightening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,14 +234,14 @@ oav-fastify   → same chain, peer: fastify ^5
 
 1. Create `packages/schema/src/keywords/<area>.ts` exporting a
    `KeywordDefinition` with `keyword`, `vocabulary`, `compile(ctx)`.
-   Flags on the definition itself drive compiler specialisation.
-   Set them correctly or performance optimisations silently mis-fire:
+   Flags on the definition itself drive compiler specialization.
+   Set them correctly or performance optimizations silently mis-fire:
    - `applicator: true`: keyword descends into subschemas (items,
      properties, allOf, not, …). Drives the inliner to use the
      function-call path for multi-keyword schemas containing this
      keyword. A missed flag costs correctness (inlined applicators can
      skip per-function evaluated-keys state) and speed (V8 can't
-     monomorphise a huge inline body).
+     monomorphize a huge inline body).
    - `annotation: true`: keyword is metadata only, emits no runtime
      code (`title`, `description`, `$id`, `$schema`, `$comment`, …).
      Lets the inliner count keyword density correctly and avoids
@@ -330,7 +330,7 @@ same way) that's wasted CPU and memory. `compileSchema(schema,
 `createValidator`) caps the tree at N leaves and short-circuits the
 hot loops once the budget is exhausted. `maxErrors: 1` is the classic
 fast-fail mode; the returned `{ valid: false, error, truncated: true }`
-tells consumers their report is partial. Codegen is specialised: when
+tells consumers their report is partial. Codegen is specialized: when
 `maxErrors` is left unset, the generated source is identical to before
 (no budget checks, no `truncated` tracking); zero overhead for
 callers who don't opt in.
@@ -437,7 +437,7 @@ having an unknown field, which 2020-12 allows in every dialect.
   `nullable`, boolean `exclusiveMinimum`; 3.2: QUERY method).
 - **Validator integration tests** in
   `packages/validator/test/versioning.test.ts` cover dispatch,
-  dialect-specific keyword behaviour, and the `dialect` override.
+  dialect-specific keyword behavior, and the `dialect` override.
 
 ## Known limitations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,13 +46,13 @@ to add a comment.
 
 Design v0 surfaces so v1 additions land as new exports / new options,
 not changed semantics. The Express 4 adapter shipped with
-`validateRequests` knowing future `validateResponses` would need to
-share option names, the default renderer, and the context shape.
-Picking those identifiers up front cost nothing; doing it after the
-fact would have meant a breaking rename. When you can't tell whether
-a new option will need to extend later, lean toward shapes that widen
-additively (`select: "first" | "deepest" | { byCode }`, not
-`byCodeOnly: boolean`).
+`validateRequests` named so that any response-validating sibling
+added later would slot in additively, sharing option names, the
+default renderer, and the context shape. Picking those identifiers
+up front cost nothing; doing it after the fact would have meant a
+breaking rename. When you can't tell whether a new option will need
+to extend later, lean toward shapes that widen additively (`select:
+"first" | "deepest" | { byCode }`, not `byCodeOnly: boolean`).
 
 ### No magic
 
@@ -161,7 +161,7 @@ in CI; they're tsx-run dev tooling, breakage shows up when you run them.
   (children always an array), path segments as `(string | number)[]`,
   the canonical formatters (`formatText` / `formatSummary` / `toJsonObject`;
   legacy aliases `formatJson` / `formatFlat` / `summarize` are still exported
-  but deprecated, removal in v2.0)
+  but deprecated, removal in v3)
   and the named-format dispatch (`formatError`, `formatErrors`,
   `KNOWN_OUTPUT_FORMATS`), `httpStatusFor` / `allowHeaderFor` /
   `toProblemDetails` for HTTP framing, RFC 6901 `resolveJsonPointer`,
@@ -210,8 +210,8 @@ options)` returns a `Validator` exposing `validateRequest(req)`,
   framework-native field names (`ExpressContext { req, res, next }`,
   `FastifyContext { request, reply }`). The `oav-express5` / Fastify
   variants are async-native and don't need `try/catch`; `oav-express4`
-  forwards thrown errors via `next(err)`. A future `validateResponses`
-  slots in additively on each adapter.
+  forwards thrown errors via `next(err)`. Any response-validating
+  sibling added later slots in additively on each adapter.
 
 ## Dependency graph (strictly enforced; no cycles)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ pnpm test
 pnpm build
 ```
 
-For schema or validator changes that could affect HTTP behaviour:
+For schema or validator changes that could affect HTTP behavior:
 
 ```bash
 cd conformance

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ and picks the matching dialect. No per-request branching.
 | 3.1.x | JSON Schema 2020-12   | Assertive `format`                                          |
 | 3.2.x | JSON Schema 2020-12   | Same as 3.1 + the `QUERY` HTTP method                       |
 
-Override via `createValidator(spec, { dialect })` to force or customise
+Override via `createValidator(spec, { dialect })` to force or customize
 one of the built-in dialects (`jsonSchemaDialect`, `openapi31Dialect`,
 `oas30Dialect`). Unknown / missing `openapi` strings fall back to the
 3.1 dialect by default; configure with
@@ -256,7 +256,7 @@ framework-typed argument differs.
 
 `oav` is not a drop-in for `express-openapi-validator`: the
 adapters cover the request-validation middleware, but you own the
-error → HTTP mapping if you customise it, you wire up multer if you
+error → HTTP mapping if you customize it, you wire up multer if you
 need file uploads, and you run your own auth middleware. The error
 tree is structured (`code`/`path`/`message`/`params`/`children`),
 the OpenAPI 3.0 dialect is built in rather than translated to
@@ -264,7 +264,7 @@ the OpenAPI 3.0 dialect is built in rather than translated to
 
 ## Known limitations
 
-Runtime-behaviour corners. For a feature-scope comparison against
+Runtime-behavior corners. For a feature-scope comparison against
 Ajv (draft versions, `$data`, async validation, etc.) see
 [docs/comparison.md](./docs/comparison.md).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # oav
 
 OpenAPI **3.0** / **3.1** / **3.2** HTTP request and response
-validator. Two primary drivers:
+validator for JavaScript and TypeScript services. Two primary drivers:
 
 - **Tenant overrides over a base spec.** When tenants extend a
   shared API (adding a required header on one route, refining a
@@ -11,33 +11,43 @@ validator. Two primary drivers:
   at load time. Custom keywords, formats, and dialects plug into
   the compiler the same way, so per-tenant validation rules don't
   require forking. See [docs/overlays.md](./docs/overlays.md).
-- **Validators that fit in microservice runners.** `oav
-compile-spec openapi.yaml` emits a single zero-dependency ES
-  module exposing the full validator surface. Targets Cloudflare
-  Workers, Vercel Edge, Lambda@Edge, Deno Deploy: runtimes where
-  `new Function()` is unavailable, or where dependency footprint
-  matters. `--only "POST /pets"` (repeatable) scopes the output to
-  specific operations without touching the source spec.
+- **Validators that fit in microservice runners.** `oav compile-spec
+openapi.yaml` emits a single zero-dependency ES module exposing
+  the full validator surface. Targets Cloudflare Workers, Vercel
+  Edge, Lambda@Edge, Deno Deploy: runtimes where `new Function()`
+  is unavailable, or where dependency footprint matters. `--only
+"POST /pets"` (repeatable) scopes the output to specific
+  operations without touching the source spec.
 
 Errors come back as a typed tree (`code`, `path`, `message`,
 `params`, `children`). One validator call covers the full HTTP
 frame: method, path, parameters, body, content type, status, and
 headers.
 
+If you only need generic JSON Schema validation across many drafts,
+start with Ajv. If you want a one-line Express middleware with file
+upload and auth handler conveniences built in, start with
+`express-openapi-validator`. See
+[docs/comparison.md](./docs/comparison.md) for the feature map.
+
 ## Install
 
-`oav` ships in two core packages, plus framework adapter packages that
-build on either `oav` or `oav-core` -- if you don't need YAML support,
-you can skip `oav` entirely (the lean path for zero-dependency / edge
-targets):
+`oav` is the package shorthand used throughout the docs. Install uses
+the scoped npm package names shown below.
 
-| Package        | When to use                                                                                                                                                                                                                                                                                      |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `oav`          | Batteries-included: YAML readers + the `oav` CLI. Depends on `yaml`; pulls in `commander` + `esbuild` for the CLI only (never imported from the library entry points, so bundlers tree-shake them out of application bundles; Node server runs load them only when the `oav` binary is invoked). |
-| `oav-core`     | Lean. Zero runtime dependencies. Same programmatic surface as `oav`, minus the YAML readers and CLI. Feed it JSON specs (or pre-parsed objects via the memory reader).                                                                                                                           |
-| `oav-express4` | Express 4 framework adapter. Thin: imports the validator from `oav-core`, exports a middleware factory plus standalone helpers. See [`docs/integration.md`](./docs/integration.md).                                                                                                              |
-| `oav-express5` | Express 5 framework adapter. Same exports as `oav-express4`; promise-native middleware shape.                                                                                                                                                                                                    |
-| `oav-fastify`  | Fastify framework adapter. Same exports as the Express adapters; ships a `preValidation` hook instead of middleware.                                                                                                                                                                             |
+| You need                                         | Package choice                  |
+| ------------------------------------------------ | ------------------------------- |
+| YAML specs, HTTP/YAML readers, and the `oav` CLI | `oav`                           |
+| JSON or pre-parsed specs with zero runtime deps  | `oav-core`                      |
+| Express 4 request middleware                     | `oav` + `oav-express4`          |
+| Express 5 request middleware                     | `oav` + `oav-express5`          |
+| Fastify `preValidation` hook                     | `oav` + `oav-fastify`           |
+| Edge/serverless validator emitted at build time  | `oav` as a dev/build dependency |
+
+`oav` is a superset of `oav-core`: same programmatic surface plus YAML
+readers and the `oav` CLI. The CLI's `commander` and `esbuild` deps
+load on demand from the binary entry, never from the library
+entrypoints, so application bundles tree-shake them out.
 
 ```bash
 npm install @aahoughton/oav            # YAML + CLI
@@ -54,6 +64,34 @@ npm install @aahoughton/oav-fastify    # Fastify adapter
 [`docs/modules.md`](./docs/modules.md) for what each subpath exports.
 
 ## Quick start
+
+### Express
+
+```ts
+import express from "express";
+import { createValidator, createYamlFileReader } from "@aahoughton/oav";
+import { loadSpec } from "@aahoughton/oav/spec";
+import { validateRequests } from "@aahoughton/oav-express5";
+
+const { document } = await loadSpec({
+  reader: createYamlFileReader(),
+  entry: "openapi.yaml",
+});
+const validator = createValidator(document);
+
+const app = express();
+app.use(express.json());
+app.use(validateRequests(validator));
+
+app.post("/pets", (req, res) => res.json({ ok: true }));
+```
+
+Invalid requests receive an `application/problem+json` response.
+Valid requests continue to your route handlers. Express 4 uses the
+same shape with `oav-express4`; Fastify uses `oav-fastify` as a
+`preValidation` hook. See [docs/integration.md](./docs/integration.md).
+
+### Framework-agnostic
 
 ```ts
 import { createValidator, createYamlFileReader, formatText } from "@aahoughton/oav";
@@ -92,14 +130,27 @@ custom formats, custom keywords, cross-field constraints, error
 budgets, version differences, overlays, and spec-derived middleware
 config.
 
+## Where to go next
+
+| Task                                      | Read                                                                   |
+| ----------------------------------------- | ---------------------------------------------------------------------- |
+| Wire into Express, Fastify, Next.js, Hono | [docs/integration.md](./docs/integration.md)                           |
+| Patch a spec you do not own               | [docs/overlays.md](./docs/overlays.md)                                 |
+| Emit standalone validators                | [packages/cli/README.md](./packages/cli/README.md#compile-spec-output) |
+| Compare against Ajv and other tools       | [docs/comparison.md](./docs/comparison.md)                             |
+| Migrate from express-openapi-validator    | [docs/migration-from-eov.md](./docs/migration-from-eov.md)             |
+| Use custom formats, keywords, or limits   | [docs/configuration.md](./docs/configuration.md)                       |
+
 ## How it compares
 
-oav's primary alternative is
-[Ajv](https://github.com/ajv-validator/ajv): directly for
-`compileSchema`, or via
-[`express-openapi-validator`](https://github.com/cdimascio/express-openapi-validator)
-for HTTP validation. (Migrating from EOV specifically:
-[docs/migration-from-eov.md](./docs/migration-from-eov.md).)
+The JavaScript ecosystem already has solid OpenAPI validation tools:
+Ajv for JSON Schema, `express-openapi-validator` for Express,
+`openapi-backend` for operationId routing plus validation, and smaller
+request/response validators for custom stacks. oav is aimed at
+HTTP-aware validation with structured errors, overlays, and standalone
+OpenAPI validator output. See [docs/comparison.md](./docs/comparison.md)
+for the feature map, and [docs/migration-from-eov.md](./docs/migration-from-eov.md)
+if you are migrating from `express-openapi-validator`.
 
 Numbers below are from the [`performance/`](./performance/README.md)
 benchmark on AWS c7i.large (Intel Sapphire Rapids, Node 22). Your
@@ -214,7 +265,8 @@ The canonical contract is the `ValidatorOptions` TSDoc.
 
 `oav` is a validator, not a middleware package: you write a short
 adapter between your framework and `validateRequest` /
-`validateResponse`. An Express 5 adapter is about this long:
+`validateResponse`, or use one of the companion adapter packages. An
+inline Express 5 adapter is about this long:
 
 ```ts
 import { allowHeaderFor, httpStatusFor, toProblemDetails } from "@aahoughton/oav";
@@ -238,34 +290,32 @@ app.use(async (req, res, next) => {
 });
 ```
 
-See [**docs/integration.md**](./docs/integration.md) for:
-
-- Adapter packages for Express 4, Express 5, and Fastify; recipes for Next.js, Hono, Bun, and Deno via the Web Standards adapter.
-- Recipes for file uploads (multer), response validation, security,
-  ignoring paths, and the full status-code switch.
-- A migration table from `express-openapi-validator`, including
-  where oav is stricter or more conformant and where you'll do more
-  wiring by hand.
-
-Companion adapter packages cover the common framework wiring:
+Companion adapter packages cover common request-validation wiring:
 [`oav-express4`](./packages/oav-express4/README.md),
-[`oav-express5`](./packages/oav-express5/README.md),
-[`oav-fastify`](./packages/oav-fastify/README.md). They
-share the same export names and option shapes; only the
-framework-typed argument differs.
+[`oav-express5`](./packages/oav-express5/README.md), and
+[`oav-fastify`](./packages/oav-fastify/README.md). They share export
+names and option shapes; only the framework type differs.
 
-`oav` is not a drop-in for `express-openapi-validator`: the
-adapters cover the request-validation middleware, but you own the
-error → HTTP mapping if you customize it, you wire up multer if you
-need file uploads, and you run your own auth middleware. The error
-tree is structured (`code`/`path`/`message`/`params`/`children`),
-the OpenAPI 3.0 dialect is built in rather than translated to
-2020-12, and the validator does not mutate `req` or `res`.
+For Next.js, Hono, Bun, Deno, and custom frameworks, use the
+framework-agnostic `validateRequest` / `validateResponse` calls or the
+Fetch helpers (`validateFetchRequest`, `validateFetchResponse`). See
+[docs/integration.md](./docs/integration.md) for body parsing,
+response validation, uploads, security, ignored paths, and custom error
+envelopes.
+
+`oav` is not a drop-in replacement for `express-openapi-validator`.
+The adapters cover request validation; response validation, auth
+dispatch, upload parsing, and custom error envelopes stay explicit in
+your application. In return, the validator does not mutate `req` or
+`res`, OpenAPI 3.0 behavior is built into the dialect, and failures
+come back as structured error trees rather than framework-specific
+error classes.
 
 ## Known limitations
 
-Runtime-behavior corners. For a feature-scope comparison against
-Ajv (draft versions, `$data`, async validation, etc.) see
+Runtime behavior corners. For feature-scope tradeoffs against Ajv and
+OpenAPI middleware packages (draft versions, `$data`, async
+validation, response interception, upload helpers), see
 [docs/comparison.md](./docs/comparison.md).
 
 - `$dynamicRef` behaves like `$ref` with anchor lookup; no runtime dynamic-scope traversal.

--- a/conformance/REPORT.md
+++ b/conformance/REPORT.md
@@ -86,13 +86,13 @@ live under `tests/draft2020-12/optional/`. Current state:
 | `non-bmp-regex.json`, `id.json`, `no-schema.json`, `unknownKeyword.json`, `refOfUnknownKeyword.json` | pass.                                                                                                                 |
 
 The per-format subtree (`optional/format/*.json`) isn't traversed by
-our runner. Those tests target strict-format-assertion behaviour; by
+our runner. Those tests target strict-format-assertion behavior; by
 spec default and our default, format is annotation-only, so most tests
 there would vacuously pass. Enabling format-assertion and running them
 is a separate exercise: each format brings its own tail of RFC edge
 cases that the suite tightens every few revisions.
 
-## Behavioural parity notes
+## Behavioral parity notes
 
 Where we agree with upstream on pass/fail, we don't try to match their
 error-message text. Our error `code`s, `path`s, and `params` are the

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,14 +1,37 @@
-# oav vs Ajv (+ express-openapi-validator)
+# oav vs other JavaScript OpenAPI validators
 
 Ajv is the canonical JSON Schema validator for JavaScript, and
 `express-openapi-validator` is the most widely-used middleware built
-on top of it. Together they cover most real-world OpenAPI validation
-in the ecosystem and have done so for years. This document maps what
-each project does so you can pick the one that fits.
+on top of it. Together they cover a large share of OpenAPI request /
+response validation in JavaScript services and have done so for years.
 
-oav covers the same ground as Ajv + `express-openapi-validator`
-combined (schema validation plus HTTP-layer checks), and trades
-differently on a handful of specifics, cataloged below.
+They are not the only options. `openapi-backend` combines routing,
+validation, auth, and mocking around operation handlers.
+`openapi-enforcer` and `openapi-enforcer-middleware` cover document
+loading, request/response validation, serialization, and mocks, with a
+stronger OpenAPI 2.0 / 3.0 story than 3.1+. `openapi-request-validator`
+and `openapi-response-validator` are smaller request/response pieces.
+Spec validators and parsers such as `@seriousme/openapi-schema-validator`
+and `@scalar/openapi-parser` validate the OpenAPI document at
+build/load time; they don't sit in the request path.
+
+This document spends most of its space on Ajv and
+`express-openapi-validator` because they are the closest comparison for
+oav's core surface: schema validation plus HTTP-layer request/response
+checks. The broader ecosystem matters, but the same decision usually
+comes down to the shape of integration you want.
+
+## Ecosystem map
+
+| Tool family                                    | Best fit                                                                                      |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Ajv                                            | JSON Schema validation, many drafts, maximum ecosystem maturity                               |
+| `express-openapi-validator`                    | Existing Express apps that want one middleware to validate requests/responses                 |
+| `openapi-backend`                              | OperationId routing, auth handlers, validation, and mocking together                          |
+| `openapi-enforcer` / middleware                | OpenAPI 2.0 / 3.0 services that want validation plus serialization/mocking                    |
+| `openapi-request-validator` / response sibling | Lower-level request or response checks around your own routing                                |
+| Spec validators/parsers                        | Validating the OpenAPI document, resolving refs, linting, or tooling                          |
+| oav                                            | HTTP-aware validation with structured errors, overlays, and standalone OpenAPI validator emit |
 
 This document is about behavior and capabilities. For raw numbers
 and methodology see [`performance/README.md`](../performance/README.md);
@@ -181,9 +204,8 @@ Ajv 8 has four runtime dependencies:
 
 oav's compiler and validator have zero runtime dependencies. The lean
 `oav-core` package ships exactly that (no runtime deps),
-and accepts JSON specs. The batteries-included `oav`
-package layers `yaml` on top for `.yaml` spec files and adds the `oav`
-CLI (with `commander` as an optional peer). The two efficiency
+and accepts JSON specs. The `oav` package adds YAML readers for
+`.yaml` spec files and the `oav` CLI. The two efficiency
 libraries Ajv pulls in (`fast-deep-equal`, `json-schema-traverse`)
 have equivalents in-tree; the two capability libraries (`fast-uri`,
 `require-from-string`) map to features oav doesn't implement (see
@@ -191,19 +213,25 @@ have equivalents in-tree; the two capability libraries (`fast-uri`,
 
 ## Summary
 
-oav and Ajv + `express-openapi-validator` cover the same ground: both
-validate OpenAPI requests and responses by 3.0 / 3.1 / 3.2 rules,
-both support custom keywords and formats, both produce
-machine-readable errors. Differences are real but bounded.
+The JavaScript ecosystem has several OpenAPI validation tools with
+different integration shapes. Pick the one whose shape fits how your
+service is already wired.
 
 Pick Ajv + `express-openapi-validator` when you want the fastest
 steady-state validate throughput on a schema you compile once, a
 large userbase, multi-draft support, or the one-line middleware
-integration. Pick oav when you want a structured error tree,
-overlays over specs you don't own, a bundled OpenAPI 3.0 dialect,
-explicit control over where validation runs in your HTTP stack, or
-when compile throughput matters (1–2 orders of magnitude above ajv,
-8× on Stripe's real-world spec; see the performance sketch above).
+integration for Express. Pick `openapi-backend` when routing and
+operation handlers should be driven by the spec. Pick
+`openapi-enforcer` when its OpenAPI 2.0 / 3.0 validation,
+serialization, and mocking model fits your service.
+
+Pick oav when you want a structured error tree, overlays over specs you
+don't own, an OpenAPI 3.0 dialect built into the validator, explicit
+control over where validation runs in your HTTP stack, or standalone
+OpenAPI HTTP validator output for edge/serverless deployments. It also
+fits compile-heavy workloads: current benchmarks show one to two orders
+of magnitude faster schema compile than Ajv, including 8× on Stripe's
+real-world spec; see the performance sketch above.
 
 For benchmark numbers rather than feature comparisons, see
 [`performance/README.md`](../performance/README.md).

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -8,9 +8,9 @@ each project does so you can pick the one that fits.
 
 oav covers the same ground as Ajv + `express-openapi-validator`
 combined (schema validation plus HTTP-layer checks), and trades
-differently on a handful of specifics, catalogued below.
+differently on a handful of specifics, cataloged below.
 
-This document is about behaviour and capabilities. For raw numbers
+This document is about behavior and capabilities. For raw numbers
 and methodology see [`performance/README.md`](../performance/README.md);
 the shape of the trade-off is sketched below.
 
@@ -130,7 +130,7 @@ Capabilities oav has that Ajv (alone or with
   out of the schema before compile (rewriting `{ nullable: true,
 type: "string" }` to `{ type: ["string", "number", "boolean",
 "object", "array"] }` with an `x-eov-type` side channel to narrow
-  back). Different mechanism, equivalent behaviour.
+  back). Different mechanism, equivalent behavior.
 - **First-class overlays.** `applyOverlays` rewrites an
   externally-owned base spec at load time (add a required header to
   every operation, extend a component schema, swap a response shape)
@@ -165,7 +165,7 @@ type: "string" }` to `{ type: ["string", "number", "boolean",
   implementation shape.
 - **Compile-time observability.** `CompiledSchema.stats` exposes
   `functionCount`, `unevaluatedTrackingEmitted`, and
-  `emittedTreeRuntime` so tests can assert on compiler optimisations
+  `emittedTreeRuntime` so tests can assert on compiler optimizations
   directly rather than grepping the generated source.
 
 ## Runtime dependencies

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -563,7 +563,7 @@ adapter:
    emits an HTML page. Install an Express error middleware to convert
    it to `application/problem+json` upstream of the validator.
 
-2. **Empty-body normalisation.** Some body parsers (streaming
+2. **Empty-body normalization.** Some body parsers (streaming
    variants, custom multi-format setups) leave `req.body === undefined`
    for empty `{}`-equivalent payloads instead of an empty object. When
    that happens, oav's `required`-field checks short-circuit on the

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,39 +1,40 @@
 # Integration guide
 
-A recipe book for wiring `oav` into HTTP frameworks. `oav` is a
-validator, not a middleware package: you write a short adapter
-between your framework and `validateRequest` / `validateResponse`,
-or use one of the companion adapter packages (`oav-express4`,
-`oav-express5`, `oav-fastify`).
+Use this guide when you already have an OpenAPI document and want to
+run request or response validation inside an HTTP framework.
 
-This document is organized:
+The common integrations have adapter packages. The remaining runtimes
+use the same framework-agnostic validator surface, or the Fetch helpers
+when the framework exposes Web Standards `Request` / `Response`.
 
-- **[What the validator expects](#what-the-validator-expects)**:
-  the framework-agnostic shapes `validateRequest` and
-  `validateResponse` work with.
-- **[Supporting helpers](#supporting-helpers)**:
-  `httpStatusFor`, `allowHeaderFor`, `toProblemDetails`,
-  `formatSummary`, `collectIssues`. The recipes below assume these.
-- **[Per-framework integration](#per-framework-integration)**:
-  Express 4, Express 5, Fastify, Next.js, Hono, Bun, Deno. Each
-  section leads with the adapter (where one exists) and falls back
-  to the manual inline recipe.
-- **[Cross-cutting recipes](#cross-cutting-recipes)**, linked from
-  the per-framework sections:
-  - [Status-code mapping](#status-code-mapping)
-  - [Preserving an existing client error envelope](#preserving-an-existing-client-error-envelope)
-  - [Body parser caveats](#body-parser-caveats)
-  - [File uploads with multer](#file-uploads-with-multer)
-  - [Deriving middleware config from the spec](#deriving-middleware-config-from-the-spec)
-  - [Streaming bodies, large uploads, and the `readBody` override](#streaming-bodies-large-uploads-and-the-readbody-override)
-  - [Response validation (no monkey-patching)](#response-validation-no-monkey-patching)
-  - [Security / authentication](#security--authentication)
-  - [Type coercion on body fields](#type-coercion-on-body-fields)
-  - [Ignoring paths not in the spec](#ignoring-paths-not-in-the-spec)
-- **[Migration paths](#migration-paths)**: pointers to focused
-  migration docs (currently only
-  [migration-from-eov.md](./migration-from-eov.md) for
-  `express-openapi-validator`).
+| Your app uses                        | Start here                                                                                    |
+| ------------------------------------ | --------------------------------------------------------------------------------------------- |
+| Express 4                            | [`oav-express4`](../packages/oav-express4/README.md), then [Express 4](#express-4)            |
+| Express 5                            | [`oav-express5`](../packages/oav-express5/README.md), then [Express 5](#express-5)            |
+| Fastify                              | [`oav-fastify`](../packages/oav-fastify/README.md), then [Fastify](#fastify)                  |
+| Next.js, Hono, Bun, Deno, Fetch APIs | [`validateFetchRequest`](#nextjs-app-router-hono-bun-deno)                                    |
+| Another framework                    | [What the validator expects](#what-the-validator-expects)                                     |
+| A custom error response shape        | [Preserving an existing client error envelope](#preserving-an-existing-client-error-envelope) |
+| File uploads, auth, response checks  | [Cross-cutting recipes](#cross-cutting-recipes)                                               |
+
+Adapters handle request validation and default
+`application/problem+json` responses. Response validation, upload
+parsing, authentication, and application-specific error envelopes stay
+explicit so they fit the service you already have.
+
+The cross-cutting recipes section covers concerns that show up across
+frameworks:
+
+- [Status-code mapping](#status-code-mapping)
+- [Preserving an existing client error envelope](#preserving-an-existing-client-error-envelope)
+- [Body parser caveats](#body-parser-caveats)
+- [File uploads with multer](#file-uploads-with-multer)
+- [Deriving middleware config from the spec](#deriving-middleware-config-from-the-spec)
+- [Streaming bodies, large uploads, and the `readBody` override](#streaming-bodies-large-uploads-and-the-readbody-override)
+- [Response validation (no monkey-patching)](#response-validation-no-monkey-patching)
+- [Security / authentication](#security--authentication)
+- [Type coercion on body fields](#type-coercion-on-body-fields)
+- [Ignoring paths not in the spec](#ignoring-paths-not-in-the-spec)
 
 ## What the validator expects
 
@@ -225,8 +226,8 @@ Custom streaming parsers, `body-parser`, fastify's bridge, and
 app-specific middleware all work the same way; oav doesn't care
 _how_ `req.body` got populated, only that it's there.
 
-See [body-parser caveats](#body-parser-caveats) for sharp edges
-that affect this pattern.
+See [body-parser caveats](#body-parser-caveats) for sharp edges that
+affect this pattern.
 
 ### Fastify
 
@@ -554,8 +555,8 @@ want to surface structured details too. `BuiltInErrorParams` in
 ### Body parser caveats
 
 oav doesn't parse bodies; it validates already-parsed bodies. Two
-sharp edges that bite both inline middleware and the
-`oav-express4` adapter:
+sharp edges that bite both inline middleware and the `oav-express4`
+adapter:
 
 1. **Malformed JSON throws before oav runs.** `express.json()` throws
    a `SyntaxError` on bad JSON, and Express's default error handler

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -6,7 +6,7 @@ between your framework and `validateRequest` / `validateResponse`,
 or use one of the companion adapter packages (`oav-express4`,
 `oav-express5`, `oav-fastify`).
 
-This document is organised:
+This document is organized:
 
 - **[What the validator expects](#what-the-validator-expects)**:
   the framework-agnostic shapes `validateRequest` and
@@ -568,7 +568,7 @@ sharp edges that bite both inline middleware and the
    that happens, oav's `required`-field checks short-circuit on the
    missing body, so validation passes for what the client thinks is an
    empty submission, even when the spec marks fields as `required`.
-   If your parser does this, normalise before calling `validateRequest`:
+   If your parser does this, normalize before calling `validateRequest`:
 
    ```ts
    body: req.body ?? {},
@@ -739,7 +739,7 @@ that pulls the common middleware-config facts into a flat shape:
 content types, body limits, required headers, security. Copy it into
 your project and adjust the interpretation choices
 (`maxLength`-as-bytes vs code points, which `x-*` extensions to
-recognise, etc.) to fit your domain.
+recognize, etc.) to fit your domain.
 
 The getter is startup-time introspection, not part of validation. Its
 job is to make the spec the single source of truth for middleware
@@ -836,7 +836,7 @@ app.get("/pets/:id", async (req, res) => {
 ```
 
 **Per-app wrapper.** Wrap `res.json` yourself if you want
-auto-interception behaviour for every response:
+auto-interception behavior for every response:
 
 ```ts
 app.use((req, res, next) => {

--- a/docs/migration-from-eov.md
+++ b/docs/migration-from-eov.md
@@ -11,7 +11,7 @@ or write the middleware inline.
 
 ## What you give up; what you get
 
-eov registers as a single middleware that wraps a lot of behaviour:
+eov registers as a single middleware that wraps a lot of behavior:
 file upload (multer), security check dispatch, response wrapping,
 typed error classes. `oav` is a ~20-line middleware (or one
 `validateRequests(...)` call via the adapter) plus your own multer /
@@ -40,7 +40,7 @@ auth wiring where needed. In exchange:
 
 ## Behavior differences to watch for
 
-The behaviour deltas surfaced by real eov-to-oav migrations. Most are
+The behavior deltas surfaced by real eov-to-oav migrations. Most are
 defensible improvements; a few are cosmetic. Either way, expect
 fixture / test churn.
 

--- a/examples/custom-keywords.ts
+++ b/examples/custom-keywords.ts
@@ -1,5 +1,5 @@
 /**
- * Custom keywords: register a schema keyword whose behaviour depends on
+ * Custom keywords: register a schema keyword whose behavior depends on
  * runtime state the spec itself can't capture — here, an "active tenant"
  * check backed by an in-memory cache. Good for Luhn checks, tick-size
  * multiples, currency-whitelists, etc.

--- a/examples/spec-digest.ts
+++ b/examples/spec-digest.ts
@@ -9,7 +9,7 @@
  *
  * This file is **documentation, not library API.** Copy it into your
  * project and adapt the interpretation choices — what `maxLength`
- * means on a binary field, which `x-*` extensions to recognise, how
+ * means on a binary field, which `x-*` extensions to recognize, how
  * nested `properties` roll up — to match your domain. Keeping those
  * decisions in application code (rather than in oav) avoids baking
  * one team's conventions into every team's startup.
@@ -90,7 +90,7 @@ function bodyLimitsByMediaType(op: OperationObject): Record<string, { maxBytes?:
  * field. `maxLength` on a `format: binary` field is the OpenAPI
  * convention for byte-count; on a plain string it means code
  * points. This recipe treats only the binary case as a byte ceiling
- * — your domain may want to recognise an `x-max-bytes` extension, a
+ * — your domain may want to recognize an `x-max-bytes` extension, a
  * custom annotation keyword, or something else entirely.
  */
 function declaredMaxBytes(schema: SchemaObject | boolean | undefined): number | undefined {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -100,7 +100,7 @@ parameter / body / response schemas are pre-compiled and inlined.
 esbuild bundles everything; the resulting module has zero imports.
 
 Consumers who were running `createValidator(await loadSpec(...))` at
-application boot get the same behaviour with no YAML parse, no
+application boot get the same behavior with no YAML parse, no
 `$ref` walk, no schema compilation at load time. Target use cases:
 
 - **Cloudflare Workers / Vercel Edge**: the runtime sandbox

--- a/packages/cli/src/emit-spec.ts
+++ b/packages/cli/src/emit-spec.ts
@@ -8,7 +8,7 @@
  * module has zero imports.
  *
  * Consumers who were doing `createValidator(await loadSpec(...))` at
- * runtime get the same behaviour with no YAML parse, no `$ref`
+ * runtime get the same behavior with no YAML parse, no `$ref`
  * resolution, no schema compilation at load. Target use cases:
  * Cloudflare Workers, Vercel Edge, Lambda@Edge, Lambda cold-start
  * latency, deno compile, single-file bundles: anywhere runtime
@@ -113,7 +113,7 @@ export function emitSpec(document: OpenAPIDocument, options: EmitSpecOptions = {
     return name;
   };
 
-  // Operations to emit, honouring `only`. Two parallel structures:
+  // Operations to emit, honoring `only`. Two parallel structures:
   //
   // - `pathMethods`: for each path that has ≥ 1 included op, the FULL
   //   set of spec-declared methods. Drives the router's paths table.
@@ -503,7 +503,7 @@ function resolveDialect(
   const bucket = detectVersionBucket(document);
 
   // Explicit override short-circuits detection. Mirror the runtime's
-  // behaviour of surfacing a warning when the override is hiding a
+  // behavior of surfacing a warning when the override is hiding a
   // category error.
   if (override !== undefined) {
     if (bucket === undefined) {

--- a/packages/cli/src/emit-standalone.ts
+++ b/packages/cli/src/emit-standalone.ts
@@ -42,7 +42,7 @@ export interface EmitStandaloneOptions {
 /**
  * Compile a JSON Schema and emit a standalone ES module source string.
  *
- * The module exports a `validate(data)` function whose behaviour
+ * The module exports a `validate(data)` function whose behavior
  * matches `compileSchema(schema, { dialect }).validate(data)`, but
  * which requires no `new Function()` at load time. Useful for edge
  * runtimes (Cloudflare Workers, Vercel Edge) and build-time-prepared

--- a/packages/cli/test/compile-spec.test.ts
+++ b/packages/cli/test/compile-spec.test.ts
@@ -1,7 +1,7 @@
 /**
  * End-to-end tests for `oav compile-spec`. Each test compiles a small
  * OpenAPI document through the real emit + esbuild bundle path, loads
- * the resulting module via a data URL, and compares its behaviour
+ * the resulting module via a data URL, and compares its behavior
  * against `createValidator(document).validateRequest` on a fixture
  * matrix. A pass means the AOT output matches the runtime validator's
  * tree shape on the covered cases.

--- a/packages/cli/test/emit-standalone.test.ts
+++ b/packages/cli/test/emit-standalone.test.ts
@@ -66,7 +66,7 @@ describe("emitStandalone", () => {
       expect(validate({ contact: "user@example.com" })).toEqual({ valid: true });
       // format defaults to annotation-only under jsonSchemaDialect, so a
       // malformed email still passes. The emitter correctly wires the
-      // formats regardless; stricter behaviour requires the assertion
+      // formats regardless; stricter behavior requires the assertion
       // vocabulary, which isn't the JSON-Schema default.
       expect(validate({ contact: "not-an-email" }).valid).toBe(true);
     } finally {
@@ -82,7 +82,7 @@ describe("emitStandalone", () => {
     ).toThrow(/not in the built-in set/);
   });
 
-  it("compiles under the OpenAPI 3.0 dialect: boolean exclusiveMaximum honoured", async () => {
+  it("compiles under the OpenAPI 3.0 dialect: boolean exclusiveMaximum honored", async () => {
     const schema: SchemaOrBoolean = {
       type: "integer",
       maximum: 10,

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -262,7 +262,7 @@ export interface SummarizeOptions {
 export type SummarizeSelect = "first" | "deepest" | { byCode: readonly string[] };
 
 /**
- * @deprecated Use {@link formatSummary}. Same defaults and behaviour.
+ * @deprecated Use {@link formatSummary}. Same defaults and behavior.
  *
  * @public
  */

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -227,12 +227,12 @@ export function countErrors(error: ValidationError): number {
 
 // ---------------------------------------------------------------------------
 // Deprecated: kept exported for source compatibility; absent from user-facing
-// docs. Behavior identical to the new canonical names. Removal in v2.0.
+// docs. Behavior identical to the new canonical names. Removal in v3.
 // ---------------------------------------------------------------------------
 
 /**
  * @deprecated Use {@link toJsonObject}. Same return shape; the new name
- *   reflects that it returns an object, not a string.
+ *   reflects that it returns an object, not a string. Removal in v3.
  *
  * @public
  */
@@ -244,18 +244,18 @@ export function formatJson(error: ValidationError): ValidationError {
  * Options for the deprecated {@link summarize}. Use
  * {@link FormatSummaryOptions} instead.
  *
- * @deprecated Use {@link FormatSummaryOptions}.
+ * @deprecated Use {@link FormatSummaryOptions}. Removal in v3.
  *
  * @public
  */
 export interface SummarizeOptions {
-  /** @deprecated See {@link FormatSummaryOptions.select}. */
+  /** @deprecated See {@link FormatSummaryOptions.select}. Removal in v3. */
   select?: SummarizeSelect;
 }
 
 /**
  * @deprecated Use {@link FormatSummarySelect}. Note: the new type also
- *   accepts `"all"` for flat all-leaves output.
+ *   accepts `"all"` for flat all-leaves output. Removal in v3.
  *
  * @public
  */
@@ -263,6 +263,7 @@ export type SummarizeSelect = "first" | "deepest" | { byCode: readonly string[] 
 
 /**
  * @deprecated Use {@link formatSummary}. Same defaults and behavior.
+ *   Removal in v3.
  *
  * @public
  */
@@ -271,7 +272,7 @@ export function summarize(error: ValidationError, options: SummarizeOptions = {}
 }
 
 /**
- * @deprecated Use `formatSummary(err, { select: "all" })`.
+ * @deprecated Use `formatSummary(err, { select: "all" })`. Removal in v3.
  *
  * @public
  */

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -227,7 +227,7 @@ export function countErrors(error: ValidationError): number {
 
 // ---------------------------------------------------------------------------
 // Deprecated: kept exported for source compatibility; absent from user-facing
-// docs. Behaviour identical to the new canonical names. Removal in v2.0.
+// docs. Behavior identical to the new canonical names. Removal in v2.0.
 // ---------------------------------------------------------------------------
 
 /**

--- a/packages/core/src/json-pointer.ts
+++ b/packages/core/src/json-pointer.ts
@@ -5,7 +5,7 @@ import type { JsonValue } from "./types.js";
  * `#`) against a root document. Percent-encoded octets are decoded
  * before `~0`/`~1` per RFC 6901 §5.
  *
- * Behaviour:
+ * Behavior:
  *   - `""` or `"/"` returns the root (the whole-document pointer).
  *   - Any other pointer MUST start with `/`.
  *   - Stray `%` characters that aren't a valid `%XX` escape are

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -2,7 +2,7 @@
  * OpenAPI version detection and dialect identity.
  *
  * The OpenAPI Specification has two major variants that affect
- * validator behaviour:
+ * validator behavior:
  *
  * - **3.0.x**: uses a draft-Wright-00-based JSON Schema dialect with
  *   its own flavours of `type` (single string only), `nullable: true`,
@@ -30,7 +30,7 @@ export type OpenAPIVersion = "3.0" | "3.1" | "3.2";
 /**
  * Inspect an OpenAPI document's `openapi` field and bucket it by
  * major.minor. Returns `undefined` when the field is missing, malformed,
- * or targets a line we don't recognise.
+ * or targets a line we don't recognize.
  *
  * @param spec - Anything shaped like an OpenAPI document. Safe on
  *               arbitrary input; returns `undefined` without throwing.

--- a/packages/core/test/format.test.ts
+++ b/packages/core/test/format.test.ts
@@ -164,7 +164,7 @@ describe("formatSummary", () => {
     expect(formatSummary(tree, { select: "all" })).toBe(formatFlat(tree));
   });
 
-  it('"all" honours a custom separator', () => {
+  it('"all" honors a custom separator', () => {
     const out = formatSummary(sampleTree(), { select: "all", separator: ", " });
     expect(out).toBe(
       'body.purr must be boolean [type], body must have required property "bark" [required]',

--- a/packages/core/test/http-status.test.ts
+++ b/packages/core/test/http-status.test.ts
@@ -72,7 +72,7 @@ describe("httpStatusFor", () => {
     // what you're asking for"), and 401 should surface ahead of 415. In
     // practice the validator short-circuits on security before checking
     // content-type, so both rarely coexist, but the helper's priority
-    // guarantees the behaviour regardless.
+    // guarantees the behavior regardless.
     const err = createBranchError("request", [], "request validation failed", [
       createLeafError("content-type", ["body"], "Content-Type not accepted", {
         contentType: "text/plain",

--- a/packages/core/test/problem-details.test.ts
+++ b/packages/core/test/problem-details.test.ts
@@ -80,12 +80,12 @@ describe("toProblemDetails", () => {
     expect(pd.detail).toBe("x");
   });
 
-  it("honours a caller-supplied `detail` override", () => {
+  it("honors a caller-supplied `detail` override", () => {
     const pd = toProblemDetails(err, { detail: "2 validation errors" });
     expect(pd.detail).toBe("2 validation errors");
   });
 
-  it("honours caller-supplied type / title / status / instance", () => {
+  it("honors caller-supplied type / title / status / instance", () => {
     const pd = toProblemDetails(err, {
       type: "https://example.com/errors/validation",
       title: "Bad pets",

--- a/packages/formats/README.md
+++ b/packages/formats/README.md
@@ -60,7 +60,7 @@ for a runnable end-to-end.
 ## Assertive vs annotation-only
 
 In JSON Schema 2020-12, `format` is advisory by default: a validator
-recognises the name but doesn't reject malformed values. OpenAPI 3.0 /
+recognizes the name but doesn't reject malformed values. OpenAPI 3.0 /
 3.1 / 3.2 treat `format` as assertive; the validator wires up the
 corresponding vocabulary so `format: email` rejects non-emails.
 When compiling directly via `oav/schema`, use

--- a/packages/oav-express4/README.md
+++ b/packages/oav-express4/README.md
@@ -42,7 +42,7 @@ Invalid requests receive a `400 application/problem+json` response (status from 
 
 > **Body parser ordering matters.** `express.json()` (or your equivalent) must run **before** `validateRequests(...)`, otherwise `req.body` is `undefined` and the validator emits `body required` for every request: a misleading error that points at the schema, not at the missing parser. Same for `cookie-parser` if your spec validates cookies. Any middleware that populates `req.body` with a parsed object satisfies oav: `express.json()`, custom streaming parsers, `body-parser`, fastify's bridge, app-specific middleware all work the same way.
 >
-> **Empty-body normalisation.** Some parsers (streaming variants, custom multi-format setups) leave `req.body === undefined` even after they run, for empty `{}`-equivalent payloads. When that happens, `required`-field checks short-circuit on the missing body, so empty submissions pass validation. Normalise via `toHttpRequest`:
+> **Empty-body normalization.** Some parsers (streaming variants, custom multi-format setups) leave `req.body === undefined` even after they run, for empty `{}`-equivalent payloads. When that happens, `required`-field checks short-circuit on the missing body, so empty submissions pass validation. Normalize via `toHttpRequest`:
 >
 > ```ts
 > import { httpRequestFromExpress, validateRequests } from "@aahoughton/oav-express4";

--- a/packages/oav-express4/README.md
+++ b/packages/oav-express4/README.md
@@ -272,6 +272,6 @@ For per-route inline multer (validator called from inside the route handler) and
 ## See also
 
 - [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core): `createValidator`, `ValidatorOptions`, `formatSummary`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
-- [`oav`](https://www.npmjs.com/package/@aahoughton/oav): batteries-included distribution of oav-core (YAML readers + the `oav` CLI).
+- [`oav`](https://www.npmjs.com/package/@aahoughton/oav): oav-core plus YAML readers and the `oav` CLI.
 - The repo-root [`docs/integration.md`](../../docs/integration.md): broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
 - The repo-root [`docs/migration-from-eov.md`](../../docs/migration-from-eov.md): porting from `express-openapi-validator`.

--- a/packages/oav-express4/src/extract.ts
+++ b/packages/oav-express4/src/extract.ts
@@ -16,9 +16,9 @@ import type { HttpRequest } from "@oav/core";
  * Cookies are read from `req.cookies` if `cookie-parser` populated
  * them, otherwise omitted.
  *
- * Pairs with future `httpRequestFromExpress5`, `httpRequestFromFastify`,
- * etc.: same name pattern as oav's existing
- * {@link httpRequestFromFetch}.
+ * Pairs with sibling `httpRequestFromExpress` in `oav-express5` and
+ * `httpRequestFromFastify` in `oav-fastify`: same name pattern as
+ * oav's existing {@link httpRequestFromFetch}.
  *
  * @public
  */

--- a/packages/oav-express4/src/index.ts
+++ b/packages/oav-express4/src/index.ts
@@ -9,8 +9,7 @@
  *   reusable from any custom middleware.
  *
  * Naming and option shapes are deliberately consistent with the
- * future `oav-express5`, `oav-fastify`, and `oav-hono` adapters,
- * and pair with future `validateResponses` on this package.
+ * sibling `oav-express5` / `oav-fastify` adapters.
  *
  * @packageDocumentation
  */

--- a/packages/oav-express4/src/middleware.ts
+++ b/packages/oav-express4/src/middleware.ts
@@ -6,10 +6,9 @@ import { renderProblemDetails } from "./render.js";
 import type { ErrorHandler, ExpressContext } from "./types.js";
 
 /**
- * Options for {@link validateRequests}. Names and semantics are
- * shared with future {@link validateResponses} and with the same
- * options on every other adapter in the family (`oav-express5`,
- * `oav-fastify`, ...); only the framework-typed argument differs.
+ * Options for {@link validateRequests}. The same option shape is
+ * used by every adapter in the family (`oav-express5`,
+ * `oav-fastify`); only the framework-typed argument differs.
  *
  * @public
  */
@@ -24,11 +23,17 @@ export interface ValidateRequestsOptions {
   toHttpRequest?: (req: Request) => HttpRequest;
   /**
    * Called when {@link Validator.validateRequest} returns an error.
-   * Default: {@link renderProblemDetails}: RFC 9457
-   * `application/problem+json` with status from `httpStatusFor`.
-   * Pass your own to render a custom envelope, call `next(err)`,
-   * map to a different status, etc. The middleware does not call
-   * `next()` after invoking `onError`; the callback is the response.
+   * Default: {@link renderProblemDetails}, which writes an RFC 9457
+   * `application/problem+json` response with status from
+   * {@link httpStatusFor}.
+   *
+   * Pass your own to render a custom envelope, map to a different
+   * status, or call `ctx.next(err)` to delegate to the host's error
+   * middleware. May be async; the middleware awaits it. Thrown errors
+   * and rejected promises forward via `next(err)`.
+   *
+   * The middleware does not call `next()` after `onError` returns;
+   * the callback owns the response.
    */
   onError?: ErrorHandler<ExpressContext>;
 }
@@ -48,8 +53,8 @@ export interface ValidateRequestsOptions {
  * middleware forwards both via `next(err)` so the host app's error
  * middleware sees them.
  *
- * Pairs with future `validateResponses(validator, opts)`. Same
- * factory shape across `oav-express5` / `oav-fastify` / `oav-hono`.
+ * Same factory shape across the sibling `oav-express5` /
+ * `oav-fastify` adapters.
  *
  * @example
  * ```ts

--- a/packages/oav-express4/src/render.ts
+++ b/packages/oav-express4/src/render.ts
@@ -2,12 +2,12 @@ import { allowHeaderFor, httpStatusFor, toProblemDetails, type ValidationError }
 import type { ExpressContext } from "./types.js";
 
 /**
- * The default `onError` for {@link validateRequests} (and future
- * `validateResponses`). Renders the validation tree as an
- * RFC 9457 `application/problem+json` response: status from
- * {@link httpStatusFor}, `Allow` header from {@link allowHeaderFor}
- * on a 405, body from {@link toProblemDetails} (whose `detail` is
- * the first failing leaf via {@link formatSummary}).
+ * The default `onError` for {@link validateRequests}. Renders the
+ * validation tree as an RFC 9457 `application/problem+json` response:
+ * status from {@link httpStatusFor}, `Allow` header from
+ * {@link allowHeaderFor} on a 405, body from {@link toProblemDetails}
+ * (whose `detail` is the first failing leaf via
+ * {@link formatSummary}).
  *
  * Exported standalone for two cases:
  *
@@ -17,9 +17,6 @@ import type { ExpressContext } from "./types.js";
  * 2. You want a slightly different renderer: use this as the
  *    starting point and adjust (e.g. swap the body, override the
  *    status, add headers).
- *
- * Pairs with future `responseValidator`'s default; the same
- * function works for both sides.
  *
  * @public
  */

--- a/packages/oav-express4/src/types.ts
+++ b/packages/oav-express4/src/types.ts
@@ -19,8 +19,8 @@ export interface ExpressContext {
 
 /**
  * Signature shared by `onError` on every adapter in the family
- * (`oav-express4`, future `oav-express5`, `oav-fastify`, ...). The
- * `Ctx` parameter is the only thing that varies; same name and shape
+ * (`oav-express4`, `oav-express5`, `oav-fastify`). The `Ctx`
+ * parameter is the only thing that varies; same name and shape
  * everywhere.
  *
  * Returning a Promise is supported on every adapter. `oav-express4`

--- a/packages/oav-express4/test/extract.test.ts
+++ b/packages/oav-express4/test/extract.test.ts
@@ -8,7 +8,7 @@ function fakeReq(overrides: Partial<Request>): Request {
 
 describe("httpRequestFromExpress", () => {
   it("extracts method, path, headers, contentType, query, and body", () => {
-    // Express normalises header keys to lowercase before middleware sees
+    // Express normalizes header keys to lowercase before middleware sees
     // them; our fixtures match that contract so the assertions are honest.
     const got = httpRequestFromExpress(
       fakeReq({

--- a/packages/oav-express4/test/integration.test.ts
+++ b/packages/oav-express4/test/integration.test.ts
@@ -12,8 +12,9 @@ import { validateRequests } from "../src/middleware.js";
  * Real-server integration tests. Spin up Express 4 on a random port,
  * round-trip via native fetch, close the server when done.
  *
- * Same `it()` names as future oav-express5 / oav-fastify integration
- * suites; adapter implementations differ, scenarios stay identical.
+ * Same `it()` names as the sibling oav-express5 / oav-fastify
+ * integration suites; adapter implementations differ, scenarios
+ * stay identical.
  */
 
 function petSpec(): OpenAPIDocument {

--- a/packages/oav-express5/README.md
+++ b/packages/oav-express5/README.md
@@ -42,7 +42,7 @@ Invalid requests receive a `400 application/problem+json` response (status from 
 
 > **Body parser ordering matters.** `express.json()` (or any equivalent that populates `req.body` with a parsed object) must run **before** `validateRequests(...)`. Same for `cookie-parser` if your spec validates cookies. Any middleware that populates `req.body` works: `express.json()`, `body-parser`, custom streaming parsers, app-specific middleware all work the same way.
 >
-> **Empty-body normalisation.** Some parsers leave `req.body === undefined` for empty `{}`-equivalent payloads. When that happens, `required`-field checks short-circuit on the missing body. Normalise via `toHttpRequest`:
+> **Empty-body normalization.** Some parsers leave `req.body === undefined` for empty `{}`-equivalent payloads. When that happens, `required`-field checks short-circuit on the missing body. Normalize via `toHttpRequest`:
 >
 > ```ts
 > import { httpRequestFromExpress, validateRequests } from "@aahoughton/oav-express5";

--- a/packages/oav-express5/README.md
+++ b/packages/oav-express5/README.md
@@ -204,6 +204,6 @@ A migrating consumer's `import { validateRequests } from "@aahoughton/oav-expres
 ## See also
 
 - [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core): `createValidator`, `ValidatorOptions`, `formatSummary`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
-- [`oav`](https://www.npmjs.com/package/@aahoughton/oav): batteries-included distribution of oav-core (YAML readers + the `oav` CLI).
+- [`oav`](https://www.npmjs.com/package/@aahoughton/oav): oav-core plus YAML readers and the `oav` CLI.
 - The repo-root [`docs/integration.md`](../../docs/integration.md): broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
 - The repo-root [`docs/migration-from-eov.md`](../../docs/migration-from-eov.md): porting from `express-openapi-validator`.

--- a/packages/oav-express5/src/index.ts
+++ b/packages/oav-express5/src/index.ts
@@ -9,9 +9,7 @@
  *   reusable from any custom middleware.
  *
  * Naming and option shapes are deliberately consistent with the
- * sibling `oav-express4` adapter and future `oav-fastify` /
- * `oav-hono` adapters, and pair with future `validateResponses`
- * on this package.
+ * sibling `oav-express4` / `oav-fastify` adapters.
  *
  * Express 5 is promise-native: the returned middleware is `async`,
  * and thrown errors / rejected promises propagate to the host's

--- a/packages/oav-express5/src/middleware.ts
+++ b/packages/oav-express5/src/middleware.ts
@@ -6,10 +6,9 @@ import { renderProblemDetails } from "./render.js";
 import type { ErrorHandler, ExpressContext } from "./types.js";
 
 /**
- * Options for {@link validateRequests}. Names and semantics are
- * shared with future {@link validateResponses} and with the same
- * options on every other adapter in the family (`oav-express4`,
- * `oav-fastify`, ...); only the framework-typed argument differs.
+ * Options for {@link validateRequests}. The same option shape is
+ * used by every adapter in the family (`oav-express4`,
+ * `oav-fastify`); only the framework-typed argument differs.
  *
  * @public
  */
@@ -24,11 +23,18 @@ export interface ValidateRequestsOptions {
   toHttpRequest?: (req: Request) => HttpRequest;
   /**
    * Called when {@link Validator.validateRequest} returns an error.
-   * Default: {@link renderProblemDetails}: RFC 9457
-   * `application/problem+json` with status from `httpStatusFor`.
-   * Pass your own to render a custom envelope, call `next(err)`,
-   * map to a different status, etc. The middleware does not call
-   * `next()` after invoking `onError`; the callback is the response.
+   * Default: {@link renderProblemDetails}, which writes an RFC 9457
+   * `application/problem+json` response with status from
+   * {@link httpStatusFor}.
+   *
+   * Pass your own to render a custom envelope, map to a different
+   * status, or call `ctx.next(err)` to delegate to the host's error
+   * middleware. May be async; the middleware awaits it. Thrown errors
+   * and rejected promises propagate to Express 5's error middleware
+   * automatically (no try/catch wrapper needed).
+   *
+   * The middleware does not call `next()` after `onError` returns;
+   * the callback owns the response.
    */
   onError?: ErrorHandler<ExpressContext>;
 }
@@ -47,8 +53,8 @@ export interface ValidateRequestsOptions {
  * thrown exceptions / rejected promises propagate to the host's
  * error middleware automatically. No try/catch wrapper needed.
  *
- * Pairs with sibling `validateRequests` in `oav-express4`, future
- * `oav-fastify`, etc. Same factory shape across the family.
+ * Pairs with sibling `validateRequests` in `oav-express4` /
+ * `oav-fastify`. Same factory shape across the family.
  *
  * @example
  * ```ts

--- a/packages/oav-express5/src/render.ts
+++ b/packages/oav-express5/src/render.ts
@@ -2,12 +2,12 @@ import { allowHeaderFor, httpStatusFor, toProblemDetails, type ValidationError }
 import type { ExpressContext } from "./types.js";
 
 /**
- * The default `onError` for {@link validateRequests} (and future
- * `validateResponses`). Renders the validation tree as an
- * RFC 9457 `application/problem+json` response: status from
- * {@link httpStatusFor}, `Allow` header from {@link allowHeaderFor}
- * on a 405, body from {@link toProblemDetails} (whose `detail` is
- * the first failing leaf via {@link formatSummary}).
+ * The default `onError` for {@link validateRequests}. Renders the
+ * validation tree as an RFC 9457 `application/problem+json` response:
+ * status from {@link httpStatusFor}, `Allow` header from
+ * {@link allowHeaderFor} on a 405, body from {@link toProblemDetails}
+ * (whose `detail` is the first failing leaf via
+ * {@link formatSummary}).
  *
  * Exported standalone for two cases:
  *
@@ -17,9 +17,6 @@ import type { ExpressContext } from "./types.js";
  * 2. You want a slightly different renderer: use this as the
  *    starting point and adjust (e.g. swap the body, override the
  *    status, add headers).
- *
- * Pairs with future `validateResponses`'s default; the same
- * function works for both sides.
  *
  * @public
  */

--- a/packages/oav-express5/src/types.ts
+++ b/packages/oav-express5/src/types.ts
@@ -19,8 +19,8 @@ export interface ExpressContext {
 
 /**
  * Signature shared by `onError` on every adapter in the family
- * (`oav-express4`, `oav-express5`, future `oav-fastify`, ...). The
- * `Ctx` parameter is the only thing that varies; same name and shape
+ * (`oav-express4`, `oav-express5`, `oav-fastify`). The `Ctx`
+ * parameter is the only thing that varies; same name and shape
  * everywhere.
  *
  * Returning a Promise is supported on every adapter. `oav-express5`

--- a/packages/oav-fastify/README.md
+++ b/packages/oav-fastify/README.md
@@ -187,11 +187,11 @@ If both fire on the same route, oav's `preValidation` hook runs first; if it pas
 
 ### Comparison with `fastify-openapi-glue`
 
-[`fastify-openapi-glue`](https://www.npmjs.com/package/fastify-openapi-glue) reads an OpenAPI spec at startup and **generates routes + handler stubs from it**. oav-fastify is a different shape: it validates against the spec but you own the route declarations. Use `fastify-openapi-glue` if you want spec-driven scaffolding; use oav-fastify if your routes already exist and you want OpenAPI as the validation source of truth.
+[`fastify-openapi-glue`](https://www.npmjs.com/package/fastify-openapi-glue) reads an OpenAPI spec at startup and **generates routes + handler stubs from it**. oav-fastify is a different shape: it validates against the spec while leaving route declarations in your app. Use `fastify-openapi-glue` if you want spec-driven scaffolding; use oav-fastify if your routes already exist and you want OpenAPI as the validation source of truth.
 
 ## See also
 
 - [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core): `createValidator`, `ValidatorOptions`, `formatSummary`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
-- [`oav`](https://www.npmjs.com/package/@aahoughton/oav): batteries-included distribution of oav-core (YAML readers + the `oav` CLI).
+- [`oav`](https://www.npmjs.com/package/@aahoughton/oav): oav-core plus YAML readers and the `oav` CLI.
 - The repo-root `docs/integration.md`: broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
 - The repo-root `docs/migration-from-eov.md`: porting from `express-openapi-validator`.

--- a/packages/oav-fastify/src/extract.ts
+++ b/packages/oav-fastify/src/extract.ts
@@ -17,8 +17,8 @@ import type { HttpRequest } from "@oav/core";
  * populated them, otherwise omitted.
  *
  * Pairs with sibling `httpRequestFromExpress` in `oav-express4` /
- * `oav-express5`, future `httpRequestFromHono`, etc.; same name
- * pattern as oav's existing {@link httpRequestFromFetch}.
+ * `oav-express5`: same name pattern as oav's existing
+ * {@link httpRequestFromFetch}.
  *
  * @public
  */

--- a/packages/oav-fastify/src/index.ts
+++ b/packages/oav-fastify/src/index.ts
@@ -10,9 +10,7 @@
  *   reusable from any custom hook.
  *
  * Naming and option shapes are deliberately consistent with the
- * sibling `oav-express4` / `oav-express5` adapters and future
- * `oav-hono` adapter, and pair with future `validateResponses` on
- * this package.
+ * sibling `oav-express4` / `oav-express5` adapters.
  *
  * Fastify is async-native: the returned hook is `async`, and
  * thrown errors / rejected promises propagate to Fastify's error

--- a/packages/oav-fastify/src/middleware.ts
+++ b/packages/oav-fastify/src/middleware.ts
@@ -6,11 +6,9 @@ import { renderProblemDetails } from "./render.js";
 import type { ErrorHandler, FastifyContext } from "./types.js";
 
 /**
- * Options for {@link validateRequests}. Names and semantics are
- * shared with future {@link validateResponses} and with the same
- * options on every other adapter in the family (`oav-express4`,
- * `oav-express5`, future `oav-hono`, ...); only the
- * framework-typed argument differs.
+ * Options for {@link validateRequests}. The same option shape is
+ * used by every adapter in the family (`oav-express4`,
+ * `oav-express5`); only the framework-typed argument differs.
  *
  * @public
  */
@@ -25,12 +23,18 @@ export interface ValidateRequestsOptions {
   toHttpRequest?: (request: FastifyRequest) => HttpRequest;
   /**
    * Called when {@link Validator.validateRequest} returns an error.
-   * Default: {@link renderProblemDetails}: RFC 9457
-   * `application/problem+json` with status from `httpStatusFor`.
-   * Pass your own to render a custom envelope, throw (handed to
-   * Fastify's error handler), map to a different status, etc. The
-   * hook does not call `reply.send()` after invoking `onError`;
-   * the callback is the response.
+   * Default: {@link renderProblemDetails}, which writes an RFC 9457
+   * `application/problem+json` response with status from
+   * {@link httpStatusFor}.
+   *
+   * Pass your own to render a custom envelope, map to a different
+   * status, or throw to delegate to Fastify's error handler. May be
+   * async; the hook awaits it. Thrown errors and rejected promises
+   * propagate to Fastify's error handler automatically (no try/catch
+   * wrapper needed).
+   *
+   * The hook does not call `reply.send()` after `onError` returns;
+   * the callback owns the response.
    */
   onError?: ErrorHandler<FastifyContext>;
 }

--- a/packages/oav-fastify/src/render.ts
+++ b/packages/oav-fastify/src/render.ts
@@ -2,16 +2,16 @@ import { allowHeaderFor, httpStatusFor, toProblemDetails, type ValidationError }
 import type { FastifyContext } from "./types.js";
 
 /**
- * The default `onError` for {@link validateRequests} (and future
- * `validateResponses`). Renders the validation tree as an
- * RFC 9457 `application/problem+json` response: status from
- * {@link httpStatusFor}, `Allow` header from {@link allowHeaderFor}
- * on a 405, body from {@link toProblemDetails} (whose `detail` is
- * the first failing leaf via {@link formatSummary}).
+ * The default `onError` for {@link validateRequests}. Renders the
+ * validation tree as an RFC 9457 `application/problem+json` response:
+ * status from {@link httpStatusFor}, `Allow` header from
+ * {@link allowHeaderFor} on a 405, body from {@link toProblemDetails}
+ * (whose `detail` is the first failing leaf via
+ * {@link formatSummary}).
  *
  * Exported standalone for two cases:
  *
- * 1. You want oav's rendering as the fallback in your own hook —
+ * 1. You want oav's rendering as the fallback in your own hook:
  *    call this directly when you don't want to handle the error
  *    yourself.
  * 2. You want a slightly different renderer: use this as the

--- a/packages/oav-fastify/src/types.ts
+++ b/packages/oav-fastify/src/types.ts
@@ -23,9 +23,9 @@ export interface FastifyContext {
 
 /**
  * Signature shared by `onError` on every adapter in the family
- * (`oav-express4`, `oav-express5`, `oav-fastify`, future
- * `oav-hono`, ...). The `Ctx` parameter is the only thing that
- * varies; same name and shape everywhere.
+ * (`oav-express4`, `oav-express5`, `oav-fastify`). The `Ctx`
+ * parameter is the only thing that varies; same name and shape
+ * everywhere.
  *
  * Returning a Promise is supported on every adapter. `oav-fastify`
  * awaits the return; rejected promises propagate through Fastify's

--- a/packages/oav/README.md
+++ b/packages/oav/README.md
@@ -1,8 +1,7 @@
 # oav
 
-Batteries-included distribution of `oav-core`. Adds YAML
-readers and the `oav` CLI on top of the lean validator package; the
-programmatic surface is identical.
+Distribution of `oav-core` with YAML readers and the `oav` CLI added.
+The programmatic validator surface is identical to the lean package.
 
 ```ts
 import { createValidator, createYamlFileReader } from "@aahoughton/oav";

--- a/packages/router/src/matcher.ts
+++ b/packages/router/src/matcher.ts
@@ -16,7 +16,7 @@ import type { HttpMethod, OperationObject, PathItem } from "@oav/core";
  * that template expressions be delimited by `{}`; multiple per segment
  * with literal separators are spec-legal (cf. RFC 6570). Mainstream
  * routers (path-to-regexp, hono, find-my-way, gorilla/mux, werkzeug)
- * all use the non-greedy left-to-right rule modelled here.
+ * all use the non-greedy left-to-right rule modeled here.
  *
  * @public
  */
@@ -151,7 +151,7 @@ function parseSegment(seg: string): Segment {
   // with one non-greedy `[^/]+?` capture per template part; the trailing
   // `$` anchor + lazy capture resolves multi-param ambiguity left-to-right
   // (e.g. `{x}.{y}` against `a.b.c` captures `x="a"`, `y="b.c"`), matching
-  // path-to-regexp / hono / find-my-way / werkzeug behaviour.
+  // path-to-regexp / hono / find-my-way / werkzeug behavior.
   const names: string[] = [];
   let regexSrc = "^";
   let i = 0;
@@ -184,7 +184,7 @@ function parseSegment(seg: string): Segment {
   }
   regexSrc += "$";
   // No template parts ended up in the segment despite a `{`; degenerate.
-  // Fall back to literal so behaviour matches the !includes("{") branch.
+  // Fall back to literal so behavior matches the !includes("{") branch.
   if (names.length === 0) {
     return { kind: "literal", value: decodeURIComponent(seg) };
   }

--- a/packages/router/test/router.test.ts
+++ b/packages/router/test/router.test.ts
@@ -18,7 +18,7 @@ describe("parseTemplate", () => {
     expect(parseTemplate("/")).toEqual([]);
   });
 
-  it("recognises compound segments with multiple {name} parts and a literal separator", () => {
+  it("recognizes compound segments with multiple {name} parts and a literal separator", () => {
     const segs = parseTemplate("/commits/{sha}.{ext}");
     expect(segs).toHaveLength(2);
     expect(segs[0]).toEqual({ kind: "literal", value: "commits" });

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -114,7 +114,7 @@ short-circuits hot loops once the budget is exhausted. `maxErrors: 1`
 is classic fast-fail; larger values bound CPU/memory on huge invalid
 payloads. Results carry `truncated: true` when the tree was capped.
 Omit the option for zero-overhead unlimited collection: codegen is
-specialised so uncapped callers emit plain `errors.push` with no
+specialized so uncapped callers emit plain `errors.push` with no
 budget checks.
 
 ## `$ref` and cycles

--- a/packages/schema/src/codegen/codegen.ts
+++ b/packages/schema/src/codegen/codegen.ts
@@ -361,7 +361,7 @@ export function pathJoinExpr(baseExpr: string, segments: PathSegmentLike[]): str
  * path segment. Used by {@link pathJoinExpr}.
  *
  * @param expr - The raw JavaScript expression.
- * @returns A tagged object recognised by path helpers.
+ * @returns A tagged object recognized by path helpers.
  *
  * @example
  * ```ts

--- a/packages/schema/src/compiler/compiler.ts
+++ b/packages/schema/src/compiler/compiler.ts
@@ -27,7 +27,7 @@ const TREE_RUNTIME_HELPERS = /\b(?:createLeafError|createBranchError|wrapErrors)
 /**
  * Default mode for {@link CompileOptions.strict}. Warns on partially-
  * implemented keywords (currently `$dynamicRef`); silent on unknown
- * keys. Callers opt into stricter behaviour with `"strict"` or opt
+ * keys. Callers opt into stricter behavior with `"strict"` or opt
  * out with `"off"`.
  */
 const DEFAULT_STRICT_MODE = "warn-partial" as const;
@@ -101,7 +101,7 @@ function runStrictLint(
   mode: "warn-partial" | "strict",
   rules: { refSuppressesSiblings: boolean },
 ): StrictIssue[] {
-  // The full set of names the active dialect recognises, including
+  // The full set of names the active dialect recognizes, including
   // `implements` entries on existing definitions (e.g. `if` implements
   // `then` + `else`; those don't have their own KeywordDefinition but
   // are legitimate keys).
@@ -227,7 +227,7 @@ export interface ValidationResult {
 
 /**
  * Compile-time statistics about the generated validator. Exposed so
- * tests can assert on compiler behaviour (e.g. "did subschema inlining
+ * tests can assert on compiler behavior (e.g. "did subschema inlining
  * fire?") without grepping the generated source.
  *
  * @public
@@ -242,10 +242,10 @@ export interface CompileStats {
   /**
    * `true` iff the compiler actually emitted `evalProps` / `evalItems`
    * Set machinery anywhere in the generated source. When `false`, the
-   * unevaluated-keys-gating optimisation is taking effect: the schema
+   * unevaluated-keys-gating optimization is taking effect: the schema
    * doesn't use `unevaluatedProperties` / `unevaluatedItems`, so the
    * compiler suppressed the per-function Set allocation and merge loop.
-   * Surfaced so tests can assert on the optimisation directly instead
+   * Surfaced so tests can assert on the optimization directly instead
    * of grepping the generated JS.
    */
   unevaluatedTrackingEmitted: boolean;
@@ -420,7 +420,7 @@ export interface CompileOptions {
    * effectively predicate mode (no errors collected, validation
    * collapses to yes/no); for that, prefer
    * {@link CompileOptions.predicate} which compiles a fully
-   * specialised function with no error infrastructure at all.
+   * specialized function with no error infrastructure at all.
    * `compileSchema` throws on `maxErrors <= 0`.
    */
   maxErrors?: number;
@@ -428,7 +428,7 @@ export interface CompileOptions {
    * Compile-time schema linting. All modes collect to
    * {@link CompileStats.strictIssues} rather than throwing.
    *
-   * - `"off"`: silence on everything (pre-v-strict behaviour).
+   * - `"off"`: silence on everything (pre-v-strict behavior).
    * - `"warn-partial"` (default): warn on keywords flagged as
    *   partially-implemented (currently `$dynamicRef`; its runtime
    *   dynamic-scope rebinding is not emitted).
@@ -512,7 +512,7 @@ export interface CompileState {
    * Set to `true` the first time any generated function actually
    * allocates an `evalProps` / `evalItems` Set. Surfaced in
    * {@link CompileStats.unevaluatedTrackingEmitted} so callers can
-   * observe the gating optimisation's effect.
+   * observe the gating optimization's effect.
    */
   unevaluatedEmitted: boolean;
 }

--- a/packages/schema/src/compiler/runtime.ts
+++ b/packages/schema/src/compiler/runtime.ts
@@ -87,7 +87,7 @@ export type Validator = (data: unknown, path: (string | number)[]) => Validation
 /**
  * The JSON-Schema-flavored typeof function: distinguishes `integer`,
  * `number`, `null`, `array`, `object`, etc. (everything that JSON Schema
- * 2020-12's `type` keyword recognises).
+ * 2020-12's `type` keyword recognizes).
  *
  * @param value - Any value.
  * @returns The JSON Schema type name.
@@ -114,7 +114,7 @@ export function typeOf(value: unknown): string {
 }
 
 /**
- * Structural equality for JSON values: honours array ordering, object key
+ * Structural equality for JSON values: honors array ordering, object key
  * sets (not ordering), and NaN-as-not-equal. Used by `enum`, `const`, and
  * `uniqueItems`.
  *

--- a/packages/schema/src/keywords/array-validation.ts
+++ b/packages/schema/src/keywords/array-validation.ts
@@ -64,7 +64,7 @@ export const uniqueItemsKeyword: KeywordDefinition = {
       // Runtime helper does one Map-backed scan for primitives plus a
       // pairwise deepEqual sweep of object/array items. Replaces the
       // previous inline O(N^2) nested loop; generated code stays tiny
-      // and V8 gets to monomorphise the hot helper.
+      // and V8 gets to monomorphize the hot helper.
       g.const(dup, `${NAMES.DEPS}.findDuplicate(${ctx.data})`);
       g.if(`${dup} !== null`, () => {
         // Duplicate indices live in params.duplicates; keep the

--- a/packages/schema/src/keywords/context.ts
+++ b/packages/schema/src/keywords/context.ts
@@ -307,7 +307,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
       // registered with `annotation: true` and emit no code; safe to
       // skip. Unknown keys fall through to `validationKeys` so the
       // inliner conservatively refuses to inline them, which matches
-      // the old behaviour for pre-`annotation`-flag unknowns.
+      // the old behavior for pre-`annotation`-flag unknowns.
       if (inputs.byKeyword.get(k)?.annotation === true) continue;
       if (INLINE_DISQUALIFIERS.has(k)) return false;
       validationKeys.push(k);
@@ -345,8 +345,8 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     // Multi-keyword inline is limited to pure-leaf combinations
     // (type + required + bounds, etc.). Schemas that contain any
     // applicator are left to the function-call path; the per-call
-    // dispatch pays for itself on hot loops because V8 monomorphises
-    // the function better than it can optimise a massive inlined
+    // dispatch pays for itself on hot loops because V8 monomorphizes
+    // the function better than it can optimize a massive inlined
     // loop body.
     if (validationKeys.some((k) => isApplicatorKey(inputs.byKeyword, k))) return false;
     if (validationKeys.length > MAX_INLINE_KEYWORDS) return false;
@@ -555,7 +555,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
 
 /**
  * Build a JS statement that pushes a single {@link ValidationError}
- * expression into the errors accumulator, optionally honouring the
+ * expression into the errors accumulator, optionally honoring the
  * `maxErrors` budget when `gated` is `true`. Callers of this helper
  * pass it to {@link CodeGen.line} or embed it into a generated block.
  *

--- a/packages/schema/src/keywords/custom.ts
+++ b/packages/schema/src/keywords/custom.ts
@@ -11,7 +11,7 @@ import type { KeywordCompileContext, KeywordDefinition } from "./types.js";
 export const customKeywordVocabulary = "https://oav.dev/vocab/custom-keywords";
 
 /**
- * Failure detail a {@link CustomKeywordValidator} may return to customise
+ * Failure detail a {@link CustomKeywordValidator} may return to customize
  * the emitted {@link import("@oav/core").ValidationError}. Omitted fields
  * take sensible defaults: `message` becomes
  * `"value failed custom keyword \"<name>\""`; `params` defaults to `{}`.
@@ -29,7 +29,7 @@ export interface CustomKeywordFailure {
  *
  * - Return `true` for a valid value.
  * - Return `false` to emit a generic failure error for that keyword.
- * - Return a {@link CustomKeywordFailure} object to customise the error
+ * - Return a {@link CustomKeywordFailure} object to customize the error
  *   `message` and/or `params`.
  *
  * The `schemaValue` argument is the JSON value the keyword carries in

--- a/packages/schema/src/keywords/meta-data.ts
+++ b/packages/schema/src/keywords/meta-data.ts
@@ -45,7 +45,7 @@ export const descriptionKeyword = annotationKeyword("description");
  * `default`: a suggested default value for the schema. Preserved as
  * metadata only; oav never injects defaults into request bodies or
  * response bodies (see the `useDefaults` discussion in
- * [`docs/comparison.md`](../../../docs/comparison.md) if you need that behaviour).
+ * [`docs/comparison.md`](../../../docs/comparison.md) if you need that behavior).
  *
  * @public
  */
@@ -93,7 +93,7 @@ export const examplesKeyword = annotationKeyword("examples");
 
 /**
  * OpenAPI-specific annotation: `example` (singular). Deprecated in
- * favour of `examples` per OpenAPI 3.1, still widely used in 3.0 specs.
+ * favor of `examples` per OpenAPI 3.1, still widely used in 3.0 specs.
  *
  * @public
  */

--- a/packages/schema/src/keywords/types.ts
+++ b/packages/schema/src/keywords/types.ts
@@ -307,11 +307,34 @@ export interface KeywordDefinition {
   vocabulary: string;
   /** Generate validation code for this keyword. */
   compile: (ctx: KeywordCompileContext) => void;
-  /** Other keywords this keyword depends on (all must be compiled first). */
+  /**
+   * Reserved for declarative compile-time ordering. Currently unused;
+   * keyword execution order comes from the vocabulary's `keywords`
+   * array order (with `unevaluatedProperties` / `unevaluatedItems`
+   * pushed to the tail). Author your vocabulary's array in the order
+   * keywords should run; do not rely on this field.
+   */
   dependsOn?: string[];
-  /** Keywords this keyword semantically implements (compiler skips those). */
+  /**
+   * Names of keywords whose semantics this keyword subsumes. The
+   * dispatcher treats them as already-handled when this keyword is
+   * present, so the strict-mode unknown-key check doesn't flag them
+   * and the per-keyword inliner doesn't emit duplicate code.
+   *
+   * Use when a custom keyword semantically replaces a built-in pair:
+   * `discriminator` declares `implements: ["oneOf", "anyOf"]` because
+   * its dispatch logic supersedes both; `if`/`then`/`else` declares
+   * `implements: ["then", "else"]` so the partner keys aren't dispatched
+   * a second time on their own; `contains` declares
+   * `implements: ["minContains", "maxContains"]` so the bounds-only
+   * keys are folded into the `contains` codegen.
+   */
   implements?: string[];
-  /** If set, this keyword runs before the named keyword. */
+  /**
+   * Reserved for declarative compile-time ordering. Currently unused;
+   * see {@link KeywordDefinition.dependsOn}. Set the vocabulary's
+   * `keywords` array order instead.
+   */
   before?: string;
   /** Marks whether this keyword tracks evaluated properties/items. */
   evaluates?: { properties?: boolean; items?: boolean };

--- a/packages/schema/src/keywords/types.ts
+++ b/packages/schema/src/keywords/types.ts
@@ -363,7 +363,7 @@ export interface DialectRules {
   /**
    * OpenAPI 3.0 semantics: when a schema has `$ref`, every sibling
    * keyword is ignored. Default `false` (JSON Schema 2020-12 and
-   * OpenAPI 3.1+ semantics, where siblings are honoured).
+   * OpenAPI 3.1+ semantics, where siblings are honored).
    */
   refSuppressesSiblings: boolean;
 }

--- a/packages/schema/test/inlining.test.ts
+++ b/packages/schema/test/inlining.test.ts
@@ -1,5 +1,5 @@
 /**
- * Behavioural tests for the subschema-inlining optimisation. We assert
+ * Behavioral tests for the subschema-inlining optimization. We assert
  * on `v.stats.functionCount` (the compiler's own tally of
  * `validate_N` helper functions emitted), so the shape of the
  * generated source can change without breaking these tests.
@@ -41,7 +41,7 @@ describe("subschema inlining", () => {
       items: { type: "object", required: ["x"], properties: { x: { type: "number" } } },
     });
     // items' schema has `properties` (applicator), so it stays a
-    // function; V8 monomorphises the hot-loop call better that way
+    // function; V8 monomorphizes the hot-loop call better that way
     // than inlining would.
     expect(v.stats.functionCount).toBe(2);
   });
@@ -71,7 +71,7 @@ describe("subschema inlining", () => {
     expect(v.stats.functionCount).toBeGreaterThanOrEqual(2);
   });
 
-  it("inlining preserves validation behaviour: tree form", () => {
+  it("inlining preserves validation behavior: tree form", () => {
     const v = compile({ type: "array", items: { type: "number" } });
     expect(v.validate([1, 2, 3]).valid).toBe(true);
     const r = v.validate([1, "two", 3]);
@@ -80,7 +80,7 @@ describe("subschema inlining", () => {
     expect(r.error?.path).toEqual([1]);
   });
 
-  it("inlining preserves validation behaviour: property form", () => {
+  it("inlining preserves validation behavior: property form", () => {
     const v = compile({ type: "object", properties: { age: { type: "integer" } } });
     expect(v.validate({ age: 5 }).valid).toBe(true);
     const r = v.validate({ age: "x" });

--- a/packages/schema/test/keyword-custom.test.ts
+++ b/packages/schema/test/keyword-custom.test.ts
@@ -62,7 +62,7 @@ describe("custom keywords", () => {
     expect(received[1]?.path).toEqual(["b"]);
   });
 
-  it("honours custom message and params on failure objects", () => {
+  it("honors custom message and params on failure objects", () => {
     const fn: CustomKeywordValidator = (data) => {
       if (typeof data !== "string") return true;
       if (data.includes(" ")) {

--- a/packages/schema/test/keyword-properties.test.ts
+++ b/packages/schema/test/keyword-properties.test.ts
@@ -79,7 +79,7 @@ describe("additionalProperties keyword", () => {
     expect(v.validate({ a: "x", b: "not num" }).valid).toBe(false);
   });
 
-  it("honours patternProperties as a coverage source", () => {
+  it("honors patternProperties as a coverage source", () => {
     const v = compile({
       patternProperties: { "^x-": true },
       additionalProperties: false,

--- a/packages/schema/test/path-leak-probe.test.ts
+++ b/packages/schema/test/path-leak-probe.test.ts
@@ -10,7 +10,7 @@ function walkLeaves(err: Err, acc: Err[] = []): Err[] {
 }
 
 describe("error paths survive path-array reuse", () => {
-  // Regression probe for the lazy-path optimisation. Generated
+  // Regression probe for the lazy-path optimization. Generated
   // validators traverse a shared mutable path array (push/pop around
   // function-call boundaries); errors constructed inside a callee
   // must snapshot the path so the caller's subsequent pop doesn't
@@ -34,7 +34,7 @@ describe("error paths survive path-array reuse", () => {
     expect(typeErr?.path).toEqual([0]);
   });
 
-  // Regression probe for the inline-pathSegments optimisation (#50).
+  // Regression probe for the inline-pathSegments optimization (#50).
   // A single-keyword leaf inlined with a pending segment must place
   // the segment in its error's .path; the inliner no longer
   // pre-materializes `[...path, seg]` for the inner ctx, so a leaf

--- a/packages/schema/test/strict-mode.test.ts
+++ b/packages/schema/test/strict-mode.test.ts
@@ -67,14 +67,14 @@ describe("strict mode", () => {
       xml: { name: "Msg" },
       externalDocs: { url: "https://example.com/docs" },
     } as unknown as SchemaOrBoolean;
-    // Base JSON Schema dialect does NOT recognise `xml` / `externalDocs`;
+    // Base JSON Schema dialect does NOT recognize `xml` / `externalDocs`;
     // they're OpenAPI extensions, not core JSON Schema keywords.
     const baseIssues = compileSchema(schema, {
       dialect: jsonSchemaDialect,
       strict: "strict",
     }).stats.strictIssues;
     expect(baseIssues.map((i) => i.keyword).sort()).toEqual(["externalDocs", "xml"]);
-    // Both OpenAPI dialects DO recognise them.
+    // Both OpenAPI dialects DO recognize them.
     for (const dialect of [openapi31Dialect, oas30Dialect]) {
       const issues = compileSchema(schema, { dialect, strict: "strict" }).stats.strictIssues;
       expect(issues).toEqual([]);

--- a/packages/schema/test/walk-subschemas.test.ts
+++ b/packages/schema/test/walk-subschemas.test.ts
@@ -43,7 +43,7 @@ describe("walkSubschemas", () => {
     expect(paths).toContain("dependentSchemas.trigger");
   });
 
-  it("honours a `false` return to prune the subtree", () => {
+  it("honors a `false` return to prune the subtree", () => {
     const schema: SchemaOrBoolean = {
       properties: { a: { properties: { aa: { type: "string" } } } },
     };

--- a/packages/spec/test/overlay.test.ts
+++ b/packages/spec/test/overlay.test.ts
@@ -92,7 +92,7 @@ describe("applyOverlays", () => {
   });
 
   it("extendSchemas inserts the extension verbatim when the target schema doesn't exist", () => {
-    // Pin the silent-create behaviour explicitly so a future "throw on
+    // Pin the silent-create behavior explicitly so a future "throw on
     // missing target" change is a deliberate decision, not an accident.
     const patched = applyOverlays(base(), [
       { extendSchemas: { NewType: { type: "string", minLength: 1 } } },

--- a/packages/validator/src/deserialize.ts
+++ b/packages/validator/src/deserialize.ts
@@ -109,7 +109,7 @@ function coerceScalar(value: string, schema: SchemaObject | boolean | undefined)
  * patterns (which may use wildcards like `application/*` or `*\/*`). Returns
  * the most-specific match, or `undefined`.
  *
- * Media-type parameters (the bits after `;`) are honoured on both sides:
+ * Media-type parameters (the bits after `;`) are honored on both sides:
  * a pattern like `application/json; version=1` only matches a concrete
  * `application/json; version=1` (extra parameters on the concrete side
  * are allowed). A pattern with no parameters matches any concrete type
@@ -181,7 +181,7 @@ function parseMediaType(
 }
 
 /**
- * Find the response entry that matches a given status code, honouring the
+ * Find the response entry that matches a given status code, honoring the
  * OpenAPI precedence: exact status > `NXX` class > `default`.
  *
  * @param status - The response status.

--- a/packages/validator/src/from-fetch.ts
+++ b/packages/validator/src/from-fetch.ts
@@ -6,7 +6,7 @@
  * route-level handlers in Next.js App Router, Hono, Bun, Deno, and
  * any other runtime whose HTTP primitives are `Request` / `Response`.
  *
- * The content-type dispatcher recognises JSON (`application/json` and
+ * The content-type dispatcher recognizes JSON (`application/json` and
  * `*+json`), URL-encoded forms, multipart/form-data, and text/*. For
  * anything else, the raw bytes come through as a `Uint8Array`; the
  * validator's `format: "binary"` opaque-body bypass accepts any value
@@ -38,8 +38,8 @@ export interface FetchRequestOptions {
    * unchanged, so opaque placeholders (a temp-file path, a Buffer
    * handle, etc.) are valid.
    *
-   * If you want default behaviour for most content types and custom
-   * behaviour for one or two, import {@link readBodyFromFetch} and
+   * If you want default behavior for most content types and custom
+   * behavior for one or two, import {@link readBodyFromFetch} and
    * delegate to it from inside your callback.
    *
    * @example
@@ -101,7 +101,7 @@ export async function httpRequestFromFetch(
  * The default content-type-driven body reader exposed for composition.
  * Call this from inside a {@link FetchRequestOptions.readBody} callback
  * when you want to handle some content types yourself and delegate the
- * rest to the built-in behaviour. Recognises JSON, `*+json`,
+ * rest to the built-in behavior. Recognizes JSON, `*+json`,
  * URL-encoded forms, `multipart/form-data`, and `text/*`; anything
  * else comes through as a `Uint8Array`.
  *

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -87,7 +87,7 @@ export interface Validator {
    * in practice). On failure, `error` is the same
    * {@link ValidationError} tree `validateRequest` would return.
    *
-   * Body parsing recognises `application/json` (and `*+json`),
+   * Body parsing recognizes `application/json` (and `*+json`),
    * `application/x-www-form-urlencoded`, `multipart/form-data`
    * (file fields come through as `Uint8Array`), and `text/*`. Any
    * other content type is read as raw bytes; the spec's
@@ -202,9 +202,9 @@ export interface Validator {
    */
   readonly specHygieneIssues: readonly SpecHygieneIssue[];
   /**
-   * Runtime observability for compile-time-specialisation optimisations.
+   * Runtime observability for compile-time-specialization optimizations.
    * The counters live on the validator, not inside a ValidationError
-   * tree, so tests can assert on the optimisation directly rather than
+   * tree, so tests can assert on the optimization directly rather than
    * through indirect signals (throwing test schemas, source grepping).
    */
   readonly stats: ValidatorStats;

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -70,10 +70,70 @@ function dialectFor(version: OpenAPIVersion): Dialect {
  * `validateRequest` / `validateResponse` each return a full
  * {@link ValidationError} tree (or `null`).
  *
+ * - **Per-call HTTP validation**: {@link Validator.validateRequest},
+ *   {@link Validator.validateResponse}.
+ * - **Web Standards convenience**: {@link Validator.validateFetchRequest},
+ *   {@link Validator.validateFetchResponse}. Wrap the per-call methods
+ *   with body-parsing for `Request` / `Response` consumers (Next.js,
+ *   Hono, Bun, Deno).
+ * - **Spec introspection**: {@link Validator.getOperation},
+ *   {@link Validator.detectedVersion}.
+ * - **Construction-time output**: {@link Validator.warnings},
+ *   {@link Validator.specHygieneIssues}.
+ * - **Live observability**: {@link Validator.stats}.
+ *
  * @public
  */
 export interface Validator {
+  /**
+   * Validate one HTTP request against the spec. Returns `null` when the
+   * request matches the operation declared at its method + path,
+   * including parameters, headers, cookies, body, and content type;
+   * returns a {@link ValidationError} tree otherwise.
+   *
+   * The returned tree's top-level `code` is `"request"` for any failure,
+   * with branch children under `body`, `query.<name>`, `header.<name>`,
+   * `cookie.<name>`, `path-param.<name>`, or `security`. Route and
+   * method mismatches surface as top-level `"route"` / `"method"`
+   * codes; see {@link httpStatusFor} for the canonical status mapping.
+   *
+   * Does not mutate `req`. Synchronous: parameter deserialization,
+   * content-type matching, and schema validation all run inline. Per
+   * `req` cost is dominated by the schema validation; bodies that
+   * pass validation incur a single tree walk and no allocation.
+   *
+   * Paths the spec doesn't declare are treated according to
+   * {@link ValidatorOptions.ignoreUndocumented} and
+   * {@link ValidatorOptions.ignorePaths}: by default an undeclared
+   * path returns a `"route"` error; configure to bypass the validator
+   * entirely.
+   *
+   * @see {@link Validator.validateResponse} for the response-side pair.
+   * @see {@link Validator.validateFetchRequest} for the Web Standards convenience wrapper.
+   * @see {@link Validator.getOperation} to look up the matched operation without validating.
+   */
   validateRequest(req: HttpRequest): ValidationError | null;
+  /**
+   * Validate one HTTP response against the spec, given the request it
+   * answers. Returns `null` when the response status, content type,
+   * headers, and body all match the responses declared on the operation
+   * `req` resolves to; returns a {@link ValidationError} tree otherwise.
+   *
+   * The returned tree's top-level `code` is `"response"`, with branch
+   * children under `body`, `header.<name>`, or `status`. The `req`
+   * argument is used only to locate the operation; its body isn't
+   * read.
+   *
+   * Response-body schemas compile lazily on first use per `(status,
+   * mediaType)` pairing; {@link ValidatorStats.responseBodiesCompiled}
+   * counts how many have been compiled since construction.
+   *
+   * Does not mutate `req` or `res`. Synchronous, like
+   * {@link Validator.validateRequest}.
+   *
+   * @see {@link Validator.validateRequest} for the request-side pair.
+   * @see {@link Validator.validateFetchResponse} for the Web Standards convenience wrapper.
+   */
   validateResponse(req: HttpRequest, res: HttpResponse): ValidationError | null;
   /**
    * Parse a Web Standards {@link Request} and validate it in one call.

--- a/packages/validator/test/fetch-validators.test.ts
+++ b/packages/validator/test/fetch-validators.test.ts
@@ -10,7 +10,7 @@ import { createValidator } from "../src/validator.js";
 /**
  * Four concerns under test here:
  *   - `httpRequestFromFetch`: content-type dispatch, URL parsing,
- *     header normalisation, multipart + form-urlencoded + JSON + text
+ *     header normalization, multipart + form-urlencoded + JSON + text
  *     + unknown media types.
  *   - `httpResponseFromFetch`: mirrored coverage on the response side.
  *   - `validator.validateFetchRequest`: the discriminated-union result

--- a/packages/validator/test/versioning.test.ts
+++ b/packages/validator/test/versioning.test.ts
@@ -153,7 +153,7 @@ describe("3.0 support", () => {
     expect(err).not.toBeNull();
   });
 
-  it("honours boolean exclusiveMaximum (priority < 10, not ≤)", () => {
+  it("honors boolean exclusiveMaximum (priority < 10, not ≤)", () => {
     const v = createValidator(spec30());
     // priority = 9 is fine
     expect(

--- a/performance/README.md
+++ b/performance/README.md
@@ -120,7 +120,7 @@ validate:
 
 Per-library line per task. `ops/s` is tinybench's measured throughput,
 `/ op` is mean latency per call. Bigger ops/s = faster. The relative
-table at the end normalises against ajv as baseline.
+table at the end normalizes against ajv as baseline.
 
 ### Spec mode
 
@@ -190,7 +190,7 @@ Raw per-batch data lands in `results/mem-<timestamp>.json`.
 
 Deliberately omitted. Without paired valid/invalid fixtures per
 schema, any choice of synthetic input (`{}`, an example mined from
-the spec, a type-driven synthesised value) would favour one library's
+the spec, a type-driven synthesized value) would favor one library's
 fast-path over another in ways that don't reflect real workloads. If
 you need validate throughput numbers on real shapes, copy the
 relevant body schema into `schemas.ts` with hand-authored inputs and
@@ -233,7 +233,7 @@ ajv for parity with oav's always-collect-everything default.
   here; oav is roughly 1.4× on trivial shapes, ~3× on object and
   composition shapes, ~3× on large-array shapes. `maxErrors: 1`
   closes the ajv gap on invalid payloads (apples-to-apples with
-  ajv's default fail-fast behaviour).
+  ajv's default fail-fast behavior).
 - **Predicate mode (`predicate: true`).** When consumers only need a
   yes/no answer — routing, gating, hot-path filtering — `oav-predicate`
   brings oav onto parity with ajv's default (fail-fast) mode on invalid
@@ -249,7 +249,7 @@ ajv for parity with oav's always-collect-everything default.
 - **`@oav/schema`**'s remaining validate overhead vs ajv comes from
   two structural choices: schemas that contain applicators
   (`properties` / `items` / `allOf` / ...) compile to a function
-  call rather than inlining into the enclosing body (V8 monomorphises
+  call rather than inlining into the enclosing body (V8 monomorphizes
   hot-loop calls better than massive inline bodies); and oav collects
   complete error trees by default, while ajv defaults to
   `allErrors: false`. Set `maxErrors: 1` on oav for apples-to-apples

--- a/performance/run.ts
+++ b/performance/run.ts
@@ -288,7 +288,7 @@ async function benchSpec(path: string): Promise<void> {
       // `logger: false` suppresses "unknown format X" warnings that
       // would otherwise flood the output; the schemas use OAS-specific
       // formats (`duration`, `float`) that neither ajv nor
-      // ajv-formats recognise by default.
+      // ajv-formats recognize by default.
       new Ajv({ allErrors: true, strict: false, logger: false }).compile(schema as never);
       ajvTimes.push(performance.now() - t0);
     } catch (err) {
@@ -394,7 +394,7 @@ if (specPath !== undefined) {
   const filtered = filter ? perfSchemas.filter((s) => s.name.includes(filter)) : perfSchemas;
   for (const s of filtered) await benchSchema(s);
 
-  // Relative table: each library's ops/sec normalised to ajv's.
+  // Relative table: each library's ops/sec normalized to ajv's.
   console.log("\n=== Relative throughput (vs ajv = 1.00) ===");
   console.log(
     "schema".padEnd(14) +


### PR DESCRIPTION
## Summary

- **Top-level docs cleanup.** Reframed the README opener around the two primary drivers (tenant overlays, microservice runners), restored the inline manual Express-5 adapter snippet, normalized section heading casing, broadened `docs/comparison.md` to cover `openapi-backend` / `openapi-enforcer` / smaller per-piece validators, and replaced the long TOC in `docs/integration.md` with an entry-point table plus a recipe list.
- **Spelling normalization.** Swept British spellings to American across docs, READMEs, source TSDoc, and tests (perl word-boundary substitution; no behavior changes).
- **TSDoc tightening.** Added a field-group roadmap above the `Validator` interface and wrote TSDoc for the bare `validateRequest` / `validateResponse` methods. Expanded `KeywordDefinition.implements` with concrete vocabulary examples; documented `dependsOn` and `before` honestly as currently unused (they are declared but never read by the compiler). Normalized the `ValidateRequestsOptions.onError` prose so the three adapters share lead sentence, structure, and closing invariant.
- **Scrub of references to nonexistent symbols.** Removed every TSDoc and contributor-doc mention of `oav-hono`, `httpRequestFromHono`, the adapter-level `validateResponses` plural factory, and `responseValidator`. Sibling references to existing packages stay.
- **Deprecation targets.** Bumped removal on `formatJson` / `summarize` / `formatFlat` / `SummarizeOptions` / `SummarizeSelect` from v2.0 to v3 and surfaced the version in each `@deprecated` tag.

Closes #259.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (953 passing)
- [x] `pnpm lint` (oxlint + oxfmt --check)
- [ ] Spot-check the rendered README and `docs/comparison.md` on the PR view
- [ ] Confirm the new `Validator` TSDoc surfaces in IDE tooling