### PR TITLE
fix(validator): required response headers when res.headers is absent

### DIFF
--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -812,11 +812,12 @@ export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions
     } else {
       const responseCompiled = cache.responses.get(statusKey);
       if (responseCompiled !== undefined) {
-        if (res.headers && responseCompiled.headers.size > 0) {
+        if (responseCompiled.headers.size > 0) {
+          const headers = res.headers ?? {};
           for (const [lowered, entry] of responseCompiled.headers) {
             const hdr = entry.object;
             const name = entry.name;
-            const raw = res.headers[lowered] ?? res.headers[name];
+            const raw = headers[lowered] ?? headers[name];
             if (hdr.required && (raw === undefined || raw === "")) {
               children.push(
                 createLeafError(

--- a/packages/validator/test/response.test.ts
+++ b/packages/validator/test/response.test.ts
@@ -79,6 +79,12 @@ describe("validateResponse", () => {
       { status: 200, headers: { "x-count": "-1" } },
     );
     expect(leafAt(invalid, "header.X-Count")).toBeDefined();
+
+    // Regression for #255: a runtime response with required headers
+    // declared in the spec but no `headers` object at all used to slip
+    // past validation entirely. Treat absent `headers` as `{}`.
+    const absent = sv.validateResponse({ method: "GET", path: "/items" }, { status: 200 });
+    expect(leafAt(absent, "header.X-Count")).toBeDefined();
   });
 
   it("writeOnly properties are rejected in response bodies", () => {


### PR DESCRIPTION
## Summary

- Drop the `res.headers &&` truthiness guard on the response-header validation loop in `packages/validator/src/validator.ts`. Default to `{}` when reading instead, so a runtime response with required headers declared in the spec but no `headers` object on the `HttpResponse` produces the expected `header-param` leaf for each missing header.
- Add a regression case in `packages/validator/test/response.test.ts` covering the bare-required scenario (no `headers` field on the response).

Confirmed the regression test fails on `main` (1 of 8 in `response.test.ts`) and passes with the fix.

Closes #255.

## Test plan

- [x] `pnpm vitest run packages/validator/test/response.test.ts` (8 passed)
- [x] `pnpm test` (953 passed)
- [x] `pnpm typecheck`
- [x] `pnpm lint`