### PR TITLE
feat(validator): enum-valued validateSecurity with strict mode

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,18 +5,18 @@ canonical reference is the
 [`ValidatorOptions`](../packages/validator/src/validator.ts) TSDoc;
 this page is a recipe-oriented overview.
 
-| Option                  | Effect                                                                                                                                |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `dialect`               | Force a specific schema dialect, bypassing version detection.                                                                         |
-| `formats`               | Extra string format validators merged on top of the built-ins.                                                                        |
-| `keywords`              | Register user-defined schema keywords (see below).                                                                                    |
-| `maxErrors`             | Cap on leaf errors; `1` is fast-fail, default is uncapped.                                                                            |
-| `strict`                | Compile-time schema lint mode: `"off"`, `"warn-partial"` (default), or `"strict"`. Issues surface via `validator.stats.strictIssues`. |
-| `strictQueryParameters` | Reject undeclared query parameters. Default `false`.                                                                                  |
-| `validateSecurity`      | Shape-only security check (bearer / basic / apiKey). Default `false` (auth middleware runs upstream); set `true` to opt in.           |
-| `ignoreUndocumented`    | Return `null` on requests whose path the router can't match. Default `false`.                                                         |
-| `ignorePaths`           | Predicate `(path) => boolean`; returning `true` short-circuits validation to `null` before routing.                                   |
-| `onUnknownVersion`      | Policy for specs with missing/unsupported `openapi`: `"fallback31"` (default), `"warn"`, or `"throw"`.                                |
+| Option                  | Effect                                                                                                                                                                                         |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dialect`               | Force a specific schema dialect, bypassing version detection.                                                                                                                                  |
+| `formats`               | Extra string format validators merged on top of the built-ins.                                                                                                                                 |
+| `keywords`              | Register user-defined schema keywords (see below).                                                                                                                                             |
+| `maxErrors`             | Cap on leaf errors; `1` is fast-fail, default is uncapped.                                                                                                                                     |
+| `strict`                | Compile-time schema lint mode: `"off"`, `"warn-partial"` (default), or `"strict"`. Issues surface via `validator.stats.strictIssues`.                                                          |
+| `strictQueryParameters` | Reject undeclared query parameters. Default `false`.                                                                                                                                           |
+| `validateSecurity`      | `"off"` (default), `"shape"` (check recognized schemes; pass on oauth2/oidc/mTLS), or `"strict"` (fail on unrecognized schemes). Boolean form deprecated; `true`->`"shape"`, `false`->`"off"`. |
+| `ignoreUndocumented`    | Return `null` on requests whose path the router can't match. Default `false`.                                                                                                                  |
+| `ignorePaths`           | Predicate `(path) => boolean`; returning `true` short-circuits validation to `null` before routing.                                                                                            |
+| `onUnknownVersion`      | Policy for specs with missing/unsupported `openapi`: `"fallback31"` (default), `"warn"`, or `"throw"`.                                                                                         |
 
 ## Custom keywords
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -902,12 +902,12 @@ budget burns for free.
 ### Security / authentication
 
 `oav` performs **shape-only** security validation (when opted in
-via `validateSecurity: true`): it confirms the request carries the
-credential location declared by the spec (a `Bearer` token in
-`Authorization`, the declared apiKey header / query / cookie, a
-base64 `Basic user:pass` pair), but it does **not** verify the
-credential itself. That's your auth middleware's job; keep it
-upstream of the validator.
+via `validateSecurity: "shape"` or `"strict"`): it confirms the
+request carries the credential location declared by the spec (a
+`Bearer` token in `Authorization`, the declared apiKey header /
+query / cookie, a base64 `Basic user:pass` pair), but it does
+**not** verify the credential itself. That's your auth middleware's
+job; keep it upstream of the validator.
 
 ```ts
 app.use(authenticateJwt); // verifies tokens, populates req.user
@@ -922,20 +922,27 @@ override). Supported:
 - `http` with `scheme: "basic"`: requires `Authorization: Basic <base64>`; the base64 must decode to a `user:pass` shape (no credential verification).
 - `apiKey` in `header`, `query`, or `cookie`: declared name must be present and non-empty.
 
-`oauth2`, `openIdConnect`, and `mutualTLS` schemes are accepted in the
-spec but not shape-checked at the validator layer. Failures surface as
-a single leaf error with `code: "security"` and `path: ["security"]`,
-mapping to HTTP 401 in the default status recipe.
+`oauth2`, `openIdConnect`, and `mutualTLS` schemes (and HTTP schemes
+other than bearer / basic) aren't shape-checkable at the validator
+layer. In `"shape"` mode they silently pass; in `"strict"` mode they
+fail with a `security` leaf error so the gap surfaces rather than
+slipping through. Failures (recognized or strict-mode unrecognized)
+surface as a single leaf error with `code: "security"` and
+`path: ["security"]`, mapping to HTTP 401 in the default status
+recipe.
 
 **Off by default.** Real apps run auth middleware upstream of the
 validator, so by the time `validateRequest` runs the credential has
 already been verified. Enable with `createValidator(spec, {
-validateSecurity: true })` when there's no auth middleware (early
+validateSecurity: "shape" })` when there's no auth middleware (early
 dev / prototyping) or when the auth layer only decorates `req`
-without rejecting unauthenticated traffic. The check is shape-only
-and is **not** a substitute for actual credential verification.
-See `ValidatorOptions.validateSecurity` for the option contract;
-this section is the recipe.
+without rejecting unauthenticated traffic. Use `"strict"` when you
+want every declared scheme to either be shape-checkable or fail
+loudly. None of the modes substitute for actual credential
+verification. The boolean form (`true` / `false`) is a deprecated
+alias preserved through v3; `true` aliases `"shape"`, `false`
+aliases `"off"`. See `ValidatorOptions.validateSecurity` for the
+option contract; this section is the recipe.
 
 #### Per-scheme auth dispatch
 
@@ -995,7 +1002,7 @@ Mount the dispatcher as middleware _before_ `validateRequests` (or
 your inline validator middleware). Reject (`401` / `403` per your
 policy) on `{ ok: false }` before validation runs. The validator's
 own `validateSecurity` shape check is then redundant; leave it at
-its default `false`.
+its default `"off"`.
 
 For framework-adapter consumers (`oav-express4`, future siblings),
 the same dispatcher pattern works; only the request-shape extraction

--- a/docs/migration-from-eov.md
+++ b/docs/migration-from-eov.md
@@ -103,11 +103,11 @@ makes sense for your API.
 
 ### Security and file uploads
 
-| eov option                  | oav equivalent                                                                                                                                                                                                                      |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `validateSecurity: true`    | Off by default in oav (real apps gate security upstream of validation). Opt in with `createValidator(spec, { validateSecurity: true })` for shape-only checks on `bearer` / `basic` / `apiKey`.                                     |
-| `validateSecurity.handlers` | Your own auth middleware, run before the validator. `oav` only checks credential **shape**, not validity. For declarative per-scheme dispatch, see the [integration.md security recipe](./integration.md#per-scheme-auth-dispatch). |
-| `fileUploader: true`        | Your own multer middleware; see [integration.md file uploads](./integration.md#file-uploads-with-multer).                                                                                                                           |
+| eov option                  | oav equivalent                                                                                                                                                                                                                                                                              |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `validateSecurity: true`    | Off by default in oav (real apps gate security upstream of validation). Opt in with `createValidator(spec, { validateSecurity: "shape" })` for shape-only checks on `bearer` / `basic` / `apiKey`, or `"strict"` to fail on schemes the validator can't shape-check (oauth2 / oidc / mTLS). |
+| `validateSecurity.handlers` | Your own auth middleware, run before the validator. `oav` only checks credential **shape**, not validity. For declarative per-scheme dispatch, see the [integration.md security recipe](./integration.md#per-scheme-auth-dispatch).                                                         |
+| `fileUploader: true`        | Your own multer middleware; see [integration.md file uploads](./integration.md#file-uploads-with-multer).                                                                                                                                                                                   |
 
 ### Handler wiring
 

--- a/packages/oav-express4/README.md
+++ b/packages/oav-express4/README.md
@@ -103,7 +103,7 @@ validateRequests(validator, {
 `ValidatorOptions.validateSecurity` is off by default; real apps run auth middleware upstream of the validator, so by the time `validateRequests` runs the credential has already been verified. During early dev (no auth wired yet) or with decorator-only auth that just attaches `req.user`, opt in:
 
 ```ts
-const validator = createValidator(spec, { validateSecurity: true });
+const validator = createValidator(spec, { validateSecurity: "shape" });
 app.use(validateRequests(validator));
 ```
 

--- a/packages/oav-express5/README.md
+++ b/packages/oav-express5/README.md
@@ -101,7 +101,7 @@ validateRequests(validator, {
 `ValidatorOptions.validateSecurity` is off by default; real apps run auth middleware upstream of the validator, so by the time `validateRequests` runs the credential has already been verified. During early dev (no auth wired yet) or with decorator-only auth that just attaches `req.user`, opt in:
 
 ```ts
-const validator = createValidator(spec, { validateSecurity: true });
+const validator = createValidator(spec, { validateSecurity: "shape" });
 app.use(validateRequests(validator));
 ```
 

--- a/packages/oav-fastify/README.md
+++ b/packages/oav-fastify/README.md
@@ -97,7 +97,7 @@ validateRequests(validator, {
 `ValidatorOptions.validateSecurity` is off by default; real apps run auth middleware (or hooks) upstream of the validator. During early dev (no auth wired yet) or with decorator-only auth that just attaches `request.user`, opt in:
 
 ```ts
-const validator = createValidator(spec, { validateSecurity: true });
+const validator = createValidator(spec, { validateSecurity: "shape" });
 app.addHook("preValidation", validateRequests(validator));
 ```
 

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -86,17 +86,17 @@ the upstream test suites live in
 
 ## Options
 
-| Option                  | Effect                                                                                                                                          |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dialect`               | Force a specific {@link Dialect}, bypassing version detection.                                                                                  |
-| `formats`               | Extra string format validators merged with `oav/formats`.                                                                                       |
-| `keywords`              | User-registered schema keywords (see below).                                                                                                    |
-| `maxErrors`             | Cap on leaf errors; `1` is fast-fail. Default: uncapped.                                                                                        |
-| `strictQueryParameters` | Reject undeclared query parameters. Default `false`.                                                                                            |
-| `validateSecurity`      | Shape-only security check (bearer / basic / apiKey credential location). Default `false` (auth middleware runs upstream); set `true` to opt in. |
-| `ignoreUndocumented`    | Return `null` on requests whose path the router can't match. Default `false`.                                                                   |
-| `ignorePaths`           | `(path: string) => boolean` predicate that short-circuits validation when it returns `true` (runs before routing).                              |
-| `onUnknownVersion`      | `"fallback31"` \| `"warn"` \| `"throw"` when `openapi` is missing or unsupported. Default `"fallback31"`.                                       |
+| Option                  | Effect                                                                                                                                                                                         |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dialect`               | Force a specific {@link Dialect}, bypassing version detection.                                                                                                                                 |
+| `formats`               | Extra string format validators merged with `oav/formats`.                                                                                                                                      |
+| `keywords`              | User-registered schema keywords (see below).                                                                                                                                                   |
+| `maxErrors`             | Cap on leaf errors; `1` is fast-fail. Default: uncapped.                                                                                                                                       |
+| `strictQueryParameters` | Reject undeclared query parameters. Default `false`.                                                                                                                                           |
+| `validateSecurity`      | `"off"` (default), `"shape"` (check recognized schemes; pass on oauth2/oidc/mTLS), or `"strict"` (fail on unrecognized schemes). Boolean form deprecated; `true`->`"shape"`, `false`->`"off"`. |
+| `ignoreUndocumented`    | Return `null` on requests whose path the router can't match. Default `false`.                                                                                                                  |
+| `ignorePaths`           | `(path: string) => boolean` predicate that short-circuits validation when it returns `true` (runs before routing).                                                                             |
+| `onUnknownVersion`      | `"fallback31"` \| `"warn"` \| `"throw"` when `openapi` is missing or unsupported. Default `"fallback31"`.                                                                                      |
 
 ## Custom keywords
 

--- a/packages/validator/src/operation-cache.ts
+++ b/packages/validator/src/operation-cache.ts
@@ -32,7 +32,7 @@ export interface OperationCache {
    * Pre-compiled shape-only security check, or `undefined` when the
    * operation has no effective security requirement (either because
    * nothing was declared, it's opted out via `security: []`, or the
-   * `validateSecurity` option is `false`).
+   * `validateSecurity` option is `"off"`).
    */
   security: CompiledSecurity | undefined;
 }

--- a/packages/validator/src/security.ts
+++ b/packages/validator/src/security.ts
@@ -45,6 +45,18 @@ export interface CompiledSecurityRequirement {
 export type CompiledSecurity = CompiledSecurityRequirement[];
 
 /**
+ * Strictness toggle for shape-only security validation. `"shape"`
+ * checks recognized schemes (`bearer`, `basic`, `apiKey`) and silently
+ * passes on everything else (oauth2, openIdConnect, mutualTLS, HTTP
+ * non-bearer/non-basic). `"strict"` checks recognized schemes and
+ * fails the request on any unrecognized scheme. Mirrors the `"shape"`
+ * / `"strict"` values of {@link ValidatorOptions.validateSecurity}.
+ *
+ * @internal
+ */
+export type SecurityMode = "shape" | "strict";
+
+/**
  * Compile the effective security for one operation. Applies OAS
  * precedence: operation-level `security` (including an explicit empty
  * array opt-out) overrides `document.security`. Unknown scheme names
@@ -61,6 +73,7 @@ export function compileOperationSecurity(
   operation: OperationObject,
   document: OpenAPIDocument,
   resolveRef: <T>(v: T | ReferenceObject | undefined) => T | undefined,
+  mode: SecurityMode = "shape",
 ): CompiledSecurity | undefined {
   const effective = operation.security ?? document.security;
   if (effective === undefined || effective.length === 0) return undefined;
@@ -71,17 +84,18 @@ export function compileOperationSecurity(
     resolvedSchemes[name] = resolveRef<SecuritySchemeObject>(raw);
   }
 
-  return effective.map((req) => compileRequirement(req, resolvedSchemes));
+  return effective.map((req) => compileRequirement(req, resolvedSchemes, mode));
 }
 
 function compileRequirement(
   req: SecurityRequirementObject,
   schemes: Record<string, SecuritySchemeObject | undefined>,
+  mode: SecurityMode,
 ): CompiledSecurityRequirement {
   const compiled: CompiledSchemeCheck[] = [];
   for (const name of Object.keys(req)) {
     const scheme = schemes[name];
-    compiled.push(compileSchemeCheck(name, scheme));
+    compiled.push(compileSchemeCheck(name, scheme, mode));
   }
   return { schemes: compiled };
 }
@@ -89,6 +103,7 @@ function compileRequirement(
 function compileSchemeCheck(
   name: string,
   scheme: SecuritySchemeObject | undefined,
+  mode: SecurityMode,
 ): CompiledSchemeCheck {
   if (scheme === undefined) {
     return {
@@ -100,18 +115,37 @@ function compileSchemeCheck(
     case "http":
       if (scheme.scheme?.toLowerCase() === "bearer") return bearerCheck(name);
       if (scheme.scheme?.toLowerCase() === "basic") return basicCheck(name);
-      // Other http schemes (digest, mutual, etc.) aren't shape-checked
-      // in v1. Accept to avoid false 401s on schemes we don't yet
-      // understand.
-      return { scheme: name, check: () => null };
+      return unsupportedSchemeCheck(name, `http "${scheme.scheme ?? "?"}"`, mode);
     case "apiKey":
       return apiKeyCheck(name, scheme);
-    // oauth2 / openIdConnect / mutualTLS: v1 non-goals. See oav#104.
-    // Treat as pass rather than block, so specs using them continue
-    // to validate requests without security producing spurious 401s.
+    case "oauth2":
+      return unsupportedSchemeCheck(name, "oauth2", mode);
+    case "openIdConnect":
+      return unsupportedSchemeCheck(name, "openIdConnect", mode);
+    case "mutualTLS":
+      return unsupportedSchemeCheck(name, "mutualTLS", mode);
     default:
-      return { scheme: name, check: () => null };
+      return unsupportedSchemeCheck(name, String(scheme.type), mode);
   }
+}
+
+function unsupportedSchemeCheck(
+  name: string,
+  description: string,
+  mode: SecurityMode,
+): CompiledSchemeCheck {
+  // Shape mode: pass. The validator can't shape-check the credential
+  // (oauth2, openIdConnect, mutualTLS, HTTP digest/mutual/etc.), so
+  // declaring it satisfied avoids spurious 401s. Strict mode: fail,
+  // surfacing the gap rather than letting the caller assume coverage.
+  if (mode === "shape") return { scheme: name, check: () => null };
+  return {
+    scheme: name,
+    check: () =>
+      `scheme "${name}" (${description}) is not shape-checkable; ` +
+      `set validateSecurity to "shape" to allow it through, ` +
+      `or verify the credential in your auth middleware`,
+  };
 }
 
 function bearerCheck(name: string): CompiledSchemeCheck {

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -44,8 +44,25 @@ import {
   resolveOperationRef,
   type OperationCache,
 } from "./operation-cache.js";
-import { checkSecurity, compileOperationSecurity } from "./security.js";
+import { checkSecurity, compileOperationSecurity, type SecurityMode } from "./security.js";
 import { checkBodyContentType, validateBody, validateParameter } from "./validate-step.js";
+
+/**
+ * Coerce {@link ValidatorOptions.validateSecurity} (boolean | enum
+ * string | undefined) to the `"off" | "shape" | "strict"` value the
+ * security compiler reads. `true` aliases `"shape"`; `false` and
+ * `undefined` alias `"off"`. The boolean form is deprecated and will
+ * be removed in v3.
+ *
+ * @internal
+ */
+function normalizeSecurityMode(
+  value: boolean | "off" | "shape" | "strict" | undefined,
+): "off" | SecurityMode {
+  if (value === true) return "shape";
+  if (value === false || value === undefined) return "off";
+  return value;
+}
 
 /**
  * Pick the dialect for a given OpenAPI version. 3.1 and 3.2 share the
@@ -419,20 +436,33 @@ export interface ValidatorOptions {
    * apiKey header); it does not verify the credential itself. Credential
    * verification stays with the app's auth middleware.
    *
-   * Supported schemes: `http` with `scheme: "bearer"` or `"basic"`, and
-   * `apiKey` in header / query / cookie. `oauth2`, `openIdConnect`, and
-   * `mutualTLS` are accepted in the spec but not shape-checked at the
-   * validator layer.
+   * Modes:
    *
-   * Defaults to `false`. Real apps gate security upstream of validation:
-   * by the time the validator runs, the auth middleware has already
-   * verified (or rejected) the credential. Opt in with `true` when
+   * - `"off"` (default): no security check.
+   * - `"shape"`: shape-check recognized schemes (`http` with
+   *   `scheme: "bearer"` or `"basic"`, and `apiKey` in header / query /
+   *   cookie). Silently passes on schemes the validator can't inspect
+   *   (`oauth2`, `openIdConnect`, `mutualTLS`, HTTP digest/mutual/etc.):
+   *   declaring them satisfied avoids spurious 401s on specs that use
+   *   them.
+   * - `"strict"`: shape-check recognized schemes; fail with a `security`
+   *   leaf error on any unrecognized scheme. The strict opt-in for
+   *   callers who want the gap to surface rather than silently pass.
+   *
+   * Real apps gate security upstream of validation: by the time the
+   * validator runs, the auth middleware has already verified (or
+   * rejected) the credential. Opt in to `"shape"` or `"strict"` when
    * there's no auth middleware (early dev / prototyping) or when the
    * auth layer only decorates `req` without rejecting unauthenticated
-   * traffic. Opting in is shape-only and is **not** a substitute for
-   * actual credential verification.
+   * traffic. None of the modes substitute for actual credential
+   * verification.
+   *
+   * The boolean form is a deprecated alias preserved for compatibility:
+   * `true` aliases `"shape"`, `false` aliases `"off"`. Both will be
+   * removed in v3 alongside the other deprecations queued for that
+   * release. New code should use the strings.
    */
-  validateSecurity?: boolean;
+  validateSecurity?: boolean | "off" | "shape" | "strict";
   /** When `true`, reject unknown query parameters (default: `false`). */
   strictQueryParameters?: boolean;
   /**
@@ -678,14 +708,19 @@ export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions
 
   const operationCache = new WeakMap<OperationObject, OperationCache>();
 
-  const validateSecurity = options.validateSecurity === true;
+  const securityMode = normalizeSecurityMode(options.validateSecurity);
 
   const cacheFor = (pathMatch: RouteMatch): OperationCache => {
     const existing = operationCache.get(pathMatch.operation);
     if (existing !== undefined) return existing;
     const cache = buildOperationCache(pathMatch, { resolveRef, compile, compileForDirection });
-    if (validateSecurity) {
-      cache.security = compileOperationSecurity(pathMatch.operation, spec, resolveRef);
+    if (securityMode !== "off") {
+      cache.security = compileOperationSecurity(
+        pathMatch.operation,
+        spec,
+        resolveRef,
+        securityMode,
+      );
     }
     operationCache.set(pathMatch.operation, cache);
     return cache;

--- a/packages/validator/test/security.test.ts
+++ b/packages/validator/test/security.test.ts
@@ -333,4 +333,123 @@ describe("security validation: configuration", () => {
     // No headers / query; oauth2 isn't shape-checked, so pass.
     expect(v.validateRequest({ method: "GET", path: "/ping" })).toBeNull();
   });
+
+  describe('validateSecurity: "off" | "shape" | "strict"', () => {
+    it('"off" skips the check (same as default / `false`)', () => {
+      const spec = specWith({ bearerAuth: { type: "http", scheme: "bearer" } }, [
+        { bearerAuth: [] },
+      ]);
+      const v = createValidator(spec, { validateSecurity: "off" });
+      expect(v.validateRequest({ method: "GET", path: "/ping" })).toBeNull();
+    });
+
+    it('"shape" matches the legacy `true` behavior on recognized schemes', () => {
+      const spec = specWith({ bearerAuth: { type: "http", scheme: "bearer" } }, [
+        { bearerAuth: [] },
+      ]);
+      const v = createValidator(spec, { validateSecurity: "shape" });
+      expect(v.validateRequest({ method: "GET", path: "/ping" })?.code).toBe("request");
+      expect(
+        v.validateRequest({
+          method: "GET",
+          path: "/ping",
+          headers: { authorization: "Bearer abc" },
+        }),
+      ).toBeNull();
+    });
+
+    it('"shape" silently passes on oauth2 (matching legacy `true`)', () => {
+      const spec = specWith(
+        {
+          oauth: {
+            type: "oauth2",
+            flows: { implicit: { authorizationUrl: "https://example.com/auth", scopes: {} } },
+          },
+        },
+        [{ oauth: ["read"] }],
+      );
+      const v = createValidator(spec, { validateSecurity: "shape" });
+      expect(v.validateRequest({ method: "GET", path: "/ping" })).toBeNull();
+    });
+
+    it('"strict" rejects oauth2 with a security leaf error', () => {
+      const spec = specWith(
+        {
+          oauth: {
+            type: "oauth2",
+            flows: { implicit: { authorizationUrl: "https://example.com/auth", scopes: {} } },
+          },
+        },
+        [{ oauth: ["read"] }],
+      );
+      const v = createValidator(spec, { validateSecurity: "strict" });
+      const err = v.validateRequest({ method: "GET", path: "/ping" });
+      expect(firstLeaf(err)?.code).toBe("security");
+    });
+
+    it('"strict" rejects openIdConnect / mutualTLS', () => {
+      const oidcSpec = specWith(
+        { oidc: { type: "openIdConnect", openIdConnectUrl: "https://example.com/.well-known" } },
+        [{ oidc: [] }],
+      );
+      const oidcV = createValidator(oidcSpec, { validateSecurity: "strict" });
+      expect(firstLeaf(oidcV.validateRequest({ method: "GET", path: "/ping" }))?.code).toBe(
+        "security",
+      );
+
+      const mtlsSpec = specWith({ mtls: { type: "mutualTLS" } }, [{ mtls: [] }]);
+      const mtlsV = createValidator(mtlsSpec, { validateSecurity: "strict" });
+      expect(firstLeaf(mtlsV.validateRequest({ method: "GET", path: "/ping" }))?.code).toBe(
+        "security",
+      );
+    });
+
+    it('"strict" rejects HTTP non-bearer / non-basic (digest etc.)', () => {
+      const spec = specWith({ digestAuth: { type: "http", scheme: "digest" } }, [
+        { digestAuth: [] },
+      ]);
+      const v = createValidator(spec, { validateSecurity: "strict" });
+      expect(firstLeaf(v.validateRequest({ method: "GET", path: "/ping" }))?.code).toBe("security");
+    });
+
+    it('"strict" still accepts recognized schemes when the credential is well-formed', () => {
+      const spec = specWith({ bearerAuth: { type: "http", scheme: "bearer" } }, [
+        { bearerAuth: [] },
+      ]);
+      const v = createValidator(spec, { validateSecurity: "strict" });
+      expect(
+        v.validateRequest({
+          method: "GET",
+          path: "/ping",
+          headers: { authorization: "Bearer abc" },
+        }),
+      ).toBeNull();
+    });
+
+    it('boolean form: `true` aliases "shape", `false` aliases "off"', () => {
+      const spec = specWith(
+        {
+          oauth: {
+            type: "oauth2",
+            flows: { implicit: { authorizationUrl: "https://example.com/auth", scopes: {} } },
+          },
+        },
+        [{ oauth: ["read"] }],
+      );
+      // `true` -> "shape": oauth2 silently passes.
+      expect(
+        createValidator(spec, { validateSecurity: true }).validateRequest({
+          method: "GET",
+          path: "/ping",
+        }),
+      ).toBeNull();
+      // `false` -> "off": no check at all (same as default).
+      expect(
+        createValidator(spec, { validateSecurity: false }).validateRequest({
+          method: "GET",
+          path: "/ping",
+        }),
+      ).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Replace `validateSecurity: boolean` with an enum: `"off" | "shape" | "strict"`. The value declares intent at the call site, so a reader of `validateSecurity: "shape"` knows the check is partial without consulting TSDoc.
- `"strict"` closes the silent-pass gap: schemes the validator can't shape-check (`oauth2`, `openIdConnect`, `mutualTLS`, HTTP non-bearer/basic) emit a `security` leaf error rather than slipping through.
- Boolean form preserved as a deprecated alias (`true` -> `"shape"`, `false` -> `"off"`); removal queued for v3 alongside the other deprecations.

Design discussion: #257 (comment by @aahoughton outlines the vocabulary problem and the enum reframe).

## Why

`validateSecurity: true` was lying about being binary. It shape-checked `bearer` / `basic` / `apiKey` and silently passed on every other scheme. The name promised one contract; the runtime delivered two. A modifier (the originally-proposed `unsupportedSecurity` knob) would have papered the gap; the enum closes it by making the caller articulate intent.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint` (oxlint + oxfmt --check)
- [x] `pnpm test` (961 passing, including 7 new cases for the enum modes + boolean aliasing)
- [ ] Reviewer eyeballs the TSDoc rewrite on `ValidatorOptions.validateSecurity` (lines ~413-449 of `packages/validator/src/validator.ts`)
- [ ] Reviewer eyeballs the doc updates (`docs/configuration.md`, `docs/integration.md`, `docs/migration-from-eov.md`, four package READMEs)