### PR TITLE
perf(schema): low-risk codegen wins (regex hoist, primitive equality, oneOf cleanup, required predicate)

### DIFF
--- a/packages/schema/src/keywords/composition.ts
+++ b/packages/schema/src/keywords/composition.ts
@@ -181,6 +181,15 @@ export const oneOfKeyword: KeywordDefinition = {
     schemas.forEach((sub) => {
       const fn = ctx.compileSubschema(sub);
       const errVar = ctx.gen.scope.name("e");
+      if (outProps === null && outItems === null) {
+        ctx.gen.const(errVar, `${fn}(${ctx.data}, ${ctx.path})`);
+        ctx.gen.if(
+          `${errVar} === null`,
+          (g) => g.line(`${matchCount} += 1;`),
+          (g) => g.line(`${errsVar}.push(${errVar});`),
+        );
+        return;
+      }
       const propsVar = ctx.gen.scope.name("bProps");
       const itemsVar = ctx.gen.scope.name("bItems");
       ctx.gen.const(propsVar, outProps !== null ? "new Set()" : "undefined");

--- a/packages/schema/src/keywords/equality.ts
+++ b/packages/schema/src/keywords/equality.ts
@@ -3,6 +3,10 @@ import type { JsonValue } from "@oav/core";
 import type { KeywordCompileContext, KeywordDefinition } from "./types.js";
 import { CORE_VALIDATION_VOCAB } from "./vocabulary-uris.js";
 
+function isJsonPrimitive(v: JsonValue): v is string | number | boolean | null {
+  return v === null || typeof v === "string" || typeof v === "number" || typeof v === "boolean";
+}
+
 /**
  * The JSON Schema 2020-12 `enum` keyword. Data must be deep-equal to one of
  * the listed values.
@@ -15,16 +19,10 @@ export const enumKeyword: KeywordDefinition = {
   compile(ctx: KeywordCompileContext): void {
     const values = ctx.schema as JsonValue[];
     const valuesLit = JSON.stringify(values);
-    const valuesVar = ctx.hoistConstant(valuesLit, "enumValues");
-    const matched = ctx.gen.scope.name("matched");
-    ctx.gen.let(matched, "false");
-    ctx.gen.forOf("candidate", valuesVar, (g) => {
-      g.if(`${NAMES.DEPS}.deepEqual(${ctx.data}, candidate)`, (gi) => {
-        gi.line(`${matched} = true;`);
-        gi.line("break;");
-      });
-    });
-    ctx.gen.if(`!${matched}`, () => {
+    const prims = values.filter(isJsonPrimitive);
+    const objs = values.filter((v) => !isJsonPrimitive(v));
+
+    const emitMismatch = (): void => {
       ctx.emitError(
         "leaf",
         ctx.leafErrorExpr(
@@ -33,7 +31,33 @@ export const enumKeyword: KeywordDefinition = {
           `{ allowed: ${valuesLit}, actual: ${ctx.data} }`,
         ),
       );
-    });
+    };
+
+    if (objs.length === 0) {
+      const setVar = ctx.hoistConstant(`new Set(${JSON.stringify(prims)})`, "enumSet");
+      ctx.gen.if(`!${setVar}.has(${ctx.data})`, emitMismatch);
+      return;
+    }
+
+    const matched = ctx.gen.scope.name("matched");
+    const objsVar = ctx.hoistConstant(JSON.stringify(objs), "enumObjs");
+    const loopBody = (g: typeof ctx.gen) => {
+      g.forOf("candidate", objsVar, (gi) => {
+        gi.if(`${NAMES.DEPS}.deepEqual(${ctx.data}, candidate)`, (gii) => {
+          gii.line(`${matched} = true;`);
+          gii.line("break;");
+        });
+      });
+    };
+    if (prims.length > 0) {
+      const setVar = ctx.hoistConstant(`new Set(${JSON.stringify(prims)})`, "enumSet");
+      ctx.gen.let(matched, `${setVar}.has(${ctx.data})`);
+      ctx.gen.if(`!${matched}`, loopBody);
+    } else {
+      ctx.gen.let(matched, "false");
+      loopBody(ctx.gen);
+    }
+    ctx.gen.if(`!${matched}`, emitMismatch);
   },
 };
 
@@ -49,7 +73,10 @@ export const constKeyword: KeywordDefinition = {
   compile(ctx: KeywordCompileContext): void {
     const value = ctx.schema as JsonValue;
     const valueLit = JSON.stringify(value);
-    ctx.gen.if(`!${NAMES.DEPS}.deepEqual(${ctx.data}, ${valueLit})`, () => {
+    const checkExpr = isJsonPrimitive(value)
+      ? `${ctx.data} !== ${valueLit}`
+      : `!${NAMES.DEPS}.deepEqual(${ctx.data}, ${valueLit})`;
+    ctx.gen.if(checkExpr, () => {
       ctx.emitError(
         "leaf",
         ctx.leafErrorExpr(

--- a/packages/schema/src/keywords/object-validation.ts
+++ b/packages/schema/src/keywords/object-validation.ts
@@ -78,6 +78,14 @@ export const requiredKeyword: KeywordDefinition = {
     const required = ctx.schema as string[];
     if (required.length === 0) return;
     const requiredVar = ctx.hoistConstant(JSON.stringify(required), "required");
+    if (ctx.predicate) {
+      ctx.gen.if(isObjectGuard(ctx.data), (g) => {
+        g.forOf("_req", requiredVar, (gi) => {
+          gi.line(`if (!Object.prototype.hasOwnProperty.call(${ctx.data}, _req)) return false;`);
+        });
+      });
+      return;
+    }
     const missingVar = ctx.gen.scope.name("missing");
     ctx.gen.if(isObjectGuard(ctx.data), (g) => {
       g.const(missingVar, "[]");

--- a/packages/schema/src/keywords/properties.ts
+++ b/packages/schema/src/keywords/properties.ts
@@ -51,16 +51,15 @@ export const patternPropertiesKeyword: KeywordDefinition = {
     const patterns = ctx.schema as Record<string, SchemaOrBoolean>;
     const entries = Object.keys(patterns);
     if (entries.length === 0) return;
+    const subs: Array<{ regex: string; sub: SchemaOrBoolean | undefined }> = entries.map(
+      (pattern) => {
+        const subSchema = patterns[pattern];
+        const patternLit = quoteString(pattern);
+        const regexVar = ctx.hoistConstant(`${NAMES.DEPS}.compilePattern(${patternLit})`, "re");
+        return { regex: regexVar, sub: subSchema };
+      },
+    );
     ctx.gen.if(isObjectGuard(ctx.data), (g) => {
-      const subs: Array<{ regex: string; sub: SchemaOrBoolean | undefined }> = entries.map(
-        (pattern) => {
-          const subSchema = patterns[pattern];
-          const patternLit = quoteString(pattern);
-          const regexVar = g.scope.name("re");
-          g.line(`const ${regexVar} = ${NAMES.DEPS}.compilePattern(${patternLit});`);
-          return { regex: regexVar, sub: subSchema };
-        },
-      );
       const keyVar = g.scope.name("key");
       g.forIn(keyVar, ctx.data, (gi) => {
         for (const { regex, sub } of subs) {
@@ -94,15 +93,11 @@ export const additionalPropertiesKeyword: KeywordDefinition = {
     const knownProps = Object.keys(ctx.parentSchema.properties ?? {});
     const patterns = Object.keys(ctx.parentSchema.patternProperties ?? {});
     const knownSet = knownProps.length > 0 ? JSON.stringify(knownProps) : "[]";
-    const patternVars: string[] = [];
+    const patternVars: string[] = patterns.map((p) =>
+      ctx.hoistConstant(`${NAMES.DEPS}.compilePattern(${quoteString(p)})`, "re"),
+    );
+    const known = ctx.hoistConstant(`new Set(${knownSet})`, "known");
     ctx.gen.if(isObjectGuard(ctx.data), (g) => {
-      for (const p of patterns) {
-        const v = g.scope.name("re");
-        const lit = quoteString(p);
-        g.line(`const ${v} = ${NAMES.DEPS}.compilePattern(${lit});`);
-        patternVars.push(v);
-      }
-      const known = ctx.hoistConstant(`new Set(${knownSet})`, "known");
       const key = g.scope.name("key");
       g.forIn(key, ctx.data, (gi) => {
         gi.if(`${known}.has(${key})`, (gii) => gii.line("continue;"));

--- a/packages/schema/src/keywords/string.ts
+++ b/packages/schema/src/keywords/string.ts
@@ -63,9 +63,8 @@ export const patternKeyword: KeywordDefinition = {
   vocabulary: CORE_VALIDATION_VOCAB,
   compile(ctx: KeywordCompileContext): void {
     const source = ctx.schema as string;
-    const patternVar = ctx.gen.scope.name("pattern");
     const patternLit = quoteString(source);
-    ctx.gen.line(`const ${patternVar} = ${NAMES.DEPS}.compilePattern(${patternLit});`);
+    const patternVar = ctx.hoistConstant(`${NAMES.DEPS}.compilePattern(${patternLit})`, "pattern");
     ctx.gen.if(`typeof ${ctx.data} === "string" && !${patternVar}.test(${ctx.data})`, () => {
       ctx.emitError(
         "leaf",

--- a/packages/schema/test/keyword-string.test.ts
+++ b/packages/schema/test/keyword-string.test.ts
@@ -70,9 +70,8 @@ describe("string keywords", () => {
     expect(v.validate("abc123").valid).toBe(false);
   });
 
-  it("pattern surfaces the error when the regex is malformed under both modes", () => {
-    const v = compile({ pattern: "(" });
-    expect(() => v.validate("anything")).toThrow(/Invalid regular expression/);
+  it("pattern with a malformed regex throws at compile time (fail-fast on bad spec)", () => {
+    expect(() => compile({ pattern: "(" })).toThrow(/Invalid regular expression/);
   });
 
   it("format is annotation-only by default (spec default)", () => {


### PR DESCRIPTION
Closes #263.

Four independently-revertable codegen changes, one per commit. No semantic or error-shape changes. Full suite (961 tests) green at every commit; typecheck + lint clean.

## Commits

1. `perf(schema): hoist compilePattern() calls to factory scope` -- `pattern`, `patternProperties`, `additionalProperties` now hoist `deps.compilePattern(...)` to module scope via `ctx.hoistConstant`, so the (memoized) Map lookup happens once at factory init instead of per-validate. Behavior change: a malformed regex throws at compile time instead of validate time. Net win (fail-fast on bad spec data); the one test asserting the deferred-throw was updated to assert the new contract.
2. `perf(schema): primitive-aware const / enum codegen` -- `const` of a JSON primitive emits `data !== <literal>` directly (skips `deps.deepEqual`). `enum` splits values into primitives (hoisted Set, O(1) `.has`) and objects (deepEqual loop fallback). All-primitive enums (status / kind / discriminator) collapse to a single `if (!set.has(data))`.
3. `perf(schema): drop dead bProps / bItems locals in tree-mode oneOf` -- when evaluated-key tracking is off globally, tree-mode `oneOf` now mirrors the predicate-mode shape: skip the per-branch `bProps` / `bItems` consts and call the subfunction with two args instead of four.
4. `perf(schema): predicate-mode short-circuit for required` -- predicate-mode `required` returns `false` on the first missing key, skipping the `missing[]` allocation and the second loop. Tree-mode unchanged (deferred to #264, which needs a small design pass on error ordering).

## Perf deltas (synthetic bench, ns/op, lower is better)

`bench:long` (`tsx run.ts --time=1500`) baseline vs after:

| Scenario | tree valid | tree invalid | pred valid | pred invalid |
|----------|-----------:|-------------:|-----------:|-------------:|
| tiny | 22 -> 26 (noise) | 37 -> 39 | 23 -> 26 | 23 -> 28 |
| petstore | 111 -> 112 | 197 -> 199 | 81 -> 81 | **44 -> 30 (-31%)** |
| tree | 51 -> 49 (-4%) | 82 -> 83 | 42 -> 42 | 34 -> 36 |
| composition | 277 -> 288 | 292 -> 279 | **90 -> 73 (-18%)** | **98 -> 62 (-37%)** |
| array-heavy | 2770 -> 2755 | 2820 -> 2800 | 2310 -> 2310 | 2300 -> 2290 |
| unique-prims | 9930 -> 9620 (-3%) | 5700 -> 5490 (-4%) | 9690 -> 9490 | 5180 -> 5070 |

The `tiny` row shifted in the same direction for Ajv (which we did not change: `ajv validate (valid)` 34.92M -> 29.75M ops/s in the same bench run), so that scenario hit ambient CPU noise. Other scenarios show Ajv flat, so they are clean reads.

Real-world per-spec compile benchmarks (stripe, github, adyen, digitalocean, petstore-31) are within +/-5% of baseline with no consistent direction. The regex hoist moves a tiny amount of work from validate time to factory-init time; that shift is below measurement noise on the per-spec compile benchmarks.

Raw logs: `/tmp/oav-bench-*-baseline.log` vs `/tmp/oav-bench-*-after.log` (local).

## Test plan

- [x] `pnpm test` (961 tests pass after each commit)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` + `pnpm fmt --check` clean
- [x] Inspected generated source for `pattern`, `patternProperties`, `additionalProperties`, `const`, `enum` (all-prim / all-objs / mixed), `oneOf` (tracking on / off), `required` (tree / predicate) -- all match expected shape
- [x] Synthetic + real-world benches re-run, deltas captured above