### PR TITLE
chore(deps): exclude express from dependabot dev-minor-and-patch group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,11 +28,24 @@ updates:
       types:
         patterns:
           - "@types/*"
+        exclude-patterns:
+          # Keep @types/express out of the group: per-package grouping
+          # converges to one workspace-wide version, which would pin the
+          # oav-express4 and oav-express5 adapters to the same @types/express
+          # major and break one of them.
+          - "@types/express"
       dev-minor-and-patch:
         dependency-type: development
         update-types:
           - minor
           - patch
+        exclude-patterns:
+          # See note above. The major-version ignore on `express` doesn't
+          # fire when grouping presents the change as a patch (oav-express5
+          # silently gets rewritten from 5.x to a 4.x patch), so keep both
+          # out of the group entirely.
+          - "express"
+          - "@types/express"
 
   - package-ecosystem: npm
     directory: "/performance"


### PR DESCRIPTION
## Summary

- Dependabot's group resolver converges a dependency name to a single workspace-wide version. With `express 4.22.1` in `oav-express4` and `express 5.2.1` in `oav-express5`, the resolver picked 4.22.2 and rewrote both, downgrading the v5 adapter to v4. PR #276 was caught by the oav-express5 promise-chain integration test (Express 4 doesn't auto-forward thrown async-handler errors).
- The existing `semver-major` ignore on `express` doesn't fire here because the grouped bump is filed as a patch (`4.22.1 -> 4.22.2`).
- Excludes `express` and `@types/express` from the `dev-minor-and-patch` and `types` groups so each adapter bumps independently.

## Test plan

- [ ] CI green on this PR.
- [ ] Trigger dependabot (or wait for the next weekly run) and confirm separate per-package express PRs are filed instead of one bundled bump.