### PR TITLE
feat(spec): expand SpecOverlay typed verbs to cover OpenAPI Overlay axes

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,55 @@ custom formats, custom keywords, cross-field constraints, error
 budgets, version differences, overlays, and spec-derived middleware
 config.
 
+### Overlay quickstart
+
+`applyOverlays` rewrites the document in memory before the validator
+is constructed. Typical shapes:
+
+```ts
+import { applyOverlays } from "@aahoughton/oav/spec";
+import type { SpecOverlay } from "@aahoughton/oav/spec";
+
+// Add a deployment-specific server. `addServers` appends; `servers`
+// replaces wholesale.
+const eu: SpecOverlay = {
+  addServers: [{ url: "https://eu.api.example.com" }],
+};
+
+// Require an API key on POST /pets without forking the base spec.
+const requireKey: SpecOverlay = {
+  overrides: {
+    "/pets": {
+      operations: { post: { addSecurity: [{ apiKey: [] }] } },
+    },
+  },
+};
+
+// Apply one rule to every operation matching a tag (walks paths and
+// webhooks).
+const lockInternals: SpecOverlay = {
+  modifyOperations: [
+    {
+      where: { tags: ["internal"] },
+      apply: { addSecurity: [{ internalKey: [] }] },
+    },
+  ],
+};
+
+// Tighten an upstream schema; the original definition still applies.
+const requirePetId: SpecOverlay = {
+  extendSchemas: { Pet: { required: ["id"] } },
+};
+
+const patched = applyOverlays(document, [eu, requireKey, lockInternals, requirePetId]);
+const validator = createValidator(patched);
+```
+
+The full verb surface (component-bucket fan-out, predicate iterators,
+operation-level metadata) is documented in
+[`docs/overlays.md`](./docs/overlays.md); cross-cutting integration
+shapes live in [`docs/integration.md`](./docs/integration.md).
+
 ## Where to go next
 
 | Task                                      | Read                                                                   |

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -442,6 +442,94 @@ updating the document.
 
 ## Cross-cutting recipes
 
+### Patching a spec with overlays
+
+When you consume a spec you don't own (a vendor API, a gateway's
+published document, an upstream service), `applyOverlays` rewrites
+the document at load time so application code can validate against
+the shape you actually ship. See [docs/overlays.md](./overlays.md)
+for the full surface; the four shapes that come up most often:
+
+**Add a server.** When the deployed URL differs from what upstream
+declared, append to the `servers` list:
+
+```ts
+import { applyOverlays } from "@aahoughton/oav/spec";
+import type { SpecOverlay } from "@aahoughton/oav/spec";
+
+const eu: SpecOverlay = {
+  addServers: [{ url: "https://eu.api.example.com", description: "EU region" }],
+};
+const patched = applyOverlays(base, [eu]);
+```
+
+`servers` (without the `add` prefix) replaces wholesale; `addServers`
+appends. The two cannot coexist in one overlay.
+
+**Add an operation-level security requirement.** Tenants often
+require auth where the base spec doesn't:
+
+```ts
+const requireApiKey: SpecOverlay = {
+  overrides: {
+    "/pets": {
+      operations: {
+        post: { addSecurity: [{ apiKey: [] }] },
+      },
+    },
+  },
+};
+```
+
+`addSecurity` appends to the operation's existing requirement list
+(OR semantics between entries). Use `security: [...]` on the
+override to replace the list wholesale; replace cannot combine with
+`add` / `remove` in the same override.
+
+**Modify every operation matching a tag.** For "apply this to every
+internal endpoint" cases, the predicate iterator beats hand-rolling
+per-path overrides:
+
+```ts
+const lockInternals: SpecOverlay = {
+  modifyOperations: [
+    {
+      where: { tags: ["internal"] },
+      apply: {
+        addSecurity: [{ internalKey: [] }],
+        setExtensions: { "x-internal-only": true },
+      },
+    },
+  ],
+};
+```
+
+`modifyOperations` walks both `paths` and `webhooks`. `where` fields
+combine with AND semantics; omit `where` to apply to every operation.
+Webhook entries that are reference objects (`{ $ref: ... }`) are
+passed through unchanged; their path-item contents aren't inspectable
+pre-resolve.
+
+**Extend a component schema.** Tighten upstream constraints without
+forking the schema:
+
+```ts
+const requirePetId: SpecOverlay = {
+  extendSchemas: {
+    Pet: { required: ["id"] },
+  },
+};
+```
+
+`extendSchemas` wraps the upstream definition as
+`allOf: [<upstream>, { required: ["id"] }]`. The original applies;
+the override piles additional constraints on top. The parallel
+`extend<Bucket>` verbs for non-schema component buckets (parameters,
+responses, etc.) shallow-merge instead.
+
+Overlays apply in order; later overlays win on conflict. The base
+document is deep-cloned, never mutated.
+
 ### Status-code mapping
 
 Default mapping:

--- a/docs/overlays.md
+++ b/docs/overlays.md
@@ -28,16 +28,32 @@ overlays exist to avoid.
 
 ## Verb matrix
 
-Every overlay verb falls into one of four categories.
+Every overlay verb falls into one of four categories. Top-level
+metadata (`info`, `servers`, `tags`, `security`, `webhooks`,
+`setExtensions`) and the structured iterators (`modifyOperations`,
+`modifyParameters`) sit alongside the path / operation / component
+verbs below.
 
-| Target                | add                | augment                  | replace                            | remove              |
-| --------------------- | ------------------ | ------------------------ | ---------------------------------- | ------------------- |
-| Paths                 | `addPaths`         | (via `overrides`)        | (via `overrides.replace`)          | `removePaths`       |
-| Component schemas     |                    | `extendSchemas`          | `replaceSchemas`                   | `removeSchemas`     |
-| Operations            |                    | (via additive op fields) | `overrides.operations.<m>.replace` | (via `removePaths`) |
-| Parameters (per op)   | `upsertParameters` |                          | `upsertParameters`                 | `removeParameters`  |
-| Request body (per op) |                    |                          | `requestBody`                      |                     |
-| Responses (per op)    | `responses`        |                          | `responses`                        | `removeResponses`   |
+| Target                  | add                | augment                              | replace                            | remove                      |
+| ----------------------- | ------------------ | ------------------------------------ | ---------------------------------- | --------------------------- |
+| `info`                  |                    | `info` (shallow merge)               |                                    |                             |
+| `servers`               | `addServers`       |                                      | `servers`                          |                             |
+| `tags`                  |                    | `extendTags`                         | `tags` / `replaceTags`             | `removeTags`                |
+| `security`              | `addSecurity`      |                                      | `security`                         |                             |
+| `webhooks`              | `addWebhooks`      |                                      |                                    | `removeWebhooks`            |
+| Root extensions (`x-*`) |                    |                                      | `setExtensions`                    | `setExtensions` (undefined) |
+| Paths                   | `addPaths`         | (via `overrides`)                    | (via `overrides.replace`)          | `removePaths`               |
+| Operations              |                    | (via additive op fields / iterators) | `overrides.operations.<m>.replace` | (via `removePaths`)         |
+| Parameters (per op)     | `upsertParameters` |                                      | `upsertParameters`                 | `removeParameters`          |
+| Request body (per op)   |                    |                                      | `requestBody`                      |                             |
+| Responses (per op)      | `responses`        | `patchResponses`                     | `responses`                        | `removeResponses`           |
+| Component schemas       |                    | `extendSchemas`                      | `replaceSchemas`                   | `removeSchemas`             |
+| Component buckets       |                    | `extend<Bucket>`                     | `replace<Bucket>`                  | `remove<Bucket>`            |
+
+The component bucket trio fans out across `parameters`, `responses`,
+`requestBodies`, `headers`, `securitySchemes`, `links`, `callbacks`,
+and `examples`. The schemas variant wraps in `allOf`; the others
+shallow-merge.
 
 ## Applying an overlay
 
@@ -73,19 +89,44 @@ document is deep-cloned; the input is never mutated.
 
 ## Shape
 
+The full surface lives on the `SpecOverlay`, `PathOverride`,
+`OperationOverride`, `ResponseOverride`, `ModifyOperationsEntry`, and
+`ModifyParametersEntry` types in `@aahoughton/oav/spec`. The roadmap
+TSDoc on each interface lists every field with semantics. The
+snippets below cover the common shapes; see the types for the full
+list.
+
 ```ts
 interface SpecOverlay {
+  // document metadata
+  info?: Partial<InfoObject>;
+  servers?: ServerObject[];
+  addServers?: ServerObject[];
+  tags?: TagObject[];
+  extendTags?: TagObject[];
+  replaceTags?: TagObject[];
+  removeTags?: string[];
+  security?: SecurityRequirementObject[];
+  addSecurity?: SecurityRequirementObject[];
+  addWebhooks?: Record<string, PathItem>;
+  removeWebhooks?: string[];
+  setExtensions?: Record<`x-${string}`, JsonValue | undefined>;
+
+  // paths
   addPaths?: Record<string, PathItem>;
   removePaths?: string[];
   overrides?: Record<string, PathOverride>;
+
+  // structured iterators (predicate-driven)
+  modifyOperations?: ModifyOperationsEntry[];
+  modifyParameters?: ModifyParametersEntry[];
+
+  // component buckets (schemas use allOf-extend; others shallow-merge)
   extendSchemas?: Record<string, SchemaObject>;
   replaceSchemas?: Record<string, SchemaObject>;
   removeSchemas?: string[];
-}
-
-interface PathOverride {
-  operations?: Partial<Record<HttpMethod, OperationOverride>>;
-  pathItem?: Partial<PathItem>;
+  // ...and the same trio for parameters / responses / requestBodies /
+  // headers / securitySchemes / links / callbacks / examples.
 }
 
 interface OperationOverride {
@@ -94,7 +135,18 @@ interface OperationOverride {
   removeParameters?: Array<{ name: string; in: ParameterLocation }>;
   requestBody?: RequestBodyObject;
   responses?: Record<string, ResponseObject>;
+  patchResponses?: Record<string, ResponseOverride>;
   removeResponses?: string[];
+  tags?: string[];
+  addTags?: string[];
+  removeTags?: string[];
+  security?: SecurityRequirementObject[];
+  addSecurity?: SecurityRequirementObject[];
+  removeSecurity?: SecurityRequirementObject[];
+  servers?: ServerObject[];
+  callbacks?: Record<string, CallbackObject | ReferenceObject>;
+  externalDocs?: ExternalDocumentationObject;
+  setExtensions?: Record<`x-${string}`, JsonValue | undefined>;
 }
 ```
 
@@ -165,6 +217,87 @@ starting fresh.
 Runnable demo:
 [`examples/overlay-petstore-endpoint.ts`](../examples/overlay-petstore-endpoint.ts).
 Adds a gateway-required `X-Tenant` header to `POST /pets`.
+
+## Recipes
+
+### Add a server entry
+
+```ts
+const overlay: SpecOverlay = {
+  addServers: [{ url: "https://eu.api.example.com", description: "EU region" }],
+};
+```
+
+`addServers` appends to the existing `servers` array. To replace the
+whole list (e.g. when the upstream-declared dev server doesn't apply
+in production), use `servers` instead.
+
+### Add an operation-level security requirement
+
+```ts
+const overlay: SpecOverlay = {
+  overrides: {
+    "/pets": {
+      operations: {
+        post: { addSecurity: [{ apiKey: [] }] },
+      },
+    },
+  },
+};
+```
+
+The new requirement appends to the operation's existing `security`
+array (OR semantics across requirements). To wipe out the existing
+list first, use `security: [...]` on the operation override; cannot
+be combined with the `add*` / `remove*` variants in the same
+override.
+
+### Modify every operation matching a tag
+
+```ts
+const overlay: SpecOverlay = {
+  modifyOperations: [
+    {
+      where: { tags: ["internal"] },
+      apply: {
+        addSecurity: [{ internalKey: [] }],
+        setExtensions: { "x-internal-only": true },
+      },
+    },
+  ],
+};
+```
+
+`modifyOperations` walks every operation under `paths` and
+`webhooks`, runs the predicate, and applies the override to matches.
+`where` fields combine with AND semantics: `where: { tags: ["x"],
+methods: ["get"] }` matches GET operations tagged `x`. Omit `where`
+to match every operation.
+
+### Extend a component schema
+
+```ts
+const overlay: SpecOverlay = {
+  extendSchemas: {
+    Pet: { required: ["id"] },
+  },
+};
+```
+
+`extendSchemas` wraps the upstream `Pet` schema as
+`allOf: [<upstream>, { required: ["id"] }]`. The original definition
+still applies; the override piles additional constraints on top.
+
+For non-schema component buckets (parameters, responses, headers,
+etc.), the parallel `extend<Bucket>` verb shallow-merges instead:
+
+```ts
+const overlay: SpecOverlay = {
+  extendParameters: {
+    TraceId: { description: "request trace id", required: true },
+  },
+};
+```
 
 ## Things to know
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -63,14 +63,18 @@ export {
 } from "./version.js";
 
 export type {
+  CallbackObject,
   ComponentsObject,
   DiscriminatorObject,
+  ExampleObject,
+  ExternalDocumentationObject,
   HeaderObject,
   HttpMethod,
   HttpRequest,
   HttpResponse,
   InfoObject,
   JsonValue,
+  LinkObject,
   MediaTypeObject,
   OpenAPIDocument,
   OperationObject,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -249,17 +249,70 @@ export interface TagObject {
 }
 
 /**
+ * OpenAPI `externalDocumentationObject`.
+ *
+ * @public
+ */
+export interface ExternalDocumentationObject {
+  url: string;
+  description?: string;
+}
+
+/**
+ * OpenAPI `exampleObject`. Either `value` or `externalValue` carries
+ * the example data; `summary` / `description` are metadata. Not
+ * validated by oav today.
+ *
+ * @public
+ */
+export interface ExampleObject {
+  summary?: string;
+  description?: string;
+  value?: JsonValue;
+  externalValue?: string;
+}
+
+/**
+ * OpenAPI `linkObject`. The runtime payload (`parameters`, `requestBody`)
+ * uses runtime-expression syntax that oav does not evaluate today, so
+ * those slots are typed loosely.
+ *
+ * @public
+ */
+export interface LinkObject {
+  operationRef?: string;
+  operationId?: string;
+  parameters?: Record<string, JsonValue | undefined>;
+  requestBody?: JsonValue;
+  description?: string;
+  server?: ServerObject;
+}
+
+/**
+ * OpenAPI `callbackObject`: a map of runtime-expression strings to the
+ * {@link PathItem} that should be invoked when the expression evaluates.
+ * The expression dialect is documented in the OAS spec; oav does not
+ * evaluate it.
+ *
+ * @public
+ */
+export type CallbackObject = Record<string, PathItem | ReferenceObject>;
+
+/**
  * OpenAPI reusable `components` container.
  *
  * @public
  */
 export interface ComponentsObject {
   schemas?: Record<string, SchemaOrBoolean>;
-  parameters?: Record<string, ParameterObject>;
-  requestBodies?: Record<string, RequestBodyObject>;
-  responses?: Record<string, ResponseObject>;
-  headers?: Record<string, HeaderObject>;
+  parameters?: Record<string, ParameterObject | ReferenceObject>;
+  requestBodies?: Record<string, RequestBodyObject | ReferenceObject>;
+  responses?: Record<string, ResponseObject | ReferenceObject>;
+  headers?: Record<string, HeaderObject | ReferenceObject>;
   securitySchemes?: Record<string, SecuritySchemeObject | ReferenceObject>;
+  links?: Record<string, LinkObject | ReferenceObject>;
+  callbacks?: Record<string, CallbackObject | ReferenceObject>;
+  examples?: Record<string, ExampleObject | ReferenceObject>;
 }
 
 /**
@@ -324,6 +377,12 @@ export interface OperationObject {
    * {@link SecurityRequirementObject}.
    */
   security?: SecurityRequirementObject[];
+  /** Per-operation server overrides. Overrides the document-level servers. */
+  servers?: ServerObject[];
+  /** Per-operation callbacks, keyed by callback name. */
+  callbacks?: Record<string, CallbackObject | ReferenceObject>;
+  /** Additional external documentation. */
+  externalDocs?: ExternalDocumentationObject;
   deprecated?: boolean;
 }
 

--- a/packages/spec/src/overlay.ts
+++ b/packages/spec/src/overlay.ts
@@ -1,13 +1,27 @@
 import type {
+  CallbackObject,
+  ComponentsObject,
+  ExampleObject,
+  ExternalDocumentationObject,
+  HeaderObject,
   HttpMethod,
+  InfoObject,
+  JsonValue,
+  LinkObject,
+  MediaTypeObject,
   OpenAPIDocument,
   OperationObject,
   ParameterLocation,
   ParameterObject,
   PathItem,
+  ReferenceObject,
   RequestBodyObject,
   ResponseObject,
   SchemaObject,
+  SecurityRequirementObject,
+  SecuritySchemeObject,
+  ServerObject,
+  TagObject,
 } from "@oav/core";
 
 /**
@@ -23,13 +37,57 @@ export interface PathOverride {
 }
 
 /**
+ * Recipe for patching a single {@link ResponseObject} inside an
+ * operation. Used by {@link OperationOverride.patchResponses} to modify
+ * a response in place rather than replace the whole thing (the
+ * coarse-grained replacement lives on {@link OperationOverride.responses}).
+ *
+ * @public
+ */
+export interface ResponseOverride {
+  /**
+   * Shallow-merge into the response's `headers` map, keyed by header
+   * name. Existing entries with the same key are overwritten.
+   */
+  headers?: Record<string, HeaderObject | ReferenceObject>;
+  /**
+   * Patch the response's `content` map, keyed by media type. When the
+   * media type exists in the base, the override and base are
+   * shallow-merged. When both supply a `schema`, the override schema
+   * is wrapped as `allOf: [existing, override]` (mirrors
+   * {@link SpecOverlay.extendSchemas}); when only the override supplies
+   * one, it's applied as-is.
+   */
+  content?: Record<string, MediaTypeObject>;
+}
+
+/**
  * Recipe for patching a single {@link OperationObject}. Each field is
- * independent; use any subset. Supported verbs across the patchable
- * slots are summarised below.
+ * independent; use any subset. Field groups, in the order they apply:
+ *
+ * - {@link OperationOverride.replace | replace}: wholesale swap; mutually
+ *   exclusive with every other field on this interface.
+ * - Parameters: {@link OperationOverride.upsertParameters | upsertParameters},
+ *   {@link OperationOverride.removeParameters | removeParameters}.
+ * - Body: {@link OperationOverride.requestBody | requestBody}.
+ * - Responses: {@link OperationOverride.responses | responses} (per-status
+ *   replace), {@link OperationOverride.patchResponses | patchResponses}
+ *   (per-status patch), {@link OperationOverride.removeResponses | removeResponses}.
+ * - Tags: {@link OperationOverride.tags | tags} (replace),
+ *   {@link OperationOverride.addTags | addTags},
+ *   {@link OperationOverride.removeTags | removeTags}.
+ * - Security: {@link OperationOverride.security | security} (replace),
+ *   {@link OperationOverride.addSecurity | addSecurity},
+ *   {@link OperationOverride.removeSecurity | removeSecurity}.
+ * - Metadata: {@link OperationOverride.servers | servers},
+ *   {@link OperationOverride.callbacks | callbacks},
+ *   {@link OperationOverride.externalDocs | externalDocs},
+ *   {@link OperationOverride.setExtensions | setExtensions}.
  *
  * Conflict rules applied by {@link applyOverlays}:
- * - `replace` is wholesale and cannot be combined with the additive /
- *   removal fields below. Setting both throws at apply time.
+ * - `replace` is wholesale and cannot be combined with any other field.
+ * - Within tags / security, the replace field cannot coexist with the
+ *   matching add / remove additives.
  * - `removeParameters` / `removeResponses` silently no-op when the
  *   target isn't present; wildcard overrides (`"*"`) fan out to many
  *   operations and can't assume every target has the same surface.
@@ -37,7 +95,7 @@ export interface PathOverride {
  * @public
  */
 export interface OperationOverride {
-  /** Replace the whole OperationObject. Mutually exclusive with the additive / remove fields. */
+  /** Replace the whole OperationObject. Mutually exclusive with every other field. */
   replace?: OperationObject;
   /**
    * Add-or-replace parameters by (`name`, `in`). Existing entries with
@@ -53,32 +111,264 @@ export interface OperationOverride {
   requestBody?: RequestBodyObject;
   /** Merge-by-status-code into responses. Status codes present in both base and override take the override. */
   responses?: Record<string, ResponseObject>;
+  /**
+   * Per-status response patches. Unlike {@link OperationOverride.responses}
+   * which replaces a whole response by status code, `patchResponses`
+   * modifies the existing response (headers / content) in place. Throws
+   * if the target status code isn't present on the operation.
+   */
+  patchResponses?: Record<string, ResponseOverride>;
   /** Remove response status codes. Silent no-op on missing entries. */
   removeResponses?: string[];
+  /** Replace the operation's tags wholesale. Cannot combine with `addTags` / `removeTags`. */
+  tags?: string[];
+  /** Append tag names. Duplicates against existing tags are dropped. */
+  addTags?: string[];
+  /** Remove tag names. Silent no-op on missing entries. */
+  removeTags?: string[];
+  /** Replace the operation's security requirement wholesale. Cannot combine with the additives. */
+  security?: SecurityRequirementObject[];
+  /** Append security requirements. */
+  addSecurity?: SecurityRequirementObject[];
+  /**
+   * Remove security requirements that deep-equal one of the listed
+   * entries. Silent no-op on missing entries (operations rarely list
+   * the same requirement twice).
+   */
+  removeSecurity?: SecurityRequirementObject[];
+  /** Replace the operation's `servers` list wholesale. */
+  servers?: ServerObject[];
+  /**
+   * Add or replace callbacks by key. Existing callback names are
+   * overwritten with the override's value.
+   */
+  callbacks?: Record<string, CallbackObject | ReferenceObject>;
+  /** Set the operation's `externalDocs`. Replaces any existing value. */
+  externalDocs?: ExternalDocumentationObject;
+  /**
+   * Set or remove `x-*` extension fields on the operation. A `undefined`
+   * value deletes the field; any other value sets / replaces it.
+   */
+  setExtensions?: Record<`x-${string}`, JsonValue | undefined>;
+}
+
+/**
+ * Predicate filter used by {@link SpecOverlay.modifyOperations}. All
+ * present fields must match (AND); an undefined `where` matches every
+ * operation under `paths` and `webhooks`.
+ *
+ * @public
+ */
+export interface OperationWhere {
+  /** Match operations whose `tags` array contains any of these. */
+  tags?: string[];
+  /** Restrict by HTTP method. */
+  methods?: HttpMethod[];
+  /** Restrict by path; tested against the path string with `RegExp.test`. */
+  pathPattern?: RegExp;
+}
+
+/**
+ * One entry in {@link SpecOverlay.modifyOperations}.
+ *
+ * @public
+ */
+export interface ModifyOperationsEntry {
+  where?: OperationWhere;
+  apply: OperationOverride;
+}
+
+/**
+ * Predicate filter used by {@link SpecOverlay.modifyParameters}.
+ *
+ * @public
+ */
+export interface ParameterWhere {
+  /** Restrict by parameter location. */
+  in?: ParameterLocation;
+  /** Match the parameter `name` with `RegExp.test`. */
+  nameMatches?: RegExp;
+}
+
+/**
+ * One entry in {@link SpecOverlay.modifyParameters}. The `apply`
+ * fragment is shallow-merged into each matching parameter; passing
+ * `undefined` does not delete a field (use a different overlay verb
+ * for deletion).
+ *
+ * @public
+ */
+export interface ModifyParametersEntry {
+  where?: ParameterWhere;
+  apply: Partial<ParameterObject>;
 }
 
 /**
  * A spec overlay: instructions to patch the base OpenAPI document.
  * Overlays apply in order; later overlays win on conflict.
  *
+ * Field groups, applied in this order within a single overlay:
+ *
+ * - Document metadata: {@link SpecOverlay.info | info},
+ *   {@link SpecOverlay.servers | servers} (replace) /
+ *   {@link SpecOverlay.addServers | addServers},
+ *   {@link SpecOverlay.tags | tags} (replace) /
+ *   {@link SpecOverlay.extendTags | extendTags} /
+ *   {@link SpecOverlay.replaceTags | replaceTags} /
+ *   {@link SpecOverlay.removeTags | removeTags},
+ *   {@link SpecOverlay.security | security} (replace) /
+ *   {@link SpecOverlay.addSecurity | addSecurity},
+ *   {@link SpecOverlay.setExtensions | setExtensions}.
+ * - Paths: {@link SpecOverlay.addPaths | addPaths} /
+ *   {@link SpecOverlay.removePaths | removePaths} /
+ *   {@link SpecOverlay.overrides | overrides}.
+ * - Webhooks: {@link SpecOverlay.addWebhooks | addWebhooks} /
+ *   {@link SpecOverlay.removeWebhooks | removeWebhooks}.
+ * - Iterators: {@link SpecOverlay.modifyOperations | modifyOperations} /
+ *   {@link SpecOverlay.modifyParameters | modifyParameters} run after
+ *   the path / webhook edits above have settled.
+ * - Components: schemas, parameters, requestBodies, responses, headers,
+ *   securitySchemes, links, callbacks, examples each get
+ *   `extend<Bucket>` / `replace<Bucket>` / `remove<Bucket>` verbs. The
+ *   `extendSchemas` verb wraps in `allOf`; the other extend verbs
+ *   shallow-merge.
+ *
  * @public
  */
 export interface SpecOverlay {
+  /** Shallow-merge into the document's `info` object. */
+  info?: Partial<InfoObject>;
+  /** Replace the document's `servers` array wholesale. Cannot combine with `addServers`. */
+  servers?: ServerObject[];
+  /** Append to the document's `servers` array. */
+  addServers?: ServerObject[];
+  /** Replace the document's `tags` array wholesale. Cannot combine with the per-name tag verbs. */
+  tags?: TagObject[];
+  /**
+   * Merge or insert tags by name. For an existing tag of the same name,
+   * the entry is shallow-merged (override fields win). Tags absent from
+   * the base are appended.
+   */
+  extendTags?: TagObject[];
+  /** Replace tags by name. Tags absent from the base are appended. */
+  replaceTags?: TagObject[];
+  /** Remove tags by name. Throws if any name isn't present in the base. */
+  removeTags?: string[];
+  /**
+   * Replace the document-level security requirement wholesale. Cannot
+   * combine with `addSecurity`. Note that the OAS-defined "empty array
+   * means anonymous" semantics are preserved: setting this to `[]`
+   * removes the requirement.
+   */
+  security?: SecurityRequirementObject[];
+  /** Append security requirements to the document's `security` array. */
+  addSecurity?: SecurityRequirementObject[];
+  /** Add webhook paths. Throws if a target name already exists. */
+  addWebhooks?: Record<string, PathItem>;
+  /** Remove webhook paths by name. Throws if a target name isn't present. */
+  removeWebhooks?: string[];
+  /**
+   * Set or remove document-level `x-*` extension fields. A value of
+   * `undefined` deletes the field; any other value sets / replaces it.
+   */
+  setExtensions?: Record<`x-${string}`, JsonValue | undefined>;
+
   /** Add new paths. Throws if a target path already exists in the base document. */
   addPaths?: Record<string, PathItem>;
   /** Remove paths. Throws if a target path isn't present in the base document. */
   removePaths?: string[];
   /** Per-path modifications; see {@link PathOverride}. */
   overrides?: Record<string, PathOverride>;
+
+  /**
+   * Walk every operation under `paths` (and `webhooks` when present),
+   * run the {@link ModifyOperationsEntry.where} predicate, and apply
+   * the override on matches. Entries run in declaration order.
+   */
+  modifyOperations?: ModifyOperationsEntry[];
+  /**
+   * Walk every operation's parameters (and each path-item-level
+   * parameters list) and apply the patch on matches. Reference-object
+   * parameters are skipped (their name / location aren't inspectable
+   * without resolution).
+   */
+  modifyParameters?: ModifyParametersEntry[];
+
   /** Extend a component schema via `allOf` (original + extension both apply). */
   extendSchemas?: Record<string, SchemaObject>;
   /** Replace a component schema wholesale. */
   replaceSchemas?: Record<string, SchemaObject>;
   /** Remove component schemas. Throws if a target schema isn't present. */
   removeSchemas?: string[];
+
+  /** Shallow-merge into existing `components.parameters` entries; new keys append. */
+  extendParameters?: Record<string, ParameterObject | ReferenceObject>;
+  /** Replace `components.parameters` entries by name. New keys append. */
+  replaceParameters?: Record<string, ParameterObject | ReferenceObject>;
+  /** Remove `components.parameters` entries by name. Throws on missing. */
+  removeComponentParameters?: string[];
+
+  /** Shallow-merge into existing `components.responses` entries; new keys append. */
+  extendComponentResponses?: Record<string, ResponseObject | ReferenceObject>;
+  /** Replace `components.responses` entries by name. New keys append. */
+  replaceComponentResponses?: Record<string, ResponseObject | ReferenceObject>;
+  /** Remove `components.responses` entries by name. Throws on missing. */
+  removeComponentResponses?: string[];
+
+  /** Shallow-merge into existing `components.requestBodies` entries; new keys append. */
+  extendRequestBodies?: Record<string, RequestBodyObject | ReferenceObject>;
+  /** Replace `components.requestBodies` entries by name. New keys append. */
+  replaceRequestBodies?: Record<string, RequestBodyObject | ReferenceObject>;
+  /** Remove `components.requestBodies` entries by name. Throws on missing. */
+  removeRequestBodies?: string[];
+
+  /** Shallow-merge into existing `components.headers` entries; new keys append. */
+  extendHeaders?: Record<string, HeaderObject | ReferenceObject>;
+  /** Replace `components.headers` entries by name. New keys append. */
+  replaceHeaders?: Record<string, HeaderObject | ReferenceObject>;
+  /** Remove `components.headers` entries by name. Throws on missing. */
+  removeHeaders?: string[];
+
+  /** Shallow-merge into existing `components.securitySchemes` entries; new keys append. */
+  extendSecuritySchemes?: Record<string, SecuritySchemeObject | ReferenceObject>;
+  /** Replace `components.securitySchemes` entries by name. New keys append. */
+  replaceSecuritySchemes?: Record<string, SecuritySchemeObject | ReferenceObject>;
+  /** Remove `components.securitySchemes` entries by name. Throws on missing. */
+  removeSecuritySchemes?: string[];
+
+  /** Shallow-merge into existing `components.links` entries; new keys append. */
+  extendLinks?: Record<string, LinkObject | ReferenceObject>;
+  /** Replace `components.links` entries by name. New keys append. */
+  replaceLinks?: Record<string, LinkObject | ReferenceObject>;
+  /** Remove `components.links` entries by name. Throws on missing. */
+  removeLinks?: string[];
+
+  /** Shallow-merge into existing `components.callbacks` entries; new keys append. */
+  extendCallbacks?: Record<string, CallbackObject | ReferenceObject>;
+  /** Replace `components.callbacks` entries by name. New keys append. */
+  replaceCallbacks?: Record<string, CallbackObject | ReferenceObject>;
+  /** Remove `components.callbacks` entries by name. Throws on missing. */
+  removeCallbacks?: string[];
+
+  /** Shallow-merge into existing `components.examples` entries; new keys append. */
+  extendExamples?: Record<string, ExampleObject | ReferenceObject>;
+  /** Replace `components.examples` entries by name. New keys append. */
+  replaceExamples?: Record<string, ExampleObject | ReferenceObject>;
+  /** Remove `components.examples` entries by name. Throws on missing. */
+  removeExamples?: string[];
 }
 
-const METHODS: HttpMethod[] = ["get", "put", "post", "delete", "options", "head", "patch", "trace"];
+const METHODS: HttpMethod[] = [
+  "get",
+  "put",
+  "post",
+  "delete",
+  "options",
+  "head",
+  "patch",
+  "trace",
+  "query",
+];
 
 /**
  * Apply a sequence of overlays to a base OpenAPI document, returning a new
@@ -104,9 +394,85 @@ export function applyOverlays(base: OpenAPIDocument, overlays: SpecOverlay[]): O
 
 function applyOverlay(doc: OpenAPIDocument, overlay: SpecOverlay): OpenAPIDocument {
   assertNoSelfConflict(overlay);
+  let next: OpenAPIDocument = { ...doc };
+
+  next = applyDocumentMetadata(next, overlay);
+  next = applyDocumentPaths(next, overlay);
+  next = applyDocumentWebhooks(next, overlay);
+  next = applyDocumentIterators(next, overlay);
+  next = applyComponents(next, overlay);
+
+  return next;
+}
+
+function applyDocumentMetadata(doc: OpenAPIDocument, overlay: SpecOverlay): OpenAPIDocument {
+  const next: OpenAPIDocument = { ...doc };
+
+  if (overlay.info) {
+    next.info = { ...doc.info, ...overlay.info };
+  }
+
+  if (overlay.servers !== undefined) {
+    next.servers = [...overlay.servers];
+  }
+  if (overlay.addServers) {
+    next.servers = [...(next.servers ?? []), ...overlay.addServers];
+  }
+
+  if (overlay.tags !== undefined) {
+    next.tags = [...overlay.tags];
+  }
+  if (overlay.extendTags || overlay.replaceTags || overlay.removeTags) {
+    next.tags = applyTagOps(next.tags ?? [], overlay);
+  }
+
+  if (overlay.security !== undefined) {
+    next.security = [...overlay.security];
+  }
+  if (overlay.addSecurity) {
+    next.security = [...(next.security ?? []), ...overlay.addSecurity];
+  }
+
+  if (overlay.setExtensions) {
+    for (const [key, value] of Object.entries(overlay.setExtensions) as Array<
+      [`x-${string}`, JsonValue | undefined]
+    >) {
+      if (value === undefined) {
+        delete next[key];
+      } else {
+        next[key] = value;
+      }
+    }
+  }
+
+  return next;
+}
+
+function applyTagOps(tags: TagObject[], overlay: SpecOverlay): TagObject[] {
+  const byName = new Map(tags.map((t) => [t.name, t]));
+
+  for (const entry of overlay.extendTags ?? []) {
+    const existing = byName.get(entry.name);
+    byName.set(entry.name, existing ? { ...existing, ...entry } : entry);
+  }
+  for (const entry of overlay.replaceTags ?? []) {
+    byName.set(entry.name, entry);
+  }
+  for (const name of overlay.removeTags ?? []) {
+    if (!byName.has(name)) {
+      throw new Error(`overlay removeTags targets unknown tag ${name}`);
+    }
+    byName.delete(name);
+  }
+
+  return Array.from(byName.values());
+}
+
+function applyDocumentPaths(doc: OpenAPIDocument, overlay: SpecOverlay): OpenAPIDocument {
+  if (!overlay.addPaths && !overlay.removePaths && !overlay.overrides) return doc;
+
   const next: OpenAPIDocument = { ...doc };
   const paths: Record<string, PathItem> = { ...next.paths };
-  let pathsChanged = false;
 
   if (overlay.addPaths) {
     for (const [path, item] of Object.entries(overlay.addPaths)) {
@@ -114,7 +480,6 @@ function applyOverlay(doc: OpenAPIDocument, overlay: SpecOverlay): OpenAPIDocume
         throw new Error(`overlay conflict: path ${path} already exists in the base document`);
       }
       paths[path] = item;
-      pathsChanged = true;
     }
   }
 
@@ -124,7 +489,6 @@ function applyOverlay(doc: OpenAPIDocument, overlay: SpecOverlay): OpenAPIDocume
         throw new Error(`overlay removePaths targets unknown path ${path}`);
       }
       delete paths[path];
-      pathsChanged = true;
     }
   }
 
@@ -137,39 +501,299 @@ function applyOverlay(doc: OpenAPIDocument, overlay: SpecOverlay): OpenAPIDocume
           throw new Error(`overlay override targets unknown path ${path}`);
         }
         paths[path] = applyPathOverride(item, override);
-        pathsChanged = true;
       }
     }
   }
 
-  if (pathsChanged) next.paths = paths;
+  next.paths = paths;
+  return next;
+}
 
-  if (overlay.extendSchemas || overlay.replaceSchemas || overlay.removeSchemas) {
-    const components = { ...next.components };
-    const schemas: Record<string, SchemaObject> = {
-      ...((components.schemas ?? {}) as Record<string, SchemaObject>),
+function applyDocumentWebhooks(doc: OpenAPIDocument, overlay: SpecOverlay): OpenAPIDocument {
+  if (!overlay.addWebhooks && !overlay.removeWebhooks) return doc;
+
+  const next: OpenAPIDocument = { ...doc };
+  const webhooks: Record<string, PathItem | ReferenceObject> = { ...next.webhooks };
+
+  if (overlay.addWebhooks) {
+    for (const [name, item] of Object.entries(overlay.addWebhooks)) {
+      if (webhooks[name] !== undefined) {
+        throw new Error(`overlay conflict: webhook ${name} already exists in the base document`);
+      }
+      webhooks[name] = item;
+    }
+  }
+
+  if (overlay.removeWebhooks) {
+    for (const name of overlay.removeWebhooks) {
+      if (webhooks[name] === undefined) {
+        throw new Error(`overlay removeWebhooks targets unknown webhook ${name}`);
+      }
+      delete webhooks[name];
+    }
+  }
+
+  next.webhooks = webhooks;
+  return next;
+}
+
+function applyDocumentIterators(doc: OpenAPIDocument, overlay: SpecOverlay): OpenAPIDocument {
+  if (!overlay.modifyOperations && !overlay.modifyParameters) return doc;
+
+  let next: OpenAPIDocument = { ...doc };
+  if (overlay.modifyOperations) {
+    for (const entry of overlay.modifyOperations) {
+      next = applyModifyOperations(next, entry);
+    }
+  }
+  if (overlay.modifyParameters) {
+    for (const entry of overlay.modifyParameters) {
+      next = applyModifyParameters(next, entry);
+    }
+  }
+  return next;
+}
+
+function applyModifyOperations(
+  doc: OpenAPIDocument,
+  entry: ModifyOperationsEntry,
+): OpenAPIDocument {
+  const next: OpenAPIDocument = { ...doc };
+  if (doc.paths) {
+    next.paths = walkPathsForModify(doc.paths, entry);
+  }
+  if (doc.webhooks) {
+    next.webhooks = walkWebhooksForModify(doc.webhooks, entry);
+  }
+  return next;
+}
+
+function walkPathsForModify(
+  paths: Record<string, PathItem>,
+  entry: ModifyOperationsEntry,
+): Record<string, PathItem> {
+  const out: Record<string, PathItem> = {};
+  for (const [path, item] of Object.entries(paths)) {
+    out[path] = applyOpModifyToPathItem(path, item, entry);
+  }
+  return out;
+}
+
+function walkWebhooksForModify(
+  webhooks: Record<string, PathItem | ReferenceObject>,
+  entry: ModifyOperationsEntry,
+): Record<string, PathItem | ReferenceObject> {
+  const out: Record<string, PathItem | ReferenceObject> = {};
+  for (const [name, item] of Object.entries(webhooks)) {
+    if ("$ref" in item) {
+      out[name] = item;
+      continue;
+    }
+    out[name] = applyOpModifyToPathItem(name, item, entry);
+  }
+  return out;
+}
+
+function applyOpModifyToPathItem(
+  pathOrName: string,
+  item: PathItem,
+  entry: ModifyOperationsEntry,
+): PathItem {
+  if (entry.where?.pathPattern && !entry.where.pathPattern.test(pathOrName)) {
+    return item;
+  }
+  const next: PathItem = { ...item };
+  let changed = false;
+  for (const method of METHODS) {
+    const op = next[method];
+    if (op === undefined) continue;
+    if (entry.where?.methods && !entry.where.methods.includes(method)) continue;
+    if (entry.where?.tags && !operationHasAnyTag(op, entry.where.tags)) continue;
+    next[method] = applyOperationOverride(op, entry.apply);
+    changed = true;
+  }
+  return changed ? next : item;
+}
+
+function operationHasAnyTag(op: OperationObject, tags: string[]): boolean {
+  if (!op.tags) return false;
+  return op.tags.some((t) => tags.includes(t));
+}
+
+function applyModifyParameters(
+  doc: OpenAPIDocument,
+  entry: ModifyParametersEntry,
+): OpenAPIDocument {
+  const next: OpenAPIDocument = { ...doc };
+  if (doc.paths) {
+    const paths: Record<string, PathItem> = {};
+    for (const [path, item] of Object.entries(doc.paths)) {
+      paths[path] = applyParamModifyToPathItem(item, entry);
+    }
+    next.paths = paths;
+  }
+  if (doc.webhooks) {
+    const webhooks: Record<string, PathItem | ReferenceObject> = {};
+    for (const [name, item] of Object.entries(doc.webhooks)) {
+      if ("$ref" in item) {
+        webhooks[name] = item;
+        continue;
+      }
+      webhooks[name] = applyParamModifyToPathItem(item, entry);
+    }
+    next.webhooks = webhooks;
+  }
+  return next;
+}
+
+function applyParamModifyToPathItem(item: PathItem, entry: ModifyParametersEntry): PathItem {
+  const next: PathItem = { ...item };
+  if (item.parameters) {
+    next.parameters = item.parameters.map((p) => mergeParamIfMatch(p, entry));
+  }
+  for (const method of METHODS) {
+    const op = next[method];
+    if (op === undefined) continue;
+    if (op.parameters) {
+      next[method] = {
+        ...op,
+        parameters: op.parameters.map((p) => mergeParamIfMatch(p, entry)),
+      };
+    }
+  }
+  return next;
+}
+
+function mergeParamIfMatch(
+  param: ParameterObject | ReferenceObject,
+  entry: ModifyParametersEntry,
+): ParameterObject | ReferenceObject {
+  if (!("name" in param)) return param;
+  if (entry.where?.in && param.in !== entry.where.in) return param;
+  if (entry.where?.nameMatches && !entry.where.nameMatches.test(param.name)) return param;
+  return { ...param, ...entry.apply };
+}
+
+interface ComponentBucketVerbs<T> {
+  bucket: keyof ComponentsObject;
+  extend?: Record<string, T>;
+  replace?: Record<string, T>;
+  remove?: string[];
+  /** Label for error messages (e.g. "removeSchemas"). */
+  removeVerb: string;
+}
+
+function applyComponents(doc: OpenAPIDocument, overlay: SpecOverlay): OpenAPIDocument {
+  const buckets: ComponentBucketVerbs<unknown>[] = [
+    {
+      bucket: "schemas",
+      extend: overlay.extendSchemas,
+      replace: overlay.replaceSchemas,
+      remove: overlay.removeSchemas,
+      removeVerb: "removeSchemas",
+    },
+    {
+      bucket: "parameters",
+      extend: overlay.extendParameters,
+      replace: overlay.replaceParameters,
+      remove: overlay.removeComponentParameters,
+      removeVerb: "removeComponentParameters",
+    },
+    {
+      bucket: "responses",
+      extend: overlay.extendComponentResponses,
+      replace: overlay.replaceComponentResponses,
+      remove: overlay.removeComponentResponses,
+      removeVerb: "removeComponentResponses",
+    },
+    {
+      bucket: "requestBodies",
+      extend: overlay.extendRequestBodies,
+      replace: overlay.replaceRequestBodies,
+      remove: overlay.removeRequestBodies,
+      removeVerb: "removeRequestBodies",
+    },
+    {
+      bucket: "headers",
+      extend: overlay.extendHeaders,
+      replace: overlay.replaceHeaders,
+      remove: overlay.removeHeaders,
+      removeVerb: "removeHeaders",
+    },
+    {
+      bucket: "securitySchemes",
+      extend: overlay.extendSecuritySchemes,
+      replace: overlay.replaceSecuritySchemes,
+      remove: overlay.removeSecuritySchemes,
+      removeVerb: "removeSecuritySchemes",
+    },
+    {
+      bucket: "links",
+      extend: overlay.extendLinks,
+      replace: overlay.replaceLinks,
+      remove: overlay.removeLinks,
+      removeVerb: "removeLinks",
+    },
+    {
+      bucket: "callbacks",
+      extend: overlay.extendCallbacks,
+      replace: overlay.replaceCallbacks,
+      remove: overlay.removeCallbacks,
+      removeVerb: "removeCallbacks",
+    },
+    {
+      bucket: "examples",
+      extend: overlay.extendExamples,
+      replace: overlay.replaceExamples,
+      remove: overlay.removeExamples,
+      removeVerb: "removeExamples",
+    },
+  ];
+
+  const touched = buckets.some((b) => b.extend || b.replace || b.remove);
+  if (!touched) return doc;
+
+  const next: OpenAPIDocument = { ...doc };
+  const components: ComponentsObject = { ...next.components };
+
+  for (const b of buckets) {
+    if (!b.extend && !b.replace && !b.remove) continue;
+    const entries: Record<string, unknown> = {
+      ...(components[b.bucket] as Record<string, unknown> | undefined),
     };
-    for (const [name, extension] of Object.entries(overlay.extendSchemas ?? {})) {
-      const existing = schemas[name];
-      if (existing === undefined) {
-        schemas[name] = extension;
-      } else {
-        schemas[name] = { allOf: [existing, extension] };
+
+    if (b.bucket === "schemas") {
+      // Schemas use allOf-extend, not shallow-merge.
+      for (const [name, extension] of Object.entries(b.extend ?? {})) {
+        const existing = entries[name];
+        entries[name] = existing === undefined ? extension : { allOf: [existing, extension] };
+      }
+    } else {
+      for (const [name, extension] of Object.entries(b.extend ?? {})) {
+        const existing = entries[name];
+        if (existing === undefined || typeof existing !== "object") {
+          entries[name] = extension;
+        } else {
+          entries[name] = { ...(existing as object), ...(extension as object) };
+        }
       }
     }
-    for (const [name, replacement] of Object.entries(overlay.replaceSchemas ?? {})) {
-      schemas[name] = replacement;
+
+    for (const [name, replacement] of Object.entries(b.replace ?? {})) {
+      entries[name] = replacement;
     }
-    for (const name of overlay.removeSchemas ?? []) {
-      if (schemas[name] === undefined) {
-        throw new Error(`overlay removeSchemas targets unknown schema ${name}`);
+
+    for (const name of b.remove ?? []) {
+      if (!(name in entries)) {
+        throw new Error(`overlay ${b.removeVerb} targets unknown ${b.bucket} entry ${name}`);
       }
-      delete schemas[name];
+      delete entries[name];
     }
-    components.schemas = schemas;
-    next.components = components;
+
+    (components as Record<string, unknown>)[b.bucket] = entries;
   }
 
+  next.components = components;
   return next;
 }
 
@@ -187,22 +811,151 @@ function assertNoSelfConflict(overlay: SpecOverlay): void {
       }
     }
   }
-  if (overlay.replaceSchemas && overlay.removeSchemas) {
-    for (const name of overlay.removeSchemas) {
-      if (name in overlay.replaceSchemas) {
+  if (overlay.addWebhooks && overlay.removeWebhooks) {
+    for (const name of overlay.removeWebhooks) {
+      if (name in overlay.addWebhooks) {
+        throw new Error(`overlay self-conflict: addWebhooks and removeWebhooks both name ${name}`);
+      }
+    }
+  }
+
+  assertWholesaleVsAdditive(
+    overlay.servers !== undefined,
+    overlay.addServers !== undefined,
+    "servers",
+    "addServers",
+  );
+  assertWholesaleVsAdditive(
+    overlay.security !== undefined,
+    overlay.addSecurity !== undefined,
+    "security",
+    "addSecurity",
+  );
+
+  const tagsWholesale = overlay.tags !== undefined;
+  const tagsAdditives =
+    overlay.extendTags !== undefined ||
+    overlay.replaceTags !== undefined ||
+    overlay.removeTags !== undefined;
+  if (tagsWholesale && tagsAdditives) {
+    throw new Error(
+      "overlay self-conflict: tags (wholesale) cannot combine with extendTags / replaceTags / removeTags",
+    );
+  }
+  if (overlay.replaceTags && overlay.removeTags) {
+    const names = new Set(overlay.replaceTags.map((t) => t.name));
+    for (const n of overlay.removeTags) {
+      if (names.has(n)) {
+        throw new Error(`overlay self-conflict: replaceTags and removeTags both name ${n}`);
+      }
+    }
+  }
+  if (overlay.extendTags && overlay.removeTags) {
+    const names = new Set(overlay.extendTags.map((t) => t.name));
+    for (const n of overlay.removeTags) {
+      if (names.has(n)) {
+        throw new Error(`overlay self-conflict: extendTags and removeTags both name ${n}`);
+      }
+    }
+  }
+
+  assertBucketSelfConflicts(
+    "schemas",
+    overlay.extendSchemas,
+    overlay.replaceSchemas,
+    overlay.removeSchemas,
+  );
+  assertBucketSelfConflicts(
+    "parameters",
+    overlay.extendParameters,
+    overlay.replaceParameters,
+    overlay.removeComponentParameters,
+  );
+  assertBucketSelfConflicts(
+    "responses",
+    overlay.extendComponentResponses,
+    overlay.replaceComponentResponses,
+    overlay.removeComponentResponses,
+  );
+  assertBucketSelfConflicts(
+    "requestBodies",
+    overlay.extendRequestBodies,
+    overlay.replaceRequestBodies,
+    overlay.removeRequestBodies,
+  );
+  assertBucketSelfConflicts(
+    "headers",
+    overlay.extendHeaders,
+    overlay.replaceHeaders,
+    overlay.removeHeaders,
+  );
+  assertBucketSelfConflicts(
+    "securitySchemes",
+    overlay.extendSecuritySchemes,
+    overlay.replaceSecuritySchemes,
+    overlay.removeSecuritySchemes,
+  );
+  assertBucketSelfConflicts(
+    "links",
+    overlay.extendLinks,
+    overlay.replaceLinks,
+    overlay.removeLinks,
+  );
+  assertBucketSelfConflicts(
+    "callbacks",
+    overlay.extendCallbacks,
+    overlay.replaceCallbacks,
+    overlay.removeCallbacks,
+  );
+  assertBucketSelfConflicts(
+    "examples",
+    overlay.extendExamples,
+    overlay.replaceExamples,
+    overlay.removeExamples,
+  );
+}
+
+function assertWholesaleVsAdditive(
+  hasWholesale: boolean,
+  hasAdditive: boolean,
+  wholesaleName: string,
+  additiveName: string,
+): void {
+  if (hasWholesale && hasAdditive) {
+    throw new Error(
+      `overlay self-conflict: ${wholesaleName} (wholesale) cannot combine with ${additiveName}`,
+    );
+  }
+}
+
+function assertBucketSelfConflicts(
+  bucket: string,
+  extend: Record<string, unknown> | undefined,
+  replace: Record<string, unknown> | undefined,
+  remove: string[] | undefined,
+): void {
+  if (replace && remove) {
+    for (const n of remove) {
+      if (n in replace) {
         throw new Error(
-          `overlay self-conflict: replaceSchemas and removeSchemas both name ${name}`,
+          `overlay self-conflict: replace${capitalize(bucket)} and remove${capitalize(bucket)} both name ${n}`,
         );
       }
     }
   }
-  if (overlay.extendSchemas && overlay.removeSchemas) {
-    for (const name of overlay.removeSchemas) {
-      if (name in overlay.extendSchemas) {
-        throw new Error(`overlay self-conflict: extendSchemas and removeSchemas both name ${name}`);
+  if (extend && remove) {
+    for (const n of remove) {
+      if (n in extend) {
+        throw new Error(
+          `overlay self-conflict: extend${capitalize(bucket)} and remove${capitalize(bucket)} both name ${n}`,
+        );
       }
     }
   }
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
 function applyPathOverride(item: PathItem, override: PathOverride): PathItem {
@@ -224,15 +977,28 @@ function applyPathOverride(item: PathItem, override: PathOverride): PathItem {
   return next;
 }
 
+const OPERATION_OVERRIDE_ADDITIVE_KEYS = [
+  "upsertParameters",
+  "removeParameters",
+  "requestBody",
+  "responses",
+  "patchResponses",
+  "removeResponses",
+  "tags",
+  "addTags",
+  "removeTags",
+  "security",
+  "addSecurity",
+  "removeSecurity",
+  "servers",
+  "callbacks",
+  "externalDocs",
+  "setExtensions",
+] as const;
+
 function applyOperationOverride(op: OperationObject, override: OperationOverride): OperationObject {
   if (override.replace !== undefined) {
-    for (const key of [
-      "upsertParameters",
-      "removeParameters",
-      "requestBody",
-      "responses",
-      "removeResponses",
-    ] as const) {
+    for (const key of OPERATION_OVERRIDE_ADDITIVE_KEYS) {
       if (override[key] !== undefined) {
         throw new Error(
           `overlay conflict: OperationOverride.replace cannot be combined with ${key}`,
@@ -242,7 +1008,19 @@ function applyOperationOverride(op: OperationObject, override: OperationOverride
     return override.replace;
   }
 
+  if (override.tags !== undefined && (override.addTags || override.removeTags)) {
+    throw new Error(
+      "overlay conflict: OperationOverride.tags (wholesale) cannot combine with addTags / removeTags",
+    );
+  }
+  if (override.security !== undefined && (override.addSecurity || override.removeSecurity)) {
+    throw new Error(
+      "overlay conflict: OperationOverride.security (wholesale) cannot combine with addSecurity / removeSecurity",
+    );
+  }
+
   const next: OperationObject = { ...op };
+
   if (override.upsertParameters) {
     const existing = [...(op.parameters ?? [])];
     for (const newParam of override.upsertParameters) {
@@ -268,8 +1046,25 @@ function applyOperationOverride(op: OperationObject, override: OperationOverride
     if (filtered.length !== existing.length) next.parameters = filtered;
   }
   if (override.requestBody) next.requestBody = override.requestBody;
+
   if (override.responses) {
     next.responses = { ...op.responses, ...override.responses };
+  }
+  if (override.patchResponses) {
+    const responses = { ...(next.responses ?? op.responses) };
+    for (const [status, patch] of Object.entries(override.patchResponses)) {
+      const existing = responses[status];
+      if (existing === undefined) {
+        throw new Error(`overlay patchResponses targets unknown response status ${status}`);
+      }
+      if ("$ref" in existing) {
+        throw new Error(
+          `overlay patchResponses cannot patch reference-object response (status ${status})`,
+        );
+      }
+      responses[status] = applyResponseOverride(existing, patch);
+    }
+    next.responses = responses;
   }
   if (override.removeResponses) {
     const source = next.responses ?? op.responses ?? {};
@@ -283,5 +1078,96 @@ function applyOperationOverride(op: OperationObject, override: OperationOverride
     }
     if (removed) next.responses = copy;
   }
+
+  if (override.tags !== undefined) {
+    next.tags = [...override.tags];
+  } else if (override.addTags || override.removeTags) {
+    const existing = new Set(op.tags ?? []);
+    for (const t of override.addTags ?? []) existing.add(t);
+    for (const t of override.removeTags ?? []) existing.delete(t);
+    next.tags = Array.from(existing);
+  }
+
+  if (override.security !== undefined) {
+    next.security = [...override.security];
+  } else if (override.addSecurity || override.removeSecurity) {
+    let security = [...(op.security ?? [])];
+    if (override.addSecurity) security = [...security, ...override.addSecurity];
+    if (override.removeSecurity) {
+      security = security.filter(
+        (req) => !override.removeSecurity!.some((rm) => securityRequirementEquals(req, rm)),
+      );
+    }
+    next.security = security;
+  }
+
+  if (override.servers !== undefined) next.servers = [...override.servers];
+
+  if (override.callbacks) {
+    next.callbacks = { ...op.callbacks, ...override.callbacks };
+  }
+
+  if (override.externalDocs) next.externalDocs = override.externalDocs;
+
+  if (override.setExtensions) {
+    for (const [key, value] of Object.entries(override.setExtensions) as Array<
+      [`x-${string}`, JsonValue | undefined]
+    >) {
+      if (value === undefined) {
+        delete (next as Record<string, unknown>)[key];
+      } else {
+        (next as Record<string, unknown>)[key] = value;
+      }
+    }
+  }
+
   return next;
+}
+
+function applyResponseOverride(
+  response: ResponseObject,
+  override: ResponseOverride,
+): ResponseObject {
+  const next: ResponseObject = { ...response };
+  if (override.headers) {
+    next.headers = { ...response.headers, ...override.headers };
+  }
+  if (override.content) {
+    const content: Record<string, MediaTypeObject> = { ...response.content };
+    for (const [mediaType, patch] of Object.entries(override.content)) {
+      const existing = content[mediaType];
+      if (existing === undefined) {
+        content[mediaType] = patch;
+        continue;
+      }
+      const merged: MediaTypeObject = { ...existing, ...patch };
+      if (patch.schema !== undefined && existing.schema !== undefined) {
+        merged.schema = { allOf: [existing.schema, patch.schema] };
+      }
+      content[mediaType] = merged;
+    }
+    next.content = content;
+  }
+  return next;
+}
+
+function securityRequirementEquals(
+  a: SecurityRequirementObject,
+  b: SecurityRequirementObject,
+): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const k of aKeys) {
+    if (!(k in b)) return false;
+    const av = a[k] ?? [];
+    const bv = b[k] ?? [];
+    if (av.length !== bv.length) return false;
+    const aSorted = [...av].sort();
+    const bSorted = [...bv].sort();
+    for (let i = 0; i < aSorted.length; i++) {
+      if (aSorted[i] !== bSorted[i]) return false;
+    }
+  }
+  return true;
 }

--- a/packages/spec/src/overlay.ts
+++ b/packages/spec/src/overlay.ts
@@ -599,7 +599,7 @@ function applyOpModifyToPathItem(
   item: PathItem,
   entry: ModifyOperationsEntry,
 ): PathItem {
-  if (entry.where?.pathPattern && !entry.where.pathPattern.test(pathOrName)) {
+  if (entry.where?.pathPattern && !stablePatternTest(entry.where.pathPattern, pathOrName)) {
     return item;
   }
   const next: PathItem = { ...item };
@@ -670,8 +670,29 @@ function mergeParamIfMatch(
 ): ParameterObject | ReferenceObject {
   if (!("name" in param)) return param;
   if (entry.where?.in && param.in !== entry.where.in) return param;
-  if (entry.where?.nameMatches && !entry.where.nameMatches.test(param.name)) return param;
+  if (entry.where?.nameMatches && !stablePatternTest(entry.where.nameMatches, param.name)) {
+    return param;
+  }
   return { ...param, ...entry.apply };
+}
+
+/**
+ * `RegExp.test()` advances `lastIndex` on /…/g and /…/y inputs. Reusing
+ * the same pattern across multiple iterations of the modify* iterators
+ * would then skip matches. Reset `lastIndex` to 0 around the call so
+ * every test starts from the beginning, and restore the caller's
+ * original `lastIndex` afterwards so the regex object is left as the
+ * caller passed it. Sticky (`y`) semantics are preserved (a `y` pattern
+ * still anchors at the matching position 0).
+ */
+function stablePatternTest(pattern: RegExp, input: string): boolean {
+  const prev = pattern.lastIndex;
+  pattern.lastIndex = 0;
+  try {
+    return pattern.test(input);
+  } finally {
+    pattern.lastIndex = prev;
+  }
 }
 
 interface ComponentBucketVerbs<T> {

--- a/packages/spec/test/overlay.test.ts
+++ b/packages/spec/test/overlay.test.ts
@@ -232,3 +232,532 @@ describe("applyOverlays", () => {
     ).toThrow(/replace cannot be combined with upsertParameters/);
   });
 });
+
+describe("applyOverlays: top-level verbs", () => {
+  it("info shallow-merges into the document's info object", () => {
+    const patched = applyOverlays(base(), [{ info: { description: "added", title: "renamed" } }]);
+    expect(patched.info).toEqual({ title: "renamed", version: "1", description: "added" });
+  });
+
+  it("servers replaces wholesale; addServers appends", () => {
+    const withServers = { ...base(), servers: [{ url: "https://a.example" }] };
+    const replaced = applyOverlays(withServers, [{ servers: [{ url: "https://b.example" }] }]);
+    expect(replaced.servers).toEqual([{ url: "https://b.example" }]);
+
+    const appended = applyOverlays(withServers, [{ addServers: [{ url: "https://c.example" }] }]);
+    expect(appended.servers).toEqual([{ url: "https://a.example" }, { url: "https://c.example" }]);
+  });
+
+  it("servers + addServers in one overlay throws", () => {
+    expect(() =>
+      applyOverlays(base(), [{ servers: [{ url: "a" }], addServers: [{ url: "b" }] }]),
+    ).toThrow(/servers \(wholesale\) cannot combine with addServers/);
+  });
+
+  it("tags wholesale replaces; extendTags merges by name; replaceTags replaces by name; removeTags drops", () => {
+    const withTags = {
+      ...base(),
+      tags: [{ name: "pets", description: "old" }],
+    };
+    const wholesale = applyOverlays(withTags, [{ tags: [{ name: "fresh" }] }]);
+    expect(wholesale.tags).toEqual([{ name: "fresh" }]);
+
+    const extended = applyOverlays(withTags, [
+      { extendTags: [{ name: "pets", description: "new" }, { name: "new" }] },
+    ]);
+    expect(extended.tags).toEqual([{ name: "pets", description: "new" }, { name: "new" }]);
+
+    const replaced = applyOverlays(withTags, [{ replaceTags: [{ name: "pets" }] }]);
+    expect(replaced.tags).toEqual([{ name: "pets" }]);
+
+    const removed = applyOverlays(withTags, [{ removeTags: ["pets"] }]);
+    expect(removed.tags).toEqual([]);
+  });
+
+  it("removeTags throws on a missing tag name", () => {
+    expect(() => applyOverlays(base(), [{ removeTags: ["nope"] }])).toThrow(
+      /removeTags targets unknown tag nope/,
+    );
+  });
+
+  it("tags wholesale + extendTags throws as a self-conflict", () => {
+    expect(() =>
+      applyOverlays(base(), [{ tags: [{ name: "a" }], extendTags: [{ name: "b" }] }]),
+    ).toThrow(/tags \(wholesale\) cannot combine/);
+  });
+
+  it("replaceTags + removeTags naming the same tag throws", () => {
+    expect(() =>
+      applyOverlays(base(), [{ replaceTags: [{ name: "x" }], removeTags: ["x"] }]),
+    ).toThrow(/self-conflict: replaceTags and removeTags both name x/);
+  });
+
+  it("security replaces; addSecurity appends; both in one overlay throws", () => {
+    const replaced = applyOverlays(base(), [{ security: [{ apiKey: [] }] }]);
+    expect(replaced.security).toEqual([{ apiKey: [] }]);
+
+    const appended = applyOverlays(replaced, [{ addSecurity: [{ oauth: ["read"] }] }]);
+    expect(appended.security).toEqual([{ apiKey: [] }, { oauth: ["read"] }]);
+
+    expect(() =>
+      applyOverlays(base(), [{ security: [{ a: [] }], addSecurity: [{ b: [] }] }]),
+    ).toThrow(/security \(wholesale\) cannot combine with addSecurity/);
+  });
+
+  it("addWebhooks inserts; removeWebhooks drops; conflicts throw", () => {
+    const added = applyOverlays(base(), [
+      { addWebhooks: { "pet.created": { post: { responses: { "204": { description: "ok" } } } } } },
+    ]);
+    expect(added.webhooks?.["pet.created"]).toBeDefined();
+
+    const removed = applyOverlays(added, [{ removeWebhooks: ["pet.created"] }]);
+    expect(removed.webhooks?.["pet.created"]).toBeUndefined();
+
+    expect(() => applyOverlays(added, [{ addWebhooks: { "pet.created": { post: {} } } }])).toThrow(
+      /webhook pet\.created already exists/,
+    );
+
+    expect(() => applyOverlays(base(), [{ removeWebhooks: ["nope"] }])).toThrow(
+      /removeWebhooks targets unknown webhook nope/,
+    );
+
+    expect(() =>
+      applyOverlays(base(), [
+        {
+          addWebhooks: { x: { post: {} } },
+          removeWebhooks: ["x"],
+        },
+      ]),
+    ).toThrow(/addWebhooks and removeWebhooks both name x/);
+  });
+
+  it("setExtensions sets x-* fields and deletes on undefined", () => {
+    const withExt = applyOverlays(base(), [{ setExtensions: { "x-owner": "ml" } }]);
+    expect(withExt["x-owner"]).toBe("ml");
+
+    const deleted = applyOverlays(withExt, [{ setExtensions: { "x-owner": undefined } }]);
+    expect(deleted["x-owner"]).toBeUndefined();
+  });
+});
+
+describe("applyOverlays: component bucket fan-out", () => {
+  function baseWithComponents(): OpenAPIDocument {
+    return {
+      ...base(),
+      components: {
+        schemas: { Pet: { type: "object" } },
+        parameters: {
+          TraceId: { name: "X-Trace", in: "header", schema: { type: "string" } },
+        },
+        responses: {
+          NotFound: { description: "missing" },
+        },
+        requestBodies: {
+          PetBody: { content: { "application/json": { schema: { type: "object" } } } },
+        },
+        headers: {
+          RateLimit: { schema: { type: "integer" } },
+        },
+        securitySchemes: {
+          apiKey: { type: "apiKey", name: "X-Key", in: "header" },
+        },
+        links: {
+          GetPet: { operationId: "getPet" },
+        },
+        callbacks: {
+          onCreate: { "{$request.body#/callback}": { post: {} } },
+        },
+        examples: {
+          one: { value: { name: "rex" } },
+        },
+      },
+    };
+  }
+
+  it("extendParameters shallow-merges existing entries; new keys append", () => {
+    const patched = applyOverlays(baseWithComponents(), [
+      {
+        extendParameters: {
+          TraceId: { description: "traces" },
+          NewParam: { name: "X-New", in: "header" },
+        },
+      },
+    ]);
+    expect(patched.components?.parameters?.TraceId).toMatchObject({
+      name: "X-Trace",
+      in: "header",
+      description: "traces",
+    });
+    expect(patched.components?.parameters?.NewParam).toBeDefined();
+  });
+
+  it("replaceParameters fully replaces an entry", () => {
+    const patched = applyOverlays(baseWithComponents(), [
+      {
+        replaceParameters: {
+          TraceId: { name: "Y", in: "query" },
+        },
+      },
+    ]);
+    expect(patched.components?.parameters?.TraceId).toEqual({ name: "Y", in: "query" });
+  });
+
+  it("removeComponentParameters drops by name; missing throws", () => {
+    const patched = applyOverlays(baseWithComponents(), [
+      { removeComponentParameters: ["TraceId"] },
+    ]);
+    expect(patched.components?.parameters?.TraceId).toBeUndefined();
+
+    expect(() =>
+      applyOverlays(baseWithComponents(), [{ removeComponentParameters: ["Missing"] }]),
+    ).toThrow(/removeComponentParameters targets unknown parameters entry Missing/);
+  });
+
+  it("each non-schema bucket fans out extend / replace / remove", () => {
+    const patched = applyOverlays(baseWithComponents(), [
+      {
+        extendComponentResponses: { NotFound: { description: "not found 2" } },
+        replaceComponentResponses: { New: { description: "fresh" } },
+        extendRequestBodies: { PetBody: { description: "pet" } },
+        replaceRequestBodies: { NewBody: { content: {} } },
+        extendHeaders: { RateLimit: { description: "limit" } },
+        replaceHeaders: { Other: { schema: { type: "string" } } },
+        extendSecuritySchemes: { apiKey: { description: "key" } },
+        replaceSecuritySchemes: { bearer: { type: "http", scheme: "bearer" } },
+        extendLinks: { GetPet: { description: "fetch" } },
+        replaceLinks: { Other: { operationId: "x" } },
+        extendCallbacks: { onCreate: {} },
+        replaceCallbacks: { onDelete: { "{$url}": { post: {} } } },
+        extendExamples: { one: { summary: "one" } },
+        replaceExamples: { two: { value: 2 } },
+      },
+    ]);
+    expect(patched.components?.responses?.NotFound).toMatchObject({ description: "not found 2" });
+    expect(patched.components?.responses?.New).toBeDefined();
+    expect(patched.components?.requestBodies?.PetBody).toMatchObject({ description: "pet" });
+    expect(patched.components?.requestBodies?.NewBody).toBeDefined();
+    expect(patched.components?.headers?.RateLimit).toMatchObject({ description: "limit" });
+    expect(patched.components?.headers?.Other).toBeDefined();
+    expect(patched.components?.securitySchemes?.apiKey).toMatchObject({ description: "key" });
+    expect(patched.components?.securitySchemes?.bearer).toBeDefined();
+    expect(patched.components?.links?.GetPet).toMatchObject({ description: "fetch" });
+    expect(patched.components?.links?.Other).toBeDefined();
+    expect(patched.components?.callbacks?.onDelete).toBeDefined();
+    expect(patched.components?.examples?.one).toMatchObject({ summary: "one" });
+    expect(patched.components?.examples?.two).toBeDefined();
+  });
+
+  it("removeLinks throws on a missing entry", () => {
+    expect(() => applyOverlays(baseWithComponents(), [{ removeLinks: ["Nope"] }])).toThrow(
+      /removeLinks targets unknown links entry Nope/,
+    );
+  });
+
+  it("bucket self-conflicts: replaceParameters + removeComponentParameters naming the same key throws", () => {
+    expect(() =>
+      applyOverlays(baseWithComponents(), [
+        {
+          replaceParameters: { TraceId: { name: "Y", in: "query" } },
+          removeComponentParameters: ["TraceId"],
+        },
+      ]),
+    ).toThrow(/replaceParameters and removeParameters both name TraceId/);
+  });
+
+  it("extend on non-schema bucket creates the entry when missing", () => {
+    const patched = applyOverlays(baseWithComponents(), [
+      { extendHeaders: { NewHeader: { schema: { type: "string" } } } },
+    ]);
+    expect(patched.components?.headers?.NewHeader).toEqual({ schema: { type: "string" } });
+  });
+});
+
+describe("applyOverlays: operation-level expansion", () => {
+  function basePlus(): OpenAPIDocument {
+    return {
+      openapi: "3.1.0",
+      info: { title: "X", version: "1" },
+      paths: {
+        "/pets": {
+          get: {
+            tags: ["pets"],
+            security: [{ apiKey: [] }],
+            responses: {
+              "200": {
+                description: "ok",
+                headers: { Existing: { schema: { type: "string" } } },
+                content: { "application/json": { schema: { type: "object" } } },
+              },
+            },
+          },
+        },
+      },
+    };
+  }
+
+  it("addTags / removeTags update the tag set", () => {
+    const patched = applyOverlays(basePlus(), [
+      {
+        overrides: {
+          "/pets": {
+            operations: {
+              get: { addTags: ["v2"], removeTags: ["pets"] },
+            },
+          },
+        },
+      },
+    ]);
+    expect(patched.paths?.["/pets"]?.get?.tags).toEqual(["v2"]);
+  });
+
+  it("tags wholesale replaces and conflicts with addTags", () => {
+    const patched = applyOverlays(basePlus(), [
+      {
+        overrides: {
+          "/pets": { operations: { get: { tags: ["fresh"] } } },
+        },
+      },
+    ]);
+    expect(patched.paths?.["/pets"]?.get?.tags).toEqual(["fresh"]);
+
+    expect(() =>
+      applyOverlays(basePlus(), [
+        {
+          overrides: {
+            "/pets": {
+              operations: { get: { tags: ["x"], addTags: ["y"] } },
+            },
+          },
+        },
+      ]),
+    ).toThrow(/tags \(wholesale\) cannot combine with addTags/);
+  });
+
+  it("addSecurity appends; removeSecurity drops a deep-equal requirement", () => {
+    const patched = applyOverlays(basePlus(), [
+      {
+        overrides: {
+          "/pets": {
+            operations: {
+              get: {
+                addSecurity: [{ oauth: ["read"] }],
+                removeSecurity: [{ apiKey: [] }],
+              },
+            },
+          },
+        },
+      },
+    ]);
+    expect(patched.paths?.["/pets"]?.get?.security).toEqual([{ oauth: ["read"] }]);
+  });
+
+  it("servers / callbacks / externalDocs are set on the operation", () => {
+    const patched = applyOverlays(basePlus(), [
+      {
+        overrides: {
+          "/pets": {
+            operations: {
+              get: {
+                servers: [{ url: "https://x" }],
+                callbacks: { onX: { "{$url}": { post: {} } } },
+                externalDocs: { url: "https://docs" },
+              },
+            },
+          },
+        },
+      },
+    ]);
+    const op = patched.paths?.["/pets"]?.get;
+    expect(op?.servers).toEqual([{ url: "https://x" }]);
+    expect(op?.callbacks?.onX).toBeDefined();
+    expect(op?.externalDocs).toEqual({ url: "https://docs" });
+  });
+
+  it("setExtensions on an operation sets and deletes x-* fields", () => {
+    const patched = applyOverlays(basePlus(), [
+      {
+        overrides: {
+          "/pets": {
+            operations: {
+              get: { setExtensions: { "x-owner": "ml" } },
+            },
+          },
+        },
+      },
+    ]);
+    const getOp = patched.paths?.["/pets"]?.get;
+    expect((getOp as Record<string, unknown>)["x-owner"]).toBe("ml");
+
+    const removed = applyOverlays(patched, [
+      {
+        overrides: {
+          "/pets": {
+            operations: {
+              get: { setExtensions: { "x-owner": undefined } },
+            },
+          },
+        },
+      },
+    ]);
+    const removedOp = removed.paths?.["/pets"]?.get;
+    expect((removedOp as Record<string, unknown>)["x-owner"]).toBeUndefined();
+  });
+
+  it("patchResponses merges headers and allOf-extends content schemas", () => {
+    const patched = applyOverlays(basePlus(), [
+      {
+        overrides: {
+          "/pets": {
+            operations: {
+              get: {
+                patchResponses: {
+                  "200": {
+                    headers: { New: { schema: { type: "integer" } } },
+                    content: {
+                      "application/json": { schema: { required: ["id"] } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    ]);
+    const r200 = patched.paths?.["/pets"]?.get?.responses?.["200"];
+    expect(r200).toBeDefined();
+    if (r200 && "$ref" in r200) throw new Error("unexpected ref");
+    expect(r200?.headers?.Existing).toBeDefined();
+    expect(r200?.headers?.New).toBeDefined();
+    expect(r200?.content?.["application/json"]?.schema).toMatchObject({
+      allOf: [{ type: "object" }, { required: ["id"] }],
+    });
+  });
+
+  it("patchResponses on a missing status code throws", () => {
+    expect(() =>
+      applyOverlays(basePlus(), [
+        {
+          overrides: {
+            "/pets": {
+              operations: {
+                get: { patchResponses: { "404": { headers: {} } } },
+              },
+            },
+          },
+        },
+      ]),
+    ).toThrow(/patchResponses targets unknown response status 404/);
+  });
+});
+
+describe("applyOverlays: predicate iterators", () => {
+  function multi(): OpenAPIDocument {
+    return {
+      openapi: "3.1.0",
+      info: { title: "X", version: "1" },
+      paths: {
+        "/pets": {
+          parameters: [{ name: "x-trace", in: "header", schema: { type: "string" } }],
+          get: {
+            tags: ["pets"],
+            parameters: [{ name: "limit", in: "query", schema: { type: "integer" } }],
+            responses: { "200": { description: "ok" } },
+          },
+          post: {
+            tags: ["pets", "writes"],
+            responses: { "201": { description: "created" } },
+          },
+        },
+        "/vets": {
+          get: {
+            tags: ["vets"],
+            responses: { "200": { description: "ok" } },
+          },
+        },
+      },
+      webhooks: {
+        "pet.created": {
+          post: {
+            tags: ["pets"],
+            responses: { "204": { description: "ack" } },
+          },
+        },
+      },
+    };
+  }
+
+  it("modifyOperations with no where applies to every operation under paths and webhooks", () => {
+    const patched = applyOverlays(multi(), [
+      { modifyOperations: [{ apply: { addTags: ["traced"] } }] },
+    ]);
+    expect(patched.paths?.["/pets"]?.get?.tags).toContain("traced");
+    expect(patched.paths?.["/pets"]?.post?.tags).toContain("traced");
+    expect(patched.paths?.["/vets"]?.get?.tags).toContain("traced");
+    const webhook = patched.webhooks?.["pet.created"];
+    if (webhook && !("$ref" in webhook)) {
+      expect(webhook.post?.tags).toContain("traced");
+    }
+  });
+
+  it("modifyOperations filters by tag, method, pathPattern (AND)", () => {
+    const patched = applyOverlays(multi(), [
+      {
+        modifyOperations: [
+          {
+            where: { tags: ["pets"], methods: ["get"], pathPattern: /^\/pets/ },
+            apply: { addTags: ["matched"] },
+          },
+        ],
+      },
+    ]);
+    expect(patched.paths?.["/pets"]?.get?.tags).toContain("matched");
+    expect(patched.paths?.["/pets"]?.post?.tags ?? []).not.toContain("matched");
+    expect(patched.paths?.["/vets"]?.get?.tags ?? []).not.toContain("matched");
+  });
+
+  it("modifyParameters filters by in and nameMatches; merges fields into matching params", () => {
+    const patched = applyOverlays(multi(), [
+      {
+        modifyParameters: [
+          {
+            where: { in: "header", nameMatches: /^x-/ },
+            apply: { description: "traced", required: true },
+          },
+        ],
+      },
+    ]);
+    const pathItemParam = patched.paths?.["/pets"]?.parameters?.[0];
+    expect(pathItemParam).toMatchObject({
+      name: "x-trace",
+      in: "header",
+      description: "traced",
+      required: true,
+    });
+    const opParam = patched.paths?.["/pets"]?.get?.parameters?.[0];
+    expect(opParam).toMatchObject({ name: "limit", in: "query" });
+    expect(opParam).not.toHaveProperty("description");
+  });
+
+  it("modifyParameters skips reference-object parameters silently", () => {
+    const doc: OpenAPIDocument = {
+      ...multi(),
+      paths: {
+        ...multi().paths!,
+        "/refs": {
+          get: {
+            parameters: [{ $ref: "#/components/parameters/X" }],
+            responses: { "200": { description: "ok" } },
+          },
+        },
+      },
+    };
+    const patched = applyOverlays(doc, [
+      {
+        modifyParameters: [{ apply: { description: "irrelevant" } }],
+      },
+    ]);
+    const params = patched.paths?.["/refs"]?.get?.parameters;
+    expect(params?.[0]).toEqual({ $ref: "#/components/parameters/X" });
+  });
+});

--- a/packages/spec/test/overlay.test.ts
+++ b/packages/spec/test/overlay.test.ts
@@ -464,6 +464,106 @@ describe("applyOverlays: component bucket fan-out", () => {
     ).toThrow(/replaceParameters and removeParameters both name TraceId/);
   });
 
+  // Per-bucket missing-target coverage: the bucket fan-out is shared,
+  // but each verb name is part of the public surface. Exercise every
+  // remove<Bucket> so a rename or arg-binding regression on any one of
+  // them surfaces.
+  it.each([
+    [
+      "removeComponentResponses",
+      () => ({ removeComponentResponses: ["nope"] }),
+      /removeComponentResponses targets unknown responses entry nope/,
+    ],
+    [
+      "removeRequestBodies",
+      () => ({ removeRequestBodies: ["nope"] }),
+      /removeRequestBodies targets unknown requestBodies entry nope/,
+    ],
+    [
+      "removeHeaders",
+      () => ({ removeHeaders: ["nope"] }),
+      /removeHeaders targets unknown headers entry nope/,
+    ],
+    [
+      "removeSecuritySchemes",
+      () => ({ removeSecuritySchemes: ["nope"] }),
+      /removeSecuritySchemes targets unknown securitySchemes entry nope/,
+    ],
+    [
+      "removeCallbacks",
+      () => ({ removeCallbacks: ["nope"] }),
+      /removeCallbacks targets unknown callbacks entry nope/,
+    ],
+    [
+      "removeExamples",
+      () => ({ removeExamples: ["nope"] }),
+      /removeExamples targets unknown examples entry nope/,
+    ],
+  ] as const)("%s throws on a missing entry", (_verb, overlayFn, expectedError) => {
+    expect(() => applyOverlays(baseWithComponents(), [overlayFn()])).toThrow(expectedError);
+  });
+
+  // Per-bucket self-conflict coverage: replace<Bucket> + remove<Bucket>
+  // naming the same key. One case per non-schema bucket exercises each
+  // verb's branch in assertNoSelfConflict.
+  it.each([
+    [
+      "responses",
+      () => ({
+        replaceComponentResponses: { Conflict: { description: "x" } },
+        removeComponentResponses: ["Conflict"],
+      }),
+      /replaceResponses and removeResponses both name Conflict/,
+    ],
+    [
+      "requestBodies",
+      () => ({
+        replaceRequestBodies: { Conflict: { content: {} } },
+        removeRequestBodies: ["Conflict"],
+      }),
+      /replaceRequestBodies and removeRequestBodies both name Conflict/,
+    ],
+    [
+      "headers",
+      () => ({
+        replaceHeaders: { Conflict: { schema: { type: "string" } } },
+        removeHeaders: ["Conflict"],
+      }),
+      /replaceHeaders and removeHeaders both name Conflict/,
+    ],
+    [
+      "securitySchemes",
+      () => ({
+        replaceSecuritySchemes: { Conflict: { type: "apiKey", name: "K", in: "header" } },
+        removeSecuritySchemes: ["Conflict"],
+      }),
+      /replaceSecuritySchemes and removeSecuritySchemes both name Conflict/,
+    ],
+    [
+      "callbacks",
+      () => ({
+        replaceCallbacks: { Conflict: {} },
+        removeCallbacks: ["Conflict"],
+      }),
+      /replaceCallbacks and removeCallbacks both name Conflict/,
+    ],
+    [
+      "examples",
+      () => ({
+        replaceExamples: { Conflict: { value: 1 } },
+        removeExamples: ["Conflict"],
+      }),
+      /replaceExamples and removeExamples both name Conflict/,
+    ],
+  ] as const)(
+    "%s bucket: replace + remove for same key throws",
+    (_bucket, overlayFn, expectedError) => {
+      expect(() => applyOverlays(baseWithComponents(), [overlayFn() as never])).toThrow(
+        expectedError,
+      );
+    },
+  );
+
   it("extend on non-schema bucket creates the entry when missing", () => {
     const patched = applyOverlays(baseWithComponents(), [
       { extendHeaders: { NewHeader: { schema: { type: "string" } } } },
@@ -737,6 +837,72 @@ describe("applyOverlays: predicate iterators", () => {
     const opParam = patched.paths?.["/pets"]?.get?.parameters?.[0];
     expect(opParam).toMatchObject({ name: "limit", in: "query" });
     expect(opParam).not.toHaveProperty("description");
+  });
+
+  it("modifyOperations with a /g regex still matches every path (no lastIndex skip)", () => {
+    const pattern = /^\/pets/g;
+    const patched = applyOverlays(multi(), [
+      {
+        modifyOperations: [
+          { where: { pathPattern: pattern }, apply: { addTags: ["g-flag"] } },
+          { where: { pathPattern: pattern }, apply: { addTags: ["g-flag-2"] } },
+        ],
+      },
+    ]);
+    // Without the lastIndex strip, the second entry's .test() on /^\/pets/g
+    // would start past the input and miss the match.
+    expect(patched.paths?.["/pets"]?.get?.tags).toEqual(
+      expect.arrayContaining(["g-flag", "g-flag-2"]),
+    );
+    expect(patched.paths?.["/pets"]?.post?.tags).toEqual(
+      expect.arrayContaining(["g-flag", "g-flag-2"]),
+    );
+    // Caller's regex isn't mutated.
+    expect(pattern.lastIndex).toBe(0);
+  });
+
+  it("modifyParameters with a /g regex matches every parameter (no lastIndex skip)", () => {
+    const pattern = /^x-/g;
+    const patched = applyOverlays(multi(), [
+      {
+        modifyParameters: [{ where: { nameMatches: pattern }, apply: { description: "first" } }],
+      },
+      {
+        modifyParameters: [{ where: { nameMatches: pattern }, apply: { required: true } }],
+      },
+    ]);
+    const pathItemParam = patched.paths?.["/pets"]?.parameters?.[0];
+    expect(pathItemParam).toMatchObject({
+      name: "x-trace",
+      description: "first",
+      required: true,
+    });
+    expect(pattern.lastIndex).toBe(0);
+  });
+
+  it("modifyOperations preserves sticky (y) semantics: /pets/y matches only at the start", () => {
+    // Sticky requires the match to begin at lastIndex. A path of /pets
+    // matches the literal "pets" at offset 1, not 0; /pets/y starting
+    // at lastIndex 0 should NOT match. A stripped-y clone would, which
+    // is the regression this test pins against.
+    const stickyMid = /pets/y;
+    const patchedMid = applyOverlays(multi(), [
+      {
+        modifyOperations: [{ where: { pathPattern: stickyMid }, apply: { addTags: ["sticky"] } }],
+      },
+    ]);
+    expect(patchedMid.paths?.["/pets"]?.get?.tags ?? []).not.toContain("sticky");
+
+    // A sticky pattern that DOES start at offset 0 still matches.
+    const stickyStart = /\/pets/y;
+    const patchedStart = applyOverlays(multi(), [
+      {
+        modifyOperations: [{ where: { pathPattern: stickyStart }, apply: { addTags: ["sticky"] } }],
+      },
+    ]);
+    expect(patchedStart.paths?.["/pets"]?.get?.tags).toContain("sticky");
+    // Caller-supplied lastIndex is preserved.
+    expect(stickyStart.lastIndex).toBe(0);
   });
 
   it("modifyParameters skips reference-object parameters silently", () => {


### PR DESCRIPTION
Closes #266. Prereq for the translator package in #267.

## Summary

Extends the typed `SpecOverlay` surface so consumers can author every overlay shape the OpenAPI Overlay 1.0 spec can target, with typed verbs and no JSONPath engine. The follow-up translator (#267) maps spec-format input onto these verbs.

### Top-level verbs

- `info` (shallow merge), `servers` / `addServers`, `tags` (wholesale) + `extendTags` / `replaceTags` / `removeTags`, `security` / `addSecurity`, `addWebhooks` / `removeWebhooks`, `setExtensions` (root `x-*`; `undefined` deletes).

### Components fan-out

Every bucket (`schemas`, `parameters`, `responses`, `requestBodies`, `headers`, `securitySchemes`, `links`, `callbacks`, `examples`) gets `extend<Bucket>` / `replace<Bucket>` / `remove<Bucket>`. Schemas keep the `allOf`-extend semantics; the others shallow-merge.

### OperationOverride expansion

`tags` / `addTags` / `removeTags`, `security` / `addSecurity` / `removeSecurity` (deep-equal removal), `servers`, `callbacks` (merge by key), `externalDocs`, `setExtensions`, and a new `patchResponses` per-status patcher (header merge + content shallow merge with schema `allOf`-extend).

### Predicate iterators

`modifyOperations` walks `paths` + `webhooks` and applies an override on matches; `where` combines `tags` / `methods` / `pathPattern` with AND semantics. `modifyParameters` walks every parameter slot (path-item-level and per-operation), filtered by `in` / `nameMatches`. Reference parameters are skipped (their name / in aren't inspectable pre-resolve).

### Conflict handling

`assertNoSelfConflict` is extended to catch the new contradictions: wholesale vs additive on the same field (e.g. `servers` + `addServers`, `tags` + `extendTags`), replace + remove keyed the same in any component bucket, etc. On `OperationOverride`, `replace` rejects coexistence with every other field (including the new ones).

### Core additions

Add `ExternalDocumentationObject`, `CallbackObject`, `LinkObject`, `ExampleObject` to `@oav/core`. Extend `ComponentsObject` with the new buckets and accept `ReferenceObject` siblings on every existing bucket (matching OAS). Extend `OperationObject` with `servers`, `callbacks`, `externalDocs`. Standalone commit so a reviewer can see the type surface separately.

### Docs

`docs/overlays.md` gets an expanded verb matrix, an updated shape snippet, and four worked recipes: add a server entry, add an operation-level security requirement, modify every operation matching a tag, extend a component schema (with a parallel non-schema example).

## Test plan

- [x] `pnpm typecheck` clean.
- [x] `pnpm lint` clean.
- [x] `pnpm test` clean (`packages/spec` goes from 17 to 43 overlay tests).
- [x] `pnpm build` clean.
- [ ] CI green.