### PR TITLE
chore: bump oav-express4 express to 4.22.2 + harden dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,14 +16,19 @@ updates:
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
       # Each oav-express{4,5} adapter pins to its corresponding express
-      # major on purpose — that's the whole point of having two
-      # packages. A semver-major bump here would silently turn the v4
-      # adapter into a v5 adapter (or vice versa). Within-major patch /
-      # minor bumps still flow through dev-minor-and-patch.
+      # major on purpose: that's the whole point of having two packages.
+      # Dependabot has a workspace-wide version-unification step that
+      # picks one target version for any given dep name and rewrites
+      # every package.json that names it; with express 4.x in one
+      # adapter and 5.x in the other, every bump round downgrades one
+      # adapter (#276, #283). The major-version ignore below doesn't
+      # catch this because dependabot files the cross-major rewrite as
+      # a patch. Excluding express from groups also doesn't help: the
+      # per-dep PR still unifies. Until dependabot supports per-package
+      # version scoping, ignore express family entirely and bump it by
+      # hand when an in-major patch lands upstream.
       - dependency-name: "express"
-        update-types: ["version-update:semver-major"]
       - dependency-name: "@types/express"
-        update-types: ["version-update:semver-major"]
     groups:
       types:
         patterns:

--- a/packages/oav-express4/package.json
+++ b/packages/oav-express4/package.json
@@ -63,7 +63,7 @@
     "@oav/core": "workspace:*",
     "@oav/validator": "workspace:*",
     "@types/express": "4.17.21",
-    "express": "4.22.1",
+    "express": "4.22.2",
     "tsup": "8.5.1",
     "typescript": "5.9.3",
     "vitest": "4.1.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,8 +127,8 @@ importers:
         specifier: 4.17.21
         version: 4.17.21
       express:
-        specifier: 4.22.1
-        version: 4.22.1
+        specifier: 4.22.2
+        version: 4.22.2
       tsup:
         specifier: 8.5.1
         version: 8.5.1(postcss@8.5.14)(typescript@5.9.3)(yaml@2.9.0)
@@ -1368,8 +1368,8 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  express@4.22.1:
-    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
+  express@4.22.2:
+    resolution: {integrity: sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==}
     engines: {node: '>= 0.10.0'}
 
   express@5.2.1:
@@ -1766,10 +1766,6 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
-
-  qs@6.14.2:
-    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
-    engines: {node: '>=0.6'}
 
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
@@ -2926,7 +2922,7 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express@4.22.1:
+  express@4.22.2:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
@@ -2949,7 +2945,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.14.2
+      qs: 6.15.1
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.0
@@ -3389,10 +3385,6 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-
-  qs@6.14.2:
-    dependencies:
-      side-channel: 1.1.0
 
   qs@6.15.1:
     dependencies:


### PR DESCRIPTION
## Summary

Dependabot keeps filing express bumps that converge to a single workspace-wide version and rewrite the v5 adapter to that version, breaking the v5 promise-chain integration test. We saw it in #276 (grouped bump) and again in #283 (single-dep PR). The previous config fix (#278) only excluded express from the dev-minor-and-patch group, but the workspace-wide version-unification step runs at the per-dep level too. The semver-major ignore doesn't catch it because dependabot files the cross-major rewrite as a patch.

Until dependabot supports per-package version scoping, drop the \`update-type\` qualifier on the express / @types/express ignore entries so the family is ignored unconditionally. Maintainers bump express by hand in the affected adapter when an upstream patch lands.

This PR also bumps oav-express4 from express 4.22.1 → 4.22.2 (the legitimate part of #283). oav-express5 stays at 5.2.1.

The group \`exclude-patterns\` added in #278 stay as defense-in-depth in case the unconditional ignore is ever loosened.

## Test plan

- [x] \`pnpm typecheck\` clean.
- [x] \`pnpm lint\` clean.
- [x] \`pnpm test\` clean (1004 tests).
- [ ] CI green.