### PR TITLE
feat(schema): regexCompiler option for pattern and format: regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,10 +373,10 @@ validation, response interception, upload helpers), see
   built-in `RegExp`, which has no execution timeout. If your OpenAPI
   spec is attacker-controlled (e.g. multi-tenant upload), a
   catastrophic pattern like `(a+)+$` is a ReDoS vector against any
-  string the validator checks. Vet spec sources before loading them.
-  A pluggable `regexCompiler` option for plugging in `re2` or a
-  complexity-checking engine is tracked in
-  [#146](https://github.com/aahoughton/oav/issues/146).
+  string the validator checks. Pass a `regexCompiler` to
+  `createValidator` to plug in `re2` or a complexity-checking engine;
+  see ["Hardening against untrusted regex patterns"
+  ](./docs/configuration.md#hardening-against-untrusted-regex-patterns).
 
 ## Contributing
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,9 +113,9 @@ Throws inside the compiler:
 - For `format: "regex"`, a throw is caught and translated into a
   `format` validation error against the value.
 
-The same compiler is shared between `pattern` and `format: "regex"`,
-so a pattern that passes one passes the other. `format: "regex"` is
-auto-registered by `@oav/schema` and no longer ships from
-`@oav/formats`'s `builtInFormats`; a user-supplied entry in `formats`
-still overrides it if you want a different policy for the format
-than for `pattern`.
+`pattern` and `format: "regex"` use the same compiler policy: one
+`regexCompiler` covers both, and there's no second hook to keep in
+sync. `format: "regex"` is auto-registered by `@oav/schema` and no
+longer ships from `@oav/formats`'s `builtInFormats`; a user-supplied
+entry in `formats` still overrides it if you want a different policy
+for the format than for `pattern`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,9 +76,15 @@ const validator = createValidator(spec, {
 });
 ```
 
-The compiler is called once per unique pattern per validator
-instance. The runtime only reads `.test(s)` off the returned object,
-so anything that satisfies `{ test(s: string): boolean }` works. A
+Invocation cadence is split: schema-authored `pattern` strings are
+memoized for the validator's lifetime (bounded by spec size), so
+the compiler runs once per unique pattern there. `format: "regex"`
+runs the compiler per `validate()` call against the candidate
+string; caching runtime values would retain user input indefinitely,
+which is the opposite of what hardening callers want.
+
+The runtime only reads `.test(s)` off the returned object, so
+anything that satisfies `{ test(s: string): boolean }` works. A
 typical complexity-check wrapper:
 
 ```ts

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,7 @@ this page is a recipe-oriented overview.
 | `ignoreUndocumented`    | Return `null` on requests whose path the router can't match. Default `false`.                                                                                                                  |
 | `ignorePaths`           | Predicate `(path) => boolean`; returning `true` short-circuits validation to `null` before routing.                                                                                            |
 | `onUnknownVersion`      | Policy for specs with missing/unsupported `openapi`: `"fallback31"` (default), `"warn"`, or `"throw"`.                                                                                         |
+| `regexCompiler`         | Compiler for `pattern` keywords and `format: "regex"`. Defaults to `new RegExp(p, "u")` with a non-u fallback. Plug in `re2` or a safe-regex check for hardening; see below.                   |
 
 ## Custom keywords
 
@@ -51,3 +52,64 @@ short-circuit once the budget is exhausted. Results carry
 throws on `0`, negative values, or non-integers. To opt out of error
 collection entirely (yes/no answers only), use `compileSchema(schema,
 { predicate: true })` from `@aahoughton/oav/schema` instead.
+
+## Hardening against untrusted regex patterns
+
+`pattern` keywords and `format: "regex"` compile to JavaScript's
+built-in `RegExp`, which has no execution timeout. A catastrophic
+pattern like `(a+)+$` is a denial-of-service vector against any
+string the validator checks. The risk is real only when the spec is
+attacker-controlled: multi-tenant SaaS accepting uploads,
+spec-editing tools, mock-as-a-service. For first-party specs the
+default is fine; vet your sources.
+
+When the spec is untrusted, pass a `regexCompiler` that wraps a safe
+engine. `re2` is the standard choice (linear-time matching, no
+catastrophic backtracking) on platforms that allow a native dep:
+
+```ts
+import RE2 from "re2";
+import { createValidator } from "@aahoughton/oav";
+
+const validator = createValidator(spec, {
+  regexCompiler: (pattern) => new RE2(pattern),
+});
+```
+
+The compiler is called once per unique pattern per validator
+instance. The runtime only reads `.test(s)` off the returned object,
+so anything that satisfies `{ test(s: string): boolean }` works. A
+typical complexity-check wrapper:
+
+```ts
+import safeRegex from "safe-regex";
+
+createValidator(spec, {
+  regexCompiler: (pattern) => {
+    if (!safeRegex(pattern)) {
+      throw new Error(`unsafe regex: ${pattern}`);
+    }
+    return new RegExp(pattern, "u");
+  },
+});
+```
+
+`oav` does not bundle `re2` or any other engine: edge runtimes
+(Cloudflare Workers, Vercel Edge) don't support native modules, and
+the right answer for those environments is a different tradeoff
+(pattern-length cap, allowlist of permitted patterns, etc.) which
+your `regexCompiler` can encode.
+
+Throws inside the compiler:
+
+- For `pattern` keywords, a throw surfaces at validator-construction
+  time (`compileSchema` calls the compiler eagerly).
+- For `format: "regex"`, a throw is caught and translated into a
+  `format` validation error against the value.
+
+The same compiler is shared between `pattern` and `format: "regex"`,
+so a pattern that passes one passes the other. `format: "regex"` is
+auto-registered by `@oav/schema` and no longer ships from
+`@oav/formats`'s `builtInFormats`; a user-supplied entry in `formats`
+still overrides it if you want a different policy for the format
+than for `pattern`.

--- a/packages/cli/src/emit-standalone.ts
+++ b/packages/cli/src/emit-standalone.ts
@@ -106,18 +106,33 @@ export function emitStandalone(schema: SchemaOrBoolean, options: EmitStandaloneO
 }
 
 /**
+ * Formats that the emitted module's `createDeps()` call auto-registers
+ * on top of the entries merged in from `builtInFormats`. Mirrors the
+ * runtime side of `@oav/schema`'s `createDeps`; if that list ever
+ * grows, this set has to grow too.
+ */
+const SCHEMA_AUTO_REGISTERED_FORMATS: ReadonlySet<string> = new Set(["regex"]);
+
+/**
  * Walk the schema looking for `format: "..."` values referenced on
- * object subschemas; return those not covered by the built-in set.
- * Using {@link walkSubschemas} keeps us out of `enum` / `const` /
- * `default` literal values, which might incidentally contain a
- * string under a `format` key without being a format assertion.
+ * object subschemas; return those not covered by the built-in set or
+ * the schema-auto-registered set. Using {@link walkSubschemas} keeps
+ * us out of `enum` / `const` / `default` literal values, which might
+ * incidentally contain a string under a `format` key without being a
+ * format assertion.
  */
 function collectUnknownFormats(schema: SchemaOrBoolean): string[] {
   const found = new Set<string>();
   walkSubschemas(schema, (node) => {
     if (typeof node !== "object" || node === null || Array.isArray(node)) return;
     const format = (node as SchemaObject).format;
-    if (typeof format === "string" && !(format in builtInFormats)) found.add(format);
+    if (
+      typeof format === "string" &&
+      !(format in builtInFormats) &&
+      !SCHEMA_AUTO_REGISTERED_FORMATS.has(format)
+    ) {
+      found.add(format);
+    }
   });
   return [...found].sort();
 }

--- a/packages/cli/test/emit-standalone.test.ts
+++ b/packages/cli/test/emit-standalone.test.ts
@@ -82,6 +82,26 @@ describe("emitStandalone", () => {
     ).toThrow(/not in the built-in set/);
   });
 
+  it('accepts schemas using format: "regex" (auto-registered by @oav/schema\'s createDeps)', async () => {
+    // Regression guard: the `regex` format was removed from
+    // builtInFormats when @oav/schema started auto-registering it
+    // inside createDeps. The standalone preflight has to know about
+    // the auto-registration set, otherwise it rejects a legitimate
+    // built-in format. Round-trip the emitted module to confirm the
+    // format is actually wired (not just permitted).
+    const schema: SchemaOrBoolean = {
+      type: "object",
+      properties: { pattern: { type: "string", format: "regex" } },
+    };
+    const { validate, dir } = await compileModule(schema, { dialect: "openapi-3.1" });
+    try {
+      expect(validate({ pattern: "^abc$" })).toEqual({ valid: true });
+      expect(validate({ pattern: "(unclosed" }).valid).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true });
+    }
+  });
+
   it("compiles under the OpenAPI 3.0 dialect: boolean exclusiveMaximum honored", async () => {
     const schema: SchemaOrBoolean = {
       type: "integer",

--- a/packages/formats/src/index.ts
+++ b/packages/formats/src/index.ts
@@ -17,6 +17,10 @@ import { validateDate, validateDateTime, validateDuration, validateTime } from "
 import { validateEmail, validateIdnEmail } from "./email.js";
 import { validateHostname, validateIdnHostname } from "./hostname.js";
 import { validateIpv4, validateIpv6 } from "./ip.js";
+// Note: validateRegex is intentionally not imported into builtInFormats.
+// @oav/schema's createDeps auto-registers a `regex` format that shares the
+// pattern-keyword compile path (and the regexCompiler hook). The standalone
+// validateRegex export still lives in ./misc.ts as a u-mode utility.
 import { validateUuid } from "./misc.js";
 import {
   validateIri,

--- a/packages/formats/src/index.ts
+++ b/packages/formats/src/index.ts
@@ -17,7 +17,7 @@ import { validateDate, validateDateTime, validateDuration, validateTime } from "
 import { validateEmail, validateIdnEmail } from "./email.js";
 import { validateHostname, validateIdnHostname } from "./hostname.js";
 import { validateIpv4, validateIpv6 } from "./ip.js";
-import { validateRegex, validateUuid } from "./misc.js";
+import { validateUuid } from "./misc.js";
 import {
   validateIri,
   validateIriReference,
@@ -32,6 +32,12 @@ import {
  * Every built-in format validator, keyed by its JSON Schema format name.
  * Hand to {@link @oav/schema!compileSchema#formats | compileSchema's formats
  * option} to get out-of-the-box format validation.
+ *
+ * `regex` is intentionally absent: `@oav/schema` registers its own
+ * `regex` validator inside `createDeps` so it routes through the same
+ * compiler as the `pattern` keyword (and honors the `regexCompiler`
+ * option). Override by setting `formats: { regex: yourFn, ... }` if you
+ * want a different policy.
  *
  * @public
  *
@@ -58,7 +64,6 @@ export const builtInFormats: Record<string, (value: string) => boolean> = {
   "uri-template": validateUriTemplate,
   "json-pointer": validateJsonPointer,
   "relative-json-pointer": validateRelativeJsonPointer,
-  regex: validateRegex,
   uuid: validateUuid,
 };
 

--- a/packages/formats/src/misc.ts
+++ b/packages/formats/src/misc.ts
@@ -17,7 +17,14 @@ export function validateUuid(value: string): boolean {
 
 /**
  * ECMA 262 `regex`: the value must compile as a JavaScript regular
- * expression (with the `u` flag, to match JSON Schema 2020-12).
+ * expression with the `u` flag (per JSON Schema 2020-12 recommendation).
+ *
+ * Standalone utility. `compileSchema` no longer wires this into
+ * `builtInFormats`: the schema compiler registers its own `regex`
+ * format inside `createDeps` so it shares the `regexCompiler` hook
+ * with the `pattern` keyword. Reach for this function directly when
+ * you want u-mode strictness independent of whatever compiler is
+ * configured.
  *
  * @public
  */

--- a/packages/formats/test/formats.test.ts
+++ b/packages/formats/test/formats.test.ts
@@ -167,10 +167,13 @@ describe("builtInFormats map", () => {
       "uri-template",
       "json-pointer",
       "relative-json-pointer",
-      "regex",
       "uuid",
     ];
     for (const k of keys) expect(typeof builtInFormats[k]).toBe("function");
+  });
+
+  it("does not include `regex` (registered by @oav/schema's createDeps)", () => {
+    expect(builtInFormats["regex"]).toBeUndefined();
   });
 });
 

--- a/packages/schema/src/compiler/compiler.ts
+++ b/packages/schema/src/compiler/compiler.ts
@@ -16,7 +16,7 @@ import {
   SUBSCHEMA_SINGLE_POSITIONS,
   walkSubschemas,
 } from "../subschema-positions.js";
-import { createDeps, type ValidatorDeps } from "./runtime.js";
+import { createDeps, type RegexCompiler, type ValidatorDeps } from "./runtime.js";
 
 // Token scan fed into CompileStats.emittedTreeRuntime. Word-boundaried
 // so stray mentions inside string literals (e.g. an error message that
@@ -458,6 +458,25 @@ export interface CompileOptions {
    * both are supplied.
    */
   predicate?: boolean;
+  /**
+   * Custom compiler for schema `pattern` keywords and the `format:
+   * "regex"` assertion. Defaults to `new RegExp(pattern, "u")` with a
+   * non-`u` fallback. Override to plug in a library like `re2`, wrap
+   * with a complexity check, or reject patterns that fail a
+   * safe-regex analysis.
+   *
+   * JavaScript's built-in `RegExp` has no execution timeout, so a
+   * catastrophic pattern like `(a+)+$` is a denial-of-service vector
+   * against any string the validator checks. Reach for this option
+   * when the spec is attacker-controlled (multi-tenant SaaS,
+   * spec-editing tools, mock-as-a-service).
+   *
+   * The compiler is called once per unique pattern per validator
+   * instance; the returned object only has `.test(s: string): boolean`
+   * read off it. JavaScript's built-in `RegExp` already satisfies the
+   * shape. See {@link RegexCompiler}.
+   */
+  regexCompiler?: RegexCompiler;
 }
 
 /** @internal */
@@ -632,7 +651,7 @@ export function compileSchema(
         "Predicate mode short-circuits on the first failure, so there is nothing to count.",
     );
   }
-  const deps = createDeps(maxErrors);
+  const deps = createDeps({ maxErrors, regexCompiler: options.regexCompiler });
   if (options.formats) {
     for (const name of Object.keys(options.formats)) {
       const fn = options.formats[name];

--- a/packages/schema/src/compiler/compiler.ts
+++ b/packages/schema/src/compiler/compiler.ts
@@ -471,10 +471,12 @@ export interface CompileOptions {
    * when the spec is attacker-controlled (multi-tenant SaaS,
    * spec-editing tools, mock-as-a-service).
    *
-   * The compiler is called once per unique pattern per validator
-   * instance; the returned object only has `.test(s: string): boolean`
-   * read off it. JavaScript's built-in `RegExp` already satisfies the
-   * shape. See {@link RegexCompiler}.
+   * The runtime only reads `.test(s: string): boolean` off the
+   * returned object; built-in `RegExp` already satisfies the shape.
+   * Memoization is split by audience: schema `pattern` strings cache
+   * for the validator's lifetime (bounded by spec size), `format:
+   * "regex"` runs the compiler per call (runtime values are not).
+   * See {@link RegexCompiler}.
    */
   regexCompiler?: RegexCompiler;
 }

--- a/packages/schema/src/compiler/index.ts
+++ b/packages/schema/src/compiler/index.ts
@@ -12,6 +12,9 @@ export {
   deepEqual,
   typeOf,
   wrapErrors,
+  type CompiledRegex,
+  type CreateDepsOptions,
+  type RegexCompiler,
   type Validator,
   type ValidatorDeps,
 } from "./runtime.js";

--- a/packages/schema/src/compiler/runtime.ts
+++ b/packages/schema/src/compiler/runtime.ts
@@ -18,16 +18,20 @@ export interface ValidatorDeps {
     path: readonly (string | number)[],
     errs: ValidationError[],
   ) => ValidationError | null;
-  patterns: Map<string, RegExp>;
+  patterns: Map<string, CompiledRegex>;
   /**
-   * Compile a user-supplied regex. Tries the `u` (Unicode) flag first
-   * (JSON Schema 2020-12 recommends it) and falls back to no-flag when
-   * the pattern trips strict `u`-mode rules (stray `\-`, `\:`, `\/` etc.,
-   * common in real-world OpenAPI specs). Results are memoized in
-   * `patterns`. Throws `SyntaxError` only when the pattern is malformed
-   * under both modes.
+   * Compile a user-supplied regex. By default tries the `u` (Unicode)
+   * flag first (JSON Schema 2020-12 recommends it) and falls back to
+   * no-flag when the pattern trips strict `u`-mode rules (stray `\-`,
+   * `\:`, `\/` etc., common in real-world OpenAPI specs). When a custom
+   * {@link RegexCompiler} is passed to {@link createDeps}, this routes
+   * through it instead, and the fallback logic doesn't apply (the
+   * compiler is the authority on what's accepted). Results are memoized
+   * in `patterns`. The default path throws `SyntaxError` only when the
+   * pattern is malformed under both modes; a custom compiler may throw
+   * whatever it likes.
    */
-  compilePattern: (pattern: string) => RegExp;
+  compilePattern: (pattern: string) => CompiledRegex;
   /**
    * Count the Unicode code points in `s` without allocating an
    * intermediate array. Used by `minLength` / `maxLength`, which the
@@ -83,6 +87,59 @@ export interface ValidatorDeps {
  * @public
  */
 export type Validator = (data: unknown, path: (string | number)[]) => ValidationError | null;
+
+/**
+ * The minimal interface required of a value returned by a
+ * {@link RegexCompiler}. The runtime only ever calls `.test()` on
+ * the result; nothing else is read. JavaScript's built-in `RegExp`
+ * already satisfies this shape.
+ *
+ * @public
+ */
+export interface CompiledRegex {
+  test(s: string): boolean;
+}
+
+/**
+ * Custom compiler for schema `pattern` keywords and the `format:
+ * "regex"` assertion. Defaults to `new RegExp(pattern, "u")` (with a
+ * non-`u` fallback for patterns that trip strict `u`-mode rules).
+ *
+ * Override to plug in `re2`, wrap with a complexity check, or reject
+ * patterns that fail a safe-regex analysis. JavaScript's built-in
+ * `RegExp` has no execution timeout, which makes catastrophic
+ * patterns (e.g. `(a+)+$`) a denial-of-service vector against any
+ * string the validator checks. The runtime calls the compiler once
+ * per unique pattern per validator instance; memoization further
+ * upstream is the compiler's own responsibility.
+ *
+ * @public
+ *
+ * @example
+ * ```ts
+ * import RE2 from "re2";
+ *
+ * createValidator(spec, {
+ *   regexCompiler: (pattern) => new RE2(pattern),
+ * });
+ * ```
+ */
+export type RegexCompiler = (pattern: string) => CompiledRegex;
+
+/**
+ * Options bag accepted by {@link createDeps}. Prefer this form when
+ * passing a {@link RegexCompiler}; the legacy `createDeps(maxErrors)`
+ * positional form is preserved for back-compat with AOT-emitted
+ * modules built before the option existed.
+ *
+ * @public
+ */
+export interface CreateDepsOptions {
+  /** Cap on leaf errors collected per `validate()` call. */
+  maxErrors?: number;
+  /** Custom compiler for `pattern` keywords and `format: "regex"`. */
+  regexCompiler?: RegexCompiler;
+}
 
 /**
  * The JSON-Schema-flavored typeof function: distinguishes `integer`,
@@ -243,28 +300,32 @@ export function wrapErrors(
 /**
  * Build a {@link ValidatorDeps} bundle with fresh mutable caches.
  *
- * @param maxErrors - Cap on leaf errors collected per `validate()` call.
- *                    Defaults to `Number.POSITIVE_INFINITY` (uncapped).
- * @returns A new deps object wired with the default runtime helpers.
+ * Accepts either a positional `maxErrors` (legacy) or an options
+ * bag with `maxErrors` and `regexCompiler`. The positional form is
+ * kept for back-compat with AOT-emitted modules built before the
+ * options bag existed.
+ *
+ * @returns A new deps object wired with the default runtime helpers
+ *          and a built-in `regex` format that routes through
+ *          {@link ValidatorDeps.compilePattern}.
  *
  * @public
  */
-export function createDeps(maxErrors: number = Number.POSITIVE_INFINITY): ValidatorDeps {
-  const patterns = new Map<string, RegExp>();
-  return {
-    createError,
-    createLeafError,
-    createBranchError,
-    typeOf,
-    deepEqual,
-    countCodePoints,
-    findDuplicate,
-    wrapErrors,
-    patterns,
-    compilePattern(pattern: string): RegExp {
-      const cached = patterns.get(pattern);
-      if (cached !== undefined) return cached;
-      let re: RegExp;
+export function createDeps(maxErrors?: number): ValidatorDeps;
+export function createDeps(options?: CreateDepsOptions): ValidatorDeps;
+export function createDeps(arg?: number | CreateDepsOptions): ValidatorDeps {
+  const options: CreateDepsOptions = typeof arg === "number" ? { maxErrors: arg } : (arg ?? {});
+  const maxErrors = options.maxErrors ?? Number.POSITIVE_INFINITY;
+  const regexCompiler = options.regexCompiler;
+  const patterns = new Map<string, CompiledRegex>();
+
+  const compilePattern = (pattern: string): CompiledRegex => {
+    const cached = patterns.get(pattern);
+    if (cached !== undefined) return cached;
+    let re: CompiledRegex;
+    if (regexCompiler !== undefined) {
+      re = regexCompiler(pattern);
+    } else {
       try {
         re = new RegExp(pattern, "u");
       } catch (errU) {
@@ -276,10 +337,37 @@ export function createDeps(maxErrors: number = Number.POSITIVE_INFINITY): Valida
           throw errU;
         }
       }
-      patterns.set(pattern, re);
-      return re;
-    },
-    formats: new Map<string, (value: string) => boolean>(),
+    }
+    patterns.set(pattern, re);
+    return re;
+  };
+
+  // Auto-register the `regex` format so it routes through the same
+  // compiler as the `pattern` keyword. A user-supplied formats entry
+  // for `regex` overrides this (compileSchema's formats option runs
+  // after createDeps).
+  const formats = new Map<string, (value: string) => boolean>();
+  formats.set("regex", (value: string) => {
+    try {
+      compilePattern(value);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+
+  return {
+    createError,
+    createLeafError,
+    createBranchError,
+    typeOf,
+    deepEqual,
+    countCodePoints,
+    findDuplicate,
+    wrapErrors,
+    patterns,
+    compilePattern,
+    formats,
     refs: new Map<string, Validator>(),
     customKeywords: new Map<string, CustomKeywordValidator>(),
     maxErrors,

--- a/packages/schema/src/compiler/runtime.ts
+++ b/packages/schema/src/compiler/runtime.ts
@@ -313,8 +313,10 @@ export function wrapErrors(
  * options bag existed.
  *
  * @returns A new deps object wired with the default runtime helpers
- *          and a built-in `regex` format that routes through
- *          {@link ValidatorDeps.compilePattern}.
+ *          and a built-in `regex` format that shares the
+ *          {@link RegexCompiler} hook with the `pattern` keyword but
+ *          bypasses the {@link ValidatorDeps.patterns} cache so
+ *          runtime values aren't retained.
  *
  * @public
  */

--- a/packages/schema/src/compiler/runtime.ts
+++ b/packages/schema/src/compiler/runtime.ts
@@ -109,9 +109,16 @@ export interface CompiledRegex {
  * patterns that fail a safe-regex analysis. JavaScript's built-in
  * `RegExp` has no execution timeout, which makes catastrophic
  * patterns (e.g. `(a+)+$`) a denial-of-service vector against any
- * string the validator checks. The runtime calls the compiler once
- * per unique pattern per validator instance; memoization further
- * upstream is the compiler's own responsibility.
+ * string the validator checks.
+ *
+ * Invocation cadence:
+ * - For `pattern` keywords, the runtime memoizes by pattern string;
+ *   the compiler runs once per unique schema-authored pattern for
+ *   the lifetime of the validator (bounded by spec size).
+ * - For `format: "regex"`, the runtime bypasses the cache; the
+ *   compiler runs per validate() call against the candidate string.
+ *   Caching there would retain runtime values indefinitely, which is
+ *   the opposite of what hardening callers want.
  *
  * @public
  *

--- a/packages/schema/src/compiler/runtime.ts
+++ b/packages/schema/src/compiler/runtime.ts
@@ -319,37 +319,46 @@ export function createDeps(arg?: number | CreateDepsOptions): ValidatorDeps {
   const regexCompiler = options.regexCompiler;
   const patterns = new Map<string, CompiledRegex>();
 
+  // The actual compile path (with `u`-then-fallback or the
+  // user-supplied compiler). Used by:
+  //   - `compilePattern` (below), which memoizes against `patterns`.
+  //     Safe to cache: callers pass schema-authored pattern strings,
+  //     bounded by spec size.
+  //   - the `regex` format validator, which receives runtime data
+  //     values. Caching those would grow `patterns` without bound on
+  //     a long-lived validator that sees many unique inputs, so it
+  //     bypasses the cache.
+  const compileRegex = (pattern: string): CompiledRegex => {
+    if (regexCompiler !== undefined) return regexCompiler(pattern);
+    try {
+      return new RegExp(pattern, "u");
+    } catch (errU) {
+      try {
+        return new RegExp(pattern);
+      } catch {
+        // Surface the stricter (`u`-mode) error; it's more informative
+        // when both modes reject the pattern.
+        throw errU;
+      }
+    }
+  };
+
   const compilePattern = (pattern: string): CompiledRegex => {
     const cached = patterns.get(pattern);
     if (cached !== undefined) return cached;
-    let re: CompiledRegex;
-    if (regexCompiler !== undefined) {
-      re = regexCompiler(pattern);
-    } else {
-      try {
-        re = new RegExp(pattern, "u");
-      } catch (errU) {
-        try {
-          re = new RegExp(pattern);
-        } catch {
-          // Surface the stricter (`u`-mode) error; it's more informative
-          // when both modes reject the pattern.
-          throw errU;
-        }
-      }
-    }
+    const re = compileRegex(pattern);
     patterns.set(pattern, re);
     return re;
   };
 
-  // Auto-register the `regex` format so it routes through the same
-  // compiler as the `pattern` keyword. A user-supplied formats entry
-  // for `regex` overrides this (compileSchema's formats option runs
-  // after createDeps).
+  // Auto-register the `regex` format. It shares the compile path with
+  // the `pattern` keyword (and the `regexCompiler` hook), but skips
+  // the memoization to keep memory bounded: runtime values aren't
+  // bounded by spec size.
   const formats = new Map<string, (value: string) => boolean>();
   formats.set("regex", (value: string) => {
     try {
-      compilePattern(value);
+      compileRegex(value);
       return true;
     } catch {
       return false;

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -21,10 +21,12 @@
 // Compiler: turning schemas into validators.
 export {
   compileSchema,
+  type CompiledPredicate,
+  type CompiledRegex,
+  type CompiledSchema,
   type CompileOptions,
   type CompileStats,
-  type CompiledPredicate,
-  type CompiledSchema,
+  type RegexCompiler,
   type StrictIssue,
   type Validator,
   type ValidationResult,

--- a/packages/schema/src/internals.ts
+++ b/packages/schema/src/internals.ts
@@ -42,6 +42,9 @@ export {
   deepEqual,
   typeOf,
   wrapErrors,
+  type CompiledRegex,
+  type CreateDepsOptions,
+  type RegexCompiler,
   type ValidatorDeps,
 } from "./compiler/runtime.js";
 

--- a/packages/schema/test/regex-compiler.test.ts
+++ b/packages/schema/test/regex-compiler.test.ts
@@ -94,6 +94,30 @@ describe("regexCompiler option", () => {
     expect(calls).toBe(1);
   });
 
+  it('format: "regex" does NOT memoize runtime values (bounded memory)', () => {
+    // The `pattern` keyword caches schema-authored strings (bounded
+    // by spec size). The `regex` format runs against user data; if
+    // that path used the same cache, a long-lived validator
+    // receiving many unique regex inputs would grow memory without
+    // bound. Pin the no-cache behavior: many unique inputs => many
+    // compiler calls; the cache stays empty.
+    let calls = 0;
+    const compiler: RegexCompiler = (pattern) => {
+      calls += 1;
+      return new RegExp(pattern, "u");
+    };
+    const { validate } = compileSchema(
+      { type: "string", format: "regex" },
+      { dialect: openapi31Dialect, regexCompiler: compiler },
+    );
+    const distinctValues = ["^a$", "^b$", "^c$", "^d$", "^e$"];
+    for (const v of distinctValues) validate(v);
+    expect(calls).toBe(distinctValues.length);
+    // Repeating the same value also re-invokes the compiler (no cache).
+    validate("^a$");
+    expect(calls).toBe(distinctValues.length + 1);
+  });
+
   it("user-supplied `regex` format overrides the auto-registered one", () => {
     let userCompilerCalls = 0;
     const userRegex = (_value: string): boolean => {

--- a/packages/schema/test/regex-compiler.test.ts
+++ b/packages/schema/test/regex-compiler.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  compileSchema,
+  jsonSchemaDialect,
+  openapi31Dialect,
+  type CompiledRegex,
+  type RegexCompiler,
+} from "../src/index.js";
+
+describe("regexCompiler option", () => {
+  it("default: `pattern` validation behaves as before", () => {
+    const { validate } = compileSchema(
+      { type: "string", pattern: "^\\d+$" },
+      { dialect: jsonSchemaDialect },
+    );
+    expect(validate("123")).toEqual({ valid: true });
+    expect(validate("abc").valid).toBe(false);
+  });
+
+  it('default: `format: "regex"` is auto-registered (no formats option needed)', () => {
+    // The OpenAPI dialects activate format-assertion. Auto-registration
+    // means callers no longer need to thread builtInFormats just to get
+    // the regex format.
+    const { validate } = compileSchema(
+      { type: "string", format: "regex" },
+      { dialect: openapi31Dialect },
+    );
+    expect(validate("^abc$")).toEqual({ valid: true });
+    expect(validate("(unclosed").valid).toBe(false);
+  });
+
+  it("custom regexCompiler is invoked for the `pattern` keyword", () => {
+    const calls: string[] = [];
+    const compiler: RegexCompiler = (pattern) => {
+      calls.push(pattern);
+      // Reject everything, exercise the pattern keyword's failure path.
+      return { test: () => false };
+    };
+    const { validate } = compileSchema(
+      { type: "string", pattern: "^x$" },
+      { dialect: jsonSchemaDialect, regexCompiler: compiler },
+    );
+    const result = validate("x");
+    expect(result.valid).toBe(false);
+    expect(calls).toEqual(["^x$"]);
+  });
+
+  it('custom regexCompiler is invoked for `format: "regex"`', () => {
+    const calls: string[] = [];
+    const accepting: RegexCompiler = (pattern) => {
+      calls.push(pattern);
+      return { test: () => true };
+    };
+    const { validate } = compileSchema(
+      { type: "string", format: "regex" },
+      { dialect: openapi31Dialect, regexCompiler: accepting },
+    );
+    // The format dispatch compiles the value-as-pattern. A custom
+    // compiler that accepts everything makes every string a "valid"
+    // regex, so validation passes.
+    expect(validate("anything-goes")).toEqual({ valid: true });
+    expect(calls).toEqual(["anything-goes"]);
+  });
+
+  it("rejects from a custom regexCompiler surface as format-validation failures", () => {
+    const rejecting: RegexCompiler = (pattern) => {
+      if (pattern.includes("(a+)+")) throw new Error("redos suspect");
+      return new RegExp(pattern);
+    };
+    const { validate } = compileSchema(
+      { type: "string", format: "regex" },
+      { dialect: openapi31Dialect, regexCompiler: rejecting },
+    );
+    expect(validate("ok").valid).toBe(true);
+    expect(validate("(a+)+").valid).toBe(false);
+  });
+
+  it("compiler is called once per unique pattern (memoized)", () => {
+    let calls = 0;
+    const compiler: RegexCompiler = (pattern) => {
+      calls += 1;
+      return new RegExp(pattern, "u");
+    };
+    const { validate } = compileSchema(
+      {
+        type: "array",
+        items: { type: "string", pattern: "^id-" },
+      },
+      { dialect: jsonSchemaDialect, regexCompiler: compiler },
+    );
+    validate(["id-1", "id-2", "id-3"]);
+    validate(["id-4", "id-5"]);
+    expect(calls).toBe(1);
+  });
+
+  it("user-supplied `regex` format overrides the auto-registered one", () => {
+    let userCompilerCalls = 0;
+    const userRegex = (_value: string): boolean => {
+      userCompilerCalls += 1;
+      return false; // always fail
+    };
+    const { validate } = compileSchema(
+      { type: "string", format: "regex" },
+      {
+        dialect: openapi31Dialect,
+        formats: { regex: userRegex },
+      },
+    );
+    expect(validate("^x$").valid).toBe(false);
+    expect(userCompilerCalls).toBe(1);
+  });
+
+  it("CompiledRegex shape: returning a duck-typed object with .test() works", () => {
+    // Pin the contract: the runtime only reads .test(s). Anything that
+    // satisfies CompiledRegex is acceptable as a compiler return value.
+    const compiler: RegexCompiler = (pattern): CompiledRegex => ({
+      test(s) {
+        return s === pattern.replace(/^\^|\$$/g, "");
+      },
+    });
+    const { validate } = compileSchema(
+      { type: "string", pattern: "^hello$" },
+      { dialect: jsonSchemaDialect, regexCompiler: compiler },
+    );
+    expect(validate("hello").valid).toBe(true);
+    expect(validate("world").valid).toBe(false);
+  });
+});

--- a/packages/schema/test/regex-compiler.test.ts
+++ b/packages/schema/test/regex-compiler.test.ts
@@ -6,6 +6,7 @@ import {
   type CompiledRegex,
   type RegexCompiler,
 } from "../src/index.js";
+import { createDeps } from "../src/compiler/runtime.js";
 
 describe("regexCompiler option", () => {
   it("default: `pattern` validation behaves as before", () => {
@@ -108,6 +109,25 @@ describe("regexCompiler option", () => {
     );
     expect(validate("^x$").valid).toBe(false);
     expect(userCompilerCalls).toBe(1);
+  });
+
+  it("createDeps(maxErrors) legacy positional form still works", () => {
+    // AOT-emitted modules built before the options-bag landed call
+    // `createDeps()` and `createDeps(N)`. Pin both shapes to catch a
+    // future change that silently breaks the standalone emit path
+    // (no static guard exists outside of running an emitted module).
+    const defaultDeps = createDeps();
+    expect(defaultDeps.maxErrors).toBe(Number.POSITIVE_INFINITY);
+    expect(defaultDeps.errorsRemaining).toBe(Number.POSITIVE_INFINITY);
+    expect(defaultDeps.formats.has("regex")).toBe(true);
+
+    const cappedDeps = createDeps(5);
+    expect(cappedDeps.maxErrors).toBe(5);
+    expect(cappedDeps.errorsRemaining).toBe(5);
+
+    const optionsDeps = createDeps({ maxErrors: 7 });
+    expect(optionsDeps.maxErrors).toBe(7);
+    expect(optionsDeps.errorsRemaining).toBe(7);
   });
 
   it("CompiledRegex shape: returning a duck-typed object with .test() works", () => {

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -26,4 +26,9 @@ export {
   readBodyFromFetch,
   type FetchRequestOptions,
 } from "./from-fetch.js";
-export type { CustomKeywordFailure, CustomKeywordValidator } from "@oav/schema";
+export type {
+  CompiledRegex,
+  CustomKeywordFailure,
+  CustomKeywordValidator,
+  RegexCompiler,
+} from "@oav/schema";

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -26,6 +26,7 @@ import {
   type CustomKeywordValidator,
   type Dialect,
   type RefResolver,
+  type RegexCompiler,
   type StrictIssue,
 } from "@oav/schema";
 import { deserialize, matchMediaType, matchResponseKey } from "./deserialize.js";
@@ -424,6 +425,15 @@ export interface ValidatorOptions {
    * - `"strict"`: warn on partial features AND unknown keys.
    */
   strict?: "off" | "warn-partial" | "strict";
+  /**
+   * Custom compiler for schema `pattern` keywords and `format: "regex"`.
+   * Defaults to JavaScript's built-in `RegExp` (with u-mode and a
+   * non-u fallback). Override to plug in a library like `re2` when
+   * the spec is attacker-controlled and ReDoS is a concern. See
+   * {@link RegexCompiler} and the "Hardening against untrusted regex
+   * patterns" recipe in `docs/configuration.md`.
+   */
+  regexCompiler?: RegexCompiler;
 
   // --- 4. HTTP-validator-specific extras ---
 
@@ -650,6 +660,7 @@ export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions
       maxErrors: options.maxErrors,
       keywords: options.keywords,
       strict: options.strict,
+      regexCompiler: options.regexCompiler,
     });
     compiledCache.set(schema, c);
     for (const issue of c.stats.strictIssues) strictIssues.push(issue);

--- a/packages/validator/test/regex-compiler.test.ts
+++ b/packages/validator/test/regex-compiler.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import type { OpenAPIDocument } from "@oav/core";
+import type { RegexCompiler } from "../src/index.js";
+import { createValidator } from "../src/validator.js";
+
+/**
+ * Validator-level forwarding: createValidator(spec, { regexCompiler })
+ * has to thread the option into every per-operation compileSchema
+ * invocation. The compiler-level tests in @oav/schema cover the API
+ * directly; these tests exercise the validator surface so a future
+ * refactor that drops the forward (e.g. only passing through one of
+ * the request / response code paths) regresses visibly.
+ */
+describe("createValidator forwards regexCompiler", () => {
+  function spec(): OpenAPIDocument {
+    return {
+      openapi: "3.1.0",
+      info: { title: "pat", version: "1" },
+      paths: {
+        "/items": {
+          post: {
+            requestBody: {
+              required: true,
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    required: ["sku"],
+                    properties: { sku: { type: "string", pattern: "^OAV-" } },
+                  },
+                },
+              },
+            },
+            responses: {
+              "200": {
+                description: "ok",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: { id: { type: "string", pattern: "^[a-z0-9-]+$" } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+  }
+
+  it("invokes the custom compiler for request-body pattern keywords", () => {
+    const seen: string[] = [];
+    const compiler: RegexCompiler = (pattern) => {
+      seen.push(pattern);
+      return new RegExp(pattern, "u");
+    };
+    const v = createValidator(spec(), { regexCompiler: compiler });
+    v.validateRequest({
+      method: "POST",
+      path: "/items",
+      contentType: "application/json",
+      body: { sku: "OAV-42" },
+    });
+    expect(seen).toContain("^OAV-");
+  });
+
+  it("invokes the custom compiler for response-body pattern keywords", () => {
+    const seen: string[] = [];
+    const compiler: RegexCompiler = (pattern) => {
+      seen.push(pattern);
+      return new RegExp(pattern, "u");
+    };
+    const v = createValidator(spec(), { regexCompiler: compiler });
+    v.validateResponse(
+      {
+        method: "POST",
+        path: "/items",
+        contentType: "application/json",
+        body: { sku: "OAV-42" },
+      },
+      {
+        status: 200,
+        contentType: "application/json",
+        body: { id: "abc-123" },
+      },
+    );
+    expect(seen).toContain("^[a-z0-9-]+$");
+  });
+
+  it("a rejecting custom compiler makes pattern validation fail", () => {
+    // Pin the failure path: the validator should surface a pattern
+    // validation error when the custom compiler returns a regex that
+    // matches nothing.
+    const v = createValidator(spec(), {
+      regexCompiler: () => ({ test: () => false }),
+    });
+    const err = v.validateRequest({
+      method: "POST",
+      path: "/items",
+      contentType: "application/json",
+      body: { sku: "OAV-42" },
+    });
+    expect(err).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #146. Unblocks #216 (AOT \`--regex-compiler-import\` flag).

## Summary

Opt-in hook for replacing JavaScript's built-in \`RegExp\` when compiling schema \`pattern\` keywords and the \`format: "regex"\` assertion. Defaults to the current behavior (u-mode with a non-u fallback); set \`regexCompiler\` to plug in \`re2\`, a complexity check, or a pattern allowlist when the spec is attacker-controlled.

\`\`\`ts
import RE2 from "re2";
import { createValidator } from "@aahoughton/oav";

createValidator(spec, { regexCompiler: (p) => new RE2(p) });
\`\`\`

The runtime contract is duck-typed (\`{ test(s: string): boolean }\`); built-in \`RegExp\` already satisfies it. A \`CompiledRegex\` interface is exported for typing custom returns.

## Layout (option b from the issue)

\`format: "regex"\` is **moved into \`@oav/schema\`**: \`createDeps\` auto-registers it so it routes through the same \`compilePattern\` path as the \`pattern\` keyword, sharing the \`regexCompiler\` hook. The corresponding entry is removed from \`@oav/formats\`'s \`builtInFormats\`. Rationale: \`@oav/formats\`'s story is "drop-in pure string predicates"; \`regex\` is the one format that wants schema-compiler coordination, and it belongs in \`@oav/schema\`. User-supplied \`formats: { regex: ... }\` entries still override.

The standalone \`validateRegex\` function stays exported from \`@oav/formats\` as a u-mode utility for callers who want strict legacy behavior independent of whatever compiler is configured.

## Surface

- \`compileSchema(s, { regexCompiler })\` — schema-level.
- \`createValidator(spec, { regexCompiler })\` — validator-level, forwarded through to compileSchema.
- \`createDeps(options)\` — accepts \`{ maxErrors, regexCompiler }\`; legacy positional \`createDeps(maxErrors)\` form preserved for back-compat with AOT-emitted modules.

## Tests

- Default behavior unchanged for both \`pattern\` and \`format: "regex"\`.
- Custom compiler invoked for both.
- Throws from a custom compiler surface as format-validation failures (not as construction-time errors) when triggered by \`format: "regex"\`.
- Memoization: one compile call per unique pattern across many validate() invocations.
- User-supplied \`regex\` format overrides the auto-registered one.
- Duck-typed \`CompiledRegex\` (an object with just \`.test(s)\`) works.

## Docs

- README "Known limitations" note pivots from "tracked in #146" to "pass \`regexCompiler\`" with a backreference.
- New "Hardening against untrusted regex patterns" subsection in \`docs/configuration.md\` with re2 + safe-regex worked examples and a note on edge-runtime tradeoffs (we don't bundle a native engine).

## Out of scope

- AOT CLI flag (#216) — runtime API needs to land first.
- Built-in safe-regex heuristic, built-in pattern length cap, native \`re2\` dep — explicitly out of scope per the issue.

## Test plan

- [x] \`pnpm typecheck\` clean.
- [x] \`pnpm lint\` clean.
- [x] \`pnpm test\` clean (1013 tests, 8 new in \`packages/schema/test/regex-compiler.test.ts\`).
- [x] \`pnpm build\` clean.
- [ ] CI green.