### PR TITLE
docs(core): toProblemDetails echoes request values + schema metadata

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -609,6 +609,63 @@ For richer response envelopes, `toProblemDetails` produces
 field. `collectIssues` is the raw flat leaf list if you want to roll
 your own response shape.
 
+### Redacting field values from problem-details responses
+
+`toProblemDetails` echoes input values and schema metadata into the
+response by design. The default `detail` is a one-line summary of the
+first failing leaf, which interpolates the offending value for codes
+such as `enum`, `format`, and `pattern`. Each `issues[*].params`
+carries the machine-readable detail per code (`pattern.actual`,
+`additionalProperties.unexpected`, `required.missing`,
+`enum.allowed`, `pattern.pattern`, and so on; see `BuiltInErrorParams`
+for the full set). That is the right default for trusted clients and
+developer-facing APIs: machine-readable detail is what the envelope
+exists for.
+
+It is also a fingerprinting / data-exposure surface for endpoints
+that take request bodies containing PII (emails, account numbers,
+free text) or that validate against a spec whose internals (mapping
+keys, allowed enums) shouldn't be enumerable by an unauthenticated
+client. Two override points are exposed: pass `detail` to
+`toProblemDetails` for a structural summary, and post-process
+`issues[*].params` before sending.
+
+```ts
+import { httpStatusFor, toProblemDetails, type ValidationError } from "@aahoughton/oav";
+
+function safeProblemDetails(err: ValidationError, instance: string) {
+  const pd = toProblemDetails(err, { instance });
+  return {
+    ...pd,
+    // Structural summary; nothing about the offending value reaches detail.
+    detail: `${pd.issues.length} validation error(s)`,
+    // Clear per-leaf params; clients still get code, path, pointer, message.
+    issues: pd.issues.map((issue) => ({ ...issue, params: {} })),
+  };
+}
+
+app.use(
+  validateRequests(validator, {
+    onError: (err, ctx) => {
+      ctx.res
+        .status(httpStatusFor(err))
+        .type("application/problem+json")
+        .json(safeProblemDetails(err, ctx.req.originalUrl));
+    },
+  }),
+);
+```
+
+The trade-off: clients lose machine-readable detail in exchange for
+not leaking field values or schema internals. Each issue still
+carries `code` and `pointer`, which describe what failed and where;
+the value the client sent and the value the schema expected stay on
+the server. Narrower policies (clear `params` only on
+specific codes; clear `params` only on request paths under
+`/body/...`; keep `enum.allowed` but drop `enum.actual`) compose
+straightforwardly from the same hook; the broad form above is the
+starting point.
+
 ### Preserving an existing client error envelope
 
 Migrating an existing service may mean a documented client

--- a/packages/core/src/problem-details.ts
+++ b/packages/core/src/problem-details.ts
@@ -22,7 +22,14 @@ export interface ValidationIssue {
   pointer: string;
   /** Human-readable description. */
   message: string;
-  /** Machine-readable details; shape per-code documented in {@link BuiltInErrorParams}. */
+  /**
+   * Machine-readable details for this issue; shape per-code
+   * documented in {@link BuiltInErrorParams}. Most code-specific
+   * shapes include request-derived fields (e.g. `pattern.actual`,
+   * `additionalProperties.unexpected`) or schema-derived metadata
+   * (e.g. `enum.allowed`, `maximum.maximum`). See the security note
+   * on {@link toProblemDetails} when serving untrusted clients.
+   */
   params: Record<string, unknown>;
 }
 
@@ -69,9 +76,13 @@ export interface ProblemDetailsOptions {
    * Override the human-readable `detail`. Defaults to
    * {@link formatSummary}(error): a single line describing the first
    * failing leaf (e.g. `"body.users[0].email must match format \"email\""`).
-   * Pass an explicit string for a structural summary like
-   * `` `${issues.length} validation error(s)` `` if you'd rather
-   * not surface a leaf in `detail`.
+   * The default summary interpolates the offending value for codes
+   * such as `enum`, `format`, and `pattern`; APIs serving untrusted
+   * clients should pass an explicit structural summary
+   * (e.g. `` `${issues.length} validation error(s)` ``) so leaf data
+   * does not appear in `detail`. See the security note on
+   * {@link toProblemDetails} for the corresponding `issues[*].params`
+   * concern.
    */
   detail?: string;
 }
@@ -101,6 +112,23 @@ export function collectIssues(error: ValidationError): ValidationIssue[] {
  * Convert a {@link ValidationError} tree to an RFC 9457 "Problem
  * Details for HTTP APIs" response body. Render as
  * `application/problem+json` in your HTTP layer.
+ *
+ * **Data exposure.** By design, the rendered response echoes input
+ * values and schema metadata. `detail` defaults to a one-line
+ * summary of the first failing leaf, which interpolates the
+ * offending value for codes such as `enum`, `format`, and `pattern`.
+ * Each `issues[*].params` carries the leaf's machine-readable
+ * detail (see {@link BuiltInErrorParams}), including request-derived
+ * fields (`pattern.actual`, `additionalProperties.unexpected`,
+ * `required.missing`) and schema-derived metadata (`enum.allowed`,
+ * `pattern.pattern`, `maximum.maximum`). This is the right default
+ * for trusted clients and developer-facing APIs. APIs serving
+ * untrusted clients, or APIs validating request bodies that contain
+ * PII, should override `detail` with a structural summary (e.g.
+ * `` `${pd.issues.length} validation error(s)` ``) and may want to
+ * clear `issues[*].params` before sending. See the "Redacting field
+ * values from problem-details responses" recipe in
+ * `docs/integration.md`.
  *
  * @example
  * ```ts


### PR DESCRIPTION
## Summary

- Add a TSDoc note on `toProblemDetails`, `ProblemDetailsOptions.detail`, and `ValidationIssue.params` describing the default echoing behavior: the default `detail` interpolates the offending value for codes like `enum`, `format`, and `pattern`, and `issues[*].params` carries request-derived and schema-derived fields per `BuiltInErrorParams`. Frames it as the right default for trusted clients and developer-facing APIs; flags PII / unauthenticated-client scenarios where the override hooks earn their keep.
- Add a "Redacting field values from problem-details responses" section in `docs/integration.md` with a worked recipe: pass a structural `detail` to `toProblemDetails`, then post-process `issues[*].params` to drop per-leaf detail before sending. Recipe sits between "Status-code mapping" and "Preserving an existing client error envelope" so the progression reads default-envelope, adjust-default, replace-default.

No API change. Defaults are unchanged; the override points already existed. The point is making the decision visible at the moment a caller is about to render a response.

Closes #292.

## Test plan

- [x] `pnpm typecheck` and `pnpm lint`.
- [ ] Reviewer: confirm the TSDoc renders correctly in your editor (cross-references to `BuiltInErrorParams` and `toProblemDetails` should resolve).
- [ ] Reviewer: spot-check the recipe by running it locally against an invalid request and verifying `detail` becomes the structural summary and `issues[*].params` come through as `{}`.