### PR TITLE
ci: pin auto-install-peers=true in each isolated sub-root

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,16 @@ workspace: `oav-fastify/src/*.ts` imports `import type { FastifyRequest } from "
 and there is no `@types/fastify` on DefinitelyTyped, so the package
 itself has to be present for tsc to resolve the type.
 
+Each sub-root (`conformance/`, `framework-tests/`, `performance/`,
+`performance/mem-bench/`) ships its own `.npmrc` pinning
+`auto-install-peers=true`. pnpm in CI treats a sub-root's
+`pnpm-workspace.yaml` as the project boundary and does not walk past
+it to find the root `.npmrc`; dependabot's lockfile refresh does walk
+up. Without a sub-root `.npmrc`, the two readers disagree, dependabot
+writes lockfiles with `autoInstallPeers: false`, and the CI install
+fails with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. The sub-root files
+make the value explicit so both paths agree on `true`.
+
 ## Architecture, package by package
 
 - **`@oav/core`**: the shared error-tree model plus the helpers every

--- a/conformance/.npmrc
+++ b/conformance/.npmrc
@@ -1,0 +1,10 @@
+# Pin auto-install-peers to true (pnpm's default) so this sub-root's
+# behavior is independent of the main workspace's root .npmrc, which
+# sets auto-install-peers=false to keep the framework adapters'
+# peer-dep declarations out of the main lockfile. pnpm in CI treats
+# conformance/pnpm-workspace.yaml as the project boundary and doesn't
+# walk past it to find the root .npmrc; dependabot's lockfile refresh
+# does walk up. Without this file, the two readers disagree, the
+# regenerated lockfile and pnpm's effective config mismatch, and
+# `pnpm install --frozen-lockfile` fails.
+auto-install-peers=true

--- a/framework-tests/.npmrc
+++ b/framework-tests/.npmrc
@@ -1,0 +1,10 @@
+# Pin auto-install-peers to true (pnpm's default) so this sub-root's
+# behavior is independent of the main workspace's root .npmrc, which
+# sets auto-install-peers=false to keep the framework adapters'
+# peer-dep declarations out of the main lockfile. pnpm in CI treats
+# framework-tests/pnpm-workspace.yaml as the project boundary and
+# doesn't walk past it to find the root .npmrc; dependabot's lockfile
+# refresh does walk up. Without this file, the two readers disagree,
+# the regenerated lockfile and pnpm's effective config mismatch, and
+# `pnpm install --frozen-lockfile` fails.
+auto-install-peers=true

--- a/performance/.npmrc
+++ b/performance/.npmrc
@@ -1,0 +1,10 @@
+# Pin auto-install-peers to true (pnpm's default) so this sub-root's
+# behavior is independent of the main workspace's root .npmrc, which
+# sets auto-install-peers=false to keep the framework adapters'
+# peer-dep declarations out of the main lockfile. pnpm in CI treats
+# performance/pnpm-workspace.yaml as the project boundary and doesn't
+# walk past it to find the root .npmrc; dependabot's lockfile refresh
+# does walk up. Without this file, the two readers disagree, the
+# regenerated lockfile and pnpm's effective config mismatch, and
+# `pnpm install --frozen-lockfile` fails.
+auto-install-peers=true

--- a/performance/mem-bench/.npmrc
+++ b/performance/mem-bench/.npmrc
@@ -1,0 +1,5 @@
+# Pin auto-install-peers to true (pnpm's default). See sibling
+# performance/.npmrc for the full rationale. mem-bench has its own
+# isolated pnpm root (separate from performance/), so it gets its own
+# .npmrc rather than inheriting from performance/.
+auto-install-peers=true


### PR DESCRIPTION
## Summary

Add a `.npmrc` with `auto-install-peers=true` in each isolated sub-root: `conformance/`, `framework-tests/`, `performance/`, and `performance/mem-bench/`.

## Why

The root `.npmrc` sets `auto-install-peers=false` to keep the adapter packages' peer-dep declarations (express, fastify) out of the main lockfile (introduced in #298). The sub-roots are unrelated and want pnpm's default (`true`), which is the value their lockfiles were generated under.

The bug: pnpm in CI treats a sub-root's `pnpm-workspace.yaml` as the project boundary and does NOT walk past it to find the parent `.npmrc`. CI install reads the default `true`, matches the sub-root lockfile's `autoInstallPeers: true`, succeeds.

Dependabot's lockfile refresh, however, DOES walk up to the repo root and picks up `auto-install-peers=false`. The regenerated sub-root lockfile lands with `autoInstallPeers: false`. The CI install then reads `true` (default, since it doesn't walk up), mismatches, and fails with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. That's what's blocking #301 (vitest in /framework-tests) and #302 (tsx in /conformance).

After this PR, both readers see the same value from the same file, no matter which direction they walk: dependabot finds the sub-root `.npmrc` first walking up, CI finds the same file in cwd, both get `true`, and the regenerated lockfiles stay consistent.

No lockfile churn from this commit; the existing sub-root lockfiles already record `autoInstallPeers: true`, which matches the new `.npmrc` values.

## Follow-up

After merge, `@dependabot rebase` on #301 and #302 (or wait for the next refresh cycle); they'll regenerate against the new sub-root `.npmrc` and produce lockfiles that CI accepts.

## Test plan

- [x] `pnpm install --frozen-lockfile` succeeds locally in each of the four sub-roots.
- [x] Root `pnpm install`, `pnpm test`, `pnpm typecheck`, `pnpm lint` all pass.
- [ ] CI: all jobs green (the new `.npmrc` files don't change install behavior, only consistency with dependabot).