### PR TITLE
fix(release): prefix tarball path with ./ for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,5 +157,10 @@ jobs:
               continue
             fi
             echo "publish: ${name}@${version}"
-            npm publish --access public "$tarball"
+            # `./` prefix: without it npm 11 parses a relative path
+            # containing `/` as a github user/repo spec (e.g.
+            # `pkgs/aahoughton-oav-X.tgz` -> github user `pkgs`, repo
+            # `aahoughton-oav-X.tgz`) and tries to git-clone it,
+            # failing with code 128 before any OIDC token exchange.
+            npm publish --access public "./$tarball"
           done


### PR DESCRIPTION
## Summary

Prefix the publish-loop's tarball argument with \`./\` so npm 11's argument parser treats it as a local file path rather than a github user/repo spec.

## What happened

The first OIDC trusted-publishing release (#305 / v2.2.1) failed at the very first \`npm publish\` invocation, before any OIDC token exchange. npm 11's parser saw \`pkgs/aahoughton-oav-2.2.1.tgz\` (no leading \`./\`, contains \`/\`, isn't a URL), inferred a github spec of user \`pkgs\` repo \`aahoughton-oav-2.2.1.tgz\`, and tried to clone it:

\`\`\`
npm error code 128
npm error An unknown git error occurred
npm error command git --no-replace-objects ls-remote ssh://git@github.com/pkgs/aahoughton-oav-2.2.1.tgz.git
npm error git@github.com: Permission denied (publickey).
\`\`\`

Earlier npm versions were more lenient about this disambiguation; npm 11 (which we picked up via Node 24 for the OIDC support) tightened it.

Verified: \`npm view @aahoughton/oav@2.2.1\`, \`@aahoughton/oav-core@2.2.1\`, etc. all return E404. The git tags exist but nothing reached the registry, so we're in a clean state for the retry.

## Recovery plan

After this merges:

1. \`workflow_dispatch\` the release workflow with \`tag: oav-core-v2.2.1\` (any of the five sibling tags works; release-please links them all to the same commit).
2. The publish loop's \`npm view\` skip check makes it safe even if some tarballs ended up partially published, but in this case none did, so all five should go to the registry on the first retry.
3. Confirms OIDC trusted publishing actually works end-to-end (the first failure happened too early to exercise it).

## Test plan

- [x] Local: \`bash -n .github/workflows/release.yml\` (no syntax errors).
- [ ] CI: confirm \`ci.yml\` is green on this branch (release.yml itself isn't exercised on the PR; only \`pr-title\` plus the standard test/lint/typecheck/build matrix).
- [ ] Post-merge: workflow_dispatch with \`tag: oav-core-v2.2.1\`, watch the \`Publish\` step for OIDC-related lines, confirm all five packages land on npm at 2.2.1.