### PR TITLE
chore(adapters): list LICENSE in published files arrays

### DIFF
--- a/packages/oav-express4/package.json
+++ b/packages/oav-express4/package.json
@@ -26,7 +26,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "LICENSE"
   ],
   "type": "module",
   "sideEffects": false,

--- a/packages/oav-express5/package.json
+++ b/packages/oav-express5/package.json
@@ -26,7 +26,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "LICENSE"
   ],
   "type": "module",
   "sideEffects": false,

--- a/packages/oav-fastify/package.json
+++ b/packages/oav-fastify/package.json
@@ -25,7 +25,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "LICENSE"
   ],
   "type": "module",
   "sideEffects": false,

--- a/packages/oav/package.json
+++ b/packages/oav/package.json
@@ -33,7 +33,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "LICENSE"
   ],
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
Adds `LICENSE` to the `files` array of `oav`, `oav-express4`, `oav-express5`, `oav-fastify`, matching `oav-core`. LICENSE was already shipping (pnpm pack walks up to the root file), but the explicit listing makes it discoverable from the manifest and avoids divergence if a per-package LICENSE ever lands.