### PR TITLE
chore(release): strip devDependencies from published tarballs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ performance/results/
 *.log
 oav-*.tgz
 aahoughton-oav-*.tgz
+package.json.bak
 MIGRATION-NOTES.md
 .claude/
 mise.toml

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -20,7 +20,8 @@
         "packages/oav/src/cli.ts",
         "examples/**",
         "performance/**",
-        "conformance/**"
+        "conformance/**",
+        "scripts/**"
       ],
       "rules": {
         "no-console": "off"

--- a/package.json
+++ b/package.json
@@ -130,7 +130,8 @@
     "lint": "oxlint && oxfmt --check .",
     "fmt": "oxfmt --write .",
     "typecheck": "tsc -b && tsc -p examples",
-    "prepack": "pnpm build",
+    "prepack": "pnpm build && node ./scripts/pack-devdeps.mjs strip",
+    "postpack": "node ./scripts/pack-devdeps.mjs restore",
     "prepublishOnly": "pnpm test"
   },
   "devDependencies": {

--- a/packages/oav-express4/package.json
+++ b/packages/oav-express4/package.json
@@ -54,7 +54,8 @@
     "build": "tsup",
     "test": "vitest run",
     "typecheck": "tsc -b",
-    "prepack": "node -e \"if((process.env.npm_config_user_agent||'').startsWith('npm/'))throw Error('Use pnpm pack: npm pack does not rewrite workspace:* deps.')\" && tsup"
+    "prepack": "node -e \"if((process.env.npm_config_user_agent||'').startsWith('npm/'))throw Error('Use pnpm pack: npm pack does not rewrite workspace:* deps.')\" && tsup && node ../../scripts/pack-devdeps.mjs strip",
+    "postpack": "node ../../scripts/pack-devdeps.mjs restore"
   },
   "dependencies": {
     "@aahoughton/oav-core": "workspace:*"

--- a/packages/oav-express5/package.json
+++ b/packages/oav-express5/package.json
@@ -54,7 +54,8 @@
     "build": "tsup",
     "test": "vitest run",
     "typecheck": "tsc -b",
-    "prepack": "node -e \"if((process.env.npm_config_user_agent||'').startsWith('npm/'))throw Error('Use pnpm pack: npm pack does not rewrite workspace:* deps.')\" && tsup"
+    "prepack": "node -e \"if((process.env.npm_config_user_agent||'').startsWith('npm/'))throw Error('Use pnpm pack: npm pack does not rewrite workspace:* deps.')\" && tsup && node ../../scripts/pack-devdeps.mjs strip",
+    "postpack": "node ../../scripts/pack-devdeps.mjs restore"
   },
   "dependencies": {
     "@aahoughton/oav-core": "workspace:*"

--- a/packages/oav-fastify/package.json
+++ b/packages/oav-fastify/package.json
@@ -53,7 +53,8 @@
     "build": "tsup",
     "test": "vitest run",
     "typecheck": "tsc -b",
-    "prepack": "node -e \"if((process.env.npm_config_user_agent||'').startsWith('npm/'))throw Error('Use pnpm pack: npm pack does not rewrite workspace:* deps.')\" && tsup"
+    "prepack": "node -e \"if((process.env.npm_config_user_agent||'').startsWith('npm/'))throw Error('Use pnpm pack: npm pack does not rewrite workspace:* deps.')\" && tsup && node ../../scripts/pack-devdeps.mjs strip",
+    "postpack": "node ../../scripts/pack-devdeps.mjs restore"
   },
   "dependencies": {
     "@aahoughton/oav-core": "workspace:*"

--- a/packages/oav/package.json
+++ b/packages/oav/package.json
@@ -131,7 +131,8 @@
     "build": "tsup",
     "test": "vitest run",
     "typecheck": "tsc -b",
-    "prepack": "node -e \"if((process.env.npm_config_user_agent||'').startsWith('npm/'))throw Error('Use pnpm pack: npm pack does not rewrite workspace:* deps.')\" && tsup"
+    "prepack": "node -e \"if((process.env.npm_config_user_agent||'').startsWith('npm/'))throw Error('Use pnpm pack: npm pack does not rewrite workspace:* deps.')\" && tsup && node ../../scripts/pack-devdeps.mjs strip",
+    "postpack": "node ../../scripts/pack-devdeps.mjs restore"
   },
   "dependencies": {
     "@aahoughton/oav-core": "workspace:*",

--- a/scripts/pack-devdeps.mjs
+++ b/scripts/pack-devdeps.mjs
@@ -1,0 +1,40 @@
+// Strip / restore `devDependencies` on the current package's
+// package.json around `pnpm pack`. Devdeps in a published tarball
+// are dead weight; for sub-packages they additionally expose the
+// `@oav/*` workspace names (rewritten to `0.0.0`).
+//
+// Considered alternative: `clean-publish` (the canonical npm-ecosystem
+// tool for this) is incompatible with our setup. Its documented pnpm-
+// workspaces pattern relies on `publishConfig.directory`, which pnpm
+// 10 mishandles for `workspace:*` deps at pack time (pnpm/pnpm#6253):
+// `pnpm pack` errors with ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL,
+// breaking the pack-smoke CI job that simulates a real install.
+// `pnpm publish` handles it, but `pnpm pack` does not.
+//
+// Use:
+//   prepack:  ... && node <path>/pack-devdeps.mjs strip
+//   postpack: node <path>/pack-devdeps.mjs restore
+//
+// `strip` is self-healing: if a `.bak` from a previous failed run
+// exists, it is restored first so the strip starts from a clean
+// source.
+
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+
+const mode = process.argv[2];
+const path = "package.json";
+const bak = "package.json.bak";
+
+if (mode === "strip") {
+  if (existsSync(bak)) renameSync(bak, path);
+  const orig = readFileSync(path, "utf8");
+  writeFileSync(bak, orig);
+  const pkg = JSON.parse(orig);
+  delete pkg.devDependencies;
+  writeFileSync(path, JSON.stringify(pkg, null, 2) + "\n");
+} else if (mode === "restore") {
+  if (existsSync(bak)) renameSync(bak, path);
+} else {
+  console.error(`pack-devdeps: expected "strip" or "restore", got ${JSON.stringify(mode)}`);
+  process.exit(2);
+}


### PR DESCRIPTION
All five tarballs were publishing their `devDependencies`. The sub-packages additionally leaked internal `@oav/*` workspace names (rewritten to `0.0.0`, unresolvable).

`scripts/pack-devdeps.mjs` runs from each package's prepack to stash the local manifest and write a stripped copy; postpack restores. The strip step is self-healing if a prior run failed mid-pack.

Considered the canonical [`clean-publish`](https://github.com/shashkovdanil/clean-publish) tool but its documented pnpm-workspaces pattern relies on `publishConfig.directory`, which trips [pnpm/pnpm#6253](https://github.com/pnpm/pnpm/issues/6253): `pnpm pack` errors with `ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL` on `workspace:*` deps when that field is set, breaking the pack-smoke job. `pnpm publish` handles it, but `pnpm pack` doesn't. The homebrew script sidesteps the bug and keeps pack-smoke working without changes.

Verified: `pnpm pack` on each of the five packages produces a tarball whose manifest has no `devDependencies` key; local manifests are restored after pack completes.