### PR TITLE
feat(oav): make esbuild an optional peer dependency

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -16,9 +16,11 @@ npx @aahoughton/oav validate openapi.yaml --request req.http
 
 The CLI lives in the `oav` package, not `oav-core`. `oav-core`
 doesn't ship a `bin` or any CLI glue. `oav` carries `commander`
-(argv parsing) and `esbuild` (AOT bundling for `compile-schema` /
-`compile-spec`) as regular dependencies. Users who only need the
-programmatic API install `oav-core` instead.
+(argv parsing) as a regular dependency. `esbuild` (AOT bundling
+for `compile-schema` / `compile-spec`) is an optional peer
+dependency; install it alongside `oav` only if you use those
+commands. Users who only need the programmatic API install
+`oav-core` instead.
 
 ## Commands
 

--- a/packages/oav/README.md
+++ b/packages/oav/README.md
@@ -18,7 +18,7 @@ const validator = createValidator(document);
 
 | Package    | When to use                                                                                                                                                                                             |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `oav`      | Includes YAML readers and the `oav` CLI binary. Pulls in `yaml`, `commander`, and `esbuild` (CLI-only).                                                                                                 |
+| `oav`      | Includes YAML readers and the `oav` CLI binary. Pulls in `yaml` and `commander`. `esbuild` is an optional peer dep; install it alongside `oav` if you use `oav compile-schema` / `oav compile-spec`.    |
 | `oav-core` | Lean. Zero runtime dependencies. JSON specs only (or pre-parsed objects via the memory reader). Use on Cloudflare Workers, Vercel Edge, Lambda@Edge, or anywhere the YAML/CLI footprint isn't worth it. |
 
 `oav` re-exports every subpath of `oav-core` at matching paths

--- a/packages/oav/package.json
+++ b/packages/oav/package.json
@@ -136,7 +136,6 @@
   "dependencies": {
     "@aahoughton/oav-core": "workspace:*",
     "commander": "^15.0.0",
-    "esbuild": "^0.28.0",
     "yaml": "^2.6.0"
   },
   "devDependencies": {
@@ -150,6 +149,14 @@
     "tsup": "8.5.1",
     "typescript": "5.9.3",
     "vitest": "4.1.8"
+  },
+  "peerDependencies": {
+    "esbuild": "^0.28.0"
+  },
+  "peerDependenciesMeta": {
+    "esbuild": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=22"

--- a/packages/oav/src/cli.ts
+++ b/packages/oav/src/cli.ts
@@ -1,29 +1,25 @@
 #!/usr/bin/env node
 export {};
 
-// `commander` and `esbuild` are regular dependencies of
-// `oav`, so a normal install puts them in node_modules.
-// If they're missing, the install is corrupted; catch the dynamic
-// import up front and print a clearer message than the default
-// ERR_MODULE_NOT_FOUND trace.
-for (const { name, purpose } of [
-  { name: "commander", purpose: "argv parsing" },
-  { name: "esbuild", purpose: "AOT compile-schema / compile-spec bundling" },
-] as const) {
-  try {
-    await import(name);
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ERR_MODULE_NOT_FOUND") {
-      process.stderr.write(
-        `error: the oav CLI can't resolve '${name}' (${purpose}). ` +
-          "It's declared as a dependency of @aahoughton/oav; reinstall the package to repair the node_modules tree:\n" +
-          "    npm install --force @aahoughton/oav\n" +
-          "    pnpm install --force\n",
-      );
-      process.exit(2);
-    }
-    throw err;
+// `commander` is a regular dependency of `oav`, so a normal install
+// puts it in node_modules. If it's missing, the install is corrupted;
+// catch the dynamic import up front and print a clearer message than
+// the default ERR_MODULE_NOT_FOUND trace. `esbuild` is an optional
+// peer dependency (only `compile-schema` / `compile-spec` use it);
+// its absence is reported lazily by those commands.
+try {
+  await import("commander");
+} catch (err) {
+  if ((err as NodeJS.ErrnoException).code === "ERR_MODULE_NOT_FOUND") {
+    process.stderr.write(
+      "error: the oav CLI can't resolve 'commander' (argv parsing). " +
+        "It's declared as a dependency of @aahoughton/oav; reinstall the package to repair the node_modules tree:\n" +
+        "    npm install --force @aahoughton/oav\n" +
+        "    pnpm install --force\n",
+    );
+    process.exit(2);
   }
+  throw err;
 }
 
 const { buildProgram, defaultCommandIo } = await import("@oav/cli");

--- a/packages/oav/tsup.config.ts
+++ b/packages/oav/tsup.config.ts
@@ -68,7 +68,7 @@ function rewriteOavCore(): Plugin {
   };
 }
 
-const external = ["yaml", "commander"];
+const external = ["yaml", "commander", "esbuild"];
 
 export default defineConfig([
   {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,9 +76,6 @@ importers:
       commander:
         specifier: ^15.0.0
         version: 15.0.0
-      esbuild:
-        specifier: ^0.28.0
-        version: 0.28.0
       yaml:
         specifier: ^2.6.0
         version: 2.9.0


### PR DESCRIPTION
`esbuild` is used only by `oav compile-schema` / `oav compile-spec`; the existing `bundleEmitted` lazy import already prints an install hint when it's missing. Moves the declaration in `packages/oav/package.json` to `peerDependencies` + `peerDependenciesMeta.esbuild.optional = true`, drops the eager preflight check in `src/cli.ts`, refreshes the README rows in `packages/oav` and `packages/cli`, and marks esbuild `external` in `tsup.config.ts` for safety (esbuild's own bundler already leaves the dynamic import alone, but the explicit entry documents intent).

Install impact: users who run `oav compile-schema` / `oav compile-spec` without an explicit `esbuild` install will hit the existing peer-dep error message on next upgrade. Default install drops the ~10 MB esbuild blob for everyone else.

`feat` because release-please should pick this up as a minor bump (2.3.0).