### PR TITLE
perf: large-response benchmarks, object-guard hoist, single-pass required, empty-params sharing

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -328,7 +328,7 @@ export function createError(params: CreateErrorParams): ValidationError {
     code: params.code,
     path: [...params.path],
     message: params.message,
-    params: params.params ?? {},
+    params: params.params ?? EMPTY_PARAMS,
     children: params.children ?? [],
   };
 }
@@ -356,7 +356,7 @@ export function createLeafError(
   code: string,
   path: PathSegment[],
   message: string,
-  params: Record<string, unknown> = {},
+  params: Record<string, unknown> = EMPTY_PARAMS,
   extraSegment?: PathSegment,
   extraSegment2?: PathSegment,
 ): ValidationError {
@@ -392,6 +392,15 @@ export function createLeafError(
 // freeze is a runtime safety net against accidental mutation.
 const EMPTY_CHILDREN = Object.freeze([]) as unknown as ValidationError[];
 
+// Shared frozen empty params for the common no-details case (branch
+// wrappers like the "schema" node, leaves whose `code` carries no
+// params). Mirrors EMPTY_CHILDREN: one value instead of a fresh `{}`
+// per error. Safe because `params` is read-only by contract (consumers
+// narrow and read it; nothing in the validator mutates it after
+// construction) and the freeze is the runtime safety net. Call sites
+// that do carry details pass their own object and never see this.
+const EMPTY_PARAMS = Object.freeze({}) as Record<string, unknown>;
+
 /**
  * Construct a branch error that wraps a list of child errors (e.g. the
  * per-branch failures of an `oneOf` keyword).
@@ -421,7 +430,7 @@ export function createBranchError(
   path: PathSegment[],
   message: string,
   children: ValidationError[],
-  params: Record<string, unknown> = {},
+  params: Record<string, unknown> = EMPTY_PARAMS,
   extraSegment?: PathSegment,
   extraSegment2?: PathSegment,
 ): ValidationError {

--- a/packages/schema/src/compiler/compiler.ts
+++ b/packages/schema/src/compiler/compiler.ts
@@ -963,6 +963,10 @@ function compileSchemaKeywords(
   const runOrder = orderKeywordsForSchema(schema, state);
   // OAS 3.0: when `$ref` is present, every sibling keyword is ignored.
   const refOnly = state.refSuppressesSiblings && "$ref" in schema;
+  // Shared per-function-body locals (e.g. the object-shape guard). One
+  // map per function so keywords on this schema reuse a single emitted
+  // `const`; see KeywordCompileContext.scopeLocal.
+  const scopeLocals = new Map<string, string>();
   const seen = new Set<string>();
   for (const kw of runOrder) {
     if (seen.has(kw.keyword)) continue;
@@ -989,6 +993,7 @@ function compileSchemaKeywords(
         state.hoistedConsts.push(`const ${name} = ${expr};`);
         return name;
       },
+      scopeLocals,
     });
     kw.compile(ctx);
     seen.add(kw.keyword);

--- a/packages/schema/src/keywords/context.ts
+++ b/packages/schema/src/keywords/context.ts
@@ -68,6 +68,15 @@ export interface KeywordContextInputs {
    * {@link KeywordCompileContext.hoistConstant}.
    */
   hoistConstant?: (expr: string, prefix?: string) => string;
+  /**
+   * Per-function-body memo backing
+   * {@link KeywordCompileContext.scopeLocal}. The compiler creates one
+   * map per validator function and threads the same instance into every
+   * keyword context for that function, so keywords sharing a key reuse a
+   * single emitted `const`. Omitted in inline contexts, where each
+   * keyword emits its own local (no cross-keyword sharing needed).
+   */
+  scopeLocals?: Map<string, string>;
 }
 
 /**
@@ -190,6 +199,21 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
       inputs.gen.const(name, expr);
       return name;
     });
+
+  // Per-function-body shared local: emit `const <name> = <expr>;` once
+  // per key, hand back the same identifier on repeat calls. When no
+  // shared memo is threaded in (inline contexts, tests), fall back to a
+  // fresh local each call: still computed once at the emission point,
+  // just not shared across keywords.
+  const scopeLocal = (key: string, expr: string, prefix = "L"): string => {
+    const sink = inputs.scopeLocals;
+    const cached = sink?.get(key);
+    if (cached !== undefined) return cached;
+    const name = inputs.gen.scope.name(prefix);
+    inputs.gen.const(name, expr);
+    sink?.set(key, name);
+    return name;
+  };
 
   const errorStatement = (kind: ErrorKind, errExpr: string): string => {
     if (predicate) {
@@ -550,6 +574,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     branchErrorExpr,
     validateSubschema,
     hoistConstant,
+    scopeLocal,
   };
 }
 

--- a/packages/schema/src/keywords/object-validation.ts
+++ b/packages/schema/src/keywords/object-validation.ts
@@ -86,23 +86,22 @@ export const requiredKeyword: KeywordDefinition = {
       });
       return;
     }
-    const missingVar = ctx.gen.scope.name("missing");
+    // Single pass: emit one leaf per missing key directly from the
+    // membership scan. The errors come out in `required`-array order
+    // (the scan order), which is the same order the previous
+    // collect-into-`missing`-then-replay form produced, and the budget
+    // break lands after the same key, so the error tree and truncation
+    // flag are unchanged. The intermediate `missing` array is just gone.
     ctx.gen.if(isObjectGuard(ctx.data), (g) => {
-      g.const(missingVar, "[]");
       g.forOf("_req", requiredVar, (gi) => {
-        gi.if(`!Object.prototype.hasOwnProperty.call(${ctx.data}, _req)`, (gii) => {
-          gii.line(`${missingVar}.push(_req);`);
-        });
-      });
-      g.if(`${missingVar}.length > 0`, (gi) => {
-        gi.forOf("_m", missingVar, () => {
+        gi.if(`!Object.prototype.hasOwnProperty.call(${ctx.data}, _req)`, () => {
           ctx.emitError(
             "leaf",
             ctx.leafErrorExpr(
               quoteString("required"),
-              `\`must have required property "\${_m}"\``,
-              `{ missing: _m }`,
-              ["_m"],
+              `\`must have required property "\${_req}"\``,
+              `{ missing: _req }`,
+              ["_req"],
             ),
           );
           ctx.emitBudgetBreak();

--- a/packages/schema/src/keywords/object-validation.ts
+++ b/packages/schema/src/keywords/object-validation.ts
@@ -6,6 +6,18 @@ function isObjectGuard(dataExpr: string): string {
   return `typeof ${dataExpr} === "object" && ${dataExpr} !== null && !Array.isArray(${dataExpr})`;
 }
 
+/**
+ * The object-shape guard, computed once per validator-function scope and
+ * shared across every object keyword on the same schema (`type`,
+ * `required`, `properties`, `additionalProperties`, ...). Without this
+ * each keyword re-emits the guard inline, repeating the `Array.isArray`
+ * call per keyword on every object that reaches them. See
+ * {@link KeywordCompileContext.scopeLocal}.
+ */
+function objectGuardVar(ctx: KeywordCompileContext): string {
+  return ctx.scopeLocal(`isObject:${ctx.data}`, isObjectGuard(ctx.data), "obj");
+}
+
 function keyCountExpr(dataExpr: string): string {
   return `Object.keys(${dataExpr}).length`;
 }
@@ -21,7 +33,7 @@ export const maxPropertiesKeyword: KeywordDefinition = {
   compile(ctx: KeywordCompileContext): void {
     const limit = nonNegativeIntegerLiteral(ctx.schema, "maxProperties");
     const count = ctx.gen.scope.name("count");
-    ctx.gen.if(isObjectGuard(ctx.data), (g) => {
+    ctx.gen.if(objectGuardVar(ctx), (g) => {
       g.const(count, keyCountExpr(ctx.data));
       g.if(`${count} > ${limit}`, () => {
         ctx.emitError(
@@ -48,7 +60,7 @@ export const minPropertiesKeyword: KeywordDefinition = {
   compile(ctx: KeywordCompileContext): void {
     const limit = nonNegativeIntegerLiteral(ctx.schema, "minProperties");
     const count = ctx.gen.scope.name("count");
-    ctx.gen.if(isObjectGuard(ctx.data), (g) => {
+    ctx.gen.if(objectGuardVar(ctx), (g) => {
       g.const(count, keyCountExpr(ctx.data));
       g.if(`${count} < ${limit}`, () => {
         ctx.emitError(
@@ -79,7 +91,7 @@ export const requiredKeyword: KeywordDefinition = {
     if (required.length === 0) return;
     const requiredVar = ctx.hoistConstant(JSON.stringify(required), "required");
     if (ctx.predicate) {
-      ctx.gen.if(isObjectGuard(ctx.data), (g) => {
+      ctx.gen.if(objectGuardVar(ctx), (g) => {
         g.forOf("_req", requiredVar, (gi) => {
           gi.line(`if (!Object.prototype.hasOwnProperty.call(${ctx.data}, _req)) return false;`);
         });
@@ -92,7 +104,7 @@ export const requiredKeyword: KeywordDefinition = {
     // collect-into-`missing`-then-replay form produced, and the budget
     // break lands after the same key, so the error tree and truncation
     // flag are unchanged. The intermediate `missing` array is just gone.
-    ctx.gen.if(isObjectGuard(ctx.data), (g) => {
+    ctx.gen.if(objectGuardVar(ctx), (g) => {
       g.forOf("_req", requiredVar, (gi) => {
         gi.if(`!Object.prototype.hasOwnProperty.call(${ctx.data}, _req)`, () => {
           ctx.emitError(

--- a/packages/schema/src/keywords/properties.ts
+++ b/packages/schema/src/keywords/properties.ts
@@ -8,6 +8,16 @@ function isObjectGuard(dataExpr: string): string {
 }
 
 /**
+ * Shared object-shape guard for this scope. Same cache key as the
+ * object-validation keywords, so `properties` and `required` on one
+ * schema reference a single emitted `const`. See
+ * {@link KeywordCompileContext.scopeLocal}.
+ */
+function objectGuardVar(ctx: KeywordCompileContext): string {
+  return ctx.scopeLocal(`isObject:${ctx.data}`, isObjectGuard(ctx.data), "obj");
+}
+
+/**
  * The `properties` keyword. For each named property present in the data,
  * validate its value against the corresponding subschema.
  *
@@ -19,7 +29,7 @@ export const propertiesKeyword: KeywordDefinition = {
   applicator: true,
   compile(ctx: KeywordCompileContext): void {
     const props = ctx.schema as Record<string, SchemaOrBoolean>;
-    ctx.gen.if(isObjectGuard(ctx.data), (g) => {
+    ctx.gen.if(objectGuardVar(ctx), (g) => {
       for (const name of Object.keys(props)) {
         const subSchema = props[name];
         if (subSchema === undefined) continue;
@@ -59,7 +69,7 @@ export const patternPropertiesKeyword: KeywordDefinition = {
         return { regex: regexVar, sub: subSchema };
       },
     );
-    ctx.gen.if(isObjectGuard(ctx.data), (g) => {
+    ctx.gen.if(objectGuardVar(ctx), (g) => {
       const keyVar = g.scope.name("key");
       g.forIn(keyVar, ctx.data, (gi) => {
         for (const { regex, sub } of subs) {
@@ -97,7 +107,7 @@ export const additionalPropertiesKeyword: KeywordDefinition = {
       ctx.hoistConstant(`${NAMES.DEPS}.compilePattern(${quoteString(p)})`, "re"),
     );
     const known = ctx.hoistConstant(`new Set(${knownSet})`, "known");
-    ctx.gen.if(isObjectGuard(ctx.data), (g) => {
+    ctx.gen.if(objectGuardVar(ctx), (g) => {
       const key = g.scope.name("key");
       g.forIn(key, ctx.data, (gi) => {
         gi.if(`${known}.has(${key})`, (gii) => gii.line("continue;"));
@@ -146,7 +156,7 @@ export const propertyNamesKeyword: KeywordDefinition = {
   applicator: true,
   compile(ctx: KeywordCompileContext): void {
     const subSchema = ctx.schema as SchemaOrBoolean;
-    ctx.gen.if(isObjectGuard(ctx.data), (g) => {
+    ctx.gen.if(objectGuardVar(ctx), (g) => {
       const key = g.scope.name("key");
       g.forIn(key, ctx.data, () => {
         ctx.validateSubschema(subSchema, key, { segment: key });

--- a/packages/schema/src/keywords/types.ts
+++ b/packages/schema/src/keywords/types.ts
@@ -293,6 +293,37 @@ export interface KeywordCompileContext {
    * debugging of generated source. Defaults to `"C"`.
    */
   hoistConstant(expr: string, prefix?: string): string;
+  /**
+   * Compute a runtime value once per validator-function scope and share
+   * it across keywords. Emits `const <name> = <expr>;` into the current
+   * function body the first time a given `key` is seen, and returns the
+   * same identifier for every later call with that `key` within the same
+   * function. Use for values derived from the runtime `data` that more
+   * than one keyword on the same schema needs: the object-shape guard
+   * (`typeof data === "object" && …`) is the canonical case, shared by
+   * `required` / `properties` / `additionalProperties` / etc.
+   *
+   * The sibling of {@link KeywordCompileContext.hoistConstant}: that one
+   * lifts a compile-time-derived constant to module scope (runs once at
+   * factory init); this one caches a per-call value inside the validator
+   * body (runs once per `validate()`). Reach for `hoistConstant` when the
+   * value depends only on the schema, `scopeLocal` when it depends on the
+   * data.
+   *
+   * Call this at the keyword's top-level entry (before opening loops or
+   * `if` blocks), so the emitted `const` dominates every sibling
+   * keyword's code. The `expr` must be evaluable at that point (i.e.
+   * rooted in the function's `data` parameter) and side-effect-free; it
+   * is computed unconditionally, so a guard that would throw on the wrong
+   * input type is not a valid `expr`.
+   *
+   * @param key - Stable cache key. Keywords that want to share a value
+   *   must pass the same key (e.g. `` `isObject:${ctx.data}` ``).
+   * @param expr - The JS expression to bind. Must match for a given key.
+   * @param prefix - Identifier prefix for readable generated source.
+   *   Defaults to `"L"`.
+   */
+  scopeLocal(key: string, expr: string, prefix?: string): string;
 }
 
 /**

--- a/performance/error-tree-anatomy.ts
+++ b/performance/error-tree-anatomy.ts
@@ -1,0 +1,126 @@
+/**
+ * Error-tree memory anatomy: where the bytes go when oav collects a full
+ * error tree on a broadly-invalid large payload (default, non-`maxErrors`
+ * mode). Companion to `large-payload.ts`, which showed that the default
+ * collect-all mode retains ~60x the payload size and is ~2.8x heavier
+ * than ajv's `allErrors` tree. This breaks that retention down by
+ * component so an optimization targets the right thing.
+ *
+ * Method: build the tree once, then null out one component at a time
+ * (messages -> params -> paths), forcing GC and reading `heapUsed` after
+ * each, so each delta approximates that component's retained cost. Also
+ * counts leaf vs branch nodes and empty vs non-empty params.
+ *
+ * Run with --expose-gc so the deltas are meaningful:
+ *   node --expose-gc --import tsx error-tree-anatomy.ts
+ *   pnpm bench:anatomy
+ *
+ * Headline finding (N=200000): paths and node objects are ~95% of the
+ * retained tree; messages ~4%, params <1%. The gap vs ajv is structural
+ * (a rich node per error + a materialised path array per node), not a
+ * field that can be trimmed. `maxErrors` bounds node count and is the
+ * real lever for large invalid payloads.
+ */
+
+import { compileSchema, jsonSchemaDialect } from "../packages/schema/src/index.ts";
+import type { ValidationError } from "../packages/core/src/index.ts";
+
+const SCHEMA = {
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  type: "array",
+  items: {
+    type: "object",
+    required: ["id", "name"],
+    properties: {
+      id: { type: "integer", minimum: 1 },
+      name: { type: "string", minLength: 1 },
+      tags: { type: "array", items: { type: "string" } },
+    },
+    additionalProperties: false,
+  },
+};
+
+const N = Number.parseInt(process.env.LP_N ?? "200000", 10);
+
+function buildInvalid(n: number): unknown[] {
+  const out = new Array(n);
+  for (let i = 0; i < n; i += 1) out[i] = { id: `oops-${i}`, tags: [1, 2, 3], extra: true };
+  return out;
+}
+
+const gc = (globalThis as { gc?: () => void }).gc ?? (() => {});
+function heapMB(): number {
+  gc();
+  return process.memoryUsage().heapUsed / 1024 / 1024;
+}
+
+function walk(e: ValidationError, fn: (x: ValidationError) => void): void {
+  fn(e);
+  for (const c of e.children) walk(c, fn);
+}
+
+function main(): void {
+  if ((globalThis as { gc?: () => void }).gc === undefined) {
+    console.warn("warning: run with --expose-gc for meaningful deltas\n");
+  }
+
+  const data = buildInvalid(N);
+  const v = compileSchema(SCHEMA as Record<string, unknown>, { dialect: jsonSchemaDialect });
+  const res = v.validate(data) as { valid: boolean; error?: ValidationError };
+  const root = res.error;
+  if (root === undefined) throw new Error("expected the payload to be invalid");
+
+  let leaves = 0;
+  let branches = 0;
+  let msgChars = 0;
+  let pathSegs = 0;
+  let emptyParams = 0;
+  let nonEmptyParams = 0;
+  walk(root, (e) => {
+    if (e.children.length === 0) leaves += 1;
+    else branches += 1;
+    msgChars += e.message.length;
+    pathSegs += e.path.length;
+    if (Object.keys(e.params).length === 0) emptyParams += 1;
+    else nonEmptyParams += 1;
+  });
+
+  // Drop the parsed payload's grip is not possible (still referenced by
+  // `data`); we measure the tree's marginal cost by component instead.
+  const base = heapMB();
+  walk(root, (e) => {
+    (e as { message: string }).message = "";
+  });
+  const afterMsg = heapMB();
+  walk(root, (e) => {
+    (e as { params: unknown }).params = {};
+  });
+  const afterParams = heapMB();
+  walk(root, (e) => {
+    (e as { path: unknown }).path = [];
+  });
+  const afterPath = heapMB();
+
+  console.log(`error-tree anatomy: N=${N} (broadly-invalid array)\n`);
+  console.log(`nodes:   ${leaves} leaves, ${branches} branches`);
+  console.log(`params:  ${emptyParams} empty, ${nonEmptyParams} non-empty`);
+  console.log(
+    `totals:  ${(msgChars / 1e6).toFixed(1)}M message chars, ${(pathSegs / 1e6).toFixed(1)}M path segments\n`,
+  );
+  console.log(`retained heap (tree live):    ${base.toFixed(0)}MB`);
+  console.log(
+    `  - messages: ${(base - afterMsg).toFixed(0)}MB   (heap now ${afterMsg.toFixed(0)}MB)`,
+  );
+  console.log(
+    `  - params:   ${(afterMsg - afterParams).toFixed(0)}MB   (heap now ${afterParams.toFixed(0)}MB)`,
+  );
+  console.log(
+    `  - paths:    ${(afterParams - afterPath).toFixed(0)}MB   (heap now ${afterPath.toFixed(0)}MB)`,
+  );
+  console.log(`  - node objects + children arrays: ~${afterPath.toFixed(0)}MB (remainder)`);
+
+  // Keep the tree reachable until after measurement.
+  if (root.children.length < 0) console.log("unreachable");
+}
+
+main();

--- a/performance/large-payload.ts
+++ b/performance/large-payload.ts
@@ -1,0 +1,277 @@
+/**
+ * Large-response stress benchmark: how oav behaves when the payload is
+ * a very large array (tens to hundreds of MB once parsed), which is the
+ * regime real API responses hit and the synthetic `run.ts`
+ * microbenchmarks (100-element arrays) do not.
+ *
+ * What it isolates that ops/sec cannot:
+ *
+ *   - parse vs validate split. A large body is `JSON.parse`d into a JS
+ *     object graph before any validator runs; that parse + residency
+ *     often dwarfs validation. We measure both.
+ *   - retained memory. oav's DEFAULT mode collects every error into a
+ *     tree. On a broadly-invalid large payload that is ~one node per
+ *     failure: an unbounded-memory / OOM vector. `maxErrors` and
+ *     `predicate` bound it. We measure the RSS the validator retains
+ *     on top of the (already resident) payload.
+ *   - the default-mode mismatch vs Ajv. Ajv's default is `allErrors:
+ *     false` (fast-fail); oav's default is collect-all. Comparing
+ *     Ajv-default against oav-default compares fast-fail against
+ *     collect-all. This script runs both Ajv modes so the comparison
+ *     can be made honestly: Ajv-default ~ oav-maxErrors:1,
+ *     Ajv-allErrors ~ oav-default.
+ *
+ * Each (engine+mode, validity) scenario runs in its own child process
+ * so retained error trees never overlap in one heap and a crash in one
+ * cell is contained. The parent spawns, the child measures one cell and
+ * prints a single JSON line.
+ *
+ * Usage (from performance/, after `pnpm install`):
+ *   pnpm bench:large                 # default element count
+ *   LP_N=1000000 pnpm bench:large    # ~hundreds of MB; needs RAM
+ *   LP_HEAP=1024 pnpm bench:large    # cap child heap (MB) to force the
+ *                                    # OOM vector to show as a crash
+ */
+
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import Ajv from "ajv/dist/2020.js";
+import { compileSchema, jsonSchemaDialect } from "../packages/schema/src/index.ts";
+
+// ----- shared shape -----
+
+const SCHEMA = {
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  type: "array",
+  items: {
+    type: "object",
+    required: ["id", "name"],
+    properties: {
+      id: { type: "integer", minimum: 1 },
+      name: { type: "string", minLength: 1 },
+      tags: { type: "array", items: { type: "string" } },
+    },
+    additionalProperties: false,
+  },
+} as const;
+
+type Engine = "oav-default" | "oav-maxErrors1" | "oav-predicate" | "ajv-default" | "ajv-allErrors";
+type Validity = "valid" | "invalid";
+
+const ENGINES: Engine[] = [
+  "oav-default",
+  "oav-maxErrors1",
+  "oav-predicate",
+  "ajv-default",
+  "ajv-allErrors",
+];
+const VALIDITIES: Validity[] = ["valid", "invalid"];
+
+const N = Number.parseInt(process.env.LP_N ?? "500000", 10);
+const HEAP_MB = process.env.LP_HEAP ? Number.parseInt(process.env.LP_HEAP, 10) : null;
+
+function buildArray(n: number, validity: Validity): unknown[] {
+  const out = new Array(n);
+  if (validity === "valid") {
+    for (let i = 0; i < n; i += 1) {
+      out[i] = { id: i + 1, name: `item-${i}`, tags: ["a", "b", "c"] };
+    }
+  } else {
+    // Every element fails several ways at once (wrong-typed id, missing
+    // name, wrong-typed tag, an additional property). This maximises the
+    // error-tree size in collect-all mode: the point is to expose the
+    // memory vector, not to model a typical near-valid payload.
+    for (let i = 0; i < n; i += 1) {
+      out[i] = { id: `oops-${i}`, tags: [1, 2, 3], extra: true };
+    }
+  }
+  return out;
+}
+
+interface CellResult {
+  engine: Engine;
+  validity: Validity;
+  n: number;
+  payloadMB: number;
+  parseMs: number;
+  validateMs: number;
+  payloadRssMB: number; // resident growth from building the parsed payload
+  retainedMB: number; // RSS the validator adds on top, after validate (tree live)
+  valid: boolean;
+  truncated: boolean | null;
+}
+
+function rssMB(): number {
+  return process.memoryUsage().rss / 1024 / 1024;
+}
+
+function gc(): void {
+  // Exposed when the child is spawned with --expose-gc; harmless no-op otherwise.
+  (globalThis as { gc?: () => void }).gc?.();
+}
+
+function now(): number {
+  return Number(process.hrtime.bigint() / 1000n) / 1000; // ms
+}
+
+// ----- child: measure one cell -----
+
+function runCell(engine: Engine, validity: Validity): CellResult {
+  const startRss = (gc(), rssMB());
+
+  const data = buildArray(N, validity);
+  // A reusable JSON string so we can time parse independently of build.
+  const json = JSON.stringify(data);
+  const payloadMB = json.length / 1024 / 1024;
+
+  gc();
+  const payloadRssMB = rssMB() - startRss;
+
+  // Parse cost, on its own, against the same bytes the validator will see.
+  const p0 = now();
+  const parsed = JSON.parse(json);
+  const parseMs = now() - p0;
+
+  let valid = false;
+  let truncated: boolean | null = null;
+  const baseRss = (gc(), rssMB());
+  const v0 = now();
+
+  if (engine.startsWith("oav")) {
+    const opts =
+      engine === "oav-predicate"
+        ? ({ dialect: jsonSchemaDialect, predicate: true } as const)
+        : engine === "oav-maxErrors1"
+          ? ({ dialect: jsonSchemaDialect, maxErrors: 1 } as const)
+          : ({ dialect: jsonSchemaDialect } as const);
+    const compiled = compileSchema(SCHEMA as Record<string, unknown>, opts);
+    const res = compiled.validate(parsed) as boolean | { valid: boolean; truncated?: boolean };
+    if (typeof res === "boolean") {
+      valid = res;
+    } else {
+      valid = res.valid;
+      truncated = res.truncated ?? false;
+    }
+  } else {
+    const ajv = new Ajv({ allErrors: engine === "ajv-allErrors", strict: false });
+    const validateFn = ajv.compile(SCHEMA);
+    valid = validateFn(parsed) as boolean;
+  }
+
+  const validateMs = now() - v0;
+  // No GC here: we want the memory the validator is *retaining* (the
+  // error tree) measured while it is still reachable.
+  const retainedMB = rssMB() - baseRss;
+
+  // Keep `parsed`/result reachable past the measurement.
+  if (valid && (parsed as unknown[]).length < 0) throw new Error("unreachable");
+
+  return {
+    engine,
+    validity,
+    n: N,
+    payloadMB,
+    parseMs,
+    validateMs,
+    payloadRssMB,
+    retainedMB,
+    valid,
+    truncated,
+  };
+}
+
+// ----- parent: orchestrate cells in isolated children -----
+
+function spawnCell(engine: Engine, validity: Validity): Promise<CellResult | { error: string }> {
+  return new Promise((resolve) => {
+    const selfPath = fileURLToPath(import.meta.url);
+    const nodeArgs = ["--expose-gc"];
+    if (HEAP_MB !== null) nodeArgs.push(`--max-old-space-size=${HEAP_MB}`);
+    nodeArgs.push("--import", "tsx", selfPath, "--worker");
+    const child = spawn(process.execPath, nodeArgs, {
+      env: { ...process.env, LP_ENGINE: engine, LP_VALIDITY: validity },
+      stdio: ["ignore", "pipe", "inherit"],
+    });
+    let out = "";
+    child.stdout.on("data", (b) => {
+      out += b.toString();
+    });
+    child.on("close", (code) => {
+      const line = out.trim().split("\n").filter(Boolean).at(-1);
+      if (code !== 0 || !line) {
+        resolve({ error: code === null ? "killed (likely OOM)" : `exit ${code}` });
+        return;
+      }
+      try {
+        resolve(JSON.parse(line) as CellResult);
+      } catch {
+        resolve({ error: "unparseable child output" });
+      }
+    });
+  });
+}
+
+function fmt(n: number, digits = 1): string {
+  return n.toFixed(digits);
+}
+
+async function main(): Promise<void> {
+  console.log(
+    `large-payload stress: N=${N} elements per array${HEAP_MB ? `, heap cap ${HEAP_MB}MB` : ""}`,
+  );
+  console.log(
+    "(each cell runs in its own process; retainedMB = RSS the validator adds on top of the parsed payload)\n",
+  );
+
+  const rows: Array<{ engine: Engine; validity: Validity; r: CellResult | { error: string } }> = [];
+  for (const validity of VALIDITIES) {
+    for (const engine of ENGINES) {
+      process.stdout.write(`  ${engine} / ${validity} ... `);
+      const r = await spawnCell(engine, validity);
+      console.log("error" in r ? `ERROR: ${r.error}` : "ok");
+      rows.push({ engine, validity, r });
+    }
+  }
+
+  // Table
+  const header = [
+    "engine",
+    "validity",
+    "payloadMB",
+    "parseMs",
+    "validateMs",
+    "retainedMB",
+    "valid",
+    "trunc",
+  ];
+  console.log("\n" + header.join("\t"));
+  for (const { engine, validity, r } of rows) {
+    if ("error" in r) {
+      console.log([engine, validity, "-", "-", "-", "-", "-", r.error].join("\t"));
+      continue;
+    }
+    console.log(
+      [
+        engine,
+        validity,
+        fmt(r.payloadMB),
+        fmt(r.parseMs),
+        fmt(r.validateMs),
+        fmt(r.retainedMB),
+        String(r.valid),
+        r.truncated === null ? "-" : String(r.truncated),
+      ].join("\t"),
+    );
+  }
+}
+
+// ----- entry -----
+
+if (process.argv.includes("--worker")) {
+  const engine = process.env.LP_ENGINE as Engine;
+  const validity = process.env.LP_VALIDITY as Validity;
+  const result = runCell(engine, validity);
+  process.stdout.write(JSON.stringify(result) + "\n");
+} else {
+  void main();
+}

--- a/performance/package.json
+++ b/performance/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "bench": "tsx run.ts",
     "bench:long": "tsx run.ts --time=1500",
-    "bench:mem": "tsx mem.ts"
+    "bench:mem": "tsx mem.ts",
+    "bench:large": "tsx large-payload.ts"
   },
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "^15.3.5",

--- a/performance/package.json
+++ b/performance/package.json
@@ -8,7 +8,8 @@
     "bench": "tsx run.ts",
     "bench:long": "tsx run.ts --time=1500",
     "bench:mem": "tsx mem.ts",
-    "bench:large": "tsx large-payload.ts"
+    "bench:large": "tsx large-payload.ts",
+    "bench:anatomy": "node --expose-gc --import tsx error-tree-anatomy.ts"
   },
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "^15.3.5",


### PR DESCRIPTION
## Motivation

Getting ahead of a large-API-response evaluation. The synthetic
microbenchmarks only exercised 100-element arrays; this work adds the
large-payload tooling, lands the per-element codegen wins from #264 that
that regime hits, and characterises (and trims where safe) the error
tree's memory footprint.

## What's here

**Tooling**
- `performance/large-payload.ts` (`pnpm bench:large`): per-(engine+mode,
  validity) cells in isolated child processes; reports the
  parse-vs-validate split and the RSS the validator retains on top of
  the parsed payload. Runs both ajv modes so the default-mode mismatch
  (ajv fast-fails by default, oav collects all) is comparable honestly.
- `performance/error-tree-anatomy.ts` (`pnpm bench:anatomy`): breaks
  collect-all tree retention down by component.

**Codegen wins (addresses #264 items 1 and 3)**
- Single-pass tree-mode `required`: emit one leaf per missing key
  directly from the membership scan, dropping the `missing` array and
  the second loop. Order/budget/tree shape unchanged.
- Share the object-shape guard across keywords via a new
  `ctx.scopeLocal` primitive: `required` / `properties` /
  `additionalProperties` / etc. now reference one `const obj0 = <guard>`
  per scope instead of each re-emitting `typeof … && !Array.isArray(…)`.

**Error footprint**
- Share a frozen empty `params` default across errors (mirrors
  `EMPTY_CHILDREN`). Minor but free allocation hygiene.

#264 item 2 (hoist `countCodePoints`) is deferred: `countCodePoints`
throws on non-strings so it can't be hoisted unguarded, which needs the
grouped string-block (route B) we ruled out as not worth the inliner
risk for a marginal gain.

## Findings (handed off for the eval)

- **OOM landmine:** oav's *default* collect-all mode retains ~60x the
  payload size in error tree on a broadly-invalid large array (killed
  at 1M elements under a 1.5GB cap). `maxErrors` / `predicate` stay
  flat. For large responses, `maxErrors` is the correct config, and
  ajv-default (fast-fail) only compares apples-to-apples against
  oav-`maxErrors:1`.
- **Parse dominates:** on a 53MB valid payload, `JSON.parse` (~212ms)
  was ~3x validate (~75ms); oav does not stream.
- **Error tree ~2.8x heavier than ajv** when collecting all errors, and
  the anatomy shows that's structural (nodes + path arrays = 95%), not
  a trimmable field. Lever is `maxErrors`; an opt-in flat mode is the
  only path to ajv-class footprint with all errors, filed as #314.
- **AJV #837** (`additionalProperties: false` across `allOf`) is handled
  by `unevaluatedProperties: false`, which oav supports
  (`packages/schema/test/unevaluated-composition.test.ts`).

## Codegen perf delta (synthetic, warmed)

- petstore validate: +6% valid / +23% invalid
- array-heavy: flat (dominated by per-item dispatch, not the guard)

## Verification

`pnpm typecheck`, `pnpm test` (1047 tests), `pnpm lint` all green. No
change to error tree shape, ordering, or `code`/`path`/`params` for any
existing test.

## Follow-up

- #314 — opt-in flat error mode (build on concrete demand)
- #264 item 2 — deferred (see above)
