### PR TITLE
perf(schema): object hot-path codegen (single-pass required + shared guard)

### DIFF
--- a/packages/schema/src/compiler/compiler.ts
+++ b/packages/schema/src/compiler/compiler.ts
@@ -963,6 +963,10 @@ function compileSchemaKeywords(
   const runOrder = orderKeywordsForSchema(schema, state);
   // OAS 3.0: when `$ref` is present, every sibling keyword is ignored.
   const refOnly = state.refSuppressesSiblings && "$ref" in schema;
+  // Shared per-function-body locals (e.g. the object-shape guard). One
+  // map per function so keywords on this schema reuse a single emitted
+  // `const`; see KeywordCompileContext.scopeLocal.
+  const scopeLocals = new Map<string, string>();
   const seen = new Set<string>();
   for (const kw of runOrder) {
     if (seen.has(kw.keyword)) continue;
@@ -989,6 +993,7 @@ function compileSchemaKeywords(
         state.hoistedConsts.push(`const ${name} = ${expr};`);
         return name;
       },
+      scopeLocals,
     });
     kw.compile(ctx);
     seen.add(kw.keyword);

--- a/packages/schema/src/keywords/context.ts
+++ b/packages/schema/src/keywords/context.ts
@@ -68,6 +68,15 @@ export interface KeywordContextInputs {
    * {@link KeywordCompileContext.hoistConstant}.
    */
   hoistConstant?: (expr: string, prefix?: string) => string;
+  /**
+   * Per-function-body memo backing
+   * {@link KeywordCompileContext.scopeLocal}. The compiler creates one
+   * map per validator function and threads the same instance into every
+   * keyword context for that function, so keywords sharing a key reuse a
+   * single emitted `const`. Omitted in inline contexts, where each
+   * keyword emits its own local (no cross-keyword sharing needed).
+   */
+  scopeLocals?: Map<string, string>;
 }
 
 /**
@@ -190,6 +199,21 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
       inputs.gen.const(name, expr);
       return name;
     });
+
+  // Per-function-body shared local: emit `const <name> = <expr>;` once
+  // per key, hand back the same identifier on repeat calls. When no
+  // shared memo is threaded in (inline contexts, tests), fall back to a
+  // fresh local each call: still computed once at the emission point,
+  // just not shared across keywords.
+  const scopeLocal = (key: string, expr: string, prefix = "L"): string => {
+    const sink = inputs.scopeLocals;
+    const cached = sink?.get(key);
+    if (cached !== undefined) return cached;
+    const name = inputs.gen.scope.name(prefix);
+    inputs.gen.const(name, expr);
+    sink?.set(key, name);
+    return name;
+  };
 
   const errorStatement = (kind: ErrorKind, errExpr: string): string => {
     if (predicate) {
@@ -550,6 +574,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     branchErrorExpr,
     validateSubschema,
     hoistConstant,
+    scopeLocal,
   };
 }
 

--- a/packages/schema/src/keywords/object-validation.ts
+++ b/packages/schema/src/keywords/object-validation.ts
@@ -86,23 +86,22 @@ export const requiredKeyword: KeywordDefinition = {
       });
       return;
     }
-    const missingVar = ctx.gen.scope.name("missing");
+    // Single pass: emit one leaf per missing key directly from the
+    // membership scan. The errors come out in `required`-array order
+    // (the scan order), which is the same order the previous
+    // collect-into-`missing`-then-replay form produced, and the budget
+    // break lands after the same key, so the error tree and truncation
+    // flag are unchanged. The intermediate `missing` array is just gone.
     ctx.gen.if(isObjectGuard(ctx.data), (g) => {
-      g.const(missingVar, "[]");
       g.forOf("_req", requiredVar, (gi) => {
-        gi.if(`!Object.prototype.hasOwnProperty.call(${ctx.data}, _req)`, (gii) => {
-          gii.line(`${missingVar}.push(_req);`);
-        });
-      });
-      g.if(`${missingVar}.length > 0`, (gi) => {
-        gi.forOf("_m", missingVar, () => {
+        gi.if(`!Object.prototype.hasOwnProperty.call(${ctx.data}, _req)`, () => {
           ctx.emitError(
             "leaf",
             ctx.leafErrorExpr(
               quoteString("required"),
-              `\`must have required property "\${_m}"\``,
-              `{ missing: _m }`,
-              ["_m"],
+              `\`must have required property "\${_req}"\``,
+              `{ missing: _req }`,
+              ["_req"],
             ),
           );
           ctx.emitBudgetBreak();

--- a/packages/schema/src/keywords/object-validation.ts
+++ b/packages/schema/src/keywords/object-validation.ts
@@ -6,6 +6,18 @@ function isObjectGuard(dataExpr: string): string {
   return `typeof ${dataExpr} === "object" && ${dataExpr} !== null && !Array.isArray(${dataExpr})`;
 }
 
+/**
+ * The object-shape guard, computed once per validator-function scope and
+ * shared across every object keyword on the same schema (`type`,
+ * `required`, `properties`, `additionalProperties`, ...). Without this
+ * each keyword re-emits the guard inline, repeating the `Array.isArray`
+ * call per keyword on every object that reaches them. See
+ * {@link KeywordCompileContext.scopeLocal}.
+ */
+function objectGuardVar(ctx: KeywordCompileContext): string {
+  return ctx.scopeLocal(`isObject:${ctx.data}`, isObjectGuard(ctx.data), "obj");
+}
+
 function keyCountExpr(dataExpr: string): string {
   return `Object.keys(${dataExpr}).length`;
 }
@@ -21,7 +33,7 @@ export const maxPropertiesKeyword: KeywordDefinition = {
   compile(ctx: KeywordCompileContext): void {
     const limit = nonNegativeIntegerLiteral(ctx.schema, "maxProperties");
     const count = ctx.gen.scope.name("count");
-    ctx.gen.if(isObjectGuard(ctx.data), (g) => {
+    ctx.gen.if(objectGuardVar(ctx), (g) => {
       g.const(count, keyCountExpr(ctx.data));
       g.if(`${count} > ${limit}`, () => {
         ctx.emitError(
@@ -48,7 +60,7 @@ export const minPropertiesKeyword: KeywordDefinition = {
   compile(ctx: KeywordCompileContext): void {
     const limit = nonNegativeIntegerLiteral(ctx.schema, "minProperties");
     const count = ctx.gen.scope.name("count");
-    ctx.gen.if(isObjectGuard(ctx.data), (g) => {
+    ctx.gen.if(objectGuardVar(ctx), (g) => {
       g.const(count, keyCountExpr(ctx.data));
       g.if(`${count} < ${limit}`, () => {
         ctx.emitError(
@@ -79,7 +91,7 @@ export const requiredKeyword: KeywordDefinition = {
     if (required.length === 0) return;
     const requiredVar = ctx.hoistConstant(JSON.stringify(required), "required");
     if (ctx.predicate) {
-      ctx.gen.if(isObjectGuard(ctx.data), (g) => {
+      ctx.gen.if(objectGuardVar(ctx), (g) => {
         g.forOf("_req", requiredVar, (gi) => {
           gi.line(`if (!Object.prototype.hasOwnProperty.call(${ctx.data}, _req)) return false;`);
         });
@@ -92,7 +104,7 @@ export const requiredKeyword: KeywordDefinition = {
     // collect-into-`missing`-then-replay form produced, and the budget
     // break lands after the same key, so the error tree and truncation
     // flag are unchanged. The intermediate `missing` array is just gone.
-    ctx.gen.if(isObjectGuard(ctx.data), (g) => {
+    ctx.gen.if(objectGuardVar(ctx), (g) => {
       g.forOf("_req", requiredVar, (gi) => {
         gi.if(`!Object.prototype.hasOwnProperty.call(${ctx.data}, _req)`, () => {
           ctx.emitError(

--- a/packages/schema/src/keywords/properties.ts
+++ b/packages/schema/src/keywords/properties.ts
@@ -8,6 +8,16 @@ function isObjectGuard(dataExpr: string): string {
 }
 
 /**
+ * Shared object-shape guard for this scope. Same cache key as the
+ * object-validation keywords, so `properties` and `required` on one
+ * schema reference a single emitted `const`. See
+ * {@link KeywordCompileContext.scopeLocal}.
+ */
+function objectGuardVar(ctx: KeywordCompileContext): string {
+  return ctx.scopeLocal(`isObject:${ctx.data}`, isObjectGuard(ctx.data), "obj");
+}
+
+/**
  * The `properties` keyword. For each named property present in the data,
  * validate its value against the corresponding subschema.
  *
@@ -19,7 +29,7 @@ export const propertiesKeyword: KeywordDefinition = {
   applicator: true,
   compile(ctx: KeywordCompileContext): void {
     const props = ctx.schema as Record<string, SchemaOrBoolean>;
-    ctx.gen.if(isObjectGuard(ctx.data), (g) => {
+    ctx.gen.if(objectGuardVar(ctx), (g) => {
       for (const name of Object.keys(props)) {
         const subSchema = props[name];
         if (subSchema === undefined) continue;
@@ -59,7 +69,7 @@ export const patternPropertiesKeyword: KeywordDefinition = {
         return { regex: regexVar, sub: subSchema };
       },
     );
-    ctx.gen.if(isObjectGuard(ctx.data), (g) => {
+    ctx.gen.if(objectGuardVar(ctx), (g) => {
       const keyVar = g.scope.name("key");
       g.forIn(keyVar, ctx.data, (gi) => {
         for (const { regex, sub } of subs) {
@@ -97,7 +107,7 @@ export const additionalPropertiesKeyword: KeywordDefinition = {
       ctx.hoistConstant(`${NAMES.DEPS}.compilePattern(${quoteString(p)})`, "re"),
     );
     const known = ctx.hoistConstant(`new Set(${knownSet})`, "known");
-    ctx.gen.if(isObjectGuard(ctx.data), (g) => {
+    ctx.gen.if(objectGuardVar(ctx), (g) => {
       const key = g.scope.name("key");
       g.forIn(key, ctx.data, (gi) => {
         gi.if(`${known}.has(${key})`, (gii) => gii.line("continue;"));
@@ -146,7 +156,7 @@ export const propertyNamesKeyword: KeywordDefinition = {
   applicator: true,
   compile(ctx: KeywordCompileContext): void {
     const subSchema = ctx.schema as SchemaOrBoolean;
-    ctx.gen.if(isObjectGuard(ctx.data), (g) => {
+    ctx.gen.if(objectGuardVar(ctx), (g) => {
       const key = g.scope.name("key");
       g.forIn(key, ctx.data, () => {
         ctx.validateSubschema(subSchema, key, { segment: key });

--- a/packages/schema/src/keywords/types.ts
+++ b/packages/schema/src/keywords/types.ts
@@ -293,6 +293,37 @@ export interface KeywordCompileContext {
    * debugging of generated source. Defaults to `"C"`.
    */
   hoistConstant(expr: string, prefix?: string): string;
+  /**
+   * Compute a runtime value once per validator-function scope and share
+   * it across keywords. Emits `const <name> = <expr>;` into the current
+   * function body the first time a given `key` is seen, and returns the
+   * same identifier for every later call with that `key` within the same
+   * function. Use for values derived from the runtime `data` that more
+   * than one keyword on the same schema needs: the object-shape guard
+   * (`typeof data === "object" && …`) is the canonical case, shared by
+   * `required` / `properties` / `additionalProperties` / etc.
+   *
+   * The sibling of {@link KeywordCompileContext.hoistConstant}: that one
+   * lifts a compile-time-derived constant to module scope (runs once at
+   * factory init); this one caches a per-call value inside the validator
+   * body (runs once per `validate()`). Reach for `hoistConstant` when the
+   * value depends only on the schema, `scopeLocal` when it depends on the
+   * data.
+   *
+   * Call this at the keyword's top-level entry (before opening loops or
+   * `if` blocks), so the emitted `const` dominates every sibling
+   * keyword's code. The `expr` must be evaluable at that point (i.e.
+   * rooted in the function's `data` parameter) and side-effect-free; it
+   * is computed unconditionally, so a guard that would throw on the wrong
+   * input type is not a valid `expr`.
+   *
+   * @param key - Stable cache key. Keywords that want to share a value
+   *   must pass the same key (e.g. `` `isObject:${ctx.data}` ``).
+   * @param expr - The JS expression to bind. Must match for a given key.
+   * @param prefix - Identifier prefix for readable generated source.
+   *   Defaults to `"L"`.
+   */
+  scopeLocal(key: string, expr: string, prefix?: string): string;
 }
 
 /**


### PR DESCRIPTION
Addresses items 1 and 3 of #264. The object hot path runs per array
element on large responses, so these are the per-element constant-factor
wins from that issue.

## Changes

- **Single-pass tree-mode `required`.** Emit one leaf per missing key
  directly from the membership scan, dropping the `missing` array and
  the replay loop. Errors come out in the same `required`-array order
  and the budget break lands after the same key, so the error tree,
  ordering, and truncation flag are unchanged (guarded by
  `keyword-object` and `max-errors` tests).
- **Share the object-shape guard across keywords.** Adds
  `ctx.scopeLocal(key, expr)`: compute a runtime value once per
  validator-function body and share the emitted `const` across keywords
  by key (the runtime-data sibling of `hoistConstant`). `required` /
  `properties` / `additionalProperties` / `patternProperties` /
  `propertyNames` / `min`/`maxProperties` now reference one
  `const obj0 = typeof … && !Array.isArray(…)` instead of each
  re-emitting the guard. A 4-object-keyword schema drops from 4 inline
  guards to 1.

## Not included

#264 item 2 (hoist `countCodePoints`) is deferred: it throws on
non-strings so it can't be hoisted unguarded, which needs the grouped
string-block approach (route B) judged not worth the inliner risk for a
marginal gain.

## Perf (synthetic, warmed)

petstore validate +6% valid / +23% invalid; array-heavy flat (dominated
by per-item dispatch, not the guard).

## Verification

`pnpm typecheck`, `pnpm test` (1047), `pnpm lint` green. No change to
error tree shape, ordering, or `code`/`path`/`params`.
