### PR TITLE
perf: large-response benchmarks (stress + error-tree anatomy)

### DIFF
--- a/performance/error-tree-anatomy.ts
+++ b/performance/error-tree-anatomy.ts
@@ -1,0 +1,126 @@
+/**
+ * Error-tree memory anatomy: where the bytes go when oav collects a full
+ * error tree on a broadly-invalid large payload (default, non-`maxErrors`
+ * mode). Companion to `large-payload.ts`, which showed that the default
+ * collect-all mode retains ~60x the payload size and is ~2.8x heavier
+ * than ajv's `allErrors` tree. This breaks that retention down by
+ * component so an optimization targets the right thing.
+ *
+ * Method: build the tree once, then null out one component at a time
+ * (messages -> params -> paths), forcing GC and reading `heapUsed` after
+ * each, so each delta approximates that component's retained cost. Also
+ * counts leaf vs branch nodes and empty vs non-empty params.
+ *
+ * Run with --expose-gc so the deltas are meaningful:
+ *   node --expose-gc --import tsx error-tree-anatomy.ts
+ *   pnpm bench:anatomy
+ *
+ * Headline finding (N=200000): paths and node objects are ~95% of the
+ * retained tree; messages ~4%, params <1%. The gap vs ajv is structural
+ * (a rich node per error + a materialised path array per node), not a
+ * field that can be trimmed. `maxErrors` bounds node count and is the
+ * real lever for large invalid payloads.
+ */
+
+import { compileSchema, jsonSchemaDialect } from "../packages/schema/src/index.ts";
+import type { ValidationError } from "../packages/core/src/index.ts";
+
+const SCHEMA = {
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  type: "array",
+  items: {
+    type: "object",
+    required: ["id", "name"],
+    properties: {
+      id: { type: "integer", minimum: 1 },
+      name: { type: "string", minLength: 1 },
+      tags: { type: "array", items: { type: "string" } },
+    },
+    additionalProperties: false,
+  },
+};
+
+const N = Number.parseInt(process.env.LP_N ?? "200000", 10);
+
+function buildInvalid(n: number): unknown[] {
+  const out = new Array(n);
+  for (let i = 0; i < n; i += 1) out[i] = { id: `oops-${i}`, tags: [1, 2, 3], extra: true };
+  return out;
+}
+
+const gc = (globalThis as { gc?: () => void }).gc ?? (() => {});
+function heapMB(): number {
+  gc();
+  return process.memoryUsage().heapUsed / 1024 / 1024;
+}
+
+function walk(e: ValidationError, fn: (x: ValidationError) => void): void {
+  fn(e);
+  for (const c of e.children) walk(c, fn);
+}
+
+function main(): void {
+  if ((globalThis as { gc?: () => void }).gc === undefined) {
+    console.warn("warning: run with --expose-gc for meaningful deltas\n");
+  }
+
+  const data = buildInvalid(N);
+  const v = compileSchema(SCHEMA as Record<string, unknown>, { dialect: jsonSchemaDialect });
+  const res = v.validate(data) as { valid: boolean; error?: ValidationError };
+  const root = res.error;
+  if (root === undefined) throw new Error("expected the payload to be invalid");
+
+  let leaves = 0;
+  let branches = 0;
+  let msgChars = 0;
+  let pathSegs = 0;
+  let emptyParams = 0;
+  let nonEmptyParams = 0;
+  walk(root, (e) => {
+    if (e.children.length === 0) leaves += 1;
+    else branches += 1;
+    msgChars += e.message.length;
+    pathSegs += e.path.length;
+    if (Object.keys(e.params).length === 0) emptyParams += 1;
+    else nonEmptyParams += 1;
+  });
+
+  // Drop the parsed payload's grip is not possible (still referenced by
+  // `data`); we measure the tree's marginal cost by component instead.
+  const base = heapMB();
+  walk(root, (e) => {
+    (e as { message: string }).message = "";
+  });
+  const afterMsg = heapMB();
+  walk(root, (e) => {
+    (e as { params: unknown }).params = {};
+  });
+  const afterParams = heapMB();
+  walk(root, (e) => {
+    (e as { path: unknown }).path = [];
+  });
+  const afterPath = heapMB();
+
+  console.log(`error-tree anatomy: N=${N} (broadly-invalid array)\n`);
+  console.log(`nodes:   ${leaves} leaves, ${branches} branches`);
+  console.log(`params:  ${emptyParams} empty, ${nonEmptyParams} non-empty`);
+  console.log(
+    `totals:  ${(msgChars / 1e6).toFixed(1)}M message chars, ${(pathSegs / 1e6).toFixed(1)}M path segments\n`,
+  );
+  console.log(`retained heap (tree live):    ${base.toFixed(0)}MB`);
+  console.log(
+    `  - messages: ${(base - afterMsg).toFixed(0)}MB   (heap now ${afterMsg.toFixed(0)}MB)`,
+  );
+  console.log(
+    `  - params:   ${(afterMsg - afterParams).toFixed(0)}MB   (heap now ${afterParams.toFixed(0)}MB)`,
+  );
+  console.log(
+    `  - paths:    ${(afterParams - afterPath).toFixed(0)}MB   (heap now ${afterPath.toFixed(0)}MB)`,
+  );
+  console.log(`  - node objects + children arrays: ~${afterPath.toFixed(0)}MB (remainder)`);
+
+  // Keep the tree reachable until after measurement.
+  if (root.children.length < 0) console.log("unreachable");
+}
+
+main();

--- a/performance/large-payload.ts
+++ b/performance/large-payload.ts
@@ -1,0 +1,277 @@
+/**
+ * Large-response stress benchmark: how oav behaves when the payload is
+ * a very large array (tens to hundreds of MB once parsed), which is the
+ * regime real API responses hit and the synthetic `run.ts`
+ * microbenchmarks (100-element arrays) do not.
+ *
+ * What it isolates that ops/sec cannot:
+ *
+ *   - parse vs validate split. A large body is `JSON.parse`d into a JS
+ *     object graph before any validator runs; that parse + residency
+ *     often dwarfs validation. We measure both.
+ *   - retained memory. oav's DEFAULT mode collects every error into a
+ *     tree. On a broadly-invalid large payload that is ~one node per
+ *     failure: an unbounded-memory / OOM vector. `maxErrors` and
+ *     `predicate` bound it. We measure the RSS the validator retains
+ *     on top of the (already resident) payload.
+ *   - the default-mode mismatch vs Ajv. Ajv's default is `allErrors:
+ *     false` (fast-fail); oav's default is collect-all. Comparing
+ *     Ajv-default against oav-default compares fast-fail against
+ *     collect-all. This script runs both Ajv modes so the comparison
+ *     can be made honestly: Ajv-default ~ oav-maxErrors:1,
+ *     Ajv-allErrors ~ oav-default.
+ *
+ * Each (engine+mode, validity) scenario runs in its own child process
+ * so retained error trees never overlap in one heap and a crash in one
+ * cell is contained. The parent spawns, the child measures one cell and
+ * prints a single JSON line.
+ *
+ * Usage (from performance/, after `pnpm install`):
+ *   pnpm bench:large                 # default element count
+ *   LP_N=1000000 pnpm bench:large    # ~hundreds of MB; needs RAM
+ *   LP_HEAP=1024 pnpm bench:large    # cap child heap (MB) to force the
+ *                                    # OOM vector to show as a crash
+ */
+
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import Ajv from "ajv/dist/2020.js";
+import { compileSchema, jsonSchemaDialect } from "../packages/schema/src/index.ts";
+
+// ----- shared shape -----
+
+const SCHEMA = {
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  type: "array",
+  items: {
+    type: "object",
+    required: ["id", "name"],
+    properties: {
+      id: { type: "integer", minimum: 1 },
+      name: { type: "string", minLength: 1 },
+      tags: { type: "array", items: { type: "string" } },
+    },
+    additionalProperties: false,
+  },
+} as const;
+
+type Engine = "oav-default" | "oav-maxErrors1" | "oav-predicate" | "ajv-default" | "ajv-allErrors";
+type Validity = "valid" | "invalid";
+
+const ENGINES: Engine[] = [
+  "oav-default",
+  "oav-maxErrors1",
+  "oav-predicate",
+  "ajv-default",
+  "ajv-allErrors",
+];
+const VALIDITIES: Validity[] = ["valid", "invalid"];
+
+const N = Number.parseInt(process.env.LP_N ?? "500000", 10);
+const HEAP_MB = process.env.LP_HEAP ? Number.parseInt(process.env.LP_HEAP, 10) : null;
+
+function buildArray(n: number, validity: Validity): unknown[] {
+  const out = new Array(n);
+  if (validity === "valid") {
+    for (let i = 0; i < n; i += 1) {
+      out[i] = { id: i + 1, name: `item-${i}`, tags: ["a", "b", "c"] };
+    }
+  } else {
+    // Every element fails several ways at once (wrong-typed id, missing
+    // name, wrong-typed tag, an additional property). This maximises the
+    // error-tree size in collect-all mode: the point is to expose the
+    // memory vector, not to model a typical near-valid payload.
+    for (let i = 0; i < n; i += 1) {
+      out[i] = { id: `oops-${i}`, tags: [1, 2, 3], extra: true };
+    }
+  }
+  return out;
+}
+
+interface CellResult {
+  engine: Engine;
+  validity: Validity;
+  n: number;
+  payloadMB: number;
+  parseMs: number;
+  validateMs: number;
+  payloadRssMB: number; // resident growth from building the parsed payload
+  retainedMB: number; // RSS the validator adds on top, after validate (tree live)
+  valid: boolean;
+  truncated: boolean | null;
+}
+
+function rssMB(): number {
+  return process.memoryUsage().rss / 1024 / 1024;
+}
+
+function gc(): void {
+  // Exposed when the child is spawned with --expose-gc; harmless no-op otherwise.
+  (globalThis as { gc?: () => void }).gc?.();
+}
+
+function now(): number {
+  return Number(process.hrtime.bigint() / 1000n) / 1000; // ms
+}
+
+// ----- child: measure one cell -----
+
+function runCell(engine: Engine, validity: Validity): CellResult {
+  const startRss = (gc(), rssMB());
+
+  const data = buildArray(N, validity);
+  // A reusable JSON string so we can time parse independently of build.
+  const json = JSON.stringify(data);
+  const payloadMB = json.length / 1024 / 1024;
+
+  gc();
+  const payloadRssMB = rssMB() - startRss;
+
+  // Parse cost, on its own, against the same bytes the validator will see.
+  const p0 = now();
+  const parsed = JSON.parse(json);
+  const parseMs = now() - p0;
+
+  let valid = false;
+  let truncated: boolean | null = null;
+  const baseRss = (gc(), rssMB());
+  const v0 = now();
+
+  if (engine.startsWith("oav")) {
+    const opts =
+      engine === "oav-predicate"
+        ? ({ dialect: jsonSchemaDialect, predicate: true } as const)
+        : engine === "oav-maxErrors1"
+          ? ({ dialect: jsonSchemaDialect, maxErrors: 1 } as const)
+          : ({ dialect: jsonSchemaDialect } as const);
+    const compiled = compileSchema(SCHEMA as Record<string, unknown>, opts);
+    const res = compiled.validate(parsed) as boolean | { valid: boolean; truncated?: boolean };
+    if (typeof res === "boolean") {
+      valid = res;
+    } else {
+      valid = res.valid;
+      truncated = res.truncated ?? false;
+    }
+  } else {
+    const ajv = new Ajv({ allErrors: engine === "ajv-allErrors", strict: false });
+    const validateFn = ajv.compile(SCHEMA);
+    valid = validateFn(parsed) as boolean;
+  }
+
+  const validateMs = now() - v0;
+  // No GC here: we want the memory the validator is *retaining* (the
+  // error tree) measured while it is still reachable.
+  const retainedMB = rssMB() - baseRss;
+
+  // Keep `parsed`/result reachable past the measurement.
+  if (valid && (parsed as unknown[]).length < 0) throw new Error("unreachable");
+
+  return {
+    engine,
+    validity,
+    n: N,
+    payloadMB,
+    parseMs,
+    validateMs,
+    payloadRssMB,
+    retainedMB,
+    valid,
+    truncated,
+  };
+}
+
+// ----- parent: orchestrate cells in isolated children -----
+
+function spawnCell(engine: Engine, validity: Validity): Promise<CellResult | { error: string }> {
+  return new Promise((resolve) => {
+    const selfPath = fileURLToPath(import.meta.url);
+    const nodeArgs = ["--expose-gc"];
+    if (HEAP_MB !== null) nodeArgs.push(`--max-old-space-size=${HEAP_MB}`);
+    nodeArgs.push("--import", "tsx", selfPath, "--worker");
+    const child = spawn(process.execPath, nodeArgs, {
+      env: { ...process.env, LP_ENGINE: engine, LP_VALIDITY: validity },
+      stdio: ["ignore", "pipe", "inherit"],
+    });
+    let out = "";
+    child.stdout.on("data", (b) => {
+      out += b.toString();
+    });
+    child.on("close", (code) => {
+      const line = out.trim().split("\n").filter(Boolean).at(-1);
+      if (code !== 0 || !line) {
+        resolve({ error: code === null ? "killed (likely OOM)" : `exit ${code}` });
+        return;
+      }
+      try {
+        resolve(JSON.parse(line) as CellResult);
+      } catch {
+        resolve({ error: "unparseable child output" });
+      }
+    });
+  });
+}
+
+function fmt(n: number, digits = 1): string {
+  return n.toFixed(digits);
+}
+
+async function main(): Promise<void> {
+  console.log(
+    `large-payload stress: N=${N} elements per array${HEAP_MB ? `, heap cap ${HEAP_MB}MB` : ""}`,
+  );
+  console.log(
+    "(each cell runs in its own process; retainedMB = RSS the validator adds on top of the parsed payload)\n",
+  );
+
+  const rows: Array<{ engine: Engine; validity: Validity; r: CellResult | { error: string } }> = [];
+  for (const validity of VALIDITIES) {
+    for (const engine of ENGINES) {
+      process.stdout.write(`  ${engine} / ${validity} ... `);
+      const r = await spawnCell(engine, validity);
+      console.log("error" in r ? `ERROR: ${r.error}` : "ok");
+      rows.push({ engine, validity, r });
+    }
+  }
+
+  // Table
+  const header = [
+    "engine",
+    "validity",
+    "payloadMB",
+    "parseMs",
+    "validateMs",
+    "retainedMB",
+    "valid",
+    "trunc",
+  ];
+  console.log("\n" + header.join("\t"));
+  for (const { engine, validity, r } of rows) {
+    if ("error" in r) {
+      console.log([engine, validity, "-", "-", "-", "-", "-", r.error].join("\t"));
+      continue;
+    }
+    console.log(
+      [
+        engine,
+        validity,
+        fmt(r.payloadMB),
+        fmt(r.parseMs),
+        fmt(r.validateMs),
+        fmt(r.retainedMB),
+        String(r.valid),
+        r.truncated === null ? "-" : String(r.truncated),
+      ].join("\t"),
+    );
+  }
+}
+
+// ----- entry -----
+
+if (process.argv.includes("--worker")) {
+  const engine = process.env.LP_ENGINE as Engine;
+  const validity = process.env.LP_VALIDITY as Validity;
+  const result = runCell(engine, validity);
+  process.stdout.write(JSON.stringify(result) + "\n");
+} else {
+  void main();
+}

--- a/performance/package.json
+++ b/performance/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "bench": "tsx run.ts",
     "bench:long": "tsx run.ts --time=1500",
-    "bench:mem": "tsx mem.ts"
+    "bench:mem": "tsx mem.ts",
+    "bench:large": "tsx large-payload.ts"
   },
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "^15.3.5",

--- a/performance/package.json
+++ b/performance/package.json
@@ -8,7 +8,8 @@
     "bench": "tsx run.ts",
     "bench:long": "tsx run.ts --time=1500",
     "bench:mem": "tsx mem.ts",
-    "bench:large": "tsx large-payload.ts"
+    "bench:large": "tsx large-payload.ts",
+    "bench:anatomy": "node --expose-gc --import tsx error-tree-anatomy.ts"
   },
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "^15.3.5",


### PR DESCRIPTION
The synthetic `run.ts` microbenchmarks only exercise 100-element arrays.
These two diagnostics target the large-response regime (tens to hundreds
of MB) that real API responses hit.

## Added

- **`large-payload.ts` (`pnpm bench:large`).** Per-(engine+mode,
  validity) cells in isolated child processes; reports the
  parse-vs-validate split and the RSS the validator retains on top of
  the parsed payload. Runs oav (default / `maxErrors:1` / predicate) and
  both ajv modes, so the default-mode mismatch is comparable honestly:
  ajv fast-fails by default, oav collects all, so ajv-default only lines
  up against oav-`maxErrors:1`.
- **`error-tree-anatomy.ts` (`pnpm bench:anatomy`).** Breaks collect-all
  tree retention down by component (messages / params / paths / node
  objects) via null-and-measure heap deltas.

## What they surfaced

- oav's *default* collect-all mode is an OOM vector on large invalid
  payloads (~60x payload size in error tree; killed at 1M elements under
  a 1.5GB cap). `maxErrors` / `predicate` stay flat. `maxErrors` is the
  correct config for large responses.
- `JSON.parse` dominates: ~3x validate on a 53MB valid payload; oav does
  not stream.
- oav's error tree is ~2.8x heavier than ajv's `allErrors` output, and
  the anatomy shows it's structural (nodes + path arrays = 95%), not a
  trimmable field. Filed as #314 (opt-in flat error mode), to build on
  concrete demand.

No `src` changes; nothing in the published packages is touched.
