### PR TITLE
perf(schema): bound minLength/maxLength by string length before walking code points

### DIFF
--- a/packages/schema/src/compiler/runtime.ts
+++ b/packages/schema/src/compiler/runtime.ts
@@ -45,6 +45,20 @@ export interface ValidatorDeps {
    */
   countCodePoints: (s: string) => number;
   /**
+   * Length-bounded `maxLength` check. Returns `true` iff `s` has more
+   * than `limit` code points, short-circuiting on `s.length` so valid
+   * strings inside their bound skip the O(n) code-point walk and the
+   * worst case walks at most `limit + 1` code points. See
+   * {@link exceedsMaxCodePoints}.
+   */
+  exceedsMaxCodePoints: (s: string, limit: number) => boolean;
+  /**
+   * Length-bounded `minLength` check. Returns `true` iff `s` has fewer
+   * than `limit` code points, short-circuiting on `s.length`. See
+   * {@link belowMinCodePoints}.
+   */
+  belowMinCodePoints: (s: string, limit: number) => boolean;
+  /**
    * Find the first duplicate in an array. Returns `{ a, b }` where
    * `arr[a]` and `arr[b]` are structurally equal (JSON deep equality)
    * and `a < b`, or `null` when every item is unique. Backs `uniqueItems`.
@@ -249,6 +263,69 @@ export function countCodePoints(s: string): number {
   return n;
 }
 
+/**
+ * True iff `s` has strictly more than `limit` Unicode code points,
+ * deciding from `s.length` (UTF-16 code units) without walking the
+ * string whenever possible. Backs `maxLength`.
+ *
+ * A string of U code units holds between `ceil(U/2)` and `U` code
+ * points (each code point is one or two units). So:
+ *   - `U <= limit`     => count <= limit, cannot exceed. No walk.
+ *   - `U > 2 * limit`  => count >= ceil(U/2) > limit, must exceed. No walk.
+ *   - otherwise walk, stopping as soon as the count passes `limit`.
+ *
+ * The common case (ASCII / BMP strings inside their bound) is decided
+ * by the first check, so valid data never pays the O(n) scan, and even
+ * the worst case walks at most `limit + 1` code points.
+ *
+ * @param s - The string to measure.
+ * @param limit - The `maxLength` bound (a non-negative integer).
+ * @returns `true` when `s` exceeds the bound.
+ *
+ * @public
+ */
+export function exceedsMaxCodePoints(s: string, limit: number): boolean {
+  const u = s.length;
+  if (u <= limit) return false;
+  if (u > 2 * limit) return true;
+  let n = 0;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- iterator drives the counter
+  for (const _ of s) {
+    n += 1;
+    if (n > limit) return true;
+  }
+  return false;
+}
+
+/**
+ * True iff `s` has strictly fewer than `limit` Unicode code points,
+ * deciding from `s.length` (UTF-16 code units) without walking the
+ * string whenever possible. Backs `minLength`.
+ *
+ * With `count` in `[ceil(U/2), U]` for `U = s.length`:
+ *   - `U < limit`         => count <= U < limit, must be below. No walk.
+ *   - `U >= 2 * limit - 1` => count >= ceil(U/2) >= limit, cannot be below. No walk.
+ *   - otherwise walk, stopping as soon as the count reaches `limit`.
+ *
+ * @param s - The string to measure.
+ * @param limit - The `minLength` bound (a non-negative integer).
+ * @returns `true` when `s` is shorter than the bound.
+ *
+ * @public
+ */
+export function belowMinCodePoints(s: string, limit: number): boolean {
+  const u = s.length;
+  if (u < limit) return true;
+  if (u >= 2 * limit - 1) return false;
+  let n = 0;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- iterator drives the counter
+  for (const _ of s) {
+    n += 1;
+    if (n >= limit) return false;
+  }
+  return true;
+}
+
 export function deepEqual(a: unknown, b: unknown): boolean {
   if (a === b) return true;
   if (typeof a !== typeof b) return false;
@@ -381,6 +458,8 @@ export function createDeps(arg?: number | CreateDepsOptions): ValidatorDeps {
     typeOf,
     deepEqual,
     countCodePoints,
+    exceedsMaxCodePoints,
+    belowMinCodePoints,
     findDuplicate,
     wrapErrors,
     patterns,

--- a/packages/schema/src/keywords/string.ts
+++ b/packages/schema/src/keywords/string.ts
@@ -13,14 +13,18 @@ export const maxLengthKeyword: KeywordDefinition = {
   vocabulary: CORE_VALIDATION_VOCAB,
   compile(ctx: KeywordCompileContext): void {
     const limit = nonNegativeIntegerLiteral(ctx.schema, "maxLength");
-    const lenExpr = codePointLengthExpr(ctx.data);
-    ctx.gen.if(`typeof ${ctx.data} === "string" && ${lenExpr} > ${limit}`, () => {
+    // Condition short-circuits on `.length`; valid strings inside the
+    // bound never walk. The `actual` in the error params keeps the
+    // exact code-point count (cold path, only built when the error fires).
+    const condExpr = `${NAMES.DEPS}.exceedsMaxCodePoints(${ctx.data}, ${limit})`;
+    const actualExpr = codePointLengthExpr(ctx.data);
+    ctx.gen.if(`typeof ${ctx.data} === "string" && ${condExpr}`, () => {
       ctx.emitError(
         "leaf",
         ctx.leafErrorExpr(
           quoteString("maxLength"),
           `\`must have at most ${limit} characters\``,
-          `{ maxLength: ${limit}, actual: ${lenExpr} }`,
+          `{ maxLength: ${limit}, actual: ${actualExpr} }`,
         ),
       );
     });
@@ -38,14 +42,17 @@ export const minLengthKeyword: KeywordDefinition = {
   vocabulary: CORE_VALIDATION_VOCAB,
   compile(ctx: KeywordCompileContext): void {
     const limit = nonNegativeIntegerLiteral(ctx.schema, "minLength");
-    const lenExpr = codePointLengthExpr(ctx.data);
-    ctx.gen.if(`typeof ${ctx.data} === "string" && ${lenExpr} < ${limit}`, () => {
+    // Condition short-circuits on `.length`; the `actual` in the error
+    // params keeps the exact code-point count (cold path).
+    const condExpr = `${NAMES.DEPS}.belowMinCodePoints(${ctx.data}, ${limit})`;
+    const actualExpr = codePointLengthExpr(ctx.data);
+    ctx.gen.if(`typeof ${ctx.data} === "string" && ${condExpr}`, () => {
       ctx.emitError(
         "leaf",
         ctx.leafErrorExpr(
           quoteString("minLength"),
           `\`must have at least ${limit} characters\``,
-          `{ minLength: ${limit}, actual: ${lenExpr} }`,
+          `{ minLength: ${limit}, actual: ${actualExpr} }`,
         ),
       );
     });

--- a/packages/schema/test/keyword-string.test.ts
+++ b/packages/schema/test/keyword-string.test.ts
@@ -40,6 +40,51 @@ describe("string keywords", () => {
     expect(elapsed).toBeLessThan(2000);
   });
 
+  it("maxLength decides each .length band correctly (skip-pass / walk / skip-fail)", () => {
+    const v = compile({ maxLength: 3 });
+    // length <= limit: cannot exceed (skip-pass band).
+    expect(v.validate("ab").valid).toBe(true);
+    expect(v.validate("abc").valid).toBe(true);
+    // limit < length <= 2*limit: walk band. ASCII overshoots; surrogate
+    // pairs (length 4-6, 2-3 code points) can still pass.
+    expect(v.validate("abcd").valid).toBe(false);
+    expect(v.validate("🦀🦀🦀").valid).toBe(true); // length 6, 3 code points
+    // length > 2*limit: must exceed (skip-fail band).
+    expect(v.validate("aaaaaaa").valid).toBe(false);
+  });
+
+  it("minLength decides each .length band correctly (skip-fail / walk / skip-pass)", () => {
+    const v = compile({ minLength: 3 });
+    // length < limit: must be below (skip-fail band).
+    expect(v.validate("ab").valid).toBe(false);
+    // limit <= length < 2*limit-1: walk band.
+    expect(v.validate("ab🦀").valid).toBe(true); // length 4, 3 code points
+    expect(v.validate("🦀🦀").valid).toBe(false); // length 4, 2 code points
+    // length >= 2*limit-1: cannot be below (skip-pass band).
+    expect(v.validate("🦀🦀🦀").valid).toBe(true); // length 6, 3 code points
+  });
+
+  it("reports the exact code-point count in `actual` even when the bound short-circuits on .length", () => {
+    // maxLength failure decided by the skip-fail band (length > 2*limit)
+    // must still surface the true code-point count, not s.length.
+    const max = compile({ maxLength: 2 });
+    const res = max.validate("🦀🦀🦀"); // length 6, 3 code points
+    expect(res.valid).toBe(false);
+    expect(res.error?.code).toBe("maxLength");
+    expect(res.error?.params).toMatchObject({ maxLength: 2, actual: 3 });
+
+    const min = compile({ minLength: 5 });
+    const res2 = min.validate("ab"); // length 2 < 5, skip-fail band
+    expect(res2.valid).toBe(false);
+    expect(res2.error?.params).toMatchObject({ minLength: 5, actual: 2 });
+  });
+
+  it("maxLength: 0 admits only the empty string", () => {
+    const v = compile({ maxLength: 0 });
+    expect(v.validate("").valid).toBe(true);
+    expect(v.validate("a").valid).toBe(false);
+  });
+
   it("pattern matches against an ECMA-262 regex (unicode)", () => {
     const v = compile({ pattern: "^[a-z]+$" });
     expect(v.validate("abc").valid).toBe(true);

--- a/performance/schemas.ts
+++ b/performance/schemas.ts
@@ -186,6 +186,32 @@ const arrayHeavy: PerfSchema = {
   invalidInputs: [makeInvalidArray(100)],
 };
 
+// 7. Large strings with length bounds — exercises minLength / maxLength
+// code-point counting. Real API payloads carry big text fields
+// (descriptions, content, base64 blobs) under generous maxLength caps.
+// The valid body sits well under its cap, so a length-bounded check can
+// decide the outcome from `.length` without walking; the invalid body
+// overshoots its cap by >2x, the other short-circuitable case.
+const longString: PerfSchema = {
+  name: "long-string",
+  description: "object with large minLength/maxLength-bounded string fields",
+  schema: {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    type: "object",
+    required: ["body"],
+    properties: {
+      title: { type: "string", minLength: 1, maxLength: 200 },
+      body: { type: "string", minLength: 1, maxLength: 1_000_000 },
+    },
+  },
+  validInputs: [{ title: "Hello", body: makeAscii(100_000) }],
+  invalidInputs: [{ title: "", body: makeAscii(2_500_000) }],
+};
+
+function makeAscii(n: number): string {
+  return "a".repeat(n);
+}
+
 function makeValidArray(n: number): Array<Record<string, unknown>> {
   const out = [];
   for (let i = 0; i < n; i += 1) {
@@ -207,4 +233,5 @@ export const perfSchemas: PerfSchema[] = [
   composition,
   arrayHeavy,
   uniquePrimitives,
+  longString,
 ];


### PR DESCRIPTION
Closes #319.

## Problem

`minLength` / `maxLength` emitted an unconditional `deps.countCodePoints(data)` walk over the whole string (`packages/schema/src/keywords/string.ts`). Two costs:

1. The full O(n) scan runs on the **success path** for every bounded string, even when the bound is trivially satisfied.
2. It is **unbounded in time** on large strings: a 10 MB body with `maxLength: 100` scans all 10 MB before rejecting. `maxErrors` / `predicate` mode do not close this; the scan happens before any error is constructed.

## Approach

For a string of `U = s.length` UTF-16 code units, the code-point count `C` satisfies `ceil(U/2) <= C <= U`, so the bound is usually decided by `.length` without walking:

- **maxLength** (fails iff `C > limit`): `U <= limit` cannot exceed; `U > 2*limit` must exceed; otherwise walk, early-exiting at `limit + 1`.
- **minLength** (fails iff `C < limit`): `U < limit` must be below; `U >= 2*limit - 1` cannot be below; otherwise walk, early-exiting at `limit`.

Two runtime helpers (`exceedsMaxCodePoints`, `belowMinCodePoints`) implement this; the emitted condition becomes one boolean call. The error `params.actual` keeps the exact `countCodePoints` count on the cold path (only built when the error fires).

Generated condition before / after:

```js
// before
if (typeof data === "string" && deps.countCodePoints(data) > 100) { ... }
// after
if (typeof data === "string" && deps.exceedsMaxCodePoints(data, 100)) { ... }
```

This also subsumes the `countCodePoints` double-call dedup noted in #264 item 2: the condition collapses to a single call.

## Measured impact

New `long-string` benchmark (100 KB valid body under a 1 MB cap, 2.5 MB invalid body over it):

| metric | before | after |
|---|---|---|
| `oav validate (valid)` | 763 µs | **42 ns** (full body walk eliminated) |
| `oav validate (invalid)` | 28.7 ms | **9.3 ms** (one cold-path `actual` walk, was two) |

No regression on the common small-string path (`petstore`, ~16 M ops/s): for short strings `u <= limit` is strictly cheaper than a full walk.

## Tests

- New cases cover all three decision bands (skip-pass / walk / skip-fail) for both keywords, the surrogate-pair middle band, `maxLength: 0`, and that `actual` reports the true code-point count even when the condition short-circuited on `.length`.
- Existing emoji-as-1 (#12) and large-string-non-OOM (#143) regression tests still pass.
- Full suite (1051 tests), typecheck, and lint all green.

## Commits

- `chore(performance):` add the `long-string` benchmark (regression guard).
- `perf(schema):` the optimization + tests.
