### PR TITLE
perf(schema): low-risk codegen cleanups (redundant isFinite, length hoist, unused eval params)

### DIFF
--- a/packages/schema/src/compiler/compiler.ts
+++ b/packages/schema/src/compiler/compiler.ts
@@ -781,9 +781,18 @@ function compileValidator(schema: SchemaOrBoolean, state: CompileState): string 
   // (which are the only consumer of `path`) are never emitted.
   // Callers of these functions (composition keywords, ref, etc.)
   // therefore omit the path argument in predicate mode as well.
+  //
+  // The `outEvalProps` / `outEvalItems` out-parameters only exist to
+  // merge a branch's evaluated keys back to the caller, which only
+  // happens when the compile unit uses `unevaluated*`. When tracking is
+  // globally off (the common OpenAPI case), nothing reads them and no
+  // call site passes them, so drop them from every signature.
+  const evalParams = state.unevaluatedTracking
+    ? `, ${NAMES.OUT_EVAL_PROPS}, ${NAMES.OUT_EVAL_ITEMS}`
+    : "";
   const params = state.predicate
-    ? `${NAMES.DATA}, ${NAMES.OUT_EVAL_PROPS}, ${NAMES.OUT_EVAL_ITEMS}`
-    : `${NAMES.DATA}, ${NAMES.PATH}, ${NAMES.OUT_EVAL_PROPS}, ${NAMES.OUT_EVAL_ITEMS}`;
+    ? `${NAMES.DATA}${evalParams}`
+    : `${NAMES.DATA}, ${NAMES.PATH}${evalParams}`;
   state.functionBodies.push(`function ${name}(${params}) {\n${body}\n}`);
   return name;
 }

--- a/packages/schema/src/keywords/items.ts
+++ b/packages/schema/src/keywords/items.ts
@@ -17,8 +17,13 @@ export const prefixItemsKeyword: KeywordDefinition = {
     const schemas = ctx.schema as SchemaOrBoolean[];
     if (schemas.length === 0) return;
     ctx.gen.if(`Array.isArray(${ctx.data})`, (g) => {
+      // Hoist `data.length` once: the per-position validateSubschema
+      // calls are opaque to V8, which would otherwise reload the length
+      // on every tuple-position comparison.
+      const len = g.scope.name("len");
+      g.const(len, `${ctx.data}.length`);
       schemas.forEach((sub, i) => {
-        g.if(`${ctx.data}.length > ${i}`, (gi) => {
+        g.if(`${len} > ${i}`, (gi) => {
           ctx.validateSubschema(sub, `${ctx.data}[${i}]`, { segment: String(i) });
           if (ctx.evaluatedItemsVar !== null) {
             gi.line(`${ctx.evaluatedItemsVar}.add(${i});`);
@@ -46,7 +51,12 @@ export const itemsKeyword: KeywordDefinition = {
     const start = prefixLen;
     ctx.gen.if(`Array.isArray(${ctx.data})`, (g) => {
       const i = g.scope.name("i");
-      g.line(`for (let ${i} = ${start}; ${i} < ${ctx.data}.length; ${i} += 1) {`);
+      // Hoist the length: the per-item validateSubschema call is opaque
+      // to V8, so `data.length` in the loop condition would reload each
+      // iteration. Item validation never resizes the array.
+      const len = g.scope.name("len");
+      g.const(len, `${ctx.data}.length`);
+      g.line(`for (let ${i} = ${start}; ${i} < ${len}; ${i} += 1) {`);
       g.indent();
       if (subSchema === true) {
         if (ctx.evaluatedItemsVar !== null) {
@@ -101,12 +111,16 @@ export const containsKeyword: KeywordDefinition = {
       const count = g.scope.name("count");
       g.let(count, "0");
       const i = g.scope.name("i");
+      // Hoist the length once for whichever loop runs below; the
+      // sub-validator call in the body is opaque to V8.
+      const len = g.scope.name("len");
+      g.const(len, `${ctx.data}.length`);
       if (ctx.predicate) {
         // Predicate mode: count passing items via the sub-validator's
         // boolean return; no path, no error array. The match list
         // exists only to populate `evaluatedItems` for any sibling
         // `unevaluatedItems`.
-        g.forRange(i, `${ctx.data}.length`, (gi) => {
+        g.forRange(i, len, (gi) => {
           gi.if(`${fn}(${ctx.data}[${i}])`, (gii) => {
             gii.line(`${count} += 1;`);
             if (ctx.evaluatedItemsVar !== null) {
@@ -120,7 +134,7 @@ export const containsKeyword: KeywordDefinition = {
       }
       const matchedIdx = g.scope.name("matched");
       g.const(matchedIdx, "[]");
-      g.forRange(i, `${ctx.data}.length`, (gi) => {
+      g.forRange(i, len, (gi) => {
         const errVar = gi.scope.name("e");
         // Function-call subschema: push/pop around the call so the
         // callee sees the extended path via the shared array (avoids

--- a/packages/schema/src/keywords/type-predicates.ts
+++ b/packages/schema/src/keywords/type-predicates.ts
@@ -23,7 +23,10 @@ export function typePredicate(dataExpr: string, typeName: string): string {
     case "number":
       return `(typeof ${dataExpr} === "number" && Number.isFinite(${dataExpr}))`;
     case "integer":
-      return `(typeof ${dataExpr} === "number" && Number.isFinite(${dataExpr}) && Number.isInteger(${dataExpr}))`;
+      // `Number.isInteger` already returns false for NaN and +/-Infinity,
+      // so a sibling `Number.isFinite` check would be redundant. The
+      // `typeof` keeps the call off non-number values.
+      return `(typeof ${dataExpr} === "number" && Number.isInteger(${dataExpr}))`;
     default:
       return "false";
   }

--- a/packages/schema/src/keywords/type.ts
+++ b/packages/schema/src/keywords/type.ts
@@ -22,7 +22,7 @@ export const typeKeyword: KeywordDefinition = {
         "leaf",
         ctx.leafErrorExpr(
           quoteString("type"),
-          `"must be " + ${JSON.stringify(formatTypeList(expected))}`,
+          JSON.stringify(`must be ${formatTypeList(expected)}`),
           `{ expected: ${expectedLit}, actual: ${actualExpr} }`,
         ),
       );


### PR DESCRIPTION
Addresses #321. A batch of low-risk codegen cleanups found in the read-through that produced #319 / #320, now that #316 has landed (single-pass `required` + shared object guard).

## Changes

1. **Drop the redundant `Number.isFinite` in the integer predicate.** `Number.isInteger` already returns `false` for `NaN` / `±Infinity`, so the sibling check was dead work. The guard condition runs on *valid* data, so this is a hot-path saving; the `typeof` short-circuit keeps the call off non-numbers.
   ```js
   // before
   typeof x === "number" && Number.isFinite(x) && Number.isInteger(x)
   // after
   typeof x === "number" && Number.isInteger(x)
   ```

2. **Hoist `data.length` out of the array loops** (`items`, `prefixItems`, `contains`). The per-item sub-validator call is opaque to V8, so `data.length` in the loop condition would reload each iteration. Item validation never resizes the array.
   ```js
   if (Array.isArray(data)) {
     const len0 = data.length;
     for (let i0 = 0; i0 < len0; i0 += 1) { ... }
   }
   ```

3. **Drop the `outEvalProps` / `outEvalItems` out-parameters when the compile unit never uses `unevaluated*`** (the common OpenAPI case, `stats.unevaluatedTrackingEmitted === false`). Nothing reads them and no call site passes them, so they were always-`undefined` dead weight. Gated on `state.unevaluatedTracking`; the 4-param signature is kept verbatim when tracking is on.
   ```js
   // tracking off
   function validate_1(data, path) { ... }
   // tracking on (unchanged)
   function validate_0(data, path, outEvalProps, outEvalItems) { ... }
   ```

4. **Nit:** the type-mismatch message folds to a single literal (`"must be object"`) instead of `"must be " + "object"` in the emitted source.

## Deliberately skipped

The issue's `required` for-of→indexed-for item: #316 already rewrote that emitter (single-pass) and kept `for...of`. V8 optimizes array `for...of` well, and converting it would churn the carefully-ordered single-pass logic for no measurable gain.

## Verification

No behavior change. Full suite (1051 tests), typecheck, and lint all green. Array-heavy benchmark unchanged (the wins are fewer ops / smaller generated code, confirmed in the emitted source, rather than a throughput cliff).
