### PR TITLE
perf(schema): bind property value to a local before validating it

### DIFF
--- a/packages/schema/src/keywords/properties.ts
+++ b/packages/schema/src/keywords/properties.ts
@@ -18,6 +18,18 @@ function objectGuardVar(ctx: KeywordCompileContext): string {
 }
 
 /**
+ * Whether it pays to bind a property's value to a local before
+ * validating it. Object subschemas read the value (often several
+ * times, and across opaque helper calls V8 can't see through, which
+ * would otherwise force re-reads of `data[key]`); booleans and the
+ * empty schema never touch it, so binding there would just add a dead
+ * property read per key.
+ */
+function bindsValue(sub: SchemaOrBoolean): boolean {
+  return typeof sub === "object" && sub !== null && Object.keys(sub).length > 0;
+}
+
+/**
  * The `properties` keyword. For each named property present in the data,
  * validate its value against the corresponding subschema.
  *
@@ -35,7 +47,13 @@ export const propertiesKeyword: KeywordDefinition = {
         if (subSchema === undefined) continue;
         const keyLit = quoteString(name);
         g.if(`Object.prototype.hasOwnProperty.call(${ctx.data}, ${keyLit})`, (gi) => {
-          ctx.validateSubschema(subSchema, `${ctx.data}[${keyLit}]`, { segment: keyLit });
+          let dataExpr = `${ctx.data}[${keyLit}]`;
+          if (bindsValue(subSchema)) {
+            const valueVar = gi.scope.name("v");
+            gi.const(valueVar, dataExpr);
+            dataExpr = valueVar;
+          }
+          ctx.validateSubschema(subSchema, dataExpr, { segment: keyLit });
           if (ctx.evaluatedPropertiesVar !== null) {
             gi.line(`${ctx.evaluatedPropertiesVar}.add(${keyLit});`);
           }
@@ -133,7 +151,13 @@ export const additionalPropertiesKeyword: KeywordDefinition = {
           ctx.emitBudgetBreak();
           return;
         }
-        ctx.validateSubschema(subSchema, `${ctx.data}[${key}]`, { segment: key });
+        let dataExpr = `${ctx.data}[${key}]`;
+        if (bindsValue(subSchema)) {
+          const valueVar = gi.scope.name("v");
+          gi.const(valueVar, dataExpr);
+          dataExpr = valueVar;
+        }
+        ctx.validateSubschema(subSchema, dataExpr, { segment: key });
         if (ctx.evaluatedPropertiesVar !== null) {
           gi.line(`${ctx.evaluatedPropertiesVar}.add(${key});`);
         }


### PR DESCRIPTION
Closes #320.

## Problem

`properties` / `additionalProperties` passed `data[key]` straight into the subschema's checks. An object subschema with several keywords therefore re-read the property on each check:

```js
if (Object.prototype.hasOwnProperty.call(data, "name")) {
  if (!(typeof data["name"] === "string")) { ... }
  if (typeof data["name"] === "string" && deps.exceedsMaxCodePoints(data["name"], 50)) { ... }
  if (typeof data["name"] === "string" && deps.belowMinCodePoints(data["name"], 1)) { ... }
}
```

V8 CSEs most constant-key reads, but the gap is **opaque calls**: after `deps.exceedsMaxCodePoints(data["name"], 50)` (or a custom format / pattern test) V8 must assume `data` could have mutated and reloads `data["name"]`. The repeated expression also enlarges the function body against V8's inlining budget on wide schemas.

## Change

Bind the value once and validate the local:

```js
if (Object.prototype.hasOwnProperty.call(data, "name")) {
  const v0 = data["name"];
  if (!(typeof v0 === "string")) { ... }
  if (typeof v0 === "string" && deps.exceedsMaxCodePoints(v0, 50)) { ... }
  if (typeof v0 === "string" && deps.belowMinCodePoints(v0, 1)) { ... }
}
```

Guarded by `bindsValue()`: only object subschemas that actually read the value get the local. Booleans (`true` / `false`) and the empty schema (`{}`) keep the bare `data[key]`, so a non-reading property never pays a dead read:

```js
if (Object.prototype.hasOwnProperty.call(data, "flag")) { }   // properties: { flag: true }
if (Object.prototype.hasOwnProperty.call(data, "empty")) { }  // properties: { empty: {} }
```

`patternProperties` is left as-is (the issue's "slightly more involved" note): binding at the top of its `for...in` would add a read for keys that match zero patterns, a workload-dependent trade rather than a clean win.

## Correctness

Behavior is identical. The value is read once instead of N times, which also gives a consistent view for the pathological getter-on-data case (matching what ajv does). Existing `properties` / `additionalProperties` tests all pass; no new source-string assertion (the repo's guidance is to test behavior, not generated code, and behavior is unchanged).

## Verification

Full suite (1051 tests), typecheck, and lint green. `petstore` A/B (its `name` field exercises the string-property path) is unchanged within noise:

| | valid | invalid |
|---|---|---|
| with | 16.05M ops/s | 11.73M ops/s |
| baseline | 15.99M ops/s | 11.47M ops/s |

The win is generated-code quality (dedup'd reads, locals immune to the opaque-call reload, smaller bodies), not a throughput cliff. Confirmed in the emitted source above.
