### PR TITLE
docs: refresh benchmark and comparison perf claims after perf work

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,9 +221,10 @@ cold-start, AOT module emit.
 
 Both libraries are sub-microsecond per check on typical OpenAPI
 bodies. On complex `oneOf`/`allOf` or large arrays, Ajv leads by
-2–4× (say 100 ns to 400 ns per call, or 1.7 µs to 4 µs). oav's
+2–4× (say 100 ns to 400 ns per call, or 1.7 µs to 4 µs); oav leads
+on `uniqueItems` arrays and length-bounded strings. oav's
 `predicate` mode (`compileSchema(..., { predicate: true })`) closes
-most of that gap for yes/no use cases.
+most of Ajv's lead on the complex shapes for yes/no use cases.
 
 For typical HTTP workloads (1k–10k req/sec × ~1 validation per
 request), the difference is invisible at any of those numbers. For

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -41,14 +41,14 @@ the shape of the trade-off is sketched below.
 
 Ajv and oav trade differently depending on the workload:
 
-| Workload                                               | Winner                                                             | Notes                                                            |
-| ------------------------------------------------------ | ------------------------------------------------------------------ | ---------------------------------------------------------------- |
-| Validate, simple schemas (tiny / tree)                 | tied                                                               | Within ~10% either way; predicate mode slightly ahead of ajv     |
-| Validate, complex shapes (oneOf / allOf, large arrays) | ajv 2–5× faster                                                    | ajv's codegen excels on deep applicators                         |
-| Validate, `uniqueItems` arrays / length-bounded strings | **oav faster**                                                    | oav ~1.5–3× on `uniqueItems`; larger margin on length-bounded strings |
-| Validate, predicate mode                               | ≈ ajv                                                              | `compileSchema(..., { predicate: true })` closes most of the gap |
-| Compile, synthetic (per shape)                         | **oav 30–180× faster**                                             | The largest gap in either direction                              |
-| Compile, real-world OpenAPI spec                       | **oav 8× on Stripe** (886 schemas); **5.5× on Adyen** (44 schemas) | Matches the synthetic trend at spec scale                        |
+| Workload                                                | Winner                                                             | Notes                                                                 |
+| ------------------------------------------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| Validate, simple schemas (tiny / tree)                  | tied                                                               | Within ~10% either way; predicate mode slightly ahead of ajv          |
+| Validate, complex shapes (oneOf / allOf, large arrays)  | ajv 2–5× faster                                                    | ajv's codegen excels on deep applicators                              |
+| Validate, `uniqueItems` arrays / length-bounded strings | **oav faster**                                                     | oav ~1.5–3× on `uniqueItems`; larger margin on length-bounded strings |
+| Validate, predicate mode                                | ≈ ajv                                                              | `compileSchema(..., { predicate: true })` closes most of the gap      |
+| Compile, synthetic (per shape)                          | **oav 30–180× faster**                                             | The largest gap in either direction                                   |
+| Compile, real-world OpenAPI spec                        | **oav 8× on Stripe** (886 schemas); **5.5× on Adyen** (44 schemas) | Matches the synthetic trend at spec scale                             |
 
 The takeaway: ajv wins steady-state validate throughput on a spec you
 compile once and reuse; oav wins anywhere validator construction is

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -43,8 +43,9 @@ Ajv and oav trade differently depending on the workload:
 
 | Workload                                               | Winner                                                             | Notes                                                            |
 | ------------------------------------------------------ | ------------------------------------------------------------------ | ---------------------------------------------------------------- |
-| Validate, simple schemas (tiny / tree)                 | tied                                                               | Within ~5% either way; predicate mode slightly ahead of ajv      |
+| Validate, simple schemas (tiny / tree)                 | tied                                                               | Within ~10% either way; predicate mode slightly ahead of ajv     |
 | Validate, complex shapes (oneOf / allOf, large arrays) | ajv 2–5× faster                                                    | ajv's codegen excels on deep applicators                         |
+| Validate, `uniqueItems` arrays / length-bounded strings | **oav faster**                                                    | oav ~1.5–3× on `uniqueItems`; larger margin on length-bounded strings |
 | Validate, predicate mode                               | ≈ ajv                                                              | `compileSchema(..., { predicate: true })` closes most of the gap |
 | Compile, synthetic (per shape)                         | **oav 30–180× faster**                                             | The largest gap in either direction                              |
 | Compile, real-world OpenAPI spec                       | **oav 8× on Stripe** (886 schemas); **5.5× on Adyen** (44 schemas) | Matches the synthetic trend at spec scale                        |

--- a/performance/README.md
+++ b/performance/README.md
@@ -248,6 +248,7 @@ ajv for parity with oav's always-collect-everything default.
 
   `maxErrors: 1` closes the gap on invalid payloads (apples-to-apples
   with ajv's default fail-fast behavior).
+
 - **Predicate mode (`predicate: true`).** When consumers only need a
   yes/no answer — routing, gating, hot-path filtering — `oav-predicate`
   brings oav onto parity with ajv's default (fail-fast) mode on invalid

--- a/performance/README.md
+++ b/performance/README.md
@@ -30,8 +30,9 @@ Two modes, one script:
 
 - **Default (synthetic).** Iterates the schemas in `./schemas.ts` — a
   curated shape distribution (trivial scalar, flat object, recursive
-  `$ref`, `oneOf`+`allOf` composition, large array of small objects).
-  Measures both `compile` and `validate`; validate has separate valid
+  `$ref`, `oneOf`+`allOf` composition, large array of small objects,
+  `uniqueItems` array, and an object with large length-bounded
+  strings). Measures both `compile` and `validate`; validate has separate valid
   / invalid tasks so neither library wins by short-circuiting. Uses
   [tinybench](https://github.com/tinylibs/tinybench) for
   warmup-plus-iterations statistics.
@@ -46,7 +47,8 @@ Two modes, one script:
   no apples-to-apples way to measure it here. Use the
   synthetic mode if you need validate throughput numbers.
 
-Output lands on stdout and as JSON at `./results.json`.
+Output lands on stdout and as JSON under `./results/<iso-timestamp>.json`
+(see [Results file](#results-file)).
 
 ### `bench-real-world.mjs` — oav end-to-end on one spec
 
@@ -108,13 +110,13 @@ retention.
 ### Synthetic mode
 
 ```
-=== petstore — flat object with bounds and formats ===
+=== petstore — object with required + scalar properties; realistic small API payload ===
 compile:
-  ajv compile                  402 ops/s       2.49ms / op
-  hyperjump compile           5.8K ops/s     172.36µs / op
-  oav compile                26.7K ops/s      37.60µs / op
+  ajv compile                  356 ops/s       2.85ms / op
+  hyperjump compile           5.9K ops/s     189.94µs / op
+  oav compile                17.1K ops/s      67.49µs / op
 validate:
-  ajv validate (valid)              25.0M ops/s      39.95ns / op
+  ajv validate (valid)              23.7M ops/s      42.95ns / op
   ...
 ```
 
@@ -229,11 +231,23 @@ ajv for parity with oav's always-collect-everything default.
   construction. oav wins across the board in the current numbers,
   by one to two orders of magnitude against ajv.
 - **Steady-state validate on the same payload shape.** Call
-  `compile` once at boot, validate many times. ajv is the fastest
-  here; oav is roughly 1.4× on trivial shapes, ~3× on object and
-  composition shapes, ~3× on large-array shapes. `maxErrors: 1`
-  closes the ajv gap on invalid payloads (apples-to-apples with
-  ajv's default fail-fast behavior).
+  `compile` once at boot, validate many times. ajv and oav trade the
+  lead by shape:
+  - **At or near ajv parity** on scalar, flat-object, and recursive
+    `$ref` shapes (within ~10–35% on the bench spec).
+  - **Behind ajv** on the applicator-heavy shapes: ~2–3× on large
+    arrays, ~3–4× on `oneOf`/`allOf` composition (the largest
+    remaining gap; see the structural note below). Predicate mode
+    closes most of the composition gap.
+  - **Ahead of ajv** on two shapes: `uniqueItems` arrays (oav's
+    primitive fast path vs ajv's pairwise scan), and length-bounded
+    strings. On the latter, `minLength` / `maxLength` decide from the
+    string's `.length` before walking code points, so a large valid
+    body costs O(1) where ajv walks the whole string (oav is
+    ~thousands× faster on that shape's valid path).
+
+  `maxErrors: 1` closes the gap on invalid payloads (apples-to-apples
+  with ajv's default fail-fast behavior).
 - **Predicate mode (`predicate: true`).** When consumers only need a
   yes/no answer — routing, gating, hot-path filtering — `oav-predicate`
   brings oav onto parity with ajv's default (fail-fast) mode on invalid


### PR DESCRIPTION
Refreshes `performance/README.md` after this round of validator perf work (#316, #322, #323, #324). No code change.

## Why

Ran the full synthetic suite (`pnpm bench:long`) on current `main`. The "Interpreting the results" validate ratios predated the recent work and were stale. Current oav-vs-ajv (= 1.00) validate throughput:

| shape | README said | now (valid / invalid) |
|---|---|---|
| trivial | ~1.4x behind | 0.94 / 0.83 (near parity) |
| flat object (petstore) | ~3x behind | 0.66 / 0.62 |
| `$ref` (tree) | (folded in) | 0.92 / 0.77 (near parity) |
| composition | ~3x | 0.26 / 0.23 (now the largest gap) |
| array-heavy | ~3x | 0.38 / 0.39 |
| `uniqueItems` | not covered | **1.62 / 3.00** (oav ahead) |
| long-string | not covered | **8974 / 1.08** (oav ahead on valid) |

## Changes

- Rewrote the steady-state validate bullet: scalar / flat-object / `$ref` are now at/near ajv parity; arrays ~2-3x and composition ~3-4x behind (composition named as the remaining gap); oav now *ahead* of ajv on `uniqueItems` and length-bounded strings, with a one-line note on why the `.length` short-circuit makes a large valid string body O(1).
- Listed the `uniqueItems` and `long-string` schemas in the synthetic shape distribution (they were missing).
- Corrected the results path: `./results/<iso-timestamp>.json`, not `./results.json` (the doc already described the real path lower down).
- Aligned the `petstore` example header with its `schemas.ts` description.

Ratios are kept qualitative (rough multipliers) to stay host-independent, matching the section's existing style.

---

**Update:** also refreshes the perf claims in the root `README.md` and `docs/comparison.md` (not just `performance/README.md`):
- Note the shapes where oav now leads ajv on validate (`uniqueItems` arrays, length-bounded strings) in both docs.
- Tighten the simple-shape tie in `docs/comparison.md` from "~5%" to "~10%" to match current numbers.

Outcome-only, no implementation detail.