### PR TITLE
fix: correctness fixes from review (path decode, spaceDelimited, emit dedup)

### DIFF
--- a/packages/cli/src/emit-spec.ts
+++ b/packages/cli/src/emit-spec.ts
@@ -25,7 +25,6 @@ import {
   oas30Dialect,
   openapi31Dialect,
   resolve,
-  type CompiledSchema,
   type Dialect,
   type RefResolver,
 } from "@oav/schema";
@@ -99,17 +98,20 @@ export function emitSpec(document: OpenAPIDocument, options: EmitSpecOptions = {
   };
 
   // Collect every compiled schema, de-duplicated by identity. Each
-  // unique CompiledSchema gets one emitted IIFE; positions reference
-  // it by generated name.
+  // unique source schema gets one emitted IIFE; positions reference
+  // it by generated name. The dedup key is the source `SchemaOrBoolean`
+  // object: `compileSchema` returns a fresh `CompiledSchema` per call,
+  // so keying on its result would never hit and would recompile +
+  // re-emit the same schema once per reference.
   const compiled: Array<{ name: string; source: string }> = [];
-  const schemaNames = new Map<CompiledSchema, string>();
+  const schemaNames = new Map<SchemaOrBoolean, string>();
   const named = (schema: SchemaOrBoolean): string => {
-    const c = compileSchema(schema, { dialect, refResolver, formats: builtInFormats });
-    const existing = schemaNames.get(c);
+    const existing = schemaNames.get(schema);
     if (existing !== undefined) return existing;
+    const c = compileSchema(schema, { dialect, refResolver, formats: builtInFormats });
     const name = `S${compiled.length}`;
     compiled.push({ name, source: c.source });
-    schemaNames.set(c, name);
+    schemaNames.set(schema, name);
     return name;
   };
 

--- a/packages/cli/test/emit-spec-dedup.test.ts
+++ b/packages/cli/test/emit-spec-dedup.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { OpenAPIDocument, SchemaOrBoolean } from "@oav/core";
+import { emitSpec } from "../src/emit-spec.js";
+
+/**
+ * Regression guard for the schema dedup in `emitSpec`. The collector
+ * keys emitted IIFEs by the source `SchemaOrBoolean` identity. When the
+ * same schema object is referenced from multiple positions, it must be
+ * compiled and emitted once, not once per reference.
+ *
+ * The bug it guards against: keying the dedup Map on the
+ * `CompiledSchema` returned by `compileSchema` (a fresh object every
+ * call) so the lookup never hit and each reference re-emitted the
+ * schema.
+ */
+describe("emitSpec schema dedup", () => {
+  it("emits one IIFE for a schema object shared across operations", () => {
+    // Same object instance reused by reference in two response bodies.
+    const shared: SchemaOrBoolean = {
+      type: "object",
+      properties: { id: { type: "string" } },
+    };
+    const document = {
+      openapi: "3.1.0",
+      info: { title: "t", version: "1" },
+      paths: {
+        "/a": {
+          get: {
+            responses: {
+              "200": { description: "ok", content: { "application/json": { schema: shared } } },
+            },
+          },
+        },
+        "/b": {
+          get: {
+            responses: {
+              "200": { description: "ok", content: { "application/json": { schema: shared } } },
+            },
+          },
+        },
+      },
+    } as unknown as OpenAPIDocument;
+
+    const source = emitSpec(document, { importPrefix: "@oav" });
+    const iifeCount = (source.match(/= \(function \(deps\) \{/g) ?? []).length;
+    expect(iifeCount).toBe(1);
+  });
+});

--- a/packages/router/src/matcher.ts
+++ b/packages/router/src/matcher.ts
@@ -1,6 +1,24 @@
 import type { HttpMethod, OperationObject, PathItem } from "@oav/core";
 
 /**
+ * Decode a single path token, tolerating malformed percent-encoding.
+ *
+ * `decodeURIComponent` throws `URIError` on bad escapes (`%`, `%zz`),
+ * and a request path is attacker-controlled, so an unguarded decode
+ * turns a malformed URL into a thrown exception that escapes
+ * `validateRequest`. Falling back to the raw token keeps matching
+ * total: a malformed token simply fails to equal any literal segment
+ * (yielding the normal 404) instead of crashing.
+ */
+function decodePathToken(token: string): string {
+  try {
+    return decodeURIComponent(token);
+  } catch {
+    return token;
+  }
+}
+
+/**
  * Segments of a parsed OpenAPI path template. Three kinds:
  *
  * - `literal`: a fixed substring (`pets`).
@@ -279,7 +297,7 @@ export function createRouter(paths: Record<string, PathItem>): Router {
       const normMethod = method.toLowerCase() as HttpMethod;
       const stripped = path.split("?")[0] ?? path;
       const trimmed = stripped.replace(/^\/+/, "").replace(/\/+$/, "");
-      const tokens = trimmed === "" ? [] : trimmed.split("/").map((s) => decodeURIComponent(s));
+      const tokens = trimmed === "" ? [] : trimmed.split("/").map(decodePathToken);
 
       // If we scan every matching path without finding the method, we
       // still want to report a 405 (not 404) and carry the union of

--- a/packages/router/test/router.test.ts
+++ b/packages/router/test/router.test.ts
@@ -75,6 +75,16 @@ describe("router", () => {
     expect(m?.pathParams).toEqual({ id: "foo/bar" });
   });
 
+  it("does not throw on malformed percent-encoding", () => {
+    // decodeURIComponent throws URIError on a bad escape; the request
+    // path is attacker-controlled, so matching must stay total. The
+    // malformed token falls back to its raw form and captures cleanly.
+    expect(() => r.match("get", "/pets/%E0%A4%A")).not.toThrow();
+    const m = r.match("get", "/pets/%zz");
+    expect(m?.operation.operationId).toBe("getPet");
+    expect(m?.pathParams).toEqual({ id: "%zz" });
+  });
+
   it("ignores trailing slashes", () => {
     expect(r.match("get", "/pets/")?.operation.operationId).toBe("listPets");
   });

--- a/packages/validator/src/deserialize.ts
+++ b/packages/validator/src/deserialize.ts
@@ -72,7 +72,10 @@ function defaultStyle(location: string): ParameterStyle {
 function arraySeparator(style: ParameterStyle, explode: boolean): string {
   if (explode) return ","; // caller should have used Array.isArray fallthrough
   if (style === "pipeDelimited") return "|";
-  if (style === "spaceDelimited") return "%20";
+  // Query values reach here already URL-decoded (adapters read from
+  // URLSearchParams / framework `req.query`), so a spaceDelimited
+  // array arrives as space-separated text, not "%20"-separated.
+  if (style === "spaceDelimited") return " ";
   return ",";
 }
 
@@ -185,19 +188,23 @@ function parseMediaType(
  * OpenAPI precedence: exact status > `NXX` class > `default`.
  *
  * @param status - The response status.
- * @param responses - The operation's responses map.
+ * @param responses - The operation's responses, as either a keyed
+ *   object or a `Map` (the validator holds responses in a `Map`, so
+ *   accepting it directly avoids an `Object.fromEntries` per call).
  * @returns The matched response key, or `undefined`.
  *
  * @public
  */
 export function matchResponseKey(
   status: number,
-  responses: Record<string, unknown>,
+  responses: Record<string, unknown> | Map<string, unknown>,
 ): string | undefined {
+  const has =
+    responses instanceof Map ? (k: string) => responses.has(k) : (k: string) => k in responses;
   const exact = String(status);
-  if (exact in responses) return exact;
+  if (has(exact)) return exact;
   const klass = `${Math.floor(status / 100)}XX`;
-  if (klass in responses) return klass;
-  if ("default" in responses) return "default";
+  if (has(klass)) return klass;
+  if (has("default")) return "default";
   return undefined;
 }

--- a/packages/validator/src/operation-cache.ts
+++ b/packages/validator/src/operation-cache.ts
@@ -25,6 +25,12 @@ export interface OperationCache {
   headerParamValidators: Map<string, CompiledSchema>;
   cookieParamValidators: Map<string, CompiledSchema>;
   parameters: ParameterObject[];
+  /**
+   * Names of every declared `in: "query"` parameter, precomputed for
+   * the `strictQueryParameters` unknown-key check so the hot path
+   * doesn't rebuild this Set per request.
+   */
+  knownQueryParameters: Set<string>;
   requestBody: RequestBodyObject | undefined;
   bodyValidators: Map<string, CompiledSchema>;
   responses: Map<string, ResponseCompiled>;
@@ -117,6 +123,10 @@ export function buildOperationCache(
     byKey.set(`${resolved.in}\0${resolved.name}`, resolved);
   }
   const parameters: ParameterObject[] = [...byKey.values()];
+  const knownQueryParameters = new Set<string>();
+  for (const p of parameters) {
+    if (p.in === "query") knownQueryParameters.add(p.name);
+  }
 
   const pathParamValidators = new Map<string, CompiledSchema>();
   const queryParamValidators = new Map<string, CompiledSchema>();
@@ -177,6 +187,7 @@ export function buildOperationCache(
 
   return {
     parameters,
+    knownQueryParameters,
     pathParamValidators,
     queryParamValidators,
     headerParamValidators,

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -802,7 +802,7 @@ export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions
     }
 
     if (options.strictQueryParameters && req.query) {
-      const known = new Set(cache.parameters.filter((p) => p.in === "query").map((p) => p.name));
+      const known = cache.knownQueryParameters;
       for (const key of Object.keys(req.query)) {
         if (!known.has(key)) {
           children.push(
@@ -848,7 +848,7 @@ export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions
     const cache = cacheFor(match);
     const children: ValidationError[] = [];
 
-    const statusKey = matchResponseKey(res.status, Object.fromEntries(cache.responses));
+    const statusKey = matchResponseKey(res.status, cache.responses);
     if (statusKey === undefined) {
       children.push(
         createLeafError("status", [], `no response defined for status ${res.status}`, {

--- a/packages/validator/test/deserialize.test.ts
+++ b/packages/validator/test/deserialize.test.ts
@@ -44,6 +44,19 @@ describe("deserialize", () => {
     expect(out).toEqual(["a", "b", "c"]);
   });
 
+  it("splits space-delimited arrays on the decoded space", () => {
+    // Query values reach deserialize already URL-decoded, so a
+    // spaceDelimited array arrives space-separated, not "%20"-separated.
+    const out = deserialize("a b c", {
+      name: "ids",
+      in: "query",
+      style: "spaceDelimited",
+      explode: false,
+      schema: { type: "array" },
+    });
+    expect(out).toEqual(["a", "b", "c"]);
+  });
+
   it("treats empty string arrays as an empty array", () => {
     const out = deserialize("", {
       name: "ids",


### PR DESCRIPTION
Addresses findings from a code review. Five fixes across three packages, grouped into three commits.

## Correctness

- **Malformed percent-encoding crash (high).** `decodeURIComponent` in the router match hot path threw `URIError` on a bad escape; the request path is attacker-controlled, so a malformed URL became a request-triggered 500 escaping `validateRequest`. Now decoded through a guarded helper that falls back to the raw token, keeping matching total.
- **spaceDelimited query arrays.** Split on the literal `"%20"`, but query values reach `deserialize` already URL-decoded, so `?ids=a%20b` validated as `["a b"]` instead of `["a", "b"]`. Split on `" "`.
- **emit-spec schema dedup.** The dedup Map was keyed on the `CompiledSchema` returned by `compileSchema` (a fresh object per call), so it never hit and each reference re-emitted an identical IIFE. Keyed on the source `SchemaOrBoolean` identity instead.

## Hot-path allocation cleanups

- `matchResponseKey` accepts a `Map` (Record overload retained for the generated module + existing callers), dropping a per-response `Object.fromEntries`.
- `knownQueryParameters` precomputed once in `OperationCache` instead of rebuilt per `strictQueryParameters` request.

## Deferred (not in this PR)

Three lower-priority review items were left out per scope discipline and filed as separate issues:

- #327 perf(router): index routes to avoid full linear scan on large specs
- #328 polish(adapters): de-duplicate express4/express5 request extraction
- #329 polish(build): assert @oav/* alias parity across the alias/rewrite tables

## Testing

Reproducer tests added for the three correctness bugs (router malformed-percent, deserialize spaceDelimited, emit-spec dedup). Full suite green: 1054 tests, typecheck and lint clean. Perf suite not re-run: no `@oav/schema` compile/validate code changed, and the one fix in a benched path (router decode) is a `try/catch` wrapper around the same call.