### PR TITLE
docs: harden recursion-depth guidance and slim CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -488,3 +488,14 @@ having an unknown field, which 2020-12 allows in every dialect.
   Sets and the merge loop that threads them up to the caller.
   See `CompileState.unevaluatedTracking` and `schemaUsesUnevaluated`
   in `packages/schema/src/compiler/compiler.ts`.
+- Recursive schemas validate by recursing on the native JS call stack
+  (a self-`$ref` emits a recursive call; `deepEqual` for
+  `uniqueItems` / `const` / `enum` descends data structurally), with
+  no depth guard. A payload nested a few thousand levels deep throws
+  `RangeError: Maximum call stack size exceeded` (empirically ~5k on a
+  default Node stack). The framework adapters catch it as a 500;
+  untrusted callers should cap nesting depth at the parse boundary
+  (see docs/configuration.md "Guarding against deeply nested
+  payloads"). A codegen-level `maxDepth` counter is filed as `polish`;
+  it would put us ahead of the common approach (push the limit to the
+  boundary) but is not required for parity.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,79 +174,57 @@ and there is no `@types/fastify` on DefinitelyTyped, so the package
 itself has to be present for tsc to resolve the type.
 
 Each sub-root (`conformance/`, `framework-tests/`, `performance/`,
-`performance/mem-bench/`) ships its own `.npmrc` pinning
-`auto-install-peers=true`. pnpm in CI treats a sub-root's
-`pnpm-workspace.yaml` as the project boundary and does not walk past
-it to find the root `.npmrc`; dependabot's lockfile refresh does walk
-up. Without a sub-root `.npmrc`, the two readers disagree, dependabot
-writes lockfiles with `autoInstallPeers: false`, and the CI install
-fails with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. The sub-root files
-make the value explicit so both paths agree on `true`.
+`performance/mem-bench/`) also ships its own `.npmrc` pinning
+`auto-install-peers=true`. CI reads the sub-root `.npmrc` (it stops at
+the sub-root's `pnpm-workspace.yaml` boundary), while dependabot's
+lockfile refresh walks up to the root; the explicit per-root file
+keeps them agreeing, otherwise dependabot writes
+`autoInstallPeers: false` lockfiles and CI fails with
+`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`.
 
 ## Architecture, package by package
 
-- **`@oav/core`**: the shared error-tree model plus the helpers every
-  other package and most consumers need. `ValidationError` tree
-  (children always an array), path segments as `(string | number)[]`,
-  the canonical formatters (`formatText` / `formatSummary` / `toJsonObject`;
-  legacy aliases `formatJson` / `formatFlat` / `summarize` are still exported
-  but deprecated, removal in v3)
-  and the named-format dispatch (`formatError`, `formatErrors`,
-  `KNOWN_OUTPUT_FORMATS`), `httpStatusFor` / `allowHeaderFor` /
-  `toProblemDetails` for HTTP framing, RFC 6901 `resolveJsonPointer`,
-  shared OpenAPI / HTTP types, and `detectOpenAPIVersion`. Everything
-  else depends on this; nothing here depends on the others.
-- **`@oav/schema`**: the JSON Schema 2020-12 compiler. Walks a schema,
-  dispatches each keyword via `KeywordDefinition.compile(ctx)`, assembles
-  the generated JS source, and `eval`s it through `new Function(deps, src)`.
-  Boolean schemas (`true`/`false`) are first-class. `$ref` uses an
-  identity-keyed cache so self-recursive refs emit normal recursive calls.
-  The public barrel holds what keyword authors need; codegen mechanics
-  (`NAMES`, `pathJoinExpr`, `rawExpr`, `quoteString`, runtime helpers,
-  `SchemaRegistry`, `SUBSCHEMA_*_POSITIONS`, `createKeywordContext`)
-  live behind the `oav/schema/internals` subpath. Reach
-  for them only when a plugin genuinely needs them (not covered by
-  semver).
-- **`@oav/formats`**: pure string validators; exported as a `Record<string,
-(s: string) => boolean>` suitable for `compileSchema`'s `formats` option.
-- **`@oav/spec`**: `DocumentReader` abstraction (file/http/memory/composite)
-  plus `resolveSpec()` which inlines external `$ref`s and leaves circular
-  ones as internal refs. `applyOverlays()` handles the extension system.
-- **`@oav/overlay-spec`**: translator from OpenAPI Overlay 1.0
-  spec-format documents (`{overlay, info, actions:[{target, update?|remove?}]}`)
-  to `@oav/spec`'s typed `SpecOverlay`. Closed-form recogniser, not a
-  JSONPath engine; unrecognised target shapes throw with the
-  offending string. See `packages/overlay-spec/README.md` for the
-  recognised target table. Ships at the `oav/overlay-spec` subpath.
-- **`@oav/router`**: a sorted-list route matcher. Routes are sorted once
-  at construction (more-literal segments first); `match` is a linear scan,
-  O(routes × segments). Cheap for typical OpenAPI spec sizes.
-- **`@oav/validator`**: the HTTP orchestrator. `createValidator(spec,
-options)` returns a `Validator` exposing `validateRequest(req)`,
-  `validateResponse(req, res)`, and `getOperation({ method, path })`.
-  Per-operation parameter / body / response schemas are pre-compiled
-  on first access; the validator handles route matching, content-type
-  negotiation, parameter deserialization (style + explode), and
-  response-status matching. Subtrees from each sub-validator are
-  prefixed with the HTTP location (`body`, `query`, `header`, ...) so
-  error paths are unambiguous. Also exports the Fetch-API adapter
-  (`httpRequestFromFetch`, `httpResponseFromFetch`,
-  `readBodyFromFetch`) for Next.js / Hono / Bun / Deno consumers.
-- **`@oav/cli`**: thin commander wrapper. No business logic beyond arg
-  parsing, I/O, and exit codes.
-- **`@oav/oav-express4`**, **`@oav/oav-express5`**, **`@oav/oav-fastify`**:
-  framework adapters. Thin: depend on `@aahoughton/oav-core`
-  (transitive) and declare the matching framework as a peer. Each
-  exports `validateRequests` (the middleware/hook factory),
-  `httpRequestFrom<Framework>` (the standalone extractor), and
-  `renderProblemDetails` (the default error renderer). Option and
-  type names (`ValidateRequestsOptions`, `ErrorHandler<Ctx>`) are
-  identical across the family; per-framework `Context` types use
-  framework-native field names (`ExpressContext { req, res, next }`,
-  `FastifyContext { request, reply }`). The `oav-express5` / Fastify
-  variants are async-native and don't need `try/catch`; `oav-express4`
-  forwards thrown errors via `next(err)`. Any response-validating
-  sibling added later slots in additively on each adapter.
+Import surface is in [docs/modules.md](./docs/modules.md); each
+package's README covers its responsibilities. The non-obvious nugget
+per package:
+
+- **`@oav/core`**: the shared error-tree model and HTTP/format
+  helpers. Everything depends on it; it depends on nothing. Legacy
+  formatter aliases (`formatJson` / `formatFlat` / `summarize`) are
+  deprecated, removal in v3.
+- **`@oav/schema`**: the JSON Schema 2020-12 compiler; walks a schema,
+  dispatches each keyword via `KeywordDefinition.compile(ctx)`, and
+  `eval`s the generated source through `new Function(deps, src)`.
+  Boolean schemas are first-class; `$ref` uses an identity-keyed cache
+  so self-recursive refs emit normal recursive calls. Codegen
+  mechanics live behind the `oav/schema/internals` subpath (not
+  semver-covered; reach for them only when a plugin truly needs them).
+- **`@oav/formats`**: pure string validators, a `Record<string, (s:
+string) => boolean>` shaped for `compileSchema`'s `formats` option.
+- **`@oav/spec`**: `DocumentReader` (file/http/memory/composite) plus
+  `resolveSpec()`, which inlines external `$ref`s and leaves circular
+  ones as internal refs. `applyOverlays()` is the extension system.
+- **`@oav/overlay-spec`**: OpenAPI Overlay 1.0 -> typed `SpecOverlay`.
+  Closed-form recogniser, not a JSONPath engine; unrecognised target
+  shapes throw with the offending string. Subpath `oav/overlay-spec`.
+- **`@oav/router`**: sorted-list route matcher; `match` is a linear
+  scan, O(routes x segments). Cheap for typical spec sizes (see #327).
+- **`@oav/validator`**: the HTTP orchestrator. `createValidator`
+  pre-compiles per-operation schemas on first access and prefixes each
+  sub-validator's subtree with its HTTP location (`body`, `query`, …)
+  so error paths are unambiguous. Also exports the Fetch-API adapter
+  (`httpRequestFromFetch`, …) for Next.js / Hono / Bun / Deno.
+- **`@oav/cli`**: thin commander wrapper; no business logic.
+- **`@oav/oav-express4` / `oav-express5` / `oav-fastify`**: thin
+  framework adapters with identical export names and option shapes
+  (`validateRequests`, `httpRequestFrom<Framework>`,
+  `renderProblemDetails`, `ValidateRequestsOptions`); only the
+  framework-typed `Context` field names differ
+  (`ExpressContext { req, res, next }` vs
+  `FastifyContext { request, reply }`). `oav-express4` forwards thrown
+  errors via `next(err)`; the express5 / fastify variants are
+  async-native. See the "Naming and consistency" principle for why the
+  shapes are kept identical.
 
 ## Dependency graph (strictly enforced; no cycles)
 
@@ -267,214 +245,43 @@ oav-express5  → same chain, peer: express ^5
 oav-fastify   → same chain, peer: fastify ^5
 ```
 
-## How to add a new keyword
+## Extending the compiler
 
-1. Create `packages/schema/src/keywords/<area>.ts` exporting a
-   `KeywordDefinition` with `keyword`, `vocabulary`, `compile(ctx)`.
-   Flags on the definition itself drive compiler specialization.
-   Set them correctly or performance optimizations silently mis-fire:
-   - `applicator: true`: keyword descends into subschemas (items,
-     properties, allOf, not, …). Drives the inliner to use the
-     function-call path for multi-keyword schemas containing this
-     keyword. A missed flag costs correctness (inlined applicators can
-     skip per-function evaluated-keys state) and speed (V8 can't
-     monomorphize a huge inline body).
-   - `annotation: true`: keyword is metadata only, emits no runtime
-     code (`title`, `description`, `$id`, `$schema`, `$comment`, …).
-     Lets the inliner count keyword density correctly and avoids
-     spurious "unknown-keyword" diagnostics.
-   - `evaluates: { properties?: true; items?: true }`: keyword
-     contributes to evaluated-keys / evaluated-items tracking for
-     `unevaluated*`.
+Full procedures for adding a keyword, a string format, or an output
+format are in [docs/extending.md](./docs/extending.md); the
+`KeywordCompileContext` field reference is the TSDoc on the type
+(`packages/schema/src/keywords/types.ts`), per "Type as canonical
+contract". Two gotchas the docs can't enforce, worth keeping in view:
 
-   `ctx.predicate` is `true` when the user requested predicate mode
-   (`compileSchema(..., { predicate: true })`). Most keywords don't
-   need to read this; `ctx.emitError`, `ctx.leafErrorExpr`,
-   `ctx.validateSubschema`, and `ctx.emitBudgetBreak` all do the
-   right thing automatically. Branch on it only when your keyword
-   reads a sub-validator's return value (composition keywords,
-   `$ref`, `contains`, `discriminator`, `dependentSchemas`); see the
-   "Predicate mode" section below.
+- **Keyword flags drive specialization silently.** `applicator`,
+  `annotation`, and `evaluates` on a `KeywordDefinition` change codegen
+  paths; a wrong flag mis-fires correctness or perf with no error. See
+  their TSDoc for what each breaks.
+- **New error codes need a `BuiltInErrorParams` entry** in
+  `packages/core/src/errors.ts`. Errors are emitted through generated
+  JS source, so the compiler can't check the `code`/`params` contract;
+  drift between the emitted shape and that type is a silent bug.
 
-   The context (`KeywordCompileContext`) offers:
-   - `ctx.gen`: code emitter (see the `CodeEmitter` interface).
-   - `ctx.data`, `ctx.path`, `ctx.errors`: JS expressions for the
-     current data, path array, and error accumulator.
-   - `ctx.schema`, `ctx.parentSchema`: the keyword's value and the
-     surrounding schema object.
-   - `ctx.emitError(kind, expr)` / `ctx.errorStatement(kind, expr)`:
-     push an error expression (`"leaf"` = counts against `maxErrors`,
-     `"lift"` = propagating an already-counted sub-validator result).
-   - `ctx.leafErrorExpr(codeExpr, msgExpr, paramsExpr, extraSegments?)`:
-     build a `deps.createLeafError(...)` call. Pass any per-error
-     trailing path segment (e.g. a missing property name) via
-     `extraSegments` so the runtime helper splices them; the helper
-     also picks up any segments pending from an enclosing inlined
-     `validateSubschema` call. `ctx.branchErrorExpr(...)` is the
-     equivalent for branch errors.
-   - `ctx.validateSubschema(schema, dataExpr, { segment? })`: the
-     common "descend into a subschema" pattern (inlines when simple).
-   - `ctx.compileSubschema(schema) -> fnName`: lower-level; use when
-     a keyword needs the sub-validator's return value for its own
-     logic (composition keywords do this).
-   - `ctx.resolveRef(ref)`, `ctx.evaluatedPropertiesVar` /
-     `ctx.evaluatedItemsVar`: for `$ref` and unevaluated-tracking.
-   - `ctx.effectivePathExpr`: JS expression for the runtime path
-     including any pending inline segments. Reach for this only when
-     passing the path to something other than the error helpers
-     (e.g. a user-supplied custom-keyword callback).
-   - `ctx.emitBudgetBreak()` at the tail of hot loops.
+## Error budget and predicate mode
 
-2. Add it to the vocabulary's `keywords` array in `vocabulary.ts`.
-3. Re-export from `keywords/index.ts` and top-level `src/index.ts`.
-4. Add a `test/keyword-<name>.test.ts` that compiles a schema, validates
-   good + bad data, and asserts on `code` / `path` / `params` /
-   `children` structure; never on generated code strings.
-5. Add an entry to `BuiltInErrorParams` in `packages/core/src/errors.ts`
-   describing the new error `code` and the shape of its `params`
-   object. The compiler can't check this (errors are emitted through
-   generated JS source), but it's the documented contract consumers
-   narrow against; drift here is a silent bug.
-
-## How to add a new format
-
-1. Add the validator to `packages/formats/src/<area>.ts`.
-2. Export from `packages/formats/src/index.ts`.
-3. Add it to the `builtInFormats` record.
-4. Test with RFC-sourced valid + invalid examples.
-
-## How to add a new output format
-
-Output format dispatch lives in `@oav/core` (not the CLI) so library
-consumers can render by format name too. Programmatic callers can also
-pass a renderer function directly (`formatError(err, (e) => ...)`)
-without forking the switch.
-
-1. Add the name to `KNOWN_OUTPUT_FORMATS` in
-   `packages/core/src/format-output.ts`. The `OutputFormat` type and
-   the CLI's Commander `--format` validator are both derived from it.
-2. Add the rendering function to `packages/core/src/format.ts` (or emit
-   straight from the leaves).
-3. Add a branch to `formatError()` in `packages/core/src/format-output.ts`.
-4. Add a test in `packages/core/test/format-output.test.ts`.
-
-## Error-collection modes
-
-By default the compiler collects every error into a tree. For very
-large payloads (e.g. a 10 MB JSON array where every element fails the
-same way) that's wasted CPU and memory. `compileSchema(schema,
-{ maxErrors: N })` (also exposed on `@oav/validator`'s
-`createValidator`) caps the tree at N leaves and short-circuits the
-hot loops once the budget is exhausted. `maxErrors: 1` is the classic
-fast-fail mode; the returned `{ valid: false, error, truncated: true }`
-tells consumers their report is partial. Codegen is specialized: when
-`maxErrors` is left unset, the generated source is identical to before
-(no budget checks, no `truncated` tracking); zero overhead for
-callers who don't opt in.
-
-`maxErrors` must be a positive integer (>= 1). `compileSchema` and
-`createValidator` both throw on `0`, negative values, or non-integers;
-predicate mode (below) is the explicit way to opt out of error
-collection entirely.
-
-The budget semantics show up at the keyword-authoring level through
-the `kind` argument on `ctx.emitError` / `ctx.errorStatement`:
-
-- `ctx.emitError("leaf", expr)`: a **fresh leaf error**; counts
-  against the budget. Use when the keyword itself is constructing a
-  `createLeafError(...)` expression.
-- `ctx.emitError("lift", expr)`: a **lift**, propagating a
-  sub-validator's already-counted error up the tree, or wrapping
-  already-counted children in a `createBranchError`. Always
-  unconditional.
-
-Using the wrong kind silently miscounts errors against the budget.
-The `kind` is a required argument; TypeScript enforces that a choice
-is made at every call site; the correctness of the choice is on the
-author.
-
-### Predicate mode (`compileSchema(schema, { predicate: true })`)
-
-For consumers who only need a yes/no answer (routing, gating,
-bulk-filtering), `predicate: true` compiles a `{ validate: (data) =>
-boolean }` validator. No error tree is ever constructed: leaves don't
-allocate, paths aren't snapshotted, messages aren't formatted, and the
-entire `wrapErrors` pipeline is skipped. Every failure short-circuits
-to `return false;`. Generated subfunctions drop the `path` parameter
-(there's nothing to attach errors to).
-
-Predicate mode is mutually exclusive with a finite `maxErrors`; the
-compiler throws if both are set. The two options are semantically
-incompatible; predicate already short-circuits on the first failure,
-so there is nothing to count.
-
-For **keyword authors**, most keywords get predicate mode for free
-because `ctx.emitError("leaf" | "lift", expr)` collapses to `return
-false;` when `ctx.predicate === true`; `ctx.withPathSegment`,
-`ctx.validateSubschema`, and `ctx.emitBudgetBreak` are similarly
-predicate-aware. You only need to branch on `ctx.predicate` when your
-keyword reads a sub-validator's return value for its own control flow:
-composition keywords (`allOf`, `anyOf`, `oneOf`, `not`,
-`if`/`then`/`else`, `dependentSchemas`), `contains`, `discriminator`,
-`$ref`, and `$dynamicRef` all do this. In predicate mode subfunctions
-return `boolean` (not `ValidationError | null`) and don't take a
-`path` argument, so the call expression shape changes accordingly.
-See `allOfKeyword` in `packages/schema/src/keywords/composition.ts`
-for the canonical two-branch pattern.
+User-facing `maxErrors` and predicate mode are documented in
+[docs/configuration.md](./docs/configuration.md) and
+[docs/extending.md](./docs/extending.md). Codegen is specialized so
+unset `maxErrors` emits source identical to the un-budgeted path (zero
+overhead). The one gotcha for keyword authors: the `kind` on
+`ctx.emitError` (`"leaf"` counts against the budget, `"lift"` is an
+already-counted child being propagated and never touches the counter).
+Pick wrong and the budget silently miscounts. TypeScript forces the
+choice; the correctness of it is on the author.
 
 ## Version support
 
-`@oav/validator` buckets the spec's `openapi` string at validator
-construction time via `detectOpenAPIVersion` and picks a dialect:
-
-| Spec version | Status    | Dialect                            |
-| ------------ | --------- | ---------------------------------- |
-| 3.0.x        | Supported | OAS 3.0 Schema Object flavour      |
-| 3.1.x        | Supported | JSON Schema 2020-12                |
-| 3.2.x        | Supported | JSON Schema 2020-12 + QUERY method |
-
-Dispatch is a one-liner inside `createValidator`: `dialectFor(version)`.
-The check runs once at construction; there's no per-request branching,
-so adding more versions adds zero runtime cost.
-
-### What differs in the 3.0 dialect
-
-Only three things vary from 2020-12; everything else (numeric / string
-/ array / object bounds, `enum`, `required`, `allOf`/`anyOf`/`oneOf`,
-`not`, `format`, discriminator, etc.) is shared.
-
-1. **`type` is string-only** (no arrays). `oas30TypeKeyword` enforces
-   this at compile time and adds `"null"` to the acceptable types when
-   the sibling `nullable: true` is set.
-2. **`exclusiveMaximum` / `exclusiveMinimum` are booleans**. They
-   modify the sibling `maximum` / `minimum` rather than standing alone
-   as numeric bounds. `oas30MaximumKeyword` / `oas30MinimumKeyword`
-   read the boolean and emit `>=` vs `>` (or `<=` vs `<`) accordingly.
-3. **`$ref` siblings are ignored**. The dialect's
-   `rules.refSuppressesSiblings` flag makes the keyword dispatcher
-   skip every non-`$ref` keyword in a schema that declares `$ref`.
-   `oas30Dialect` sets it to `true`; every other built-in dialect
-   sets it to `false`.
-
-Keywords not present in 3.0 (`const`, `if`/`then`/`else`, `contains`,
-`patternProperties`, `propertyNames`, `unevaluatedProperties`/`Items`,
-`prefixItems`, `$defs`, `$id`, anchors, `$dynamicRef`) are simply not
-in the 3.0 vocabulary stack; schemas that use them are treated as
-having an unknown field, which 2020-12 allows in every dialect.
-
-### Running tests per version
-
-- **Schema-level tests** (`packages/schema/test/*`) are
-  dialect-agnostic; they compile schemas with the default 2020-12
-  vocab and assert on 2020-12 semantics. Dialect-specific keyword
-  tests sit next to their keyword files where sensible.
-- **HTTP-level conformance** lives in
-  `conformance/openapi-cases/petstore-{30,31,32}/`, one petstore per
-  version, each exercising the version's distinctive features (3.0:
-  `nullable`, boolean `exclusiveMinimum`; 3.2: QUERY method).
-- **Validator integration tests** in
-  `packages/validator/test/versioning.test.ts` cover dispatch,
-  dialect-specific keyword behavior, and the `dialect` override.
+User-facing version support is in the
+[README `## Versions`](./README.md#versions); dialect internals (what
+differs in 3.0, dispatch, per-version test layout) are in
+[docs/dialects.md](./docs/dialects.md). Dispatch is a single
+`dialectFor(version)` at construction, so added versions cost nothing
+per request.
 
 ## Known limitations
 

--- a/README.md
+++ b/README.md
@@ -378,6 +378,14 @@ validation, response interception, upload helpers), see
   `createValidator` to plug in `re2` or a complexity-checking engine;
   see ["Hardening against untrusted regex patterns"
   ](./docs/configuration.md#hardening-against-untrusted-regex-patterns).
+- Recursive schemas validate by recursing on the JavaScript call
+  stack, with no depth limit. A deeply nested payload (a few thousand
+  levels, only a few KB on the wire) can exhaust the stack and throw
+  `RangeError: Maximum call stack size exceeded`. The framework
+  adapters surface this as a 500 rather than a crash, but for
+  untrusted input cap nesting depth at the parse boundary; see
+  ["Guarding against deeply nested payloads"
+  ](./docs/configuration.md#guarding-against-deeply-nested-payloads).
 
 ## Contributing
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -119,3 +119,84 @@ sync. `format: "regex"` is auto-registered by `@oav/schema` and no
 longer ships from `@oav/formats`'s `builtInFormats`; a user-supplied
 entry in `formats` still overrides it if you want a different policy
 for the format than for `pattern`.
+
+## Guarding against deeply nested payloads
+
+Recursive schemas (a `$ref` that points back at an ancestor, common
+for tree and comment structures) compile to validation functions that
+call themselves once per level of nested data. Validation depth tracks
+the payload's nesting depth, and the JavaScript call stack has no
+built-in limit you can rely on. A small but deeply nested payload (an
+array nested a few thousand levels, only a few KB on the wire) can
+exhaust the stack and throw `RangeError: Maximum call stack size
+exceeded`.
+
+`oav` does not impose a depth limit of its own: the safe ceiling
+depends on the runtime's stack size and on how much stack each
+validation frame consumes, both of which the caller controls better
+than the library can. The framework adapters catch the `RangeError`
+and turn it into a 500, so a single request fails rather than the
+process crashing. A cheap-to-send payload that reliably produces 500s
+is still a denial-of-service vector.
+
+The mitigation is a depth cap at the parse boundary, before the parsed
+body reaches the validator. A byte-size limit alone is not enough: a
+payload nested thousands of levels deep is tiny, so `express.json({
+limit })` (or its equivalent) bounds width, not depth. Walk the parsed
+value iteratively (a recursive walker would overflow on the same input
+you are trying to reject) and reject anything past a sane ceiling.
+Legitimate request bodies rarely nest beyond ten or fifteen levels; a
+cap of 32 to 64 is generous for real traffic and well clear of the
+danger zone. Set it low and raise it only if a legitimate payload
+trips it.
+
+```ts
+// Returns true if `value` nests deeper than `limit`. Iterative on
+// purpose: a recursive walker would overflow on the input it rejects.
+function tooDeep(value: unknown, limit: number): boolean {
+  const stack: Array<[unknown, number]> = [[value, 1]];
+  while (stack.length) {
+    const [node, depth] = stack.pop()!;
+    if (node === null || typeof node !== "object") continue;
+    if (depth > limit) return true;
+    if (Array.isArray(node)) {
+      for (const el of node) stack.push([el, depth + 1]);
+    } else {
+      for (const k of Object.keys(node)) {
+        stack.push([(node as Record<string, unknown>)[k], depth + 1]);
+      }
+    }
+  }
+  return false;
+}
+
+app.use(express.json({ limit: "256kb" }));
+app.use((req, res, next) => {
+  if (req.body && tooDeep(req.body, 64)) {
+    return res.status(400).json({ error: "request body nesting too deep" });
+  }
+  next();
+});
+// the validateRequests middleware comes after this guard
+```
+
+Fastify is the same shape in an `onRequest` or `preValidation` hook
+that inspects `request.body`.
+
+For standalone callers (the Fetch adapter, a handler that calls
+`validateRequest` directly), wrap the call so a stack overflow becomes
+a controlled error instead of an unhandled rejection:
+
+```ts
+try {
+  result = validator.validateRequest(req);
+} catch (err) {
+  if (err instanceof RangeError) {
+    return new Response("payload too complex", { status: 400 });
+  }
+  throw err;
+}
+```
+
+The depth guard is the primary control; the byte-size limit and the
+`try/catch` are backstops.

--- a/docs/dialects.md
+++ b/docs/dialects.md
@@ -1,0 +1,60 @@
+# Dialects and version support
+
+User-facing version support (the supported-version table, the
+`dialect` / `onUnknownVersion` overrides, Swagger 2.0) is in the
+[README `## Versions`](../README.md#versions) section. This page is the
+contributor-facing internals: how dispatch works, what varies between
+dialects, and where the per-version tests live.
+
+## Dispatch
+
+`@oav/validator` buckets the spec's `openapi` string at construction
+via `detectOpenAPIVersion` and picks a dialect with a one-liner inside
+`createValidator`: `dialectFor(version)`. The check runs once at
+construction, so adding a version adds zero per-request cost.
+
+| Spec version | Status    | Dialect                            |
+| ------------ | --------- | ---------------------------------- |
+| 3.0.x        | Supported | OAS 3.0 Schema Object flavour      |
+| 3.1.x        | Supported | JSON Schema 2020-12                |
+| 3.2.x        | Supported | JSON Schema 2020-12 + QUERY method |
+
+## What differs in the 3.0 dialect
+
+Only three things vary from 2020-12; everything else (numeric / string
+/ array / object bounds, `enum`, `required`, `allOf` / `anyOf` /
+`oneOf`, `not`, `format`, discriminator, etc.) is shared.
+
+1. **`type` is string-only** (no arrays). `oas30TypeKeyword` enforces
+   this at compile time and adds `"null"` to the acceptable types when
+   the sibling `nullable: true` is set.
+2. **`exclusiveMaximum` / `exclusiveMinimum` are booleans.** They
+   modify the sibling `maximum` / `minimum` rather than standing alone
+   as numeric bounds. `oas30MaximumKeyword` / `oas30MinimumKeyword`
+   read the boolean and emit `>=` vs `>` (or `<=` vs `<`) accordingly.
+3. **`$ref` siblings are ignored.** The dialect's
+   `rules.refSuppressesSiblings` flag makes the keyword dispatcher skip
+   every non-`$ref` keyword in a schema that declares `$ref`.
+   `oas30Dialect` sets it to `true`; every other built-in dialect sets
+   it to `false`.
+
+Keywords absent from 3.0 (`const`, `if`/`then`/`else`, `contains`,
+`patternProperties`, `propertyNames`, `unevaluatedProperties` /
+`Items`, `prefixItems`, `$defs`, `$id`, anchors, `$dynamicRef`) are
+simply not in the 3.0 vocabulary stack; schemas that use them are
+treated as having an unknown field, which 2020-12 allows in every
+dialect.
+
+## Running tests per version
+
+- **Schema-level tests** (`packages/schema/test/*`) are
+  dialect-agnostic: they compile with the default 2020-12 vocab and
+  assert 2020-12 semantics. Dialect-specific keyword tests sit next to
+  their keyword files where sensible.
+- **HTTP-level conformance** lives in
+  `conformance/openapi-cases/petstore-{30,31,32}/`, one petstore per
+  version, each exercising the version's distinctive features (3.0:
+  `nullable`, boolean `exclusiveMinimum`; 3.2: QUERY method).
+- **Validator integration tests** in
+  `packages/validator/test/versioning.test.ts` cover dispatch,
+  dialect-specific keyword behavior, and the `dialect` override.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,0 +1,107 @@
+# Extending the compiler
+
+Recipes for adding to `@oav/schema`: new keywords, new string formats,
+new output formats. The canonical contract for each lives in TSDoc on
+the relevant type; this page is the worked procedure.
+
+## Add a new keyword
+
+1. Create `packages/schema/src/keywords/<area>.ts` exporting a
+   [`KeywordDefinition`](../packages/schema/src/keywords/types.ts) with
+   `keyword`, `vocabulary`, and `compile(ctx)`. The flags on the
+   definition drive compiler specialization; set them correctly or
+   optimizations silently mis-fire. See the TSDoc on `applicator`,
+   `annotation`, and `evaluates` for what each does and what breaks
+   when it's wrong.
+2. Add it to the vocabulary's `keywords` array in `vocabulary.ts`.
+3. Re-export from `keywords/index.ts` and top-level `src/index.ts`.
+4. Add `test/keyword-<name>.test.ts` that compiles a schema, validates
+   good + bad data, and asserts on `code` / `path` / `params` /
+   `children` structure. Never assert on generated code strings.
+5. Add an entry to `BuiltInErrorParams` in
+   `packages/core/src/errors.ts` describing the new error `code` and
+   the shape of its `params`. The compiler can't check this (errors
+   are emitted through generated JS source), so it's the documented
+   contract consumers narrow against; drift here is a silent bug.
+
+### The compile context
+
+`compile(ctx)` receives a
+[`KeywordCompileContext`](../packages/schema/src/keywords/types.ts).
+Its TSDoc is the field-by-field reference: `gen`, `data` / `path` /
+`errors`, `schema` / `parentSchema`, the error helpers (`emitError`,
+`leafErrorExpr`, `branchErrorExpr`), the descent helpers
+(`validateSubschema`, `compileSubschema`, `compileAndCallSubschema`),
+`resolveRef`, the unevaluated-tracking vars, `effectivePathExpr`,
+`emitBudgetBreak`, and the hoisting helpers (`hoistConstant`,
+`scopeLocal`). Read it there rather than duplicating it here.
+
+Two cross-cutting behaviors are worth calling out because they change
+how `compile` is written.
+
+### Error budget (`maxErrors`)
+
+The `kind` argument on `ctx.emitError` / `ctx.errorStatement` carries
+the budget semantics:
+
+- `ctx.emitError("leaf", expr)`: a fresh leaf error, created in this
+  call. Counts against the `maxErrors` budget; short-circuits cleanly
+  once the cap is hit.
+- `ctx.emitError("lift", expr)`: an already-counted error being
+  propagated up (a sub-validator's return value), or a branch wrapper
+  around already-counted children. Always unconditional, never touches
+  the counter.
+
+Using the wrong kind silently miscounts errors against the budget.
+TypeScript enforces that you pass one of the two names; the
+correctness of the choice is on you. Put `ctx.emitBudgetBreak()` at
+the tail of hot loops (array items, property keys, applicator
+branches) so they stop once the cap is exhausted.
+
+### Predicate mode
+
+`compileSchema(schema, { predicate: true })` compiles a `{ validate:
+(data) => boolean }` validator that builds no error tree: leaves don't
+allocate, paths aren't snapshotted, messages aren't formatted, and
+every failure short-circuits to `return false;`. Generated
+subfunctions drop the `path` parameter.
+
+Most keywords get this for free: `ctx.emitError`,
+`ctx.validateSubschema`, and `ctx.emitBudgetBreak` all collapse to the
+predicate form automatically. You only branch on `ctx.predicate` when
+your keyword reads a sub-validator's return value for its own control
+flow: the composition keywords (`allOf`, `anyOf`, `oneOf`, `not`,
+`if`/`then`/`else`, `dependentSchemas`), plus `contains`,
+`discriminator`, `$ref`, and `$dynamicRef`. In predicate mode those
+sub-validators return `boolean` (not `ValidationError | null`) and
+take no `path` argument, so the call-expression shape changes. See
+`allOfKeyword` in
+[`packages/schema/src/keywords/composition.ts`](../packages/schema/src/keywords/composition.ts)
+for the canonical two-branch pattern.
+
+Predicate mode is mutually exclusive with a finite `maxErrors`; the
+compiler throws if both are set (predicate already short-circuits on
+the first failure, so there's nothing to count).
+
+## Add a new format
+
+1. Add the validator to `packages/formats/src/<area>.ts`.
+2. Export it from `packages/formats/src/index.ts`.
+3. Add it to the `builtInFormats` record.
+4. Test with RFC-sourced valid + invalid examples.
+
+## Add a new output format
+
+Output-format dispatch lives in `@oav/core` (not the CLI) so library
+consumers can render by format name too. Programmatic callers can also
+pass a renderer function directly (`formatError(err, (e) => ...)`)
+without forking the switch.
+
+1. Add the name to `KNOWN_OUTPUT_FORMATS` in
+   `packages/core/src/format-output.ts`. The `OutputFormat` type and
+   the CLI's Commander `--format` validator both derive from it.
+2. Add the rendering function to `packages/core/src/format.ts` (or
+   emit straight from the leaves).
+3. Add a branch to `formatError()` in
+   `packages/core/src/format-output.ts`.
+4. Add a test in `packages/core/test/format-output.test.ts`.

--- a/packages/schema/src/keywords/types.ts
+++ b/packages/schema/src/keywords/types.ts
@@ -367,9 +367,25 @@ export interface KeywordDefinition {
    * `keywords` array order instead.
    */
   before?: string;
-  /** Marks whether this keyword tracks evaluated properties/items. */
+  /**
+   * Declares that this keyword contributes to evaluated-properties /
+   * evaluated-items tracking, the bookkeeping `unevaluatedProperties`
+   * and `unevaluatedItems` consume. Set the relevant sub-flag for any
+   * keyword that "evaluates" object members or array positions
+   * (`properties`, `patternProperties`, `items`, `contains`, …). A
+   * missed flag silently breaks `unevaluated*` siblings, which will
+   * then see members as unevaluated and reject valid data.
+   */
   evaluates?: { properties?: boolean; items?: boolean };
-  /** When `true`, indicates the keyword takes subschemas (applicator). */
+  /**
+   * When `true`, this keyword descends into subschemas (`items`,
+   * `properties`, `allOf`, `not`, …). The flag drives the subschema
+   * inliner to take the function-call path for multi-keyword schemas
+   * containing this keyword. Setting it wrong is a silent
+   * mis-optimization: a missed flag costs correctness (an inlined
+   * applicator can skip the per-function evaluated-keys state) and
+   * speed (V8 can't monomorphize a huge inlined body).
+   */
   applicator?: boolean;
   /**
    * When `true`, declares this keyword to be pure annotation/metadata:


### PR DESCRIPTION
Two doc-only concerns, two commits.

## 1. Recursion-depth DoS guidance (`8fad28b`)

Came out of assessing an external review. Recursive schemas validate by recursing on the native JS call stack with no depth guard, so a deeply nested payload (a few KB, ~5k levels) throws `RangeError: Maximum call stack size exceeded`. Verified empirically against this library and against another widely-used JS validator: both fail at the same point, and the ecosystem norm is to push the depth limit to the caller's parse boundary rather than guard in-library.

- README: new Known-limitations bullet.
- `docs/configuration.md`: "Guarding against deeply nested payloads" recipe (iterative depth guard + middleware wiring, with size-limit and try/catch backstops).
- CLAUDE.md: contributor known-limitation note.

The in-library codegen `maxDepth` guard is tracked separately as polish (#330).

## 2. CLAUDE.md slim-down (`69f44e4`)

CLAUDE.md had grown to ~500 lines by inlining reference material that belongs next to the code, against its own "Type as canonical contract" principle. Extracted it; kept the steering, invariants, and gotchas. **501 -> 308 lines**, no information lost.

- `docs/extending.md` (new): keyword / format / output-format procedures, error-budget (leaf/lift) and predicate-mode rules for keyword authors; points to TSDoc for the `KeywordCompileContext` field reference.
- `docs/dialects.md` (new): dialect internals (what differs in 3.0, dispatch, per-version test layout).
- `types.ts`: enriched `applicator`/`evaluates` flag TSDoc with the "what breaks if set wrong" detail that was only in CLAUDE.md.
- CLAUDE.md: compressed the package-by-package map; replaced moved sections with pointers that retain the non-enforceable gotchas.

## Verification

- `pnpm typecheck` clean
- `pnpm lint` clean (oxlint + oxfmt)
- All cross-doc links resolve; README `#versions` anchor exists