### PR TITLE
fix(schema): make deepEqual iterative to stop stack overflow on deep data

### DIFF
--- a/packages/schema/src/compiler/runtime.ts
+++ b/packages/schema/src/compiler/runtime.ts
@@ -192,23 +192,6 @@ export function typeOf(value: unknown): string {
 }
 
 /**
- * Structural equality for JSON values: honors array ordering, object key
- * sets (not ordering), and NaN-as-not-equal. Used by `enum`, `const`, and
- * `uniqueItems`.
- *
- * @param a - First value.
- * @param b - Second value.
- * @returns `true` when both values are structurally equal.
- *
- * @example
- * ```ts
- * deepEqual({ a: 1, b: 2 }, { b: 2, a: 1 }); // true
- * deepEqual([1, 2], [2, 1]);                 // false
- * ```
- *
- * @public
- */
-/**
  * Find the first pair of structurally-equal elements in `arr`. Backs
  * the `uniqueItems` keyword: primitives hit a `Map` fast path (O(N)),
  * while objects/arrays fall back to pairwise `deepEqual` against the
@@ -326,31 +309,55 @@ export function belowMinCodePoints(s: string, limit: number): boolean {
   return true;
 }
 
+/**
+ * Structural equality for JSON values: honors array ordering, object key
+ * sets (not ordering), and NaN-as-not-equal. Used by `enum`, `const`, and
+ * `uniqueItems`.
+ *
+ * Iterative, over an explicit work stack of pairs left to compare, so a
+ * deeply nested payload cannot overflow the native call stack. A recursive
+ * walk would throw `RangeError: Maximum call stack size exceeded` on the
+ * same small-but-deep input the validator is meant to reject.
+ *
+ * @param a - First value.
+ * @param b - Second value.
+ * @returns `true` when both values are structurally equal.
+ *
+ * @example
+ * ```ts
+ * deepEqual({ a: 1, b: 2 }, { b: 2, a: 1 }); // true
+ * deepEqual([1, 2], [2, 1]);                 // false
+ * ```
+ *
+ * @public
+ */
 export function deepEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
-  if (typeof a !== typeof b) return false;
-  if (a === null || b === null) return false;
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b) || a.length !== b.length) return false;
-    for (let i = 0; i < a.length; i += 1) {
-      if (!deepEqual(a[i], b[i])) return false;
+  const stack: Array<[unknown, unknown]> = [[a, b]];
+  while (stack.length > 0) {
+    const [x, y] = stack.pop()!;
+    if (x === y) continue;
+    if (typeof x !== typeof y) return false;
+    if (x === null || y === null) return false;
+    if (Array.isArray(x)) {
+      if (!Array.isArray(y) || x.length !== y.length) return false;
+      for (let i = 0; i < x.length; i += 1) stack.push([x[i], y[i]]);
+      continue;
     }
-    return true;
-  }
-  if (typeof a === "object") {
-    if (typeof b !== "object" || Array.isArray(b)) return false;
-    const aObj = a as Record<string, unknown>;
-    const bObj = b as Record<string, unknown>;
-    const aKeys = Object.keys(aObj);
-    const bKeys = Object.keys(bObj);
-    if (aKeys.length !== bKeys.length) return false;
-    for (const key of aKeys) {
-      if (!Object.prototype.hasOwnProperty.call(bObj, key)) return false;
-      if (!deepEqual(aObj[key], bObj[key])) return false;
+    if (typeof x === "object") {
+      if (typeof y !== "object" || Array.isArray(y)) return false;
+      const xObj = x as Record<string, unknown>;
+      const yObj = y as Record<string, unknown>;
+      const xKeys = Object.keys(xObj);
+      if (xKeys.length !== Object.keys(yObj).length) return false;
+      for (const key of xKeys) {
+        if (!Object.prototype.hasOwnProperty.call(yObj, key)) return false;
+        stack.push([xObj[key], yObj[key]]);
+      }
+      continue;
     }
-    return true;
+    return false;
   }
-  return false;
+  return true;
 }
 
 /**

--- a/packages/schema/test/runtime-deep-equal.test.ts
+++ b/packages/schema/test/runtime-deep-equal.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { deepEqual } from "../src/compiler/runtime.js";
+import { compile } from "./helpers.js";
+
+// Builds a left-nested structure `kind` deep: arrays as [x], objects as
+// { next: x }, bottoming out at `leaf`. Iterative so the test setup
+// itself can't overflow on the depths we exercise below.
+function nest(depth: number, kind: "array" | "object", leaf: unknown): unknown {
+  let node = leaf;
+  for (let i = 0; i < depth; i += 1) {
+    node = kind === "array" ? [node] : { next: node };
+  }
+  return node;
+}
+
+describe("deepEqual: structural equality", () => {
+  it("treats identical primitives as equal", () => {
+    expect(deepEqual(1, 1)).toBe(true);
+    expect(deepEqual("x", "x")).toBe(true);
+    expect(deepEqual(true, true)).toBe(true);
+    expect(deepEqual(null, null)).toBe(true);
+  });
+
+  it("treats distinct primitives of the same type as unequal", () => {
+    expect(deepEqual(1, 2)).toBe(false);
+    expect(deepEqual("a", "b")).toBe(false);
+    expect(deepEqual(true, false)).toBe(false);
+  });
+
+  it("treats cross-type values as unequal", () => {
+    expect(deepEqual(1, "1")).toBe(false);
+    expect(deepEqual(0, false)).toBe(false);
+    expect(deepEqual(null, undefined)).toBe(false);
+    expect(deepEqual(null, {})).toBe(false);
+    expect(deepEqual([], {})).toBe(false);
+    expect(deepEqual({}, [])).toBe(false);
+  });
+
+  it("treats NaN as not equal to itself (JSON has no NaN)", () => {
+    expect(deepEqual(Number.NaN, Number.NaN)).toBe(false);
+  });
+
+  it("treats +0 and -0 as equal", () => {
+    expect(deepEqual(0, -0)).toBe(true);
+  });
+
+  it("compares arrays element-wise and order-sensitively", () => {
+    expect(deepEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+    expect(deepEqual([1, 2], [2, 1])).toBe(false);
+    expect(deepEqual([1, 2], [1, 2, 3])).toBe(false);
+    expect(deepEqual([], [])).toBe(true);
+  });
+
+  it("compares objects by key set, ignoring key order", () => {
+    expect(deepEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
+    expect(deepEqual({}, {})).toBe(true);
+  });
+
+  it("rejects objects with the same key count but different keys", () => {
+    expect(deepEqual({ a: 1 }, { b: 1 })).toBe(false);
+    expect(deepEqual({ a: 1, b: 2 }, { a: 1, c: 2 })).toBe(false);
+  });
+
+  it("rejects objects with differing key counts", () => {
+    expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+    expect(deepEqual({ a: 1, b: 2 }, { a: 1 })).toBe(false);
+  });
+
+  it("does not confuse a missing key with an undefined-valued key", () => {
+    // `{ a: undefined }` has key "a"; `{}` does not. Same intent as JSON,
+    // where neither object would carry the key, but guards the hasOwnProperty
+    // path regardless.
+    expect(deepEqual({ a: undefined }, {})).toBe(false);
+  });
+
+  it("recurses through nested mixed structures", () => {
+    const a = { id: 1, tags: ["x", "y"], meta: { nested: [{ k: 1 }] } };
+    const b = { meta: { nested: [{ k: 1 }] }, tags: ["x", "y"], id: 1 };
+    expect(deepEqual(a, b)).toBe(true);
+
+    const c = { id: 1, tags: ["x", "y"], meta: { nested: [{ k: 2 }] } };
+    expect(deepEqual(a, c)).toBe(false);
+  });
+});
+
+describe("deepEqual: stack safety on deep input", () => {
+  // A recursive implementation throws RangeError (~5k frames on a default
+  // Node stack); the iterative one must handle far deeper input.
+  const DEPTH = 100_000;
+
+  it("compares deeply nested equal arrays without overflowing", () => {
+    expect(deepEqual(nest(DEPTH, "array", 1), nest(DEPTH, "array", 1))).toBe(true);
+  });
+
+  it("compares deeply nested equal objects without overflowing", () => {
+    expect(deepEqual(nest(DEPTH, "object", "leaf"), nest(DEPTH, "object", "leaf"))).toBe(true);
+  });
+
+  it("detects a difference at the bottom of a deep structure without overflowing", () => {
+    expect(deepEqual(nest(DEPTH, "array", 1), nest(DEPTH, "array", 2))).toBe(false);
+    expect(deepEqual(nest(DEPTH, "object", "a"), nest(DEPTH, "object", "b"))).toBe(false);
+  });
+});
+
+describe("deepEqual: end-to-end through compiled keywords", () => {
+  const DEPTH = 100_000;
+
+  // `const` / `enum` compare data against a value embedded in the schema, so
+  // they only drive deepEqual deep when the *schema* value is deep, and that
+  // path overflows earlier in `JSON.stringify` at compile time (trusted,
+  // deterministic schema-author input, out of scope for payload hardening).
+  // `uniqueItems` is the keyword whose deep deepEqual operands come from the
+  // untrusted payload, so it is the meaningful end-to-end guard here.
+  it("evaluates `uniqueItems` over deeply nested object elements without overflowing", () => {
+    const v = compile({ uniqueItems: true });
+    const elem = (): unknown => nest(DEPTH, "object", "leaf");
+    // Two structurally-equal deep objects: not unique, must fail.
+    expect(v.validate([elem(), elem()]).valid).toBe(false);
+    // Differ at the bottom: unique, must pass.
+    expect(v.validate([nest(DEPTH, "object", "a"), nest(DEPTH, "object", "b")]).valid).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

`deepEqual` (backs `enum`, `const`, `uniqueItems`) recursed on the native call stack while descending JSON values. A small but deeply nested payload could throw `RangeError: Maximum call stack size exceeded` before validation rejected it. A cheap-to-send payload that reliably 500s is a denial vector, the same shape as the documented `$ref`-recursion limitation.

This rewrites the descent over an explicit work stack of pairs left to compare. Semantics are unchanged:

- array ordering honored, object key sets compared order-independently
- `NaN` not equal to itself; `+0`/`-0` equal
- missing key distinct from an `undefined`-valued key

Also reattaches the `deepEqual` TSDoc, which had drifted up above `findDuplicate`, leaving the function undocumented.

## Scope

This is the first of the pair discussed: `deepEqual` hardening stands alone. The codegen-level `maxDepth` counter for the `$ref`-recursion vector is a separate follow-up.

`const`/`enum` are deliberately not deep-tested end-to-end: their deep operand is the schema literal, which overflows earlier in compile-time `JSON.stringify` (trusted, deterministic author input). `uniqueItems` is the keyword whose deep `deepEqual` operands come from the untrusted payload, so it carries the end-to-end guard.

## Tests

New `runtime-deep-equal.test.ts`:

- structural-equality contract: primitives, `NaN`, `+0`/`-0`, cross-type, array order, object key sets, missing vs `undefined` keys, nested mixes
- stack safety at 100k depth (arrays and objects, equal and differ-at-bottom), directly and through compiled `uniqueItems`

Full schema suite green (409 tests); lint, format, typecheck clean.