### PR TITLE
feat(schema): add maxDepth to bound recursion through $ref cycles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,13 +296,18 @@ per request.
   See `CompileState.unevaluatedTracking` and `schemaUsesUnevaluated`
   in `packages/schema/src/compiler/compiler.ts`.
 - Recursive schemas validate by recursing on the native JS call stack
-  (a self-`$ref` emits a recursive call; `deepEqual` for
-  `uniqueItems` / `const` / `enum` descends data structurally), with
-  no depth guard. A payload nested a few thousand levels deep throws
-  `RangeError: Maximum call stack size exceeded` (empirically ~5k on a
-  default Node stack). The framework adapters catch it as a 500;
-  untrusted callers should cap nesting depth at the parse boundary
-  (see docs/configuration.md "Guarding against deeply nested
-  payloads"). A codegen-level `maxDepth` counter is filed as `polish`;
-  it would put us ahead of the common approach (push the limit to the
-  boundary) but is not required for parity.
+  (a self-`$ref` emits a recursive call). Unbounded, a payload nested
+  a few thousand levels deep throws `RangeError` from stack exhaustion
+  (empirically ~5k frames on a default Node stack). The
+  `maxDepth` option (`CompileOptions` / `ValidatorOptions`) bounds it:
+  the compiler instruments only recursive (`$ref` back-edge) calls with
+  a `deps.depth` counter and emits a `depth` error leaf (HTTP 400) when
+  the cap is exceeded, so a deep payload fails as a client error
+  instead of crashing. Unset, codegen is byte-identical to the
+  un-instrumented path (zero overhead); see `compileGuardedRefCall` in
+  `packages/schema/src/keywords/ref.ts` and the `compiling` /
+  `depthGated` fields on `CompileState`. `deepEqual` (for
+  `uniqueItems` / `const` / `enum`) descends iteratively, so it can't
+  overflow independently of `$ref` recursion. Untrusted callers can
+  still cap nesting at the parse boundary for defense in depth (see
+  docs/configuration.md "Guarding against deeply nested payloads").

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,15 +131,35 @@ array nested a few thousand levels, only a few KB on the wire) can
 exhaust the stack and throw `RangeError: Maximum call stack size
 exceeded`.
 
-`oav` does not impose a depth limit of its own: the safe ceiling
-depends on the runtime's stack size and on how much stack each
-validation frame consumes, both of which the caller controls better
-than the library can. The framework adapters catch the `RangeError`
-and turn it into a 500, so a single request fails rather than the
-process crashing. A cheap-to-send payload that reliably produces 500s
-is still a denial-of-service vector.
+The first line of defense is the `maxDepth` option, on both
+`createValidator` (`ValidatorOptions`) and `compileSchema`
+(`CompileOptions`). It bounds recursion inside the validator: once the
+data nests deeper than the cap through a recursive `$ref`, validation
+stops descending and emits a `depth` error (mapped to HTTP 400) instead
+of growing the stack. The counter tracks only recursive (`$ref`
+back-edge) calls, so it measures how deep the recursive structure
+nests, independent of how the schema was decomposed; non-recursive
+schemas are never instrumented, and an unset `maxDepth` compiles to the
+same code as before (zero overhead). Legitimate payloads rarely recurse
+beyond ten or fifteen levels, so a cap of 32 to 64 is generous.
 
-The mitigation is a depth cap at the parse boundary, before the parsed
+```ts
+const validator = createValidator(spec, { maxDepth: 64 });
+// A request body that recurses past 64 levels now fails as a 400
+// `depth` error rather than throwing RangeError.
+```
+
+`maxDepth` covers the validator's own recursion. For untrusted callers
+who also want to reject deep payloads before they reach any parsing or
+business logic, a depth cap at the parse boundary is a complementary
+backstop (it bounds nesting the validator never sees, e.g. fields the
+schema doesn't traverse). Without `maxDepth`, the framework adapters
+catch the `RangeError` and turn it into a 500, so the process survives;
+a cheap-to-send payload that reliably produces 500s is still a
+denial-of-service vector, which is what `maxDepth` and the
+parse-boundary guard close.
+
+The parse-boundary guard is a depth cap before the parsed
 body reaches the validator. A byte-size limit alone is not enough: a
 payload nested thousands of levels deep is tiny, so `express.json({
 limit })` (or its equivalent) bounds width, not depth. Walk the parsed
@@ -198,5 +218,5 @@ try {
 }
 ```
 
-The depth guard is the primary control; the byte-size limit and the
-`try/catch` are backstops.
+`maxDepth` is the primary control; the parse-boundary guard, the
+byte-size limit, and the `try/catch` are backstops.

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -111,6 +111,15 @@ export interface BuiltInErrorParams {
   /** Draft-07 `dependencies` array form: same as dependentRequired. */
   dependencies: { trigger: string; missing: string };
 
+  // --- Compiler safety limits ---
+  /**
+   * The data nested deeper through a recursive schema than the
+   * configured `maxDepth` allowed. `limit` is that configured cap.
+   * Emitted at the recursion boundary instead of letting a deep
+   * payload exhaust the call stack; semantically a client error (400).
+   */
+  depth: { limit: number };
+
   // --- HTTP-level wrappers (emitted by @oav/validator) ---
   /** No path template matched `path`: semantically HTTP 404. */
   route: { method: string; path: string };
@@ -216,6 +225,8 @@ export const BUILT_IN_ERROR_CODES = [
   "discriminator",
   "dependentRequired",
   "dependencies",
+  // --- Compiler safety limits ---
+  "depth",
   // --- HTTP-level wrappers (emitted by @oav/validator) ---
   "route",
   "method",

--- a/packages/schema/src/compiler/compiler.ts
+++ b/packages/schema/src/compiler/compiler.ts
@@ -425,6 +425,30 @@ export interface CompileOptions {
    */
   maxErrors?: number;
   /**
+   * Cap on recursion depth through `$ref` cycles per `validate()` call.
+   * Defaults to uncapped.
+   *
+   * Recursive schemas (a `$ref` that points back at an ancestor, common
+   * for tree / comment structures) validate by recursing on the native
+   * JS call stack. A small but deeply nested payload can exhaust the
+   * stack and throw `RangeError`. Set this to bound the recursion: when
+   * the configured depth is exceeded, validation emits a `depth` error
+   * leaf (mapped to HTTP 400) at the boundary instead of descending
+   * further, so a deep payload fails as invalid rather than crashing.
+   *
+   * The counter increments only at recursive (cycle-closing) `$ref`
+   * boundaries, so it measures how deep the recursive structure nests
+   * and is independent of how the schema was decomposed. Non-recursive
+   * schemas are never instrumented and pay nothing. Legitimate payloads
+   * rarely recurse beyond ten or fifteen levels; a cap of 32 to 64 is
+   * generous for real traffic.
+   *
+   * When unset, codegen is identical to the un-instrumented path (zero
+   * overhead). Must be a positive integer (>= 1); `compileSchema` throws
+   * otherwise.
+   */
+  maxDepth?: number;
+  /**
    * Compile-time schema linting. All modes collect to
    * {@link CompileStats.strictIssues} rather than throwing.
    *
@@ -506,6 +530,21 @@ export interface CompileState {
    * plain `errors.push` with no runtime overhead.
    */
   readonly gated: boolean;
+  /**
+   * `true` when a finite `maxDepth` was configured. Codegen uses this to
+   * emit the recursion-depth guard at recursive `$ref` boundaries; when
+   * unset, refs compile to a plain call with no runtime overhead.
+   */
+  readonly depthGated: boolean;
+  /**
+   * Schemas whose function body is currently being generated (the
+   * compile stack). A `$ref` whose target is in this set is a back-edge:
+   * it closes a recursion cycle, so it carries the depth guard. Forward
+   * refs (target already compiled, or not yet started) are not in the
+   * set and compile to a plain call. Added in {@link compileValidator}
+   * before walking a schema's keywords and removed once they're done.
+   */
+  readonly compiling: Set<SchemaOrBoolean>;
   /**
    * `true` when predicate mode was requested. Compiled subfunctions
    * return `boolean` (no error tree); leaf-emitting keywords emit
@@ -643,6 +682,20 @@ export function compileSchema(
         "Use `predicate: true` if you want a yes/no validator with no error tree.",
     );
   }
+  const maxDepth = options.maxDepth ?? Number.POSITIVE_INFINITY;
+  if (
+    options.maxDepth !== undefined &&
+    Number.isFinite(maxDepth) &&
+    (!Number.isInteger(maxDepth) || maxDepth < 1)
+  ) {
+    // Same contract as `maxErrors`: a cap of 0 or a non-integer would
+    // misconfigure the guard silently. `Infinity` (omitting) is the
+    // uncapped default and is accepted explicitly.
+    throw new Error(
+      `compileSchema: \`maxDepth\` must be a positive integer (got ${String(options.maxDepth)}). ` +
+        "Omit the option for uncapped recursion depth.",
+    );
+  }
   const predicate = options.predicate === true;
   if (predicate && Number.isFinite(maxErrors)) {
     // Predicate mode short-circuits at the first failure by design;
@@ -653,7 +706,7 @@ export function compileSchema(
         "Predicate mode short-circuits on the first failure, so there is nothing to count.",
     );
   }
-  const deps = createDeps({ maxErrors, regexCompiler: options.regexCompiler });
+  const deps = createDeps({ maxErrors, maxDepth, regexCompiler: options.regexCompiler });
   if (options.formats) {
     for (const name of Object.keys(options.formats)) {
       const fn = options.formats[name];
@@ -702,6 +755,8 @@ export function compileSchema(
     graph,
     nextFn: 0,
     gated: Number.isFinite(maxErrors),
+    depthGated: Number.isFinite(maxDepth),
+    compiling: new Set(),
     predicate,
     refSuppressesSiblings: options.dialect.rules.refSuppressesSiblings,
     unevaluatedTracking,
@@ -769,14 +824,26 @@ function compileValidator(schema: SchemaOrBoolean, state: CompileState): string 
   // placeholder name we just reserved, so we fall through and emit a
   // real wrapper function.
   if (isPureRefSchema(schema, state)) {
-    const targetName = resolvePureRefTarget(schema as SchemaObject, state);
-    if (targetName !== null && targetName !== name) {
-      state.compiledFor.set(schema, targetName);
-      return targetName;
+    const target = resolvePureRefSchema(schema as SchemaObject, state);
+    // A recursive (back-edge) pure-ref under depth-gating must keep its
+    // wrapper: eliding it would route the recursive call through the
+    // caller (properties / items / composition), bypassing the `$ref`
+    // keyword where the depth guard is emitted. Forward refs still elide.
+    if (target !== null && !(state.depthGated && state.compiling.has(target))) {
+      const targetName = compileValidator(target, state);
+      if (targetName !== name) {
+        state.compiledFor.set(schema, targetName);
+        return targetName;
+      }
     }
   }
 
+  // Mark this schema as on the compile stack while its body (and every
+  // subschema reachable from it) is generated, so a `$ref` back to it
+  // resolves as a recursion back-edge and gets the depth guard.
+  state.compiling.add(schema);
   const body = buildFunctionBody(schema, state);
+  state.compiling.delete(schema);
   // Predicate mode drops the `path` parameter: error expressions
   // (which are the only consumer of `path`) are never emitted.
   // Callers of these functions (composition keywords, ref, etc.)
@@ -822,17 +889,17 @@ function isPureRefSchema(schema: SchemaOrBoolean, state: CompileState): boolean 
 }
 
 /**
- * Resolve a pure-`$ref` schema's target to a function name.
- * Mirrors the resolution logic in {@link compileSchemaKeywords}'s
- * `resolveRefToFunction` but reachable from {@link compileValidator}
- * before the schema's keywords are walked.
+ * Resolve a pure-`$ref` schema's target schema (not its function name),
+ * so {@link compileValidator} can both decide whether the ref is a
+ * recursion back-edge (target on the compile stack) and, when eliding,
+ * compile it. Mirrors the resolution in {@link compileSchemaKeywords}'s
+ * `resolveRefToFunction` but reachable before the keywords are walked.
  */
-function resolvePureRefTarget(schema: SchemaObject, state: CompileState): string | null {
+function resolvePureRefSchema(schema: SchemaObject, state: CompileState): SchemaOrBoolean | null {
   const ref = (schema as Record<string, unknown>).$ref;
   if (typeof ref !== "string") return null;
   const currentBaseUri = state.graph.schemaBaseUri.get(schema) ?? state.graph.baseUri;
-  const target = state.refResolver.resolve(ref, currentBaseUri);
-  return compileValidator(target, state);
+  return state.refResolver.resolve(ref, currentBaseUri);
 }
 
 /**
@@ -968,6 +1035,12 @@ function compileSchemaKeywords(
     const target = state.refResolver.resolve(ref, currentBaseUri);
     return compileValidator(target, state);
   };
+  // A ref is recursive (a back-edge) when its target is still on the
+  // compile stack: resolving it here only walks the ref graph, it does
+  // not trigger compilation, so the result is independent of whether
+  // `resolveRefToFunction` has run for this ref yet.
+  const isRecursiveRef = (ref: string): boolean =>
+    state.compiling.has(state.refResolver.resolve(ref, currentBaseUri));
 
   const runOrder = orderKeywordsForSchema(schema, state);
   // OAS 3.0: when `$ref` is present, every sibling keyword is ignored.
@@ -991,9 +1064,11 @@ function compileSchemaKeywords(
       errors: NAMES.ERRORS,
       compileSubschema: subCompiler,
       resolveRef: resolveRefToFunction,
+      isRecursiveRef,
       evaluatedPropertiesVar,
       evaluatedItemsVar,
       gated: state.gated,
+      depthGated: state.depthGated,
       predicate: state.predicate,
       byKeyword: state.byKeyword,
       hoistConstant: (expr: string, prefix = "C"): string => {
@@ -1035,6 +1110,9 @@ function assembleSource(state: CompileState, rootName: string): string {
     // reset. Keeping the top-level `validate` arity at 1 means the
     // V8 JIT only ever sees the monomorphic call site.
     parts.push(`function validate(${NAMES.DATA}) {`);
+    // Reset the per-call recursion counter so consecutive validate()
+    // calls are independent.
+    if (state.depthGated) parts.push(`  ${NAMES.DEPS}.depth = 0;`);
     parts.push(`  return ${rootName}(${NAMES.DATA});`);
     parts.push(`}`);
   } else {
@@ -1045,6 +1123,9 @@ function assembleSource(state: CompileState, rootName: string): string {
       parts.push(`  ${NAMES.DEPS}.errorsRemaining = ${NAMES.DEPS}.maxErrors;`);
       parts.push(`  ${NAMES.DEPS}.truncated = false;`);
     }
+    // Reset the per-call recursion counter (independent of the error
+    // budget; maxDepth and maxErrors gate separately).
+    if (state.depthGated) parts.push(`  ${NAMES.DEPS}.depth = 0;`);
     parts.push(
       `  const err = ${rootName}(${NAMES.DATA}, startPath !== undefined ? [...startPath] : []);`,
     );

--- a/packages/schema/src/compiler/runtime.ts
+++ b/packages/schema/src/compiler/runtime.ts
@@ -93,6 +93,22 @@ export interface ValidatorDeps {
    * top of each top-level `validate()` call.
    */
   truncated: boolean;
+  /**
+   * The configured maximum recursion depth, or `Number.POSITIVE_INFINITY`
+   * when uncapped. Baked in at compile time; not mutated after
+   * construction. Compared against {@link ValidatorDeps.depth} at each
+   * recursive `$ref` boundary.
+   */
+  maxDepth: number;
+  /**
+   * Runtime recursion-depth counter, reset to `0` at the top of each
+   * top-level `validate()` call. Incremented before descending through a
+   * recursive (`$ref` back-edge) call and decremented after it returns,
+   * so it tracks the current nesting depth rather than a cumulative
+   * count. Only emitted when a finite {@link ValidatorDeps.maxDepth} was
+   * configured.
+   */
+  depth: number;
 }
 
 /**
@@ -158,6 +174,8 @@ export type RegexCompiler = (pattern: string) => CompiledRegex;
 export interface CreateDepsOptions {
   /** Cap on leaf errors collected per `validate()` call. */
   maxErrors?: number;
+  /** Cap on recursion depth through `$ref` cycles per `validate()` call. */
+  maxDepth?: number;
   /** Custom compiler for `pattern` keywords and `format: "regex"`. */
   regexCompiler?: RegexCompiler;
 }
@@ -402,6 +420,7 @@ export function createDeps(options?: CreateDepsOptions): ValidatorDeps;
 export function createDeps(arg?: number | CreateDepsOptions): ValidatorDeps {
   const options: CreateDepsOptions = typeof arg === "number" ? { maxErrors: arg } : (arg ?? {});
   const maxErrors = options.maxErrors ?? Number.POSITIVE_INFINITY;
+  const maxDepth = options.maxDepth ?? Number.POSITIVE_INFINITY;
   const regexCompiler = options.regexCompiler;
   const patterns = new Map<string, CompiledRegex>();
 
@@ -470,5 +489,7 @@ export function createDeps(arg?: number | CreateDepsOptions): ValidatorDeps {
     maxErrors,
     errorsRemaining: maxErrors,
     truncated: false,
+    maxDepth,
+    depth: 0,
   };
 }

--- a/packages/schema/src/keywords/context.ts
+++ b/packages/schema/src/keywords/context.ts
@@ -31,6 +31,12 @@ export interface KeywordContextInputs {
   pathSegments?: readonly string[];
   compileSubschema: (schema: SchemaOrBoolean) => string;
   resolveRef: (ref: string) => string;
+  /**
+   * Whether a `$ref` is a recursion back-edge (its target is still on
+   * the compile stack). Defaults to always-`false` when omitted. Used by
+   * the `$ref` keyword to decide whether to emit the `maxDepth` guard.
+   */
+  isRecursiveRef?: (ref: string) => boolean;
   evaluatedPropertiesVar?: string | null;
   evaluatedItemsVar?: string | null;
   /**
@@ -39,6 +45,12 @@ export interface KeywordContextInputs {
    * `errors.push(x)` / unchecked loops; zero runtime overhead.
    */
   gated?: boolean;
+  /**
+   * When `true`, a finite `maxDepth` was configured and the `$ref`
+   * keyword should emit the recursion-depth guard at back-edges. When
+   * `false` (the default), refs compile to a plain call.
+   */
+  depthGated?: boolean;
   /**
    * When `true`, predicate mode is active: the generated function
    * returns `boolean`, not `ValidationError | null`. Every
@@ -177,7 +189,9 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
   const evaluatedPropertiesVar = inputs.evaluatedPropertiesVar ?? null;
   const evaluatedItemsVar = inputs.evaluatedItemsVar ?? null;
   const gated = inputs.gated ?? false;
+  const depthGated = inputs.depthGated ?? false;
   const predicate = inputs.predicate ?? false;
+  const isRecursiveRef = inputs.isRecursiveRef ?? ((): boolean => false);
   const pathSegments = inputs.pathSegments ?? EMPTY_PATH_SEGMENTS;
   const effectivePathExpr =
     pathSegments.length === 0
@@ -562,9 +576,11 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     compileSubschema: inputs.compileSubschema,
     compileAndCallSubschema,
     resolveRef: inputs.resolveRef,
+    isRecursiveRef,
     evaluatedPropertiesVar,
     evaluatedItemsVar,
     gated,
+    depthGated,
     predicate,
     errorStatement,
     emitError,

--- a/packages/schema/src/keywords/ref.ts
+++ b/packages/schema/src/keywords/ref.ts
@@ -1,5 +1,55 @@
+import { NAMES, quoteString } from "../codegen/index.js";
 import type { KeywordCompileContext, KeywordDefinition } from "./types.js";
 import { CORE_VOCAB } from "./vocabulary-uris.js";
+
+/**
+ * Emit a recursive (`$ref` back-edge) call wrapped in the `maxDepth`
+ * guard. `deps.depth` is incremented in the condition and decremented on
+ * both branches, so it tracks the current nesting depth and unwinds with
+ * the native stack. When the cap is exceeded the call is skipped (the
+ * stack stops growing) and a `depth` leaf error stands in for the
+ * subtree that wasn't validated.
+ */
+function compileGuardedRefCall(
+  ctx: KeywordCompileContext,
+  fn: string,
+  passProps: string,
+  passItems: string,
+): void {
+  const deps = NAMES.DEPS;
+  const cond = `++${deps}.depth > ${deps}.maxDepth`;
+  if (ctx.predicate) {
+    ctx.gen.if(
+      cond,
+      (g) => {
+        g.line(`${deps}.depth -= 1;`);
+        g.line("return false;");
+      },
+      (g) => {
+        const okVar = g.scope.name("refOk");
+        g.const(okVar, `${fn}(${ctx.data}, ${passProps}, ${passItems})`);
+        g.line(`${deps}.depth -= 1;`);
+        g.line(`if (!${okVar}) return false;`);
+      },
+    );
+    return;
+  }
+  const msgExpr = "`data nesting exceeds the configured maxDepth (${" + deps + ".maxDepth})`";
+  const depthErr = ctx.leafErrorExpr(quoteString("depth"), msgExpr, `{ limit: ${deps}.maxDepth }`);
+  ctx.gen.if(
+    cond,
+    (g) => {
+      g.line(`${deps}.depth -= 1;`);
+      ctx.emitError("leaf", depthErr);
+    },
+    (g) => {
+      const errVar = g.scope.name("refErr");
+      g.const(errVar, `${fn}(${ctx.data}, ${ctx.path}, ${passProps}, ${passItems})`);
+      g.line(`${deps}.depth -= 1;`);
+      g.if(`${errVar} !== null`, () => ctx.emitError("lift", errVar));
+    },
+  );
+}
 
 function compileRefCall(ctx: KeywordCompileContext, ref: string): void {
   const fn = ctx.resolveRef(ref);
@@ -8,6 +58,13 @@ function compileRefCall(ctx: KeywordCompileContext, ref: string): void {
   // evaluated-key sets straight through.
   const passProps = ctx.evaluatedPropertiesVar ?? "undefined";
   const passItems = ctx.evaluatedItemsVar ?? "undefined";
+  // Only recursive (cycle-closing) refs can grow the call stack without
+  // bound, so the guard goes there and nowhere else; forward refs and
+  // the uncapped default compile to a plain call.
+  if (ctx.depthGated && ctx.isRecursiveRef(ref)) {
+    compileGuardedRefCall(ctx, fn, passProps, passItems);
+    return;
+  }
   if (ctx.predicate) {
     ctx.gen.line(`if (!${fn}(${ctx.data}, ${passProps}, ${passItems})) return false;`);
     return;

--- a/packages/schema/src/keywords/types.ts
+++ b/packages/schema/src/keywords/types.ts
@@ -126,6 +126,14 @@ export interface KeywordCompileContext {
    * name. Used by `$ref` and `$dynamicRef` keywords.
    */
   resolveRef(ref: string): string;
+  /**
+   * `true` when `ref` is a recursion back-edge: its target schema is
+   * still on the compile stack, so the emitted call closes a cycle.
+   * The `$ref` / `$dynamicRef` keywords consult this to decide whether
+   * to wrap the call in the {@link KeywordCompileContext.depthGated}
+   * recursion-depth guard. Forward refs return `false`.
+   */
+  isRecursiveRef(ref: string): boolean;
   /** JS expression for the Set tracking evaluated properties, or `null`. */
   readonly evaluatedPropertiesVar: string | null;
   /** JS expression for the Set tracking evaluated items, or `null`. */
@@ -137,6 +145,13 @@ export interface KeywordCompileContext {
    * {@link KeywordCompileContext.emitBudgetBreak} which inspect it.
    */
   readonly gated: boolean;
+  /**
+   * `true` when a finite `maxDepth` cap was configured. The `$ref` /
+   * `$dynamicRef` keywords read this together with
+   * {@link KeywordCompileContext.isRecursiveRef} to emit the
+   * recursion-depth guard; other keywords don't need it.
+   */
+  readonly depthGated: boolean;
   /**
    * `true` when predicate mode is active: the compiled validator
    * returns `boolean` and constructs no error tree. Most keywords

--- a/packages/schema/test/max-depth.test.ts
+++ b/packages/schema/test/max-depth.test.ts
@@ -1,0 +1,165 @@
+import { collectLeaves, httpStatusFor, type ValidationError } from "@oav/core";
+import { describe, expect, it } from "vitest";
+import { compile } from "./helpers.js";
+
+// A self-recursive object schema: each level may carry one `child`, which
+// validates against the root again. The canonical tree/comment shape.
+const recursive = {
+  type: "object",
+  properties: { child: { $ref: "#" } },
+} as const;
+
+// Build data nesting `child` exactly `depth` levels deep. Iterative so the
+// test setup never overflows on the depths it exercises.
+function nestChild(depth: number): Record<string, unknown> {
+  let node: Record<string, unknown> = {};
+  for (let i = 0; i < depth; i += 1) node = { child: node };
+  return node;
+}
+
+function leafCodes(err: ValidationError | undefined): string[] {
+  return err === undefined ? [] : collectLeaves(err).map((l) => l.code);
+}
+
+describe("maxDepth: option validation", () => {
+  it("throws on zero, negative, and non-integer caps", () => {
+    expect(() => compile(recursive, { maxDepth: 0 })).toThrow(/positive integer/);
+    expect(() => compile(recursive, { maxDepth: -3 })).toThrow(/positive integer/);
+    expect(() => compile(recursive, { maxDepth: 2.5 })).toThrow(/positive integer/);
+  });
+
+  it("accepts a positive integer and the degenerate Infinity", () => {
+    expect(() => compile(recursive, { maxDepth: 1 })).not.toThrow();
+    expect(() => compile(recursive, { maxDepth: Number.POSITIVE_INFINITY })).not.toThrow();
+  });
+});
+
+describe("maxDepth: codegen specialization", () => {
+  it("emits no depth instrumentation when unset (zero overhead)", () => {
+    const v = compile(recursive);
+    expect(v.source).not.toContain("deps.depth");
+    expect(v.source).not.toContain("maxDepth");
+  });
+
+  it("emits the guard at the recursive boundary when set", () => {
+    const v = compile(recursive, { maxDepth: 4 });
+    expect(v.source).toContain("++deps.depth > deps.maxDepth");
+    expect(v.source).toContain("deps.depth = 0;"); // per-call reset
+  });
+
+  it("does not instrument a non-recursive schema even when set", () => {
+    const flat = { type: "object", properties: { a: { type: "string" } } };
+    const v = compile(flat, { maxDepth: 4 });
+    expect(v.source).not.toContain("++deps.depth");
+    expect(v.validate({ a: "x" }).valid).toBe(true);
+    expect(v.validate({ a: 1 }).valid).toBe(false);
+  });
+});
+
+describe("maxDepth: boundary semantics", () => {
+  it("counts one level per recursive descent; allows up to the cap", () => {
+    const v = compile(recursive, { maxDepth: 3 });
+    expect(v.validate(nestChild(0)).valid).toBe(true);
+    expect(v.validate(nestChild(1)).valid).toBe(true);
+    expect(v.validate(nestChild(3)).valid).toBe(true); // exactly at the cap
+  });
+
+  it("rejects one level past the cap with a `depth` error", () => {
+    const v = compile(recursive, { maxDepth: 3 });
+    const r = v.validate(nestChild(4));
+    expect(r.valid).toBe(false);
+    expect(leafCodes(r.error)).toContain("depth");
+  });
+
+  it("reports the configured limit in the error params", () => {
+    const v = compile(recursive, { maxDepth: 2 });
+    const r = v.validate(nestChild(5));
+    expect(r.valid).toBe(false);
+    const depthLeaf = collectLeaves(r.error!).find((l) => l.code === "depth");
+    expect(depthLeaf?.params).toEqual({ limit: 2 });
+  });
+
+  it("maps the depth error to HTTP 400", () => {
+    const v = compile(recursive, { maxDepth: 2 });
+    const r = v.validate(nestChild(5));
+    expect(httpStatusFor(r.error!)).toBe(400);
+  });
+});
+
+describe("maxDepth: stack safety", () => {
+  const DEEP = 100_000;
+
+  it("rejects a pathologically deep payload instead of overflowing", () => {
+    const v = compile(recursive, { maxDepth: 64 });
+    const r = v.validate(nestChild(DEEP));
+    expect(r.valid).toBe(false);
+    expect(leafCodes(r.error)).toContain("depth");
+  });
+
+  it("confirms the same payload overflows without the guard", () => {
+    // Establishes that the guard is what prevents the crash, not some
+    // other bound: uncapped, this throws RangeError.
+    const v = compile(recursive);
+    expect(() => v.validate(nestChild(DEEP))).toThrow(RangeError);
+  });
+});
+
+describe("maxDepth: counter discipline", () => {
+  it("resets the counter between validate() calls", () => {
+    const v = compile(recursive, { maxDepth: 3 });
+    expect(v.validate(nestChild(10)).valid).toBe(false); // exhausts the counter
+    expect(v.validate(nestChild(2)).valid).toBe(true); // must not leak
+    expect(v.validate(nestChild(10)).valid).toBe(false); // and trips again
+  });
+
+  it("decrements on unwind so sibling branches don't accumulate", () => {
+    // A binary-tree schema: a balanced tree has many nodes but a small
+    // recursion depth. If the counter failed to decrement on unwind, the
+    // node count (not the depth) would trip the cap.
+    const tree = {
+      type: "object",
+      properties: { left: { $ref: "#" }, right: { $ref: "#" } },
+    };
+    const balanced = (d: number): unknown =>
+      d === 0 ? {} : { left: balanced(d - 1), right: balanced(d - 1) };
+    const v = compile(tree, { maxDepth: 3 });
+    expect(v.validate(balanced(3)).valid).toBe(true); // depth 3, 15 nodes
+    expect(v.validate(balanced(4)).valid).toBe(false); // depth 4 > cap
+  });
+});
+
+describe("maxDepth: predicate mode", () => {
+  it("guards recursion without an error tree", () => {
+    const v = compile(recursive, { maxDepth: 3, predicate: true });
+    expect(v.validate(nestChild(3))).toBe(true);
+    expect(v.validate(nestChild(4))).toBe(false);
+  });
+
+  it("rejects a pathologically deep payload instead of overflowing", () => {
+    const v = compile(recursive, { maxDepth: 64, predicate: true });
+    expect(v.validate(nestChild(100_000))).toBe(false);
+  });
+});
+
+describe("maxDepth: mutual recursion", () => {
+  it("bounds an A -> B -> A cycle", () => {
+    // Two schemas that ref each other via $defs. The cycle still has a
+    // single back-edge instrumented, which is enough to bound the stack.
+    const mutual = {
+      $defs: {
+        a: { type: "object", properties: { b: { $ref: "#/$defs/b" } } },
+        b: { type: "object", properties: { a: { $ref: "#/$defs/a" } } },
+      },
+      $ref: "#/$defs/a",
+    };
+    const v = compile(mutual, { maxDepth: 8 });
+    // Build alternating a/b nesting 100k deep, key-aligned to the schema:
+    // the root matches `a` (property `b`), whose value matches `b`
+    // (property `a`), and so on. Position 0 is the outermost level.
+    let node: Record<string, unknown> = {};
+    for (let i = 100_000 - 1; i >= 0; i -= 1) node = { [i % 2 === 0 ? "b" : "a"]: node };
+    const r = v.validate(node);
+    expect(r.valid).toBe(false);
+    expect(leafCodes(r.error)).toContain("depth");
+  });
+});

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -414,6 +414,24 @@ export interface ValidatorOptions {
    */
   maxErrors?: number;
   /**
+   * Cap on recursion depth through `$ref` cycles per
+   * `validateRequest` / `validateResponse` call. Defaults to uncapped.
+   *
+   * Recursive schemas (a `$ref` back to an ancestor, common for tree /
+   * comment shapes) validate by recursing on the JS call stack, so a
+   * small but deeply nested payload can exhaust it and throw. Set this
+   * to bound the recursion: past the cap, validation emits a `depth`
+   * error (HTTP 400) at the boundary instead of descending, so a deep
+   * payload fails as a client error rather than crashing the process.
+   *
+   * Legitimate payloads rarely recurse beyond ten or fifteen levels; a
+   * cap of 32 to 64 is generous. Non-recursive schemas are never
+   * instrumented and pay nothing; unset, codegen is identical to the
+   * un-instrumented path. Must be a positive integer (>= 1);
+   * `createValidator` throws otherwise.
+   */
+  maxDepth?: number;
+  /**
    * Compile-time schema linting applied to every schema the validator
    * compiles (request parameters / body; response headers; response
    * bodies lazily). Issues surface via
@@ -574,6 +592,16 @@ export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions
         "Use `maxErrors: 1` for fast-fail, or omit the option for uncapped error collection.",
     );
   }
+  if (
+    options.maxDepth !== undefined &&
+    Number.isFinite(options.maxDepth) &&
+    (!Number.isInteger(options.maxDepth) || options.maxDepth < 1)
+  ) {
+    throw new Error(
+      `createValidator: \`maxDepth\` must be a positive integer (got ${String(options.maxDepth)}). ` +
+        "Omit the option for uncapped recursion depth.",
+    );
+  }
   const paths = spec.paths ?? {};
   const router: Router = createRouter(paths);
   const formats = { ...builtInFormats, ...options.formats };
@@ -658,6 +686,7 @@ export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions
       formats,
       refResolver: resolver,
       maxErrors: options.maxErrors,
+      maxDepth: options.maxDepth,
       keywords: options.keywords,
       strict: options.strict,
       regexCompiler: options.regexCompiler,

--- a/packages/validator/test/max-depth.test.ts
+++ b/packages/validator/test/max-depth.test.ts
@@ -1,0 +1,90 @@
+import { collectLeaves, httpStatusFor, type OpenAPIDocument } from "@oav/core";
+import { describe, expect, it } from "vitest";
+import { createValidator } from "../src/validator.js";
+
+// A spec whose request body is a self-recursive `Node` (tree shape).
+function treeSpec(): OpenAPIDocument {
+  return {
+    openapi: "3.1.0",
+    info: { title: "t", version: "1" },
+    paths: {
+      "/tree": {
+        post: {
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": { schema: { $ref: "#/components/schemas/Node" } },
+            },
+          },
+          responses: { "200": { description: "ok" } },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        Node: {
+          type: "object",
+          properties: { child: { $ref: "#/components/schemas/Node" } },
+        },
+      },
+    },
+  };
+}
+
+function nestChild(depth: number): Record<string, unknown> {
+  let node: Record<string, unknown> = {};
+  for (let i = 0; i < depth; i += 1) node = { child: node };
+  return node;
+}
+
+function postTree(
+  body: unknown,
+): Parameters<ReturnType<typeof createValidator>["validateRequest"]>[0] {
+  return {
+    method: "POST",
+    path: "/tree",
+    contentType: "application/json",
+    headers: {},
+    body,
+  };
+}
+
+describe("createValidator maxDepth: option validation", () => {
+  it("rejects zero, negative, and non-integer caps eagerly", () => {
+    expect(() => createValidator(treeSpec(), { maxDepth: 0 })).toThrow(/positive integer/);
+    expect(() => createValidator(treeSpec(), { maxDepth: -1 })).toThrow(/positive integer/);
+    expect(() => createValidator(treeSpec(), { maxDepth: 1.5 })).toThrow(/positive integer/);
+  });
+
+  it("accepts a positive integer cap", () => {
+    expect(() => createValidator(treeSpec(), { maxDepth: 1 })).not.toThrow();
+    expect(() => createValidator(treeSpec(), { maxDepth: 64 })).not.toThrow();
+  });
+});
+
+describe("createValidator maxDepth: request body", () => {
+  it("accepts a recursive body within the cap", () => {
+    const v = createValidator(treeSpec(), { maxDepth: 8 });
+    expect(v.validateRequest(postTree(nestChild(8)))).toBeNull();
+  });
+
+  it("rejects a recursive body past the cap with a depth error mapped to 400", () => {
+    const v = createValidator(treeSpec(), { maxDepth: 8 });
+    const err = v.validateRequest(postTree(nestChild(20)));
+    expect(err?.code).toBe("request");
+    expect(collectLeaves(err!).map((l) => l.code)).toContain("depth");
+    expect(httpStatusFor(err!)).toBe(400);
+  });
+
+  it("bounds a pathologically deep body instead of overflowing", () => {
+    const v = createValidator(treeSpec(), { maxDepth: 64 });
+    const err = v.validateRequest(postTree(nestChild(100_000)));
+    expect(err?.code).toBe("request");
+    expect(collectLeaves(err!).map((l) => l.code)).toContain("depth");
+  });
+
+  it("still overflows without the cap (the guard is what prevents it)", () => {
+    const v = createValidator(treeSpec());
+    expect(() => v.validateRequest(postTree(nestChild(100_000)))).toThrow(RangeError);
+  });
+});


### PR DESCRIPTION
## What

Adds a `maxDepth` option (on `CompileOptions` and `ValidatorOptions`) that bounds recursion through `$ref` cycles. Recursive schemas validate by recursing on the native JS call stack, so a small but deeply nested payload can exhaust it and throw `RangeError` before validation rejects it. The adapters catch that as a 500, which is still a cheap-to-send denial vector.

When set, the compiler instruments recursive (`$ref` back-edge) calls with a `deps.depth` counter, incremented before descending and decremented on return so it tracks current nesting rather than a cumulative count. Past the cap it emits a `depth` error leaf (mapped to HTTP 400) instead of recursing, so a deep payload fails as a client error instead of crashing.

```ts
const validator = createValidator(spec, { maxDepth: 64 });
// A body recursing past 64 levels now fails as a 400 `depth` error
// rather than throwing RangeError.
```

## Design decisions (from the design conversation)

- **Validation error, not an exception.** A too-deep payload is request-time, caller's-data, so it returns an error tree like `maxItems`/`maxLength`, not a throw. This brings the lone `RangeError` outlier back in line with the codebase rule (construction/config throws; data-conformance returns a tree). An invalid `maxDepth` *value* still throws at construction, mirroring `maxErrors`.
- **Back-edge-only semantics.** The counter increments only at recursive (cycle-closing) `$ref` calls, so it measures how deep the recursive structure nests, independent of how the schema was decomposed. Non-recursive schemas are never instrumented and pay nothing.
- **Zero overhead when unset.** Gated on a compile-time `depthGated` flag the same way `maxErrors` is gated; unset, the generated source is byte-identical to before (confirmed by a codegen-specialization test).

## Mechanism

- Back-edges detected via a `compiling` set on `CompileState` (the compile stack): a `$ref` whose target is still being compiled closes a cycle.
- Pure-`$ref` elision is suppressed for recursive refs, so the recursive call routes through the `$ref` keyword (`compileGuardedRefCall`) where the guard lives instead of being inlined by `properties`/`items`.
- Counter is a `deps` field reset per `validate()` call; increment/decrement is localized and balanced at the back-edge call site (no parameter threading, no signature changes).
- New `depth` error code in `BuiltInErrorParams` (`params: { limit }`); maps to the default 400 via `httpStatusFor`.

## Tests

- Schema level (`packages/schema/test/max-depth.test.ts`): option validation, codegen specialization (no instrumentation when unset or non-recursive), boundary semantics, counter reset + decrement discipline (sibling branches don't accumulate), predicate mode, mutual recursion, stack safety at 100k depth (plus a control proving the unguarded path overflows).
- Validator level (`packages/validator/test/max-depth.test.ts`): end-to-end through a recursive request body, depth error mapped to 400, 100k-deep body bounded.

Full suite green (1076); lint, format, typecheck clean.

## Stacking

This builds on #332 (iterative `deepEqual`). `maxDepth` guards the `$ref`-recursion stack vector; `deepEqual` is the other structural-descent vector (`uniqueItems`/`const`/`enum`), which #332 makes iterative. The CLAUDE.md known-limitations note here states `deepEqual` descends iteratively, which is true once #332 lands. **Merge after #332** (or rebase this on main once #332 is in). The two touch different files, so no conflict is expected.