### PR TITLE
docs(adapters): add Hardening section to adapter READMEs

### DIFF
--- a/packages/oav-express4/README.md
+++ b/packages/oav-express4/README.md
@@ -29,7 +29,7 @@ import express from "express";
 import { createValidator } from "@aahoughton/oav-core";
 import { validateRequests } from "@aahoughton/oav-express4";
 
-const validator = createValidator(spec);
+const validator = createValidator(spec); // see "Hardening for untrusted input" below
 
 const app = express();
 app.use(express.json()); // ← MUST run before validateRequests
@@ -55,6 +55,22 @@ Invalid requests receive a `400 application/problem+json` response (status from 
 > ```
 >
 > Stock `express.json()` populates an empty body to `{}` and doesn't hit this, but migrators inheriting alternative parsers (e.g. `body-parser` streaming mode) often do.
+
+## Hardening for untrusted input
+
+The quick start is the minimal wiring. Before exposing the validator to untrusted callers, cap two things so a small, cheap payload can't burn CPU or exhaust the stack. Both are `createValidator` options, and both default to uncapped, so the quick start above sets neither.
+
+```ts
+const validator = createValidator(spec, {
+  maxDepth: 64, // recursion cap: a body nesting past 64 levels fails as 400
+  maxErrors: 20, // stop after 20 errors instead of walking a huge invalid body
+});
+```
+
+- **`maxDepth`** bounds recursion through self-referential (`$ref`) schemas. Without it, a few KB of deeply nested JSON can exhaust the call stack and surface as a 500. Past the cap, validation emits a `depth` error (mapped to 400) instead of descending. Legitimate payloads rarely recurse beyond ten or fifteen levels, so 32 to 64 is generous.
+- **`maxErrors`** caps how many errors one request can produce, in compute and in response size: a large array whose every element fails the same way otherwise yields one error per element. Results carry `truncated: true` when the cap was hit. Leave it unset in development if you want every error at once.
+
+A byte-size limit (`express.json({ limit })`) and a parse-boundary depth cap, applied before the request reaches the validator, are backstops for nesting the validator never traverses (fields the schema doesn't descend into); see [Guarding against deeply nested payloads](https://github.com/aahoughton/oav/blob/main/docs/configuration.md#guarding-against-deeply-nested-payloads).
 
 ## API
 

--- a/packages/oav-express4/README.md
+++ b/packages/oav-express4/README.md
@@ -63,7 +63,7 @@ The quick start is the minimal wiring. Before exposing the validator to untruste
 ```ts
 const validator = createValidator(spec, {
   maxDepth: 64, // recursion cap: a body nesting past 64 levels fails as 400
-  maxErrors: 20, // stop after 20 errors instead of walking a huge invalid body
+  maxErrors: 10, // stop after 10 errors instead of walking a huge invalid body
 });
 ```
 

--- a/packages/oav-express5/README.md
+++ b/packages/oav-express5/README.md
@@ -29,7 +29,7 @@ import express from "express";
 import { createValidator } from "@aahoughton/oav-core";
 import { validateRequests } from "@aahoughton/oav-express5";
 
-const validator = createValidator(spec);
+const validator = createValidator(spec); // see "Hardening for untrusted input" below
 
 const app = express();
 app.use(express.json()); // ← MUST run before validateRequests
@@ -53,6 +53,22 @@ Invalid requests receive a `400 application/problem+json` response (status from 
 >   }),
 > );
 > ```
+
+## Hardening for untrusted input
+
+The quick start is the minimal wiring. Before exposing the validator to untrusted callers, cap two things so a small, cheap payload can't burn CPU or exhaust the stack. Both are `createValidator` options, and both default to uncapped, so the quick start above sets neither.
+
+```ts
+const validator = createValidator(spec, {
+  maxDepth: 64, // recursion cap: a body nesting past 64 levels fails as 400
+  maxErrors: 20, // stop after 20 errors instead of walking a huge invalid body
+});
+```
+
+- **`maxDepth`** bounds recursion through self-referential (`$ref`) schemas. Without it, a few KB of deeply nested JSON can exhaust the call stack and surface as a 500. Past the cap, validation emits a `depth` error (mapped to 400) instead of descending. Legitimate payloads rarely recurse beyond ten or fifteen levels, so 32 to 64 is generous.
+- **`maxErrors`** caps how many errors one request can produce, in compute and in response size: a large array whose every element fails the same way otherwise yields one error per element. Results carry `truncated: true` when the cap was hit. Leave it unset in development if you want every error at once.
+
+A byte-size limit (`express.json({ limit })`) and a parse-boundary depth cap, applied before the request reaches the validator, are backstops for nesting the validator never traverses (fields the schema doesn't descend into); see [Guarding against deeply nested payloads](https://github.com/aahoughton/oav/blob/main/docs/configuration.md#guarding-against-deeply-nested-payloads).
 
 ## API
 

--- a/packages/oav-express5/README.md
+++ b/packages/oav-express5/README.md
@@ -61,7 +61,7 @@ The quick start is the minimal wiring. Before exposing the validator to untruste
 ```ts
 const validator = createValidator(spec, {
   maxDepth: 64, // recursion cap: a body nesting past 64 levels fails as 400
-  maxErrors: 20, // stop after 20 errors instead of walking a huge invalid body
+  maxErrors: 10, // stop after 10 errors instead of walking a huge invalid body
 });
 ```
 

--- a/packages/oav-fastify/README.md
+++ b/packages/oav-fastify/README.md
@@ -44,7 +44,7 @@ The quick start is the minimal wiring. Before exposing the validator to untruste
 ```ts
 const validator = createValidator(spec, {
   maxDepth: 64, // recursion cap: a body nesting past 64 levels fails as 400
-  maxErrors: 20, // stop after 20 errors instead of walking a huge invalid body
+  maxErrors: 10, // stop after 10 errors instead of walking a huge invalid body
 });
 ```
 

--- a/packages/oav-fastify/README.md
+++ b/packages/oav-fastify/README.md
@@ -27,7 +27,7 @@ import Fastify from "fastify";
 import { createValidator } from "@aahoughton/oav-core";
 import { validateRequests } from "@aahoughton/oav-fastify";
 
-const validator = createValidator(spec);
+const validator = createValidator(spec); // see "Hardening for untrusted input" below
 
 const app = Fastify();
 app.addHook("preValidation", validateRequests(validator));
@@ -36,6 +36,22 @@ app.post("/pets", async () => ({ ok: true }));
 ```
 
 Invalid requests receive a `400 application/problem+json` response (status from `httpStatusFor`, body from `toProblemDetails`, `Allow` header on 405). Valid requests reach the route handlers.
+
+## Hardening for untrusted input
+
+The quick start is the minimal wiring. Before exposing the validator to untrusted callers, cap two things so a small, cheap payload can't burn CPU or exhaust the stack. Both are `createValidator` options, and both default to uncapped, so the quick start above sets neither.
+
+```ts
+const validator = createValidator(spec, {
+  maxDepth: 64, // recursion cap: a body nesting past 64 levels fails as 400
+  maxErrors: 20, // stop after 20 errors instead of walking a huge invalid body
+});
+```
+
+- **`maxDepth`** bounds recursion through self-referential (`$ref`) schemas. Without it, a few KB of deeply nested JSON can exhaust the call stack and surface as a 500. Past the cap, validation emits a `depth` error (mapped to 400) instead of descending. Legitimate payloads rarely recurse beyond ten or fifteen levels, so 32 to 64 is generous.
+- **`maxErrors`** caps how many errors one request can produce, in compute and in response size: a large array whose every element fails the same way otherwise yields one error per element. Results carry `truncated: true` when the cap was hit. Leave it unset in development if you want every error at once.
+
+A body-size limit (Fastify's `bodyLimit`) and a parse-boundary depth cap in an `onRequest` / `preValidation` hook, applied before the request reaches the validator, are backstops for nesting the validator never traverses (fields the schema doesn't descend into); see [Guarding against deeply nested payloads](https://github.com/aahoughton/oav/blob/main/docs/configuration.md#guarding-against-deeply-nested-payloads).
 
 ## Mount point: `preValidation`
 


### PR DESCRIPTION
## What

Adds a **Hardening for untrusted input** section to the three adapter READMEs (`oav-express4`, `oav-express5`, `oav-fastify`), directly below each Quick start, plus a one-line pointer in the quick-start code.

This is the docs follow-up to the original question: should the default plugin examples set `maxErrors` and a depth guard? The decision (from the design discussion):

- **Keep the bare Quick start minimal.** It stays copy-paste-runnable with no options, which is what a reader onboarding in dev wants. A one-line comment points at the Hardening section.
- **Recommend both caps in a labeled Hardening section, not silently in the example.** This respects the repo's "No magic" principle (a `maxErrors` baked into copy-paste code with no visible cause later reads as surprising truncation) and matches the existing pattern where caveats follow the quick start.
- **Both are now `createValidator` options**, so the recommendation is a clean two-line config rather than the copy-paste `tooDeep` middleware the original analysis assumed: `maxDepth` (from #333) is the built-in depth guard, and the parse-boundary cap drops to a backstop.

## Section content

```ts
const validator = createValidator(spec, {
  maxDepth: 64,
  maxErrors: 10,
});
```

with a short rationale for each, the dev-time caveat on `maxErrors` ("leave it unset if you want every error at once"), and a link to the configuration guide's deep-nesting section for the parse-boundary backstop.

The section is identical across all three adapters (per the across-package symmetry they already keep), varying only the framework-native backstop reference (`express.json({ limit })` vs Fastify `bodyLimit`). `maxErrors: 10` matches the value already used in the configuration guide and the `ValidatorOptions` / `CompileOptions` TSDoc.

## Stacking

Documents the `maxDepth` option from #333, so **merge after #333**. Touches only the three README files (no overlap with #332 / #333), so no conflict. Lint and format clean.