### PR TITLE
feat(schema): flat error-collection mode

### DIFF
--- a/conformance/run-json-schema-suite.ts
+++ b/conformance/run-json-schema-suite.ts
@@ -116,6 +116,10 @@ function runFile(path: string): FileResult {
         dialect: jsonSchemaDialect,
         formats: builtInFormats,
         external: remoteSchemas as Map<string, never>,
+        // OAV_FLAT=1 runs the whole suite in flat-collection mode; the
+        // validity check below is mode-agnostic (both shapes carry
+        // `.valid`), so a clean run proves flat never changes accept/reject.
+        ...(process.env.OAV_FLAT === "1" ? { flat: true } : {}),
       });
       validate = compiled.validate;
     } catch (err) {

--- a/packages/schema/src/compiler/compiler.ts
+++ b/packages/schema/src/compiler/compiler.ts
@@ -226,6 +226,29 @@ export interface ValidationResult {
 }
 
 /**
+ * Result of a flat-mode (`flat: true`) `validate()` call. Where the
+ * default mode returns a single nested {@link ValidationError} tree
+ * under `error`, flat mode returns a de-nested list of leaf errors under
+ * `errors`: every failing leaf keyword (`type`, `required`, `minimum`, …)
+ * as its own record, plus a childless marker leaf for each failed
+ * composition keyword (`anyOf` / `oneOf`). No `"schema"` branch
+ * wrappers. Each record is a {@link ValidationError} with an empty
+ * `children`, so the `@oav/core` renderers still consume it.
+ *
+ * @public
+ */
+export interface FlatValidationResult {
+  valid: boolean;
+  /** The flat list of leaf errors. Present (and non-empty) iff `!valid`. */
+  errors?: ValidationError[];
+  /**
+   * `true` when at least one error was dropped because the configured
+   * `maxErrors` cap was hit. Only ever set on `{ valid: false }` results.
+   */
+  truncated?: boolean;
+}
+
+/**
  * Compile-time statistics about the generated validator. Exposed so
  * tests can assert on compiler behavior (e.g. "did subschema inlining
  * fire?") without grepping the generated source.
@@ -342,6 +365,23 @@ export type CompiledSchema = {
  */
 export type CompiledPredicate = {
   validate: (data: unknown) => boolean;
+  /** The generated source. Exposed for debugging/snapshot testing only. */
+  source: string;
+  /** Compile-time stats about the generated validator. */
+  stats: CompileStats;
+};
+
+/**
+ * The shape returned by {@link compileSchema} when `flat: true` is set.
+ * Same `validate(data, startPath?)` signature as {@link CompiledSchema},
+ * but returns a {@link FlatValidationResult} (a flat leaf list) instead
+ * of a nested error tree. See {@link FlatValidationResult} for the
+ * trade-off and {@link CompileOptions.flat}.
+ *
+ * @public
+ */
+export type CompiledFlatSchema = {
+  validate: (data: unknown, startPath?: readonly PathSegment[]) => FlatValidationResult;
   /** The generated source. Exposed for debugging/snapshot testing only. */
   source: string;
   /** Compile-time stats about the generated validator. */
@@ -483,6 +523,29 @@ export interface CompileOptions {
    */
   predicate?: boolean;
   /**
+   * When `true`, compile a flat-collection validator. The returned
+   * {@link CompiledFlatSchema}'s `validate(data, startPath?)` returns a
+   * {@link FlatValidationResult}: a de-nested `ValidationError[]` of
+   * leaf errors (every failing leaf keyword as its own record, plus a
+   * childless marker leaf per failed `anyOf` / `oneOf`), with no
+   * `"schema"` branch wrappers. This produces ajv-class memory on large
+   * invalid payloads, where the default nested tree retains far more
+   * (branch nodes plus per-leaf path arrays). The records are still
+   * {@link ValidationError}s (empty `children`), so the `@oav/core`
+   * renderers keep working.
+   *
+   * Reach for it when you want *every* error on a very large invalid
+   * body cheaply. For merely bounding memory, {@link CompileOptions.maxErrors}
+   * already caps the tree; flat mode is for the "all errors, cheaply"
+   * case.
+   *
+   * Composes with `maxErrors` (the flat list is capped and
+   * {@link FlatValidationResult.truncated} is set). Mutually exclusive
+   * with {@link CompileOptions.predicate} (a predicate has no errors to
+   * flatten); the compiler throws when both are supplied.
+   */
+  flat?: boolean;
+  /**
    * Custom compiler for schema `pattern` keywords and the `format:
    * "regex"` assertion. Defaults to `new RegExp(pattern, "u")` with a
    * non-`u` fallback. Override to plug in a library like `re2`, wrap
@@ -552,6 +615,14 @@ export interface CompileState {
    * {@link CompileOptions.predicate}.
    */
   readonly predicate: boolean;
+  /**
+   * `true` when flat-collection mode was requested. Compiled subfunctions
+   * return a flat `ValidationError[]` of leaves (or `null`) instead of a
+   * single (possibly branch-wrapped) node; lift sites append rather than
+   * push, and the inline-wrap and composition-wrap steps are replaced by
+   * flat appends plus marker leaves. See {@link CompileOptions.flat}.
+   */
+  readonly flat: boolean;
   /**
    * OpenAPI 3.0 semantics. When `true`, schemas containing `$ref`
    * dispatch only `$ref` and ignore every other keyword.
@@ -633,16 +704,20 @@ export function compileSchema(
 ): CompiledPredicate;
 export function compileSchema(
   schema: SchemaOrBoolean,
-  options: CompileOptions & { predicate?: false | undefined },
+  options: CompileOptions & { flat: true; predicate?: false | undefined },
+): CompiledFlatSchema;
+export function compileSchema(
+  schema: SchemaOrBoolean,
+  options: CompileOptions & { predicate?: false | undefined; flat?: false | undefined },
 ): CompiledSchema;
 export function compileSchema(
   schema: SchemaOrBoolean,
   options: CompileOptions,
-): CompiledSchema | CompiledPredicate;
+): CompiledSchema | CompiledPredicate | CompiledFlatSchema;
 export function compileSchema(
   schema: SchemaOrBoolean,
   options: CompileOptions,
-): CompiledSchema | CompiledPredicate {
+): CompiledSchema | CompiledPredicate | CompiledFlatSchema {
   const byKeyword = new Map<string, KeywordDefinition>();
   const ordered: KeywordDefinition[] = [];
   for (const vocab of options.dialect.vocabularies) {
@@ -706,6 +781,15 @@ export function compileSchema(
         "Predicate mode short-circuits on the first failure, so there is nothing to count.",
     );
   }
+  const flat = options.flat === true;
+  if (flat && predicate) {
+    // A predicate returns a boolean and collects no errors, so there is
+    // nothing to flatten. Fail loudly rather than silently ignoring one.
+    throw new Error(
+      "compileSchema: `flat: true` is mutually exclusive with `predicate: true`. " +
+        "A predicate collects no errors, so there is nothing to return as a flat list.",
+    );
+  }
   const deps = createDeps({ maxErrors, maxDepth, regexCompiler: options.regexCompiler });
   if (options.formats) {
     for (const name of Object.keys(options.formats)) {
@@ -758,6 +842,7 @@ export function compileSchema(
     depthGated: Number.isFinite(maxDepth),
     compiling: new Set(),
     predicate,
+    flat,
     refSuppressesSiblings: options.dialect.rules.refSuppressesSiblings,
     unevaluatedTracking,
     unevaluatedEmitted: false,
@@ -789,6 +874,13 @@ export function compileSchema(
     const { validate } = factory(deps);
     return { validate, source: wholeSource, stats };
   }
+  if (flat) {
+    const factory = new Function(NAMES.DEPS, wholeSource) as (
+      deps: ValidatorDeps,
+    ) => CompiledFlatSchemaFactory;
+    const { validate } = factory(deps);
+    return { validate, source: wholeSource, stats };
+  }
   const factory = new Function(NAMES.DEPS, wholeSource) as (
     deps: ValidatorDeps,
   ) => CompiledSchemaFactory;
@@ -802,6 +894,10 @@ interface CompiledSchemaFactory {
 
 interface CompiledPredicateFactory {
   validate: (data: unknown) => boolean;
+}
+
+interface CompiledFlatSchemaFactory {
+  validate: (data: unknown, startPath?: readonly PathSegment[]) => FlatValidationResult;
 }
 
 function compileValidator(schema: SchemaOrBoolean, state: CompileState): string {
@@ -1012,6 +1108,10 @@ function buildFunctionBody(schema: SchemaOrBoolean, state: CompileState): string
 
   if (state.predicate) {
     gen.line("return true;");
+  } else if (state.flat) {
+    // Flat mode: `errors` already holds this schema's leaves (or null);
+    // return it directly, no wrapping. Callers append the list.
+    gen.line(`return ${NAMES.ERRORS};`);
   } else {
     // Happy path: errors stayed null → return null directly and skip
     // the wrapErrors function call entirely.
@@ -1070,6 +1170,7 @@ function compileSchemaKeywords(
       gated: state.gated,
       depthGated: state.depthGated,
       predicate: state.predicate,
+      flat: state.flat,
       byKeyword: state.byKeyword,
       hoistConstant: (expr: string, prefix = "C"): string => {
         const name = `${prefix}_${state.nextHoistId}`;
@@ -1114,6 +1215,26 @@ function assembleSource(state: CompileState, rootName: string): string {
     // calls are independent.
     if (state.depthGated) parts.push(`  ${NAMES.DEPS}.depth = 0;`);
     parts.push(`  return ${rootName}(${NAMES.DATA});`);
+    parts.push(`}`);
+  } else if (state.flat) {
+    // Flat mode: the root returns a flat `ValidationError[]` (or null);
+    // the result carries it under `errors` rather than a tree `error`.
+    parts.push(`function validate(${NAMES.DATA}, startPath) {`);
+    if (state.gated) {
+      parts.push(`  ${NAMES.DEPS}.errorsRemaining = ${NAMES.DEPS}.maxErrors;`);
+      parts.push(`  ${NAMES.DEPS}.truncated = false;`);
+    }
+    if (state.depthGated) parts.push(`  ${NAMES.DEPS}.depth = 0;`);
+    parts.push(
+      `  const errs = ${rootName}(${NAMES.DATA}, startPath !== undefined ? [...startPath] : []);`,
+    );
+    parts.push(`  if (errs === null) return { valid: true };`);
+    if (state.gated) {
+      parts.push(
+        `  if (${NAMES.DEPS}.truncated) return { valid: false, errors: errs, truncated: true };`,
+      );
+    }
+    parts.push(`  return { valid: false, errors: errs };`);
     parts.push(`}`);
   } else {
     parts.push(`function validate(${NAMES.DATA}, startPath) {`);

--- a/packages/schema/src/compiler/index.ts
+++ b/packages/schema/src/compiler/index.ts
@@ -2,12 +2,15 @@ export {
   compileSchema,
   type CompileOptions,
   type CompileStats,
+  type CompiledFlatSchema,
   type CompiledPredicate,
   type CompiledSchema,
+  type FlatValidationResult,
   type StrictIssue,
   type ValidationResult,
 } from "./compiler.js";
 export {
+  appendErrors,
   createDeps,
   deepEqual,
   typeOf,

--- a/packages/schema/src/compiler/runtime.ts
+++ b/packages/schema/src/compiler/runtime.ts
@@ -18,6 +18,20 @@ export interface ValidatorDeps {
     path: readonly (string | number)[],
     errs: ValidationError[],
   ) => ValidationError | null;
+  /**
+   * Flat-mode error merge. Appends every error in `src` onto `dest` and
+   * returns `dest`; when `dest` is `null` it adopts `src` directly (no
+   * copy) and when `src` is `null` it returns `dest` unchanged. The
+   * leaves in `src` were already counted against the budget where they
+   * were created, so this never touches `errorsRemaining` (it is the
+   * flat-mode analogue of a tree-mode "lift"). Loop-based rather than
+   * `dest.push(...src)` so a million-element `src` cannot overflow the
+   * call stack. See {@link appendErrors}.
+   */
+  appendErrors: (
+    dest: ValidationError[] | null,
+    src: ValidationError[] | null,
+  ) => ValidationError[] | null;
   patterns: Map<string, CompiledRegex>;
   /**
    * Compile a user-supplied regex. By default tries the `u` (Unicode)
@@ -407,6 +421,35 @@ export function wrapErrors(
 }
 
 /**
+ * Flat-mode error merge: append every error in `src` onto `dest` and
+ * return the combined list. The runtime backing for every flat-mode
+ * lift site (see {@link ValidatorDeps.appendErrors}).
+ *
+ * Adopts `src` directly when `dest` is `null` (the common first-lift
+ * case allocates nothing); returns `dest` unchanged when `src` is
+ * `null`. Iterates rather than spreading (`dest.push(...src)` overflows
+ * the call stack for large `src`).
+ *
+ * @example
+ * ```ts
+ * appendErrors(null, [a]);     // [a]   (adopts src)
+ * appendErrors([a], null);     // [a]   (dest unchanged)
+ * appendErrors([a], [b, c]);   // [a, b, c]
+ * ```
+ *
+ * @public
+ */
+export function appendErrors(
+  dest: ValidationError[] | null,
+  src: ValidationError[] | null,
+): ValidationError[] | null {
+  if (src === null) return dest;
+  if (dest === null) return src;
+  for (const e of src) dest.push(e);
+  return dest;
+}
+
+/**
  * Build a {@link ValidatorDeps} bundle with fresh mutable caches.
  *
  * Accepts either a positional `maxErrors` (legacy) or an options
@@ -488,6 +531,7 @@ export function createDeps(arg?: number | CreateDepsOptions): ValidatorDeps {
     belowMinCodePoints,
     findDuplicate,
     wrapErrors,
+    appendErrors,
     patterns,
     compilePattern,
     formats,

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -21,11 +21,13 @@
 // Compiler: turning schemas into validators.
 export {
   compileSchema,
+  type CompiledFlatSchema,
   type CompiledPredicate,
   type CompiledRegex,
   type CompiledSchema,
   type CompileOptions,
   type CompileStats,
+  type FlatValidationResult,
   type RegexCompiler,
   type StrictIssue,
   type Validator,

--- a/packages/schema/src/keywords/composition.ts
+++ b/packages/schema/src/keywords/composition.ts
@@ -18,6 +18,28 @@ export const allOfKeyword: KeywordDefinition = {
     if (schemas.length === 0) return;
     const outProps = ctx.evaluatedPropertiesVar;
     const outItems = ctx.evaluatedItemsVar;
+    if (ctx.flat) {
+      // Flat mode: every conjunct must pass, so each failing branch's
+      // leaves surface directly with no wrapper and no marker (matching
+      // ajv, which exposes the failing subschema's errors as-is).
+      schemas.forEach((sub) => {
+        ctx.compileAndCallSubschema(sub, {
+          data: ctx.data,
+          onPass: (g, bProps, bItems) => {
+            if (outProps !== null && bProps !== null) {
+              g.line(`for (const k of ${bProps}) ${outProps}.add(k);`);
+            }
+            if (outItems !== null && bItems !== null) {
+              g.line(`for (const k of ${bItems}) ${outItems}.add(k);`);
+            }
+          },
+          onFail: (g, errVar) => {
+            if (errVar !== null) g.line(ctx.errorStatement("lift", errVar));
+          },
+        });
+      });
+      return;
+    }
     // Tree mode collects per-branch errors; predicate short-circuits
     // on first failure so there's nothing to collect.
     const errsVar = ctx.predicate ? null : ctx.gen.scope.name("allOfErrs");
@@ -71,6 +93,46 @@ export const anyOfKeyword: KeywordDefinition = {
     if (schemas.length === 0) return;
     const outProps = ctx.evaluatedPropertiesVar;
     const outItems = ctx.evaluatedItemsVar;
+    const n = schemas.length;
+    if (ctx.flat) {
+      // Flat mode: buffer each failing branch's leaves; if some branch
+      // matched, discard the buffer (anyOf succeeds). Otherwise flush
+      // the collected branch leaves flat and append a single childless
+      // `anyOf` marker so the composition failure is not anonymous.
+      const matched = ctx.gen.scope.name("matched");
+      ctx.gen.let(matched, "false");
+      const buf = ctx.gen.scope.name("anyOfBuf");
+      ctx.gen.let(buf, "null");
+      schemas.forEach((sub) => {
+        ctx.compileAndCallSubschema(sub, {
+          data: ctx.data,
+          onPass: (g, bProps, bItems) => {
+            g.line(`${matched} = true;`);
+            if (outProps !== null && bProps !== null) {
+              g.line(`for (const k of ${bProps}) ${outProps}.add(k);`);
+            }
+            if (outItems !== null && bItems !== null) {
+              g.line(`for (const k of ${bItems}) ${outItems}.add(k);`);
+            }
+          },
+          onFail: (g, errVar) => {
+            if (errVar !== null) g.line(ctx.appendErrorsStatement(buf, errVar));
+          },
+        });
+      });
+      ctx.gen.if(`!${matched}`, () => {
+        ctx.gen.line(ctx.appendErrorsStatement(ctx.errors, buf));
+        ctx.emitError(
+          "leaf",
+          ctx.leafErrorExpr(
+            quoteString("anyOf"),
+            `\`must match at least one of ${n} schemas\``,
+            `{ total: ${n} }`,
+          ),
+        );
+      });
+      return;
+    }
     const matched = ctx.gen.scope.name("matched");
     ctx.gen.let(matched, "false");
     // Tree mode collects per-branch errors for the final anyOf node;
@@ -95,7 +157,6 @@ export const anyOfKeyword: KeywordDefinition = {
         },
       });
     });
-    const n = schemas.length;
     if (ctx.predicate) {
       ctx.gen.line(`if (!${matched}) return false;`);
       return;
@@ -129,6 +190,48 @@ export const oneOfKeyword: KeywordDefinition = {
     if (schemas.length === 0) return;
     const outProps = ctx.evaluatedPropertiesVar;
     const outItems = ctx.evaluatedItemsVar;
+    const n = schemas.length;
+    if (ctx.flat) {
+      // Flat mode: count matches and buffer each failing branch's
+      // leaves. oneOf fails unless exactly one branch matched; on
+      // failure, flush the collected failing-branch leaves flat and
+      // append a single childless `oneOf` marker (carrying the observed
+      // match count). The buffer may be null when more than one branch
+      // matched and none failed; `appendErrors` is null-safe.
+      const matched = ctx.gen.scope.name("oneOfMatched");
+      ctx.gen.let(matched, "0");
+      const buf = ctx.gen.scope.name("oneOfBuf");
+      ctx.gen.let(buf, "null");
+      schemas.forEach((sub) => {
+        ctx.compileAndCallSubschema(sub, {
+          data: ctx.data,
+          onPass: (g, bProps, bItems) => {
+            g.line(`${matched} += 1;`);
+            if (outProps !== null && bProps !== null) {
+              g.line(`for (const k of ${bProps}) ${outProps}.add(k);`);
+            }
+            if (outItems !== null && bItems !== null) {
+              g.line(`for (const k of ${bItems}) ${outItems}.add(k);`);
+            }
+          },
+          onFail: (g, errVar) => {
+            if (errVar !== null) g.line(ctx.appendErrorsStatement(buf, errVar));
+          },
+        });
+      });
+      ctx.gen.if(`${matched} !== 1`, () => {
+        ctx.gen.line(ctx.appendErrorsStatement(ctx.errors, buf));
+        ctx.emitError(
+          "leaf",
+          ctx.leafErrorExpr(
+            quoteString("oneOf"),
+            `\`must match exactly one of ${n} schemas (matched \${${matched}})\``,
+            `{ total: ${n}, matchCount: ${matched} }`,
+          ),
+        );
+      });
+      return;
+    }
     if (ctx.predicate) {
       // Predicate mode: count branch matches; bail with `return false`
       // on the second match (>1 disallowed) or if fewer than 1
@@ -205,7 +308,6 @@ export const oneOfKeyword: KeywordDefinition = {
         (g) => g.line(`${errsVar}.push(${errVar});`),
       );
     });
-    const n = schemas.length;
     ctx.gen.if(`${matchCount} !== 1`, () => {
       ctx.emitError(
         "lift",

--- a/packages/schema/src/keywords/context.ts
+++ b/packages/schema/src/keywords/context.ts
@@ -59,6 +59,15 @@ export interface KeywordContextInputs {
    */
   predicate?: boolean;
   /**
+   * When `true`, flat-collection mode is active: each generated function
+   * returns a flat `ValidationError[]` of leaves (no branch wrappers)
+   * instead of a single tree node. Lift sites append the callee's list
+   * onto the accumulator (`deps.appendErrors`) rather than pushing one
+   * node, and the inline-wrap step is suppressed. Mutually exclusive
+   * with {@link KeywordContextInputs.predicate}.
+   */
+  flat?: boolean;
+  /**
    * The compiler's full keyword registry. Used by
    * {@link KeywordCompileContext.validateSubschema} to inline a
    * subschema's single keyword directly instead of compiling it to a
@@ -191,6 +200,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
   const gated = inputs.gated ?? false;
   const depthGated = inputs.depthGated ?? false;
   const predicate = inputs.predicate ?? false;
+  const flat = inputs.flat ?? false;
   const isRecursiveRef = inputs.isRecursiveRef ?? ((): boolean => false);
   const pathSegments = inputs.pathSegments ?? EMPTY_PATH_SEGMENTS;
   const effectivePathExpr =
@@ -241,10 +251,19 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     }
     if (kind === "leaf") return emitPushStatement(inputs.errors, errExpr, gated);
     // kind === "lift": already-counted sub-validator result being
-    // propagated, or a branch wrapper around already-counted children.
-    // Never interacts with the budget.
+    // propagated. Never interacts with the budget. In flat mode the
+    // callee returns a `ValidationError[]` (its leaves), so the lift
+    // appends that list onto the accumulator; in tree mode it returns a
+    // single node, pushed as one child.
+    if (flat) return appendErrorsStatement(inputs.errors, errExpr);
     return `(${inputs.errors} ??= []).push(${errExpr});`;
   };
+  // Append a flat `ValidationError[]` expression onto an accumulator
+  // variable via the runtime helper. Used for flat-mode lifts and for
+  // the per-branch buffers in `anyOf` / `oneOf`. The helper is null-safe
+  // on both arguments, so `destVar` may start as `null`.
+  const appendErrorsStatement = (destVar: string, srcExpr: string): string =>
+    `${destVar} = ${NAMES.DEPS}.appendErrors(${destVar}, ${srcExpr});`;
   const emitError = (kind: ErrorKind, errExpr: string): void => {
     inputs.gen.line(errorStatement(kind, errExpr));
   };
@@ -372,6 +391,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
         evaluatedItemsVar: null,
         gated,
         predicate,
+        flat,
         byKeyword: inputs.byKeyword,
         inlineDepth: inlineDepth + 1,
         hoistConstant: inputs.hoistConstant,
@@ -395,7 +415,11 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     // named function's `wrapErrors` output. Predicate mode skips the
     // snapshot/wrap entirely; inlined keywords return `false` on
     // failure so there's nothing to wrap.
-    const startVar = predicate ? null : inputs.gen.scope.name("_start");
+    // Flat mode never wraps: inlined keywords push their leaves straight
+    // onto the accumulator, so there is nothing to snapshot or collapse.
+    // Predicate mode short-circuits on failure, so likewise nothing to
+    // wrap. Skipping the snapshot here also skips the wrap block below.
+    const startVar = predicate || flat ? null : inputs.gen.scope.name("_start");
     // errors may be null (lazy allocation). Treat null as length-0 for
     // the snapshot; the wrap check below also guards against null.
     if (startVar !== null)
@@ -434,6 +458,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
         evaluatedItemsVar: null,
         gated,
         predicate,
+        flat,
         byKeyword: inputs.byKeyword,
         inlineDepth: inlineDepth + 1,
         hoistConstant: inputs.hoistConstant,
@@ -582,8 +607,10 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     gated,
     depthGated,
     predicate,
+    flat,
     errorStatement,
     emitError,
+    appendErrorsStatement,
     budgetBreakStatement,
     emitBudgetBreak,
     leafErrorExpr,

--- a/packages/schema/src/keywords/types.ts
+++ b/packages/schema/src/keywords/types.ts
@@ -167,6 +167,20 @@ export interface KeywordCompileContext {
    */
   readonly predicate: boolean;
   /**
+   * `true` when flat-collection mode is active: the compiled validator
+   * returns a flat `ValidationError[]` of leaves (no branch wrappers).
+   * Like {@link KeywordCompileContext.predicate}, most keywords don't
+   * read this: `emitError`/`errorStatement` append a sub-validator's
+   * list automatically on a `"lift"`, and the inline-wrap step is
+   * suppressed. The branch-*wrapping* composition keywords (`allOf`,
+   * `anyOf`, `oneOf`) must branch on it: instead of collecting child
+   * nodes and wrapping them, they append each failing branch's leaves
+   * flat and emit a single childless marker leaf for the composition
+   * keyword itself. Mutually exclusive with
+   * {@link KeywordCompileContext.predicate}.
+   */
+  readonly flat: boolean;
+  /**
    * Emit an error-push statement directly into the current code
    * generator. Pick the right `kind` based on where the error
    * expression came from:
@@ -191,6 +205,16 @@ export interface KeywordCompileContext {
    * larger `gen.line(...)` call.
    */
   errorStatement(kind: ErrorKind, errExpr: string): string;
+  /**
+   * Flat-mode helper: a statement that appends the flat
+   * `ValidationError[]` produced by `srcExpr` onto the accumulator
+   * variable `destVar` (via `deps.appendErrors`, null-safe on both
+   * sides). Used by the branch-wrapping composition keywords to buffer
+   * per-branch leaves (`anyOf` / `oneOf`) before deciding whether to
+   * commit or discard them. Only meaningful when
+   * {@link KeywordCompileContext.flat} is `true`.
+   */
+  appendErrorsStatement(destVar: string, srcExpr: string): string;
   /**
    * Build a budget-guarded `break;` statement for use at the bottom of
    * hot loops (array items / property keys / applicator branches).

--- a/packages/schema/test/flat-mode.test.ts
+++ b/packages/schema/test/flat-mode.test.ts
@@ -1,0 +1,284 @@
+/* eslint-disable unicorn/no-thenable -- `then` is a JSON Schema keyword here */
+import { describe, expect, it } from "vitest";
+import { collectLeaves, createBranchError, formatError, type ValidationError } from "@oav/core";
+import { compileSchema } from "../src/compiler/compiler.js";
+import { appendErrors } from "../src/compiler/runtime.js";
+import { jsonSchemaDialect } from "../src/keywords/vocabulary.js";
+
+type Opts = { maxErrors?: number };
+
+function tree(schema: unknown, opts: Opts = {}): ReturnType<typeof compileSchema> {
+  return compileSchema(schema as never, { dialect: jsonSchemaDialect, ...opts });
+}
+function flat(schema: unknown, opts: Opts = {}) {
+  return compileSchema(schema as never, { dialect: jsonSchemaDialect, flat: true, ...opts });
+}
+
+// Full-fidelity multiset key: a flat record and its tree-leaf counterpart
+// must agree on code, path, message, AND params (they go through the
+// identical leaf-emission path; only wrapping differs).
+const fullKey = (e: ValidationError): string =>
+  `${e.code}@${JSON.stringify(e.path)}|${e.message}|${JSON.stringify(e.params)}`;
+const bag = (es: ValidationError[]): string[] => es.map(fullKey).sort();
+const codesOf = (es: ValidationError[]): string[] => es.map((e) => e.code);
+
+// Schemas with NO anyOf/oneOf: flat output must equal the tree's leaf
+// set exactly (allOf / if / not wrap or mark identically across modes).
+const LEAF_CASES: Array<{ name: string; schema: unknown; data: unknown }> = [
+  { name: "type mismatch", schema: { type: "string" }, data: 42 },
+  { name: "multiple required", schema: { type: "object", required: ["a", "b", "c"] }, data: {} },
+  {
+    name: "nested object properties",
+    schema: {
+      type: "object",
+      properties: {
+        a: { type: "number" },
+        b: { type: "object", properties: { c: { type: "string" } } },
+      },
+    },
+    data: { a: "x", b: { c: 1 } },
+  },
+  {
+    name: "array items",
+    schema: { type: "array", items: { type: "number" } },
+    data: [1, "x", 2, "y"],
+  },
+  { name: "numeric bounds", schema: { type: "number", minimum: 0, maximum: 10 }, data: 20 },
+  {
+    name: "string length + pattern",
+    schema: { type: "string", minLength: 5, pattern: "^a" },
+    data: "bb",
+  },
+  {
+    name: "allOf (branch wrapper, no marker)",
+    schema: { allOf: [{ required: ["a"] }, { required: ["b"] }] },
+    data: {},
+  },
+  { name: "not (leaf marker)", schema: { not: { type: "string" } }, data: "hi" },
+  {
+    name: "if/then/else (then branch)",
+    schema: {
+      if: { type: "object", required: ["kind"] },
+      then: { required: ["x"] },
+      else: { required: ["y"] },
+    },
+    data: { kind: "a" },
+  },
+  { name: "dependentRequired", schema: { dependentRequired: { a: ["b", "c"] } }, data: { a: 1 } },
+  {
+    name: "additionalProperties",
+    schema: { type: "object", properties: { a: true }, additionalProperties: { type: "number" } },
+    data: { a: 1, b: "x", c: "y" },
+  },
+  {
+    name: "deep nesting, multiple leaves under one subschema",
+    schema: { type: "object", properties: { x: { type: "object", required: ["a", "b"] } } },
+    data: { x: {} },
+  },
+];
+
+describe("flat mode: configuration guards", () => {
+  it("rejects flat + predicate as mutually exclusive", () => {
+    expect(() =>
+      compileSchema({} as never, { dialect: jsonSchemaDialect, flat: true, predicate: true }),
+    ).toThrow(/mutually exclusive/);
+  });
+
+  it("accepts flat + maxErrors", () => {
+    expect(() =>
+      compileSchema({ type: "string" } as never, {
+        dialect: jsonSchemaDialect,
+        flat: true,
+        maxErrors: 3,
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("flat mode: valid data", () => {
+  it("returns { valid: true } with no errors array", () => {
+    const r = flat({ type: "object", required: ["a"] }).validate({ a: 1 });
+    expect(r.valid).toBe(true);
+    expect(r.errors).toBeUndefined();
+  });
+});
+
+describe("flat mode: leaf-set parity with the tree (non-composition schemas)", () => {
+  for (const { name, schema, data } of LEAF_CASES) {
+    it(`${name}: flat list equals collectLeaves(tree)`, () => {
+      const t = tree(schema).validate(data);
+      const f = flat(schema).validate(data);
+      expect(t.valid).toBe(false);
+      expect(f.valid).toBe(false);
+      // Same set of leaf errors, ignoring tree nesting and order.
+      expect(bag(f.errors!)).toEqual(bag(collectLeaves(t.error!)));
+      // And flat genuinely carries no branch wrappers.
+      for (const e of f.errors!) expect(e.children).toEqual([]);
+    });
+  }
+});
+
+describe("flat mode: composition markers", () => {
+  it("anyOf all-fail: branch leaves plus one anyOf marker", () => {
+    const r = flat({ anyOf: [{ type: "string" }, { type: "number" }] }).validate(true);
+    expect(r.valid).toBe(false);
+    expect(codesOf(r.errors!).filter((c) => c === "type")).toHaveLength(2);
+    const marker = r.errors!.find((e) => e.code === "anyOf");
+    expect(marker).toBeDefined();
+    expect(marker!.children).toEqual([]);
+    expect(marker!.params).toMatchObject({ total: 2 });
+  });
+
+  it("anyOf one-match: valid, no errors", () => {
+    const r = flat({ anyOf: [{ type: "string" }, { type: "number" }] }).validate("hi");
+    expect(r.valid).toBe(true);
+    expect(r.errors).toBeUndefined();
+  });
+
+  it("oneOf zero-match: branch leaves plus one oneOf marker (matchCount 0)", () => {
+    const r = flat({ oneOf: [{ type: "string" }, { type: "boolean" }] }).validate(42);
+    expect(r.valid).toBe(false);
+    expect(codesOf(r.errors!).filter((c) => c === "type")).toHaveLength(2);
+    const marker = r.errors!.find((e) => e.code === "oneOf");
+    expect(marker).toBeDefined();
+    expect(marker!.params).toMatchObject({ total: 2, matchCount: 0 });
+  });
+
+  it("oneOf two-match: only a oneOf marker (matchCount 2), no branch leaves", () => {
+    // 4 satisfies both `type: number` and `multipleOf: 1`.
+    const r = flat({ oneOf: [{ type: "number" }, { multipleOf: 1 }] }).validate(4);
+    expect(r.valid).toBe(false);
+    expect(r.errors!.filter((e) => e.code !== "oneOf")).toHaveLength(0);
+    const marker = r.errors!.find((e) => e.code === "oneOf");
+    expect(marker!.params).toMatchObject({ matchCount: 2 });
+  });
+
+  it("nested anyOf inside an object property keeps the leaf paths", () => {
+    const schema = {
+      type: "object",
+      properties: { v: { anyOf: [{ type: "string" }, { type: "number" }] } },
+    };
+    const r = flat(schema).validate({ v: true });
+    expect(r.valid).toBe(false);
+    // Both branch leaves and the marker sit at path ["v"].
+    for (const e of r.errors!) expect(e.path).toEqual(["v"]);
+    expect(r.errors!.find((e) => e.code === "anyOf")).toBeDefined();
+  });
+});
+
+describe("flat mode: validity agreement with the tree", () => {
+  // A broad corpus exercising composition, refs, recursion, arrays, and
+  // both valid and invalid data. Flat and tree must always agree on
+  // valid/invalid (the airtight behavioral guarantee).
+  const recursive = {
+    $id: "https://example.test/node",
+    type: "object",
+    properties: { value: { type: "number" }, children: { type: "array", items: { $ref: "#" } } },
+    required: ["value"],
+    additionalProperties: false,
+  };
+  const AGREEMENT: Array<{ schema: unknown; data: unknown }> = [
+    ...LEAF_CASES.map(({ schema, data }) => ({ schema, data })),
+    // valid counterparts
+    { schema: { type: "string" }, data: "ok" },
+    { schema: { type: "object", required: ["a", "b"] }, data: { a: 1, b: 2 } },
+    // composition
+    { schema: { anyOf: [{ type: "string" }, { type: "number" }] }, data: "x" },
+    { schema: { anyOf: [{ type: "string" }, { type: "number" }] }, data: true },
+    { schema: { oneOf: [{ type: "number" }, { multipleOf: 1 }] }, data: 4 },
+    { schema: { oneOf: [{ type: "number" }, { type: "string" }] }, data: 4 },
+    { schema: { allOf: [{ minimum: 0 }, { maximum: 10 }] }, data: 5 },
+    { schema: { allOf: [{ minimum: 0 }, { maximum: 10 }] }, data: 20 },
+    { schema: { not: { type: "string" } }, data: 1 },
+    { schema: { not: { type: "string" } }, data: "s" },
+    // recursion
+    { schema: recursive, data: { value: 1, children: [{ value: 2 }, { value: 3, children: [] }] } },
+    { schema: recursive, data: { value: 1, children: [{ value: "bad" }, { extra: true }] } },
+  ];
+
+  for (const [i, { schema, data }] of AGREEMENT.entries()) {
+    it(`case ${i}: flat.valid === tree.valid`, () => {
+      const t = tree(schema).validate(data);
+      const f = flat(schema).validate(data);
+      expect(f.valid).toBe(t.valid);
+    });
+  }
+});
+
+describe("flat mode: maxErrors and startPath", () => {
+  it("caps the flat list and sets truncated", () => {
+    const r = flat({ type: "object", required: ["a", "b", "c", "d"] }, { maxErrors: 2 }).validate(
+      {},
+    );
+    expect(r.valid).toBe(false);
+    expect(r.errors).toHaveLength(2);
+    expect(r.truncated).toBe(true);
+  });
+
+  it("resets the budget between calls", () => {
+    const v = flat({ required: ["a", "b"] }, { maxErrors: 1 });
+    expect(v.validate({}).errors).toHaveLength(1);
+    expect(v.validate({}).errors).toHaveLength(1);
+  });
+
+  it("prefixes leaf paths with startPath", () => {
+    const r = flat({ type: "string" }).validate(1, ["body"]);
+    expect(r.errors![0]!.path).toEqual(["body"]);
+  });
+});
+
+describe("flat mode: record shape and renderer interop", () => {
+  it("every record is a childless ValidationError", () => {
+    const r = flat({
+      type: "object",
+      properties: { a: { type: "number" } },
+      required: ["b"],
+    }).validate({ a: "x" });
+    for (const e of r.errors!) {
+      expect(e.children).toEqual([]);
+      expect(typeof e.code).toBe("string");
+      expect(Array.isArray(e.path)).toBe(true);
+      expect(typeof e.message).toBe("string");
+    }
+  });
+
+  it("composes with the tree renderers via a synthetic root wrap", () => {
+    const r = flat({ type: "object", required: ["a", "b"] }).validate({});
+    const wrapped = createBranchError("schema", [], "schema validation failed", r.errors!);
+    expect(collectLeaves(wrapped)).toHaveLength(2);
+    expect(() => formatError(wrapped, "flat")).not.toThrow();
+  });
+});
+
+describe("appendErrors runtime helper", () => {
+  const leaf = (i: number): ValidationError => ({
+    code: "x",
+    path: [i],
+    message: "",
+    params: {},
+    children: [],
+  });
+
+  it("adopts src when dest is null (no copy)", () => {
+    const src = [leaf(0)];
+    expect(appendErrors(null, src)).toBe(src);
+  });
+
+  it("returns dest unchanged when src is null", () => {
+    const dest = [leaf(0)];
+    expect(appendErrors(dest, null)).toBe(dest);
+  });
+
+  it("appends src onto dest in place", () => {
+    const dest = [leaf(0)];
+    const out = appendErrors(dest, [leaf(1), leaf(2)]);
+    expect(out).toBe(dest);
+    expect(out!.map((e) => e.path[0])).toEqual([0, 1, 2]);
+  });
+
+  it("does not overflow the call stack on a large src (loop, not spread)", () => {
+    const big = Array.from({ length: 200_000 }, (_, i) => leaf(i));
+    expect(() => appendErrors([leaf(-1)], big)).not.toThrow();
+    expect(appendErrors([leaf(-1)], big)!.length).toBe(200_001);
+  });
+});

--- a/performance/flat-vs-tree-mem.ts
+++ b/performance/flat-vs-tree-mem.ts
@@ -1,0 +1,78 @@
+/**
+ * Quick retained-memory comparison of tree mode vs flat mode (#314) on
+ * a broadly-invalid large array. Run:
+ *   node --expose-gc --import tsx flat-vs-tree-mem.ts
+ */
+import { compileSchema, jsonSchemaDialect } from "../packages/schema/src/index.ts";
+
+const SCHEMA = {
+  type: "array",
+  items: {
+    type: "object",
+    required: ["id", "name"],
+    properties: {
+      id: { type: "integer", minimum: 1 },
+      name: { type: "string", minLength: 1 },
+      tags: { type: "array", items: { type: "string" } },
+    },
+    additionalProperties: false,
+  },
+};
+
+const N = Number.parseInt(process.env.LP_N ?? "200000", 10);
+
+function buildInvalid(n: number): unknown[] {
+  const out = new Array(n);
+  for (let i = 0; i < n; i += 1) out[i] = { id: `oops-${i}`, tags: [1, 2, 3], extra: true };
+  return out;
+}
+
+const gc = (globalThis as { gc?: () => void }).gc ?? (() => {});
+function heapMB(): number {
+  gc();
+  gc();
+  return process.memoryUsage().heapUsed / 1024 / 1024;
+}
+
+function countLeaves(node: { children: unknown[] }): number {
+  // tree: count leaves recursively
+  let n = 0;
+  const stack: Array<{ children: unknown[] }> = [node];
+  while (stack.length > 0) {
+    const x = stack.pop()!;
+    if (x.children.length === 0) n += 1;
+    else for (const c of x.children) stack.push(c as { children: unknown[] });
+  }
+  return n;
+}
+
+// Isolate each mode in its own process (MODE=tree|flat) so a result is
+// the only thing retained beyond the shared data; cross-mode reclaim
+// can't undercount.
+function main(): void {
+  if ((globalThis as { gc?: () => void }).gc === undefined) {
+    console.warn("warning: run with --expose-gc for meaningful deltas\n");
+  }
+  const mode = process.env.MODE ?? "tree";
+  const data = buildInvalid(N);
+  const v = compileSchema(SCHEMA as Record<string, unknown>, {
+    dialect: jsonSchemaDialect,
+    ...(mode === "flat" ? { flat: true } : {}),
+  });
+  const baseline = heapMB(); // data held, no result
+  const res = v.validate(data) as {
+    valid: boolean;
+    error?: { children: unknown[] };
+    errors?: unknown[];
+  };
+  const retained = heapMB() - baseline;
+  const count =
+    mode === "flat" ? (res.errors?.length ?? 0) : res.error ? countLeaves(res.error) : 0;
+  // keep res alive past the measurement
+  if (!res.valid && count < 0) throw new Error("unreachable");
+  console.log(
+    `MODE=${mode} N=${N}: baseline=${baseline.toFixed(1)}MB retained=${retained.toFixed(1)}MB items=${count}`,
+  );
+}
+
+main();


### PR DESCRIPTION
Adds `compileSchema(schema, { flat: true })`, a third compile mode
alongside the default tree and `predicate` (#314).

## What

Returns a `FlatValidationResult` whose `errors` is a de-nested
`ValidationError[]` of leaves: every failing leaf keyword as its own
record, plus a childless marker leaf per failed `anyOf` / `oneOf`, with
no `"schema"` branch wrappers. Records stay `ValidationError`s (empty
`children`), so the `@oav/core` renderers still consume them.

- Guard: `flat + predicate` throws; `flat + maxErrors` composes (capped
  list + `truncated`).
- New `deps.appendErrors(dest, src)` runtime helper: loop-based merge
  (stack-safe on million-element lists), adopts `src` on the first lift
  (zero-copy).
- `errorStatement("lift")` appends the callee's list in flat mode, so
  every lift-based keyword (`not`, `if/then/else`, `$ref`,
  `dependentSchemas`, `contains`, properties, items, ...) works
  unchanged. Only `allOf` / `anyOf` / `oneOf` needed flat arms.

## Memory

Measured ~21% retained-memory reduction on the issue's 200k-element
broadly-invalid array (518MB tree -> 408MB flat). The original 59%
projection conflated the 1.2M leaf objects (kept; they are the errors)
with the ~400k branch wrappers (dropped). The per-leaf path arrays are
the dominant remaining cost; reclaiming those is the separate, shelved
tier-3 step (#336). See the corrected note on #314.

## Testing

- 53 unit tests: guards, leaf-set parity (flat list equals
  `collectLeaves(tree)` on code/path/message/params for non-composition
  schemas), composition markers, maxErrors, startPath, record shape,
  renderer interop, `appendErrors` stack-safety.
- Whole JSON Schema Test Suite (1290 cases) runs identically in tree and
  flat mode -- same pass/fail and same mismatch set (`OAV_FLAT=1` gate
  in the conformance harness). Flat changes accept/reject for nothing.
- Whole workspace: 1144 tests, lint + typecheck clean.

Closes #314.