### PR TITLE
perf(schema): two-phase composition (predicate decision + lazy errors)

### DIFF
--- a/packages/schema/src/compiler/compiler.ts
+++ b/packages/schema/src/compiler/compiler.ts
@@ -1,6 +1,6 @@
 import type { PathSegment, SchemaObject, SchemaOrBoolean, ValidationError } from "@oav/core";
 import { CodeGen, NAMES } from "../codegen/index.js";
-import type { Dialect, KeywordDefinition } from "../keywords/types.js";
+import type { CompileMode, Dialect, KeywordDefinition } from "../keywords/types.js";
 import { createKeywordContext, emitPushStatement } from "../keywords/context.js";
 import { createCustomKeywordDefinition, type CustomKeywordValidator } from "../keywords/custom.js";
 import {
@@ -573,7 +573,13 @@ export interface CompileState {
   readonly gen: CodeGen;
   readonly byKeyword: Map<string, KeywordDefinition>;
   readonly ordered: KeywordDefinition[];
-  readonly compiledFor: Map<SchemaOrBoolean, string>;
+  /**
+   * Compiled function name per (mode, schema). Keyed by mode first so a
+   * subschema can have both an error-mode and a predicate-mode function
+   * (the two-phase composition optimization compiles branches in both).
+   * Use {@link cacheFor} to get the inner map for a mode.
+   */
+  readonly compiledFor: Map<CompileMode, Map<SchemaOrBoolean, string>>;
   readonly functionBodies: string[];
   /**
    * `const <name> = <expr>;` lines emitted at module scope above every
@@ -586,7 +592,7 @@ export interface CompileState {
   readonly deps: ValidatorDeps;
   readonly refResolver: RefResolver;
   readonly graph: ResolvedGraph;
-  readonly compileValidator: (schema: SchemaOrBoolean) => string;
+  readonly compileValidator: (schema: SchemaOrBoolean, mode: CompileMode) => string;
   /**
    * `true` when a finite `maxErrors` was configured. Codegen uses this
    * to emit the extra budget checks; when errors are uncapped we emit
@@ -846,12 +852,15 @@ export function compileSchema(
     refSuppressesSiblings: options.dialect.rules.refSuppressesSiblings,
     unevaluatedTracking,
     unevaluatedEmitted: false,
-    compileValidator(sub) {
-      return compileValidator(sub, state);
+    compileValidator(sub, mode) {
+      return compileValidator(sub, state, mode);
     },
   };
 
-  const rootName = compileValidator(schema, state);
+  // Top-level output shape. Subschemas default to this; the composition
+  // keywords request `"predicate"` per-branch on top of it.
+  const topMode: CompileMode = predicate ? "predicate" : flat ? "flat" : "tree";
+  const rootName = compileValidator(schema, state, topMode);
 
   const wholeSource = assembleSource(state, rootName);
   const strictMode = options.strict ?? DEFAULT_STRICT_MODE;
@@ -900,15 +909,26 @@ interface CompiledFlatSchemaFactory {
   validate: (data: unknown, startPath?: readonly PathSegment[]) => FlatValidationResult;
 }
 
-function compileValidator(schema: SchemaOrBoolean, state: CompileState): string {
-  const cached = state.compiledFor.get(schema);
+/** Per-mode slice of {@link CompileState.compiledFor}, created on demand. */
+function cacheFor(state: CompileState, mode: CompileMode): Map<SchemaOrBoolean, string> {
+  let m = state.compiledFor.get(mode);
+  if (m === undefined) {
+    m = new Map();
+    state.compiledFor.set(mode, m);
+  }
+  return m;
+}
+
+function compileValidator(schema: SchemaOrBoolean, state: CompileState, mode: CompileMode): string {
+  const cache = cacheFor(state, mode);
+  const cached = cache.get(schema);
   if (cached !== undefined) return cached;
 
   // Reserve a name up front so cyclic `$ref`s that point back to this
   // schema hit the cache below and emit a normal recursive call.
   const name = `validate_${state.nextFn}`;
   state.nextFn += 1;
-  state.compiledFor.set(schema, name);
+  cache.set(schema, name);
 
   // Pure-`$ref` elision: a schema whose only non-annotation keyword is
   // `$ref` compiles to a pass-through wrapper today (allocates a
@@ -926,9 +946,9 @@ function compileValidator(schema: SchemaOrBoolean, state: CompileState): string 
     // caller (properties / items / composition), bypassing the `$ref`
     // keyword where the depth guard is emitted. Forward refs still elide.
     if (target !== null && !(state.depthGated && state.compiling.has(target))) {
-      const targetName = compileValidator(target, state);
+      const targetName = compileValidator(target, state, mode);
       if (targetName !== name) {
-        state.compiledFor.set(schema, targetName);
+        cache.set(schema, targetName);
         return targetName;
       }
     }
@@ -938,7 +958,7 @@ function compileValidator(schema: SchemaOrBoolean, state: CompileState): string 
   // subschema reachable from it) is generated, so a `$ref` back to it
   // resolves as a recursion back-edge and gets the depth guard.
   state.compiling.add(schema);
-  const body = buildFunctionBody(schema, state);
+  const body = buildFunctionBody(schema, state, mode);
   state.compiling.delete(schema);
   // Predicate mode drops the `path` parameter: error expressions
   // (which are the only consumer of `path`) are never emitted.
@@ -953,9 +973,10 @@ function compileValidator(schema: SchemaOrBoolean, state: CompileState): string 
   const evalParams = state.unevaluatedTracking
     ? `, ${NAMES.OUT_EVAL_PROPS}, ${NAMES.OUT_EVAL_ITEMS}`
     : "";
-  const params = state.predicate
-    ? `${NAMES.DATA}${evalParams}`
-    : `${NAMES.DATA}, ${NAMES.PATH}${evalParams}`;
+  const params =
+    mode === "predicate"
+      ? `${NAMES.DATA}${evalParams}`
+      : `${NAMES.DATA}, ${NAMES.PATH}${evalParams}`;
   state.functionBodies.push(`function ${name}(${params}) {\n${body}\n}`);
   return name;
 }
@@ -1052,10 +1073,12 @@ function needsItemTracking(schema: SchemaObject, state: CompileState): boolean {
   );
 }
 
-function buildFunctionBody(schema: SchemaOrBoolean, state: CompileState): string {
+function buildFunctionBody(schema: SchemaOrBoolean, state: CompileState, mode: CompileMode): string {
+  const predicate = mode === "predicate";
+  const flat = mode === "flat";
   const gen = new CodeGen();
   gen.indent();
-  if (!state.predicate) {
+  if (!predicate) {
     // Start null; lazily allocate on first push. Valid inputs never
     // touch this; the function returns null directly without
     // allocating anything.
@@ -1065,7 +1088,7 @@ function buildFunctionBody(schema: SchemaOrBoolean, state: CompileState): string
   if (schema === true) {
     // no-op; always valid
   } else if (schema === false) {
-    if (state.predicate) {
+    if (predicate) {
       gen.line("return false;");
     } else {
       const falseErr = `${NAMES.DEPS}.createLeafError("false", ${NAMES.PATH}, "schema is false, nothing is valid")`;
@@ -1086,7 +1109,7 @@ function buildFunctionBody(schema: SchemaOrBoolean, state: CompileState): string
       gen.const(evaluatedItemsVar, "new Set()");
       state.unevaluatedEmitted = true;
     }
-    compileSchemaKeywords(schema, gen, state, evaluatedPropertiesVar, evaluatedItemsVar);
+    compileSchemaKeywords(schema, gen, state, evaluatedPropertiesVar, evaluatedItemsVar, mode);
     // Merge evaluated-key sets into the caller's out-parameters when the
     // caller is tracking. Runs regardless of errors; a keyword that
     // evaluated a key evaluated it, even if other keywords flagged the
@@ -1106,9 +1129,9 @@ function buildFunctionBody(schema: SchemaOrBoolean, state: CompileState): string
     }
   }
 
-  if (state.predicate) {
+  if (predicate) {
     gen.line("return true;");
-  } else if (state.flat) {
+  } else if (flat) {
     // Flat mode: `errors` already holds this schema's leaves (or null);
     // return it directly, no wrapping. Callers append the list.
     gen.line(`return ${NAMES.ERRORS};`);
@@ -1128,12 +1151,16 @@ function compileSchemaKeywords(
   state: CompileState,
   evaluatedPropertiesVar: string | null,
   evaluatedItemsVar: string | null,
+  mode: CompileMode,
 ): void {
-  const subCompiler = (subSchema: SchemaOrBoolean): string => compileValidator(subSchema, state);
+  // Subschemas default to this function's mode; composition keywords
+  // pass `"predicate"` for branches whose result is only a boolean.
+  const subCompiler = (subSchema: SchemaOrBoolean, subMode: CompileMode = mode): string =>
+    compileValidator(subSchema, state, subMode);
   const currentBaseUri = state.graph.schemaBaseUri.get(schema) ?? state.graph.baseUri;
   const resolveRefToFunction = (ref: string): string => {
     const target = state.refResolver.resolve(ref, currentBaseUri);
-    return compileValidator(target, state);
+    return compileValidator(target, state, mode);
   };
   // A ref is recursive (a back-edge) when its target is still on the
   // compile stack: resolving it here only walks the ref graph, it does
@@ -1169,8 +1196,9 @@ function compileSchemaKeywords(
       evaluatedItemsVar,
       gated: state.gated,
       depthGated: state.depthGated,
-      predicate: state.predicate,
-      flat: state.flat,
+      predicate: mode === "predicate",
+      flat: mode === "flat",
+      unevaluatedTracking: state.unevaluatedTracking,
       byKeyword: state.byKeyword,
       hoistConstant: (expr: string, prefix = "C"): string => {
         const name = `${prefix}_${state.nextHoistId}`;

--- a/packages/schema/src/compiler/compiler.ts
+++ b/packages/schema/src/compiler/compiler.ts
@@ -1073,7 +1073,11 @@ function needsItemTracking(schema: SchemaObject, state: CompileState): boolean {
   );
 }
 
-function buildFunctionBody(schema: SchemaOrBoolean, state: CompileState, mode: CompileMode): string {
+function buildFunctionBody(
+  schema: SchemaOrBoolean,
+  state: CompileState,
+  mode: CompileMode,
+): string {
   const predicate = mode === "predicate";
   const flat = mode === "flat";
   const gen = new CodeGen();

--- a/packages/schema/src/keywords/composition.ts
+++ b/packages/schema/src/keywords/composition.ts
@@ -4,6 +4,52 @@ import type { KeywordCompileContext, KeywordDefinition } from "./types.js";
 import { APPLICATOR_VOCAB } from "./vocabulary-uris.js";
 
 /**
+ * Two-phase composition error materialization (#338). Called inside the
+ * failure guard of `anyOf` / `oneOf`, after a predicate-only decision
+ * phase has already determined the composition fails. Re-runs every
+ * branch in the enclosing error mode and collects the failing ones,
+ * then emits the same node (tree) or flat leaves + marker (flat) the
+ * eager path would have produced. Branches that pass return
+ * `null`/empty and contribute nothing, so re-running all of them
+ * reproduces the eager output exactly (the matching branches never had
+ * errors). Runs only on the failure path, so the re-validation cost is
+ * off the valid hot path.
+ *
+ * Gated by the caller on this scope tracking no evaluated keys, so
+ * branches take `(data, path)` with no eval out-params.
+ */
+function emitCompositionErrors(
+  ctx: KeywordCompileContext,
+  schemas: SchemaOrBoolean[],
+  codeExpr: string,
+  messageExpr: string,
+  paramsExpr: string,
+): void {
+  if (ctx.flat) {
+    const buf = ctx.gen.scope.name("compBuf");
+    ctx.gen.let(buf, "null");
+    schemas.forEach((sub) => {
+      const fn = ctx.compileSubschema(sub);
+      const e = ctx.gen.scope.name("e");
+      ctx.gen.const(e, `${fn}(${ctx.data}, ${ctx.path})`);
+      ctx.gen.if(`${e} !== null`, () => ctx.gen.line(ctx.appendErrorsStatement(buf, e)));
+    });
+    ctx.gen.line(ctx.appendErrorsStatement(ctx.errors, buf));
+    ctx.emitError("leaf", ctx.leafErrorExpr(codeExpr, messageExpr, paramsExpr));
+    return;
+  }
+  const errsVar = ctx.gen.scope.name("compErrs");
+  ctx.gen.const(errsVar, "[]");
+  schemas.forEach((sub) => {
+    const fn = ctx.compileSubschema(sub);
+    const e = ctx.gen.scope.name("e");
+    ctx.gen.const(e, `${fn}(${ctx.data}, ${ctx.path})`);
+    ctx.gen.if(`${e} !== null`, () => ctx.gen.line(`${errsVar}.push(${e});`));
+  });
+  ctx.emitError("lift", ctx.branchErrorExpr(codeExpr, messageExpr, errsVar, paramsExpr));
+}
+
+/**
  * The `allOf` keyword. Every subschema must validate. Children of the
  * produced error are the failing conjuncts.
  *
@@ -94,11 +140,34 @@ export const anyOfKeyword: KeywordDefinition = {
     const outProps = ctx.evaluatedPropertiesVar;
     const outItems = ctx.evaluatedItemsVar;
     const n = schemas.length;
+    if (!ctx.predicate && outProps === null && outItems === null) {
+      // Two-phase (#338): decide with predicate-compiled branches, which
+      // allocate no errors, short-circuiting on the first match. Only if
+      // none match do we re-run the branches in error mode to build the
+      // errors. The valid path (some branch matches) builds no throwaway
+      // error tree for the non-matching branches.
+      const decision = schemas
+        .map((sub) => `${ctx.compileSubschema(sub, "predicate")}(${ctx.data})`)
+        .join(" || ");
+      const matched = ctx.gen.scope.name("matched");
+      ctx.gen.const(matched, decision);
+      ctx.gen.if(`!${matched}`, () => {
+        emitCompositionErrors(
+          ctx,
+          schemas,
+          quoteString("anyOf"),
+          `\`must match at least one of ${n} schemas\``,
+          `{ total: ${n} }`,
+        );
+      });
+      return;
+    }
     if (ctx.flat) {
-      // Flat mode: buffer each failing branch's leaves; if some branch
-      // matched, discard the buffer (anyOf succeeds). Otherwise flush
-      // the collected branch leaves flat and append a single childless
-      // `anyOf` marker so the composition failure is not anonymous.
+      // Flat mode (eval tracking on): buffer each failing branch's
+      // leaves; if some branch matched, discard the buffer (anyOf
+      // succeeds). Otherwise flush the collected branch leaves flat and
+      // append a single childless `anyOf` marker so the failure is not
+      // anonymous.
       const matched = ctx.gen.scope.name("matched");
       ctx.gen.let(matched, "false");
       const buf = ctx.gen.scope.name("anyOfBuf");
@@ -191,13 +260,37 @@ export const oneOfKeyword: KeywordDefinition = {
     const outProps = ctx.evaluatedPropertiesVar;
     const outItems = ctx.evaluatedItemsVar;
     const n = schemas.length;
+    if (!ctx.predicate && outProps === null && outItems === null) {
+      // Two-phase (#338): count matches with predicate-compiled branches
+      // (no error allocation; all must run since oneOf needs the exact
+      // count). Only on a non-unique match do we re-run the branches in
+      // error mode. Re-running all reproduces the eager output: matching
+      // branches return null and contribute nothing, so the collected
+      // set is exactly the failing branches, same as today (preserving
+      // output on both the 0-match and >1-match paths).
+      const decision = schemas
+        .map((sub) => `(${ctx.compileSubschema(sub, "predicate")}(${ctx.data}) ? 1 : 0)`)
+        .join(" + ");
+      const matchCount = ctx.gen.scope.name("oneOfMatched");
+      ctx.gen.const(matchCount, decision);
+      ctx.gen.if(`${matchCount} !== 1`, () => {
+        emitCompositionErrors(
+          ctx,
+          schemas,
+          quoteString("oneOf"),
+          `\`must match exactly one of ${n} schemas (matched \${${matchCount}})\``,
+          `{ total: ${n}, matchCount: ${matchCount} }`,
+        );
+      });
+      return;
+    }
     if (ctx.flat) {
-      // Flat mode: count matches and buffer each failing branch's
-      // leaves. oneOf fails unless exactly one branch matched; on
-      // failure, flush the collected failing-branch leaves flat and
-      // append a single childless `oneOf` marker (carrying the observed
-      // match count). The buffer may be null when more than one branch
-      // matched and none failed; `appendErrors` is null-safe.
+      // Flat mode (eval tracking on): count matches and buffer each
+      // failing branch's leaves. oneOf fails unless exactly one branch
+      // matched; on failure, flush the collected failing-branch leaves
+      // flat and append a single childless `oneOf` marker (carrying the
+      // observed match count). The buffer may be null when more than one
+      // branch matched and none failed; `appendErrors` is null-safe.
       const matched = ctx.gen.scope.name("oneOfMatched");
       ctx.gen.let(matched, "0");
       const buf = ctx.gen.scope.name("oneOfBuf");
@@ -333,15 +426,17 @@ export const notKeyword: KeywordDefinition = {
   applicator: true,
   compile(ctx: KeywordCompileContext): void {
     const sub = ctx.schema as SchemaOrBoolean;
-    const fn = ctx.compileSubschema(sub);
+    // `not` consumes only the sub's pass/fail and never surfaces its
+    // errors or annotations, so compile it as a predicate regardless of
+    // this function's mode. The valid path (sub fails -> `not` passes)
+    // then builds no throwaway error tree. `predFn(data)` is `true` iff
+    // the sub matches, which is exactly when `not` must report.
+    const predFn = ctx.compileSubschema(sub, "predicate");
     if (ctx.predicate) {
-      // If the sub validates, `not` fails; short-circuit.
-      ctx.gen.line(`if (${fn}(${ctx.data})) return false;`);
+      ctx.gen.line(`if (${predFn}(${ctx.data})) return false;`);
       return;
     }
-    const errVar = ctx.gen.scope.name("notErr");
-    ctx.gen.const(errVar, `${fn}(${ctx.data}, ${ctx.path})`);
-    ctx.gen.if(`${errVar} === null`, () => {
+    ctx.gen.if(`${predFn}(${ctx.data})`, () => {
       ctx.emitError(
         "leaf",
         ctx.leafErrorExpr(quoteString("not"), `"must NOT match the schema"`, `{}`),
@@ -366,9 +461,40 @@ export const ifThenElseKeyword: KeywordDefinition = {
     const ifSchema = ctx.schema as SchemaOrBoolean;
     const thenSchema = ctx.parentSchema.then;
     const elseSchema = ctx.parentSchema.else;
-    const ifFn = ctx.compileSubschema(ifSchema);
     const outProps = ctx.evaluatedPropertiesVar;
     const outItems = ctx.evaluatedItemsVar;
+
+    // Two-phase: when this scope tracks no evaluated keys, the `if`
+    // condition's only consumed output is its pass/fail (its annotations
+    // would only matter for `unevaluated*`), so compile it as a predicate
+    // and skip building, then discarding, its error tree on the common
+    // else-taken path. `then` / `else` stay in error mode -- their errors
+    // are reported.
+    if (!ctx.predicate && outProps === null && outItems === null) {
+      const ifPred = ctx.compileSubschema(ifSchema, "predicate");
+      ctx.gen.if(
+        `${ifPred}(${ctx.data})`,
+        (g) => {
+          if (thenSchema !== undefined) {
+            const tFn = ctx.compileSubschema(thenSchema);
+            const tErr = g.scope.name("thenErr");
+            g.const(tErr, `${tFn}(${ctx.data}, ${ctx.path})`);
+            g.if(`${tErr} !== null`, () => ctx.emitError("lift", tErr));
+          }
+        },
+        (g) => {
+          if (elseSchema !== undefined) {
+            const eFn = ctx.compileSubschema(elseSchema);
+            const eErr = g.scope.name("elseErr");
+            g.const(eErr, `${eFn}(${ctx.data}, ${ctx.path})`);
+            g.if(`${eErr} !== null`, () => ctx.emitError("lift", eErr));
+          }
+        },
+      );
+      return;
+    }
+
+    const ifFn = ctx.compileSubschema(ifSchema);
     const ifProps = ctx.gen.scope.name("ifProps");
     const ifItems = ctx.gen.scope.name("ifItems");
     ctx.gen.const(ifProps, outProps !== null ? "new Set()" : "undefined");

--- a/packages/schema/src/keywords/context.ts
+++ b/packages/schema/src/keywords/context.ts
@@ -2,6 +2,7 @@ import type { SchemaObject, SchemaOrBoolean } from "@oav/core";
 import { NAMES, pathJoinExpr, rawExpr, type CodeGen } from "../codegen/index.js";
 import type {
   CompileAndCallOptions,
+  CompileMode,
   ErrorKind,
   KeywordCompileContext,
   KeywordDefinition,
@@ -29,7 +30,7 @@ export interface KeywordContextInputs {
    * {@link KeywordCompileContext.pathSegments}. Defaults to empty.
    */
   pathSegments?: readonly string[];
-  compileSubschema: (schema: SchemaOrBoolean) => string;
+  compileSubschema: (schema: SchemaOrBoolean, mode?: CompileMode) => string;
   resolveRef: (ref: string) => string;
   /**
    * Whether a `$ref` is a recursion back-edge (its target is still on
@@ -67,6 +68,13 @@ export interface KeywordContextInputs {
    * with {@link KeywordContextInputs.predicate}.
    */
   flat?: boolean;
+  /**
+   * Whether the compile unit uses `unevaluated*` (functions thread
+   * evaluated-key out-params). Defaults to `false`. Gates the
+   * predicate-decision optimization in composition keywords. See
+   * {@link KeywordCompileContext.unevaluatedTracking}.
+   */
+  unevaluatedTracking?: boolean;
   /**
    * The compiler's full keyword registry. Used by
    * {@link KeywordCompileContext.validateSubschema} to inline a
@@ -201,6 +209,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
   const depthGated = inputs.depthGated ?? false;
   const predicate = inputs.predicate ?? false;
   const flat = inputs.flat ?? false;
+  const unevaluatedTracking = inputs.unevaluatedTracking ?? false;
   const isRecursiveRef = inputs.isRecursiveRef ?? ((): boolean => false);
   const pathSegments = inputs.pathSegments ?? EMPTY_PATH_SEGMENTS;
   const effectivePathExpr =
@@ -608,6 +617,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
     depthGated,
     predicate,
     flat,
+    unevaluatedTracking,
     errorStatement,
     emitError,
     appendErrorsStatement,

--- a/packages/schema/src/keywords/types.ts
+++ b/packages/schema/src/keywords/types.ts
@@ -25,6 +25,24 @@ export interface CompileRuntime {
 export type ErrorKind = "leaf" | "lift";
 
 /**
+ * The output shape a compiled (sub)validator produces:
+ *
+ * - `"tree"`: returns a nested `ValidationError | null` (the default).
+ * - `"flat"`: returns a de-nested `ValidationError[] | null`.
+ * - `"predicate"`: returns a `boolean` and builds no errors.
+ *
+ * Usually a subschema compiles in its enclosing function's mode. The
+ * composition keywords request `"predicate"` explicitly for branches
+ * whose result is consumed only as a yes/no (the decision phase of
+ * `anyOf` / `oneOf`, the `not` assertion, the `if` condition), so the
+ * valid path never builds an error tree it then discards. See
+ * {@link KeywordCompileContext.compileSubschema}.
+ *
+ * @public
+ */
+export type CompileMode = "tree" | "flat" | "predicate";
+
+/**
  * Options for {@link KeywordCompileContext.validateSubschema}.
  *
  * @public
@@ -99,8 +117,15 @@ export interface KeywordCompileContext {
    * keywords are better served by
    * {@link KeywordCompileContext.compileAndCallSubschema}, which also
    * hides the predicate-vs-tree call-signature split.
+   *
+   * `mode` overrides the output shape of the compiled function. It
+   * defaults to the enclosing function's mode. Pass `"predicate"` to
+   * compile a branch whose result is consumed only as a boolean (its
+   * function takes `(data)` and returns `boolean`); pass the enclosing
+   * mode (or omit) for a branch whose errors are reported. See
+   * {@link CompileMode}.
    */
-  compileSubschema(schema: SchemaOrBoolean): string;
+  compileSubschema(schema: SchemaOrBoolean, mode?: CompileMode): string;
   /**
    * Compile a subschema and emit a call + pass/fail branch, abstracting
    * over the two call conventions:
@@ -180,6 +205,17 @@ export interface KeywordCompileContext {
    * {@link KeywordCompileContext.predicate}.
    */
   readonly flat: boolean;
+  /**
+   * `true` when the compile unit uses `unevaluatedProperties` /
+   * `unevaluatedItems` anywhere, so functions thread evaluated-key
+   * out-params. Composition keywords read this to gate the two-phase
+   * (predicate-decision) optimization: predicate sub-validators don't
+   * produce evaluated keys, so when tracking is on, branches whose
+   * annotations must merge (`anyOf` / `oneOf` matches, the `if`
+   * condition) keep the eager error-mode path instead. (`not` never
+   * contributes evaluated keys, so it ignores this.)
+   */
+  readonly unevaluatedTracking: boolean;
   /**
    * Emit an error-push statement directly into the current code
    * generator. Pick the right `kind` based on where the error


### PR DESCRIPTION
Closes #338.

Subschemas whose result is consumed only as a boolean now compile in
predicate mode, so the valid path no longer builds an error tree it
immediately discards. The unifying principle: compile a branch as a
predicate when only its pass/fail is consumed.

## What changed

- **`not`**: always uses a predicate sub (its result is purely a yes/no
  and it never contributes annotations).
- **`if`**: when the scope tracks no evaluated keys, the condition
  compiles as a predicate; `then`/`else` stay error-mode.
- **`anyOf` / `oneOf`**: when the scope tracks no evaluated keys, decide
  with predicate-compiled branches (`anyOf` short-circuits on first
  match; `oneOf` counts), and only on failure re-run all branches in
  error mode to materialize the errors.
- **`allOf` unchanged** -- a passing branch allocates nothing, so no
  valid-path waste.

Foundation (first commit): compile mode (`tree`/`flat`/`predicate`) is
now threaded per-subschema instead of a global flag, and `compiledFor`
is keyed by `(mode, schema)` so a branch can have both a predicate-mode
and an error-mode function. Pure refactor, no output change.

Gated on the scope tracking no evaluated keys: predicate sub-validators
don't thread the unevaluated-keys out-params, so `unevaluated*` schemas
keep the eager error-mode path.

## Performance

`composition` valid: **5.08M -> 13.9M ops/s (2.73x)**; gap to ajv
**3.89x -> 1.42x**. Schemas without hot-path `oneOf`/`anyOf`/`not`/`if`
are unchanged within noise.

Tradeoff: `composition` *invalid* ~14% slower (two-phase validates twice
on the failure path: decide, then report). Valid is the common path, so
this is a good trade.

## Correctness

- Whole JSON Schema Test Suite (1290 cases): identical verdict AND
  mismatch set to pre-change in both tree and flat mode.
- `oneOf` >1-match and `anyOf`/`not`/`if` error-tree shapes preserved on
  failure (re-running all branches reproduces the eager output).
- 1144 workspace tests, lint, typecheck green.