### PR TITLE
perf(schema): cheaper property presence via !== undefined

### DIFF
--- a/packages/schema/src/keywords/composition.ts
+++ b/packages/schema/src/keywords/composition.ts
@@ -1,5 +1,6 @@
 import { quoteString } from "../codegen/index.js";
 import type { SchemaOrBoolean } from "@oav/core";
+import { propertyAbsent, propertyPresent } from "./object-validation.js";
 import type { KeywordCompileContext, KeywordDefinition } from "./types.js";
 import { APPLICATOR_VOCAB } from "./vocabulary-uris.js";
 
@@ -575,7 +576,7 @@ export const dependentSchemasKeyword: KeywordDefinition = {
           if (sub === undefined) continue;
           const fn = ctx.compileSubschema(sub);
           const keyLit = quoteString(name);
-          g.if(`Object.prototype.hasOwnProperty.call(${ctx.data}, ${keyLit})`, (gi) => {
+          g.if(propertyPresent(ctx.data, keyLit, name), (gi) => {
             if (ctx.predicate) {
               gi.line(`if (!${fn}(${ctx.data}, ${passProps}, ${passItems})) return false;`);
               return;
@@ -614,10 +615,10 @@ export const dependenciesKeyword: KeywordDefinition = {
           const triggerLit = quoteString(trigger);
           if (Array.isArray(entry)) {
             // Array form → required-property semantics.
-            g.if(`Object.prototype.hasOwnProperty.call(${ctx.data}, ${triggerLit})`, (gi) => {
+            g.if(propertyPresent(ctx.data, triggerLit, trigger), (gi) => {
               for (const prop of entry) {
                 const propLit = quoteString(prop);
-                gi.if(`!Object.prototype.hasOwnProperty.call(${ctx.data}, ${propLit})`, () => {
+                gi.if(propertyAbsent(ctx.data, propLit, prop), () => {
                   ctx.emitError(
                     "leaf",
                     ctx.leafErrorExpr(
@@ -633,7 +634,7 @@ export const dependenciesKeyword: KeywordDefinition = {
           } else {
             // Schema form → dependent-schema semantics.
             const fn = ctx.compileSubschema(entry);
-            g.if(`Object.prototype.hasOwnProperty.call(${ctx.data}, ${triggerLit})`, (gi) => {
+            g.if(propertyPresent(ctx.data, triggerLit, trigger), (gi) => {
               if (ctx.predicate) {
                 gi.line(`if (!${fn}(${ctx.data})) return false;`);
                 return;
@@ -667,10 +668,10 @@ export const dependentRequiredKeyword: KeywordDefinition = {
           const required = deps[trigger];
           if (required === undefined) continue;
           const triggerLit = quoteString(trigger);
-          g.if(`Object.prototype.hasOwnProperty.call(${ctx.data}, ${triggerLit})`, (gi) => {
+          g.if(propertyPresent(ctx.data, triggerLit, trigger), (gi) => {
             for (const prop of required) {
               const propLit = quoteString(prop);
-              gi.if(`!Object.prototype.hasOwnProperty.call(${ctx.data}, ${propLit})`, () => {
+              gi.if(propertyAbsent(ctx.data, propLit, prop), () => {
                 ctx.emitError(
                   "leaf",
                   ctx.leafErrorExpr(

--- a/packages/schema/src/keywords/object-validation.ts
+++ b/packages/schema/src/keywords/object-validation.ts
@@ -7,6 +7,58 @@ function isObjectGuard(dataExpr: string): string {
 }
 
 /**
+ * Property names that live on `Object.prototype` (plus `__proto__`). For
+ * these, `data[key] !== undefined` is `true` even when the object does
+ * not own the key (it's inherited), so a presence check on one of these
+ * names MUST use `hasOwnProperty`. Every other name is safe to check with
+ * the cheaper `!== undefined`. From `Object.getOwnPropertyNames(Object.prototype)`.
+ */
+const INHERITED_PROPERTY_NAMES = new Set([
+  "constructor",
+  "hasOwnProperty",
+  "isPrototypeOf",
+  "propertyIsEnumerable",
+  "toLocaleString",
+  "toString",
+  "valueOf",
+  "__proto__",
+  "__defineGetter__",
+  "__defineSetter__",
+  "__lookupGetter__",
+  "__lookupSetter__",
+]);
+
+/**
+ * JS expression: property `keyExpr` is present on `dataExpr`.
+ *
+ * When the literal name is known and safe, uses `!== undefined` rather
+ * than `Object.prototype.hasOwnProperty.call`: the JSON data model has no
+ * `undefined`, so for parsed wire data the two are equivalent, and for
+ * in-memory objects an `undefined`-valued property is dropped by
+ * `JSON.stringify` anyway (so "absent" matches the wire). This is ajv's
+ * default and is markedly cheaper than a `hasOwnProperty` call on every
+ * check. Falls back to `hasOwnProperty` when the name is omitted (a
+ * runtime key) or is an inherited `Object.prototype` name, where
+ * `!== undefined` would wrongly report an inherited member as present.
+ * The single source of truth for presence so a future
+ * `ownProperties`-style strict option has one place to switch.
+ */
+export function propertyPresent(dataExpr: string, keyExpr: string, keyName?: string): string {
+  if (keyName === undefined || INHERITED_PROPERTY_NAMES.has(keyName)) {
+    return `Object.prototype.hasOwnProperty.call(${dataExpr}, ${keyExpr})`;
+  }
+  return `${dataExpr}[${keyExpr}] !== undefined`;
+}
+
+/** Negation of {@link propertyPresent}: property `keyExpr` is absent. */
+export function propertyAbsent(dataExpr: string, keyExpr: string, keyName?: string): string {
+  if (keyName === undefined || INHERITED_PROPERTY_NAMES.has(keyName)) {
+    return `!Object.prototype.hasOwnProperty.call(${dataExpr}, ${keyExpr})`;
+  }
+  return `${dataExpr}[${keyExpr}] === undefined`;
+}
+
+/**
  * The object-shape guard, computed once per validator-function scope and
  * shared across every object keyword on the same schema (`type`,
  * `required`, `properties`, `additionalProperties`, ...). Without this
@@ -90,23 +142,30 @@ export const requiredKeyword: KeywordDefinition = {
     const required = ctx.schema as string[];
     if (required.length === 0) return;
     const requiredVar = ctx.hoistConstant(JSON.stringify(required), "required");
+    // The loop variable is dynamic, but the set of names is fixed at
+    // compile time: if none of them is an inherited `Object.prototype`
+    // name, every iteration is safe to check with the cheap
+    // `data[_req] === undefined`; otherwise fall back to `hasOwnProperty`
+    // for the whole loop. Keeps `required` consistent with `properties`
+    // (an `undefined`-valued safe property is "absent" in both).
+    const absent = required.every((k) => !INHERITED_PROPERTY_NAMES.has(k))
+      ? `${ctx.data}[_req] === undefined`
+      : `!Object.prototype.hasOwnProperty.call(${ctx.data}, _req)`;
     if (ctx.predicate) {
       ctx.gen.if(objectGuardVar(ctx), (g) => {
         g.forOf("_req", requiredVar, (gi) => {
-          gi.line(`if (!Object.prototype.hasOwnProperty.call(${ctx.data}, _req)) return false;`);
+          gi.line(`if (${absent}) return false;`);
         });
       });
       return;
     }
     // Single pass: emit one leaf per missing key directly from the
-    // membership scan. The errors come out in `required`-array order
-    // (the scan order), which is the same order the previous
-    // collect-into-`missing`-then-replay form produced, and the budget
-    // break lands after the same key, so the error tree and truncation
-    // flag are unchanged. The intermediate `missing` array is just gone.
+    // membership scan. The loop is kept so `emitBudgetBreak` can `break`
+    // out of it on budget exhaustion; error order and the truncation
+    // flag are unchanged.
     ctx.gen.if(objectGuardVar(ctx), (g) => {
       g.forOf("_req", requiredVar, (gi) => {
-        gi.if(`!Object.prototype.hasOwnProperty.call(${ctx.data}, _req)`, () => {
+        gi.if(absent, () => {
           ctx.emitError(
             "leaf",
             ctx.leafErrorExpr(

--- a/packages/schema/src/keywords/properties.ts
+++ b/packages/schema/src/keywords/properties.ts
@@ -1,5 +1,6 @@
 import { NAMES, quoteString } from "../codegen/index.js";
 import type { SchemaOrBoolean } from "@oav/core";
+import { propertyPresent } from "./object-validation.js";
 import type { KeywordCompileContext, KeywordDefinition } from "./types.js";
 import { APPLICATOR_VOCAB } from "./vocabulary-uris.js";
 
@@ -46,7 +47,7 @@ export const propertiesKeyword: KeywordDefinition = {
         const subSchema = props[name];
         if (subSchema === undefined) continue;
         const keyLit = quoteString(name);
-        g.if(`Object.prototype.hasOwnProperty.call(${ctx.data}, ${keyLit})`, (gi) => {
+        g.if(propertyPresent(ctx.data, keyLit, name), (gi) => {
           let dataExpr = `${ctx.data}[${keyLit}]`;
           if (bindsValue(subSchema)) {
             const valueVar = gi.scope.name("v");

--- a/packages/schema/test/property-presence.test.ts
+++ b/packages/schema/test/property-presence.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { compileSchema } from "../src/compiler/compiler.js";
+import { jsonSchemaDialect } from "../src/keywords/vocabulary.js";
+
+function valid(schema: unknown, data: unknown): boolean {
+  return compileSchema(schema as never, { dialect: jsonSchemaDialect }).validate(data).valid;
+}
+
+// Presence is checked with `data[key] !== undefined` for ordinary
+// property names (cheaper than `hasOwnProperty`), falling back to
+// `hasOwnProperty` for names that live on `Object.prototype`. These tests
+// pin both the optimization's correctness and the resulting semantics:
+// an `undefined`-valued property is treated as absent (matching JSON
+// serialization, where `JSON.stringify` drops it).
+describe("property presence semantics", () => {
+  describe("undefined value is treated as absent", () => {
+    it("required: an undefined-valued property counts as missing", () => {
+      expect(valid({ required: ["foo"] }, { foo: undefined })).toBe(false);
+    });
+
+    it("required: a null-valued property counts as present", () => {
+      expect(valid({ required: ["foo"] }, { foo: null })).toBe(true);
+    });
+
+    it("properties: an undefined-valued property is not validated (absent)", () => {
+      expect(valid({ properties: { foo: { type: "string" } } }, { foo: undefined })).toBe(true);
+    });
+
+    it("properties: a null-valued property is validated (present)", () => {
+      expect(valid({ properties: { foo: { type: "string" } } }, { foo: null })).toBe(false);
+    });
+
+    it("required + properties agree: undefined-valued required prop fails as missing", () => {
+      const schema = { required: ["foo"], properties: { foo: { type: "string" } } };
+      expect(valid(schema, { foo: undefined })).toBe(false);
+    });
+
+    it("dependentRequired: an undefined-valued trigger does not fire", () => {
+      expect(valid({ dependentRequired: { a: ["b"] } }, { a: undefined })).toBe(true);
+    });
+
+    it("dependentRequired: a present trigger requires its companions", () => {
+      expect(valid({ dependentRequired: { a: ["b"] } }, { a: 1 })).toBe(false);
+    });
+  });
+
+  describe("inherited Object.prototype names use hasOwnProperty (not !== undefined)", () => {
+    for (const name of ["toString", "constructor", "valueOf", "hasOwnProperty", "__proto__"]) {
+      it(`required: "${name}" is missing on a plain object`, () => {
+        expect(valid({ required: [name] }, {})).toBe(false);
+      });
+
+      it(`properties: "${name}" subschema is not applied to an inherited member`, () => {
+        // The object does not own "${name}"; the inherited member must not
+        // be picked up and validated.
+        expect(valid({ properties: { [name]: { type: "string" } } }, {})).toBe(true);
+      });
+    }
+
+    it("required: an inherited name IS satisfied when actually present as an own property", () => {
+      expect(valid({ required: ["toString"] }, { toString: "x" })).toBe(true);
+    });
+
+    it("required: mixing a safe and an inherited name still checks both", () => {
+      expect(valid({ required: ["id", "toString"] }, { id: 1 })).toBe(false);
+      expect(valid({ required: ["id", "toString"] }, { id: 1, toString: "x" })).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Closes the object/property-validation gap vs ajv (the frontier left after
#337/#342).

## What

Object presence checks (`required`, `properties`, `dependentRequired`,
`dependencies`, `dependentSchemas`) used `hasOwnProperty.call` on every
property. For names that aren't inherited `Object.prototype` members,
`data[key] !== undefined` is equivalent for JSON data and much cheaper.
The choice is made **per key at compile time**:

- inherited names (`toString`, `constructor`, `valueOf`, `__proto__`,
  ...) keep `hasOwnProperty` (where `!== undefined` would wrongly report
  an inherited member as present);
- `required` decides once for its whole loop (safe iff every name is
  safe), so the budget-break loop is preserved.

## Performance (synthetic bench, valid path)

| schema | before | after | speedup | ajv/oav: was -> now |
|---|--:|--:|--:|--:|
| array-heavy | 369K | 662K | **1.80x** | 2.63x -> **1.48x** |
| petstore | 14.8M | 20.2M | **1.37x** | 1.59x -> **1.16x** |
| composition | 13.9M | 15.4M | 1.11x | 1.42x -> 1.25x |
| tree | 22.1M | 24.8M | 1.12x | -> **0.97x (oav ahead)** |

Invalid paths improve similarly. Schemas without object keywords are
unchanged.

## Breaking? Narrowly, yes

A property whose value is `undefined` is now treated as **absent**,
consistently across all the presence-checking keywords.

- **Parsed JSON (the primary use case): no-op** -- JSON has no `undefined`.
- **In-memory objects**: matches `JSON.stringify` (which drops
  `undefined`-valued keys), so it's the wire-accurate result, but the
  validity verdict can change for `{ foo: undefined }`-style inputs
  (e.g. `required: ["foo"]` flips valid -> invalid).

This belongs with the planned v3 "match ajv defaults" batch (alongside
flat-default and `maxErrors: 1`). **Not** gated behind an option: gating
would hide the win from the zero-config benchmark a drive-by evaluator
runs. If we want release-please to cut v3 from this, add a
`BREAKING CHANGE:` footer before merge.

## Verification

- Whole JSON Schema Test Suite (1290 cases): identical verdict + mismatch
  set to baseline in **both** tree and flat mode (covers the inherited-
  name cases like `required: ["toString"]`).
- 19 new presence tests pin the undefined-as-absent semantics and the
  inherited-name correctness.
- 1144 workspace tests, lint, typecheck green.