### PR TITLE
feat!: v3 - flat error output and maxErrors:1 as zero-config defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,17 +262,35 @@ contract". Two gotchas the docs can't enforce, worth keeping in view:
   JS source, so the compiler can't check the `code`/`params` contract;
   drift between the emitted shape and that type is a silent bug.
 
-## Error budget and predicate mode
+## Output modes and the error budget
 
-User-facing `maxErrors` and predicate mode are documented in
-[docs/configuration.md](./docs/configuration.md) and
-[docs/extending.md](./docs/extending.md). Codegen is specialized so
-unset `maxErrors` emits source identical to the un-budgeted path (zero
-overhead). The one gotcha for keyword authors: the `kind` on
-`ctx.emitError` (`"leaf"` counts against the budget, `"lift"` is an
-already-counted child being propagated and never touches the counter).
-Pick wrong and the budget silently miscounts. TypeScript forces the
-choice; the correctness of it is on the author.
+The zero-config default is `output: "flat"` + `maxErrors: 1` (Ajv
+parity). `output` (`"flat" | "tree" | "predicate"`) selects the result
+shape; the deprecated `flat` / `predicate` booleans are aliases that
+throw on conflict. `maxErrors` defaults to `1` and is orthogonal to
+`output`. User-facing docs are in
+[docs/configuration.md](./docs/configuration.md),
+[docs/extending.md](./docs/extending.md), and the v3
+[migration guide](./docs/migration-v3.md).
+
+Codegen is specialized so `maxErrors: Infinity` emits source identical
+to the un-budgeted path (zero overhead). The one gotcha for keyword
+authors: the `kind` on `ctx.emitError` (`"leaf"` counts against the
+budget, `"lift"` is an already-counted child being propagated and never
+touches the counter). Pick wrong and the budget silently miscounts.
+TypeScript forces the choice; the correctness of it is on the author.
+
+A finite `maxErrors` must never change a valid/invalid verdict (it only
+caps how many errors are _reported_). The budget short-circuit is unsafe
+under evaluated-key tracking: a cap can exhaust mid-evaluation and
+either starve a real error or truncate a sub-validator's evaluated-key
+set, flipping an `unevaluated*` verdict. So `CompileState.gated` is
+`finite maxErrors && !unevaluatedTracking`: schemas that use
+`unevaluatedProperties` / `unevaluatedItems` collect every error (the
+cap is not enforced). `unevaluated*` never appears in OpenAPI, so the
+HTTP fast path is unaffected. Relatedly, `contains` tests membership
+with a predicate sub-validator (never charging the budget for its
+discarded per-item errors).
 
 ## Version support
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ const { document } = await loadSpec({
 });
 const validator = createValidator(document);
 
-const err = validator.validateRequest({
+const result = validator.validateRequest({
   method: "POST",
   path: "/pets",
   contentType: "application/json",
@@ -111,19 +111,23 @@ const err = validator.validateRequest({
   body: { name: "Fido" },
 });
 
-if (err !== null) console.error(formatText(err));
+if (!result.valid) console.error(formatText(result.errors));
 ```
 
 For a multi-file spec or a spec hosted over HTTP, compose readers:
 `composeReaders([createYamlFileReader(), createSmartHttpReader(), createFileReader()])`
 handles local YAML, remote JSON / YAML, and local JSON transparently.
 
-`validateRequest` / `validateResponse` return `null` on success or a
-`ValidationError` tree on failure. Every error carries a stable `code`
-(e.g. `"type"`, `"required"`, `"content-type"`, `"oneOf"`), a `path`
-rooted at the HTTP frame (e.g. `["body", "pets", 3, "name"]`), a
-human-readable `message`, and a machine-readable `params` object whose
-shape per code is documented in `BuiltInErrorParams`.
+`validateRequest` / `validateResponse` return `{ valid: true }` on
+success, or `{ valid: false, errors, truncated }` on failure. The
+zero-config default is a flat `errors` list that stops at the first
+problem (`maxErrors: 1`), matching Ajv's defaults; raise `maxErrors` to
+collect more, or pass `output: "tree"` for a nested error tree under
+`error` (or `output: "predicate"` for a bare boolean). Every error
+carries a stable `code` (e.g. `"type"`, `"required"`, `"content-type"`,
+`"oneOf"`), a `path` rooted at the HTTP frame (e.g. `["body", "pets", 3,
+"name"]`), a human-readable `message`, and a machine-readable `params`
+object whose shape per code is documented in `BuiltInErrorParams`.
 
 Runnable end-to-end demos in [`examples/`](./examples/README.md):
 custom formats, custom keywords, cross-field constraints, error
@@ -223,7 +227,7 @@ Both libraries are sub-microsecond per check on typical OpenAPI
 bodies. On complex `oneOf`/`allOf` or large arrays, Ajv leads by
 2–4× (say 100 ns to 400 ns per call, or 1.7 µs to 4 µs); oav leads
 on `uniqueItems` arrays and length-bounded strings. oav's
-`predicate` mode (`compileSchema(..., { predicate: true })`) closes
+`predicate` mode (`compileSchema(..., { output: "predicate" })`) closes
 most of Ajv's lead on the complex shapes for yes/no use cases.
 
 For typical HTTP workloads (1k–10k req/sec × ~1 validation per
@@ -322,7 +326,7 @@ inline Express 5 adapter is about this long:
 import { allowHeaderFor, httpStatusFor, toProblemDetails } from "@aahoughton/oav";
 
 app.use(async (req, res, next) => {
-  const err = validator.validateRequest({
+  const result = validator.validateRequest({
     method: req.method,
     path: req.path,
     query: req.query as Record<string, string | string[]>,
@@ -330,15 +334,19 @@ app.use(async (req, res, next) => {
     contentType: req.get("content-type") ?? undefined,
     body: req.body,
   });
-  if (err === null) return next();
-  const allow = allowHeaderFor(err);
+  if (result.valid) return next();
+  const allow = allowHeaderFor(result.errors);
   if (allow !== undefined) res.setHeader("Allow", allow);
   res
-    .status(httpStatusFor(err))
+    .status(httpStatusFor(result.errors))
     .type("application/problem+json")
-    .json(toProblemDetails(err, { instance: req.originalUrl }));
+    .json(toProblemDetails(result.errors, { instance: req.originalUrl }));
 });
 ```
+
+`httpStatusFor`, `allowHeaderFor`, and `toProblemDetails` accept either
+the flat `errors` list or a tree `error`, so this wiring is the same
+whichever `output` the validator uses.
 
 Companion adapter packages cover common request-validation wiring:
 [`oav-express4`](./packages/oav-express4/README.md),
@@ -358,8 +366,8 @@ The adapters cover request validation; response validation, auth
 dispatch, upload parsing, and custom error envelopes stay explicit in
 your application. In return, the validator does not mutate `req` or
 `res`, OpenAPI 3.0 behavior is built into the dialect, and failures
-come back as structured error trees rather than framework-specific
-error classes.
+come back as structured errors (a flat list by default, a nested tree
+on request) rather than framework-specific error classes.
 
 ## Known limitations
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ openapi.yaml` emits a single zero-dependency ES module exposing
 "POST /pets"` (repeatable) scopes the output to specific
   operations without touching the source spec.
 
-Errors come back as a typed tree (`code`, `path`, `message`,
-`params`, `children`). One validator call covers the full HTTP
-frame: method, path, parameters, body, content type, status, and
-headers.
+Errors come back as a flat list of typed leaves (`code`, `path`,
+`message`, `params`) by default, or a nested tree on request. One
+validator call covers the full HTTP frame: method, path, parameters,
+body, content type, status, and headers.
 
 If you only need generic JSON Schema validation across many drafts,
 start with Ajv. If you want a one-line Express middleware with file
@@ -211,28 +211,30 @@ hardware will vary.
 
 **Compile: oav is meaningfully faster.**
 
-|                                            | Ajv   | oav       |
-| ------------------------------------------ | ----- | --------- |
-| Single synthetic schema (varies by shape)  | ~6 ms | 25–200 µs |
-| Real-world spec (petstore-31, ~10 schemas) | 27 ms | 1.6 ms    |
+|                                            | Ajv     | oav       |
+| ------------------------------------------ | ------- | --------- |
+| Single synthetic schema (varies by shape)  | ~2.7 ms | 15–200 µs |
+| Real-world spec (petstore-31, ~10 schemas) | 27 ms   | 1.6 ms    |
 
 Ajv compile is essentially constant overhead per schema; oav scales
-with shape. The advantage shows up wherever validator construction
-sits in the hot path: per-request, per-tenant, per-test, edge
-cold-start, AOT module emit.
+with shape, running 20–175× faster across the synthetic shapes and
+~5–8× on real-world specs (Stripe, Adyen). The advantage shows up
+wherever validator construction sits in the hot path: per-request,
+per-tenant, per-test, edge cold-start, AOT module emit.
 
-**Validate: roughly tied on simple shapes; Ajv wins on complex.**
+**Validate: close on typical shapes at matched defaults.**
 
-Both libraries are sub-microsecond per check on typical OpenAPI
-bodies. On complex `oneOf`/`allOf` or large arrays, Ajv leads by
-2–4× (say 100 ns to 400 ns per call, or 1.7 µs to 4 µs); oav leads
-on `uniqueItems` arrays and length-bounded strings. oav's
-`predicate` mode (`compileSchema(..., { output: "predicate" })`) closes
-most of Ajv's lead on the complex shapes for yes/no use cases.
+Comparing each library's zero-config default (oav flat + `maxErrors: 1`
+against Ajv `allErrors: false`, both stopping at the first error): the
+two are within ~25% on typical request bodies (small objects, recursive
+trees, large arrays). Ajv leads by ~2.5× on `oneOf` / `allOf` rejection,
+where oav materialises the composition error; oav's `predicate` mode
+(`compileSchema(..., { output: "predicate" })`) reaches parity there.
+oav leads ~1.6–3× on `uniqueItems` arrays.
 
 For typical HTTP workloads (1k–10k req/sec × ~1 validation per
-request), the difference is invisible at any of those numbers. For
-validation-heavy code (millions of validations per second), Ajv wins.
+request), the difference is invisible. For validation-heavy code
+(millions of validations per second), measure your own shapes.
 
 Full per-shape breakdown: [`docs/comparison.md`](./docs/comparison.md). Raw
 benchmark data and methodology:

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -39,22 +39,31 @@ the shape of the trade-off is sketched below.
 
 ## Performance sketch
 
-Ajv and oav trade differently depending on the workload:
+The numbers below compare matched defaults: oav's zero-config output
+(flat, `maxErrors: 1`) against Ajv's zero-config `allErrors: false`.
+Both stop at the first error. Validate ratios are oav ÷ Ajv, so `1.00`
+is parity, above is oav faster, below is Ajv faster. Synthetic bench,
+one machine; treat them as orders of magnitude, not exact figures.
 
-| Workload                                                | Winner                                                             | Notes                                                                 |
-| ------------------------------------------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------- |
-| Validate, simple schemas (tiny / tree)                  | tied                                                               | Within ~10% either way; predicate mode slightly ahead of ajv          |
-| Validate, complex shapes (oneOf / allOf, large arrays)  | ajv 2–5× faster                                                    | ajv's codegen excels on deep applicators                              |
-| Validate, `uniqueItems` arrays / length-bounded strings | **oav faster**                                                     | oav ~1.5–3× on `uniqueItems`; larger margin on length-bounded strings |
-| Validate, predicate mode                                | ≈ ajv                                                              | `compileSchema(..., { output: "predicate" })` closes most of the gap  |
-| Compile, synthetic (per shape)                          | **oav 30–180× faster**                                             | The largest gap in either direction                                   |
-| Compile, real-world OpenAPI spec                        | **oav 8× on Stripe** (886 schemas); **5.5× on Adyen** (44 schemas) | Matches the synthetic trend at spec scale                             |
+| Workload                                            | oav ÷ Ajv | Notes                                                                                                                     |
+| --------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Validate, small objects (tiny / petstore)           | 0.75–1.0  | Within ~25%; Ajv a little ahead on the rejection path                                                                     |
+| Validate, recursive tree                            | ~1.0      | Tied                                                                                                                      |
+| Validate, large array of small objects              | 0.86–0.99 | Within ~15%                                                                                                               |
+| Validate, `oneOf` / `allOf` rejection               | ~0.4      | Ajv ~2.5× faster: oav materialises the composition error (more when collecting all). `output: "predicate"` reaches parity |
+| Validate, `uniqueItems` arrays                      | 1.6–3.2   | oav faster                                                                                                                |
+| Validate, predicate mode (vs Ajv `allErrors:false`) | 0.9–3.2   | At or above parity across shapes                                                                                          |
+| Compile, synthetic (per shape)                      | 20–175×   | oav faster                                                                                                                |
+| Compile, real-world OpenAPI spec                    | ~5–8×     | oav faster: ~8× on Stripe (886 schemas), ~5.5× on Adyen (44 schemas)                                                      |
 
-The takeaway: ajv wins steady-state validate throughput on a spec you
-compile once and reuse; oav wins anywhere validator construction is
-part of the hot path (per-request, per-tenant, per-test, edge
-cold-starts). Full methodology, raw numbers, and the benchmark
-harness live in [`performance/README.md`](../performance/README.md).
+The shape of the trade-off: on validate throughput the two are close on
+typical request bodies, Ajv leads on `oneOf` / `allOf` rejection, and
+oav leads on `uniqueItems` and predicate-mode checks. oav's larger and
+more consistent advantage is compile time, which matters wherever
+validator construction is in the hot path (per-request, per-tenant,
+per-test, edge cold-start, AOT module emit). Full methodology, raw
+numbers, and the benchmark harness live in
+[`performance/README.md`](../performance/README.md).
 
 ## Where Ajv (+ express-openapi-validator) does more
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -46,7 +46,7 @@ Ajv and oav trade differently depending on the workload:
 | Validate, simple schemas (tiny / tree)                  | tied                                                               | Within ~10% either way; predicate mode slightly ahead of ajv          |
 | Validate, complex shapes (oneOf / allOf, large arrays)  | ajv 2–5× faster                                                    | ajv's codegen excels on deep applicators                              |
 | Validate, `uniqueItems` arrays / length-bounded strings | **oav faster**                                                     | oav ~1.5–3× on `uniqueItems`; larger margin on length-bounded strings |
-| Validate, predicate mode                                | ≈ ajv                                                              | `compileSchema(..., { predicate: true })` closes most of the gap      |
+| Validate, predicate mode                                | ≈ ajv                                                              | `compileSchema(..., { output: "predicate" })` closes most of the gap  |
 | Compile, synthetic (per shape)                          | **oav 30–180× faster**                                             | The largest gap in either direction                                   |
 | Compile, real-world OpenAPI spec                        | **oav 8× on Stripe** (886 schemas); **5.5× on Adyen** (44 schemas) | Matches the synthetic trend at spec scale                             |
 
@@ -159,23 +159,24 @@ type: "string" }` to `{ type: ["string", "number", "boolean",
   externally-owned base spec at load time (add a required header to
   every operation, extend a component schema, swap a response shape)
   without forking or preprocessing the upstream file.
-- **Structured error tree.** Errors preserve the applicator structure
-  (`oneOf` with per-branch `children`, `allOf` with failed-conjunct
-  children). HTTP consumers can group by HTTP location
-  (`body.items[3].name`, `query.limit`) and inspect which branch of a
-  composition failed without parsing message strings. Ajv emits a
-  flat errors array.
-- **Predicate mode.** `compileSchema(schema, { predicate: true })`
+- **Opt-in structured error tree.** Like Ajv, the default output is a
+  flat errors array. Pass `output: "tree"` and errors instead preserve
+  the applicator structure (`oneOf` with per-branch `children`, `allOf`
+  with failed-conjunct children), so HTTP consumers can inspect which
+  branch of a composition failed without parsing message strings. Ajv
+  has no equivalent nested shape. Either way, leaves carry their HTTP
+  location in the path (`body.items[3].name`, `query.limit`).
+- **Predicate mode.** `compileSchema(schema, { output: "predicate" })`
   returns `{ validate: (x) => boolean }`. No error tree construction,
   no path snapshotting, no accumulator allocation. Ajv's
   `allErrors: false` still maintains error infrastructure; oav's
   predicate mode compiles to a different function entirely.
-- **Bounded error collection.** `maxErrors: N` caps the error tree at
-  N leaves; the generated code short-circuits hot loops when the
-  budget is exhausted. Ajv has `allErrors: true | false` but no
-  explicit count budget. When unset, oav's codegen emits plain
-  `errors.push` with no runtime checks; zero overhead for the
-  uncapped case.
+- **Explicit error budget.** `maxErrors: N` caps the errors collected
+  and short-circuits hot loops when the budget is exhausted. The default
+  is `1` (fast-fail, like Ajv's `allErrors: false`); Ajv has
+  `allErrors: true | false` but no explicit count budget. Pass
+  `Number.POSITIVE_INFINITY` for zero-overhead uncapped collection
+  (codegen emits plain `errors.push` with no budget checks).
 - **Direction-aware body transforms.** Request-body validators reject
   `readOnly` properties and exempt them from `required`; response-body
   validators do the same for `writeOnly`. Applied as a pre-compile

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,19 +5,20 @@ canonical reference is the
 [`ValidatorOptions`](../packages/validator/src/validator.ts) TSDoc;
 this page is a recipe-oriented overview.
 
-| Option                  | Effect                                                                                                                                                                                         |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dialect`               | Force a specific schema dialect, bypassing version detection.                                                                                                                                  |
-| `formats`               | Extra string format validators merged on top of the built-ins.                                                                                                                                 |
-| `keywords`              | Register user-defined schema keywords (see below).                                                                                                                                             |
-| `maxErrors`             | Cap on leaf errors; `1` is fast-fail, default is uncapped.                                                                                                                                     |
-| `strict`                | Compile-time schema lint mode: `"off"`, `"warn-partial"` (default), or `"strict"`. Issues surface via `validator.stats.strictIssues`.                                                          |
-| `strictQueryParameters` | Reject undeclared query parameters. Default `false`.                                                                                                                                           |
-| `validateSecurity`      | `"off"` (default), `"shape"` (check recognized schemes; pass on oauth2/oidc/mTLS), or `"strict"` (fail on unrecognized schemes). Boolean form deprecated; `true`->`"shape"`, `false`->`"off"`. |
-| `ignoreUndocumented`    | Return `null` on requests whose path the router can't match. Default `false`.                                                                                                                  |
-| `ignorePaths`           | Predicate `(path) => boolean`; returning `true` short-circuits validation to `null` before routing.                                                                                            |
-| `onUnknownVersion`      | Policy for specs with missing/unsupported `openapi`: `"fallback31"` (default), `"warn"`, or `"throw"`.                                                                                         |
-| `regexCompiler`         | Compiler for `pattern` keywords and `format: "regex"`. Defaults to `new RegExp(p, "u")` with a non-u fallback. Plug in `re2` or a safe-regex check for hardening; see below.                   |
+| Option                  | Effect                                                                                                                                                                       |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dialect`               | Force a specific schema dialect, bypassing version detection.                                                                                                                |
+| `formats`               | Extra string format validators merged on top of the built-ins.                                                                                                               |
+| `keywords`              | Register user-defined schema keywords (see below).                                                                                                                           |
+| `output`                | Result shape: `"flat"` (default; `{ valid, errors, truncated }`), `"tree"` (nested `{ valid, error, truncated }`), or `"predicate"` (bare boolean). Mirrors `compileSchema`. |
+| `maxErrors`             | Per-call total cap on leaf errors. Default `1` (fast-fail); pass `Number.POSITIVE_INFINITY` to collect every error.                                                          |
+| `strict`                | Compile-time schema lint mode: `"off"`, `"warn-partial"` (default), or `"strict"`. Issues surface via `validator.stats.strictIssues`.                                        |
+| `strictQueryParameters` | Reject undeclared query parameters. Default `false`.                                                                                                                         |
+| `validateSecurity`      | `"off"` (default), `"shape"` (check recognized schemes; pass on oauth2/oidc/mTLS), or `"strict"` (fail on unrecognized schemes).                                             |
+| `ignoreUndocumented`    | Return `null` on requests whose path the router can't match. Default `false`.                                                                                                |
+| `ignorePaths`           | Predicate `(path) => boolean`; returning `true` short-circuits validation to `null` before routing.                                                                          |
+| `onUnknownVersion`      | Policy for specs with missing/unsupported `openapi`: `"fallback31"` (default), `"warn"`, or `"throw"`.                                                                       |
+| `regexCompiler`         | Compiler for `pattern` keywords and `format: "regex"`. Defaults to `new RegExp(p, "u")` with a non-u fallback. Plug in `re2` or a safe-regex check for hardening; see below. |
 
 ## Custom keywords
 
@@ -37,21 +38,27 @@ Custom keywords plug into generated code alongside the built-ins. See
 end-to-end run, and `CustomKeywordValidator` in the TSDoc for the full
 return-shape contract (boolean, error object, or array of errors).
 
-## Bounded error collection
+## Error budget
+
+The validator stops at the first error by default (`maxErrors: 1`),
+matching Ajv's zero-config behaviour. The cap is a per-call total
+across every location (body, query, headers).
 
 ```ts
-createValidator(spec, { maxErrors: 1 }); // fast-fail
+createValidator(spec); // fast-fail: the first error
 createValidator(spec, { maxErrors: 10 }); // bound CPU/memory on huge payloads
+createValidator(spec, { maxErrors: Number.POSITIVE_INFINITY }); // every error
 ```
 
 Hot loops (array items, object properties, `allOf` / `anyOf` branches)
-short-circuit once the budget is exhausted. Results carry
-`truncated: true` so callers know the tree was capped.
+short-circuit once the budget is exhausted. A failing result carries
+`truncated: true` when the cap was reached, so callers know more
+problems may exist.
 
 `maxErrors` must be a positive integer (>= 1); `createValidator`
-throws on `0`, negative values, or non-integers. To opt out of error
-collection entirely (yes/no answers only), use `compileSchema(schema,
-{ predicate: true })` from `@aahoughton/oav/schema` instead.
+throws on `0`, negative values, or non-integers. For a yes/no answer
+with no errors collected at all, build the validator with
+`output: "predicate"`.
 
 ## Hardening against untrusted regex patterns
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -60,7 +60,7 @@ branches) so they stop once the cap is exhausted.
 
 ### Predicate mode
 
-`compileSchema(schema, { predicate: true })` compiles a `{ validate:
+`compileSchema(schema, { output: "predicate" })` compiles a `{ validate:
 (data) => boolean }` validator that builds no error tree: leaves don't
 allocate, paths aren't snapshotted, messages aren't formatted, and
 every failure short-circuits to `return false;`. Generated

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -61,39 +61,45 @@ interface HttpResponse {
 }
 ```
 
-Both methods return `null` on success or a `ValidationError` tree on
-failure. The top-level node's `code` is `"request"` or `"response"`;
-children hang off `body`, `query.<name>`, `headers.<name>`, etc.
+Both methods return a result object: `{ valid: true }` on success, or
+`{ valid: false, errors, truncated }` on failure. By default `errors`
+is a flat `ValidationError[]` (one entry per failing leaf), and
+`truncated` indicates whether the error budget cut the list short. Each
+error's `code`, dotted path, and pointer locate the failure under
+`body`, `query.<name>`, `headers.<name>`, etc.
 
 ## Supporting helpers
 
 All shipped from `oav` (or `oav-core` for the
 lean install). The recipes below assume these are in scope.
 
-- **`httpStatusFor(err, overrides?)`**: maps a `ValidationError`
-  tree to an HTTP status: `route` → 404, `method` → 405, `security`
+`httpStatusFor`, `allowHeaderFor`, `toProblemDetails`, and
+`collectIssues` each accept either a single `ValidationError` tree or
+a flat `ValidationError[]`, so `result.errors` passes straight through.
+
+- **`httpStatusFor(errors, overrides?)`**: maps the failure to an
+  HTTP status: `route` → 404, `method` → 405, `security`
   (leaf) → 401, `content-type` (leaf) → 415, `status` (leaf) → 500,
   everything else → 400. Pass `{ default: 422 }` (or any other key)
-  to override a slot. The helper inspects the tree correctly:
+  to override a slot. The helper inspects the failure correctly:
   writing this switch by hand is a common mistake, because
   `"content-type"` / `"security"` / `"status"` appear as leaves
-  under a top-level `"request"` / `"response"` branch, not as
-  `err.code` directly.
+  under a top-level `"request"` / `"response"` branch, not as a
+  top-level `code` directly.
 
-- **`allowHeaderFor(err)`**: returns the `Allow` header value for a
+- **`allowHeaderFor(errors)`**: returns the `Allow` header value for a
   405 (RFC 9110 §15.5.6 requires it) or `undefined` otherwise.
 
-- **`toProblemDetails(err, opts?)`**: renders the error tree as an
+- **`toProblemDetails(errors, opts?)`**: renders the failure as an
   [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html)
   `application/problem+json` body with the failing leaves carried in
   an `issues` field (a non-standard field alongside the required
-  ones). The `detail` field defaults to `formatSummary(err)` (a
-  one-line description of the first failing leaf); pass `detail`
-  explicitly for an override.
+  ones). The `detail` field defaults to a one-line description of the
+  first failing leaf; pass `detail` explicitly for an override.
 
-- **`formatSummary(err, opts?)`**: render the error tree as a
-  string. Default is a single line summarising the first failing
-  leaf as `<dotted-path> <message>`; use it for log lines,
+- **`formatSummary(err, opts?)`**: render a single `ValidationError`
+  tree as a string. Default is a single line summarising the first
+  failing leaf as `<dotted-path> <message>`; use it for log lines,
   error-monitoring titles (Sentry/New Relic group by message), or
   as the top-level `message` field in custom response envelopes.
   Pass `{ select: "all" }` for a multi-line enumeration of every
@@ -101,7 +107,7 @@ lean install). The recipes below assume these are in scope.
   See `FormatSummaryOptions.select` for the full policy
   (`"first"` / `"deepest"` / `"all"` / `{ byCode }`).
 
-- **`collectIssues(err)`**: flat leaf list. Each issue carries both
+- **`collectIssues(errors)`**: flat leaf list. Each issue carries both
   a raw `path: PathSegment[]` and a pre-formatted RFC 6901 `pointer`
   string. Use this when you're keeping a custom envelope shape
   rather than RFC 9457 problem-details.
@@ -134,7 +140,7 @@ Defaults: status from `httpStatusFor`, `Allow` header from
 `allowHeaderFor` on 405, body from `toProblemDetails` (RFC 9457
 `application/problem+json`). The package also exports
 `httpRequestFromExpress(req)` (the extractor) and
-`renderProblemDetails(err, ctx)` (the default renderer) standalone,
+`renderProblemDetails(errors, ctx)` (the default renderer) standalone,
 for callers composing their own middleware. See the
 [adapter README](https://github.com/aahoughton/oav/blob/main/packages/oav-express4/README.md)
 for the options (`toHttpRequest`, `onError`), async `onError`
@@ -150,7 +156,7 @@ automatically. Wrap in `try/catch`:
 ```ts
 app.use((req, res, next) => {
   try {
-    const err = validator.validateRequest({
+    const result = validator.validateRequest({
       method: req.method,
       path: req.path,
       query: req.query as Record<string, string | string[]>,
@@ -159,13 +165,13 @@ app.use((req, res, next) => {
       body: req.body,
       cookies: req.cookies,
     });
-    if (err === null) return next();
-    const allow = allowHeaderFor(err);
+    if (result.valid) return next();
+    const allow = allowHeaderFor(result.errors);
     if (allow !== undefined) res.setHeader("Allow", allow);
     res
-      .status(httpStatusFor(err))
+      .status(httpStatusFor(result.errors))
       .type("application/problem+json")
-      .json(toProblemDetails(err, { instance: req.originalUrl }));
+      .json(toProblemDetails(result.errors, { instance: req.originalUrl }));
   } catch (e) {
     next(e);
   }
@@ -200,7 +206,7 @@ handler automatically.
 
 ```ts
 app.use(async (req, res, next) => {
-  const err = validator.validateRequest({
+  const result = validator.validateRequest({
     method: req.method,
     path: req.path,
     query: req.query as Record<string, string | string[]>,
@@ -209,13 +215,13 @@ app.use(async (req, res, next) => {
     body: req.body,
     cookies: req.cookies,
   });
-  if (err === null) return next();
-  const allow = allowHeaderFor(err);
+  if (result.valid) return next();
+  const allow = allowHeaderFor(result.errors);
   if (allow !== undefined) res.setHeader("Allow", allow);
   res
-    .status(httpStatusFor(err))
+    .status(httpStatusFor(result.errors))
     .type("application/problem+json")
-    .json(toProblemDetails(err, { instance: req.originalUrl }));
+    .json(toProblemDetails(result.errors, { instance: req.originalUrl }));
 });
 ```
 
@@ -256,7 +262,7 @@ but before the route handler.
 ```ts
 fastify.addHook("preValidation", async (request, reply) => {
   const url = new URL(request.url, `http://${request.headers.host ?? "localhost"}`);
-  const err = validator.validateRequest({
+  const result = validator.validateRequest({
     method: request.method,
     path: url.pathname,
     query: Object.fromEntries(url.searchParams.entries()),
@@ -264,13 +270,13 @@ fastify.addHook("preValidation", async (request, reply) => {
     contentType: request.headers["content-type"],
     body: request.body,
   });
-  if (err !== null) {
-    const allow = allowHeaderFor(err);
+  if (!result.valid) {
+    const allow = allowHeaderFor(result.errors);
     if (allow !== undefined) reply.header("Allow", allow);
     return reply
-      .code(httpStatusFor(err))
+      .code(httpStatusFor(result.errors))
       .type("application/problem+json")
-      .send(toProblemDetails(err, { instance: request.url }));
+      .send(toProblemDetails(result.errors, { instance: request.url }));
   }
 });
 ```
@@ -312,11 +318,11 @@ type CreatePet = { name: string; tag?: string };
 export async function POST(request: Request) {
   const result = await validator.validateFetchRequest<CreatePet>(request);
   if (!result.ok) {
-    const allow = allowHeaderFor(result.error);
+    const allow = allowHeaderFor(result.errors);
     const headers: Record<string, string> = { "Content-Type": "application/problem+json" };
     if (allow !== undefined) headers["Allow"] = allow;
-    return Response.json(toProblemDetails(result.error, { instance: request.url }), {
-      status: httpStatusFor(result.error),
+    return Response.json(toProblemDetails(result.errors, { instance: request.url }), {
+      status: httpStatusFor(result.errors),
       headers,
     });
   }
@@ -358,12 +364,12 @@ export const config = {
 export async function middleware(request: NextRequest) {
   const result = await validator.validateFetchRequest(request);
   if (result.ok) return NextResponse.next();
-  const allow = allowHeaderFor(result.error);
+  const allow = allowHeaderFor(result.errors);
   const headers: Record<string, string> = { "Content-Type": "application/problem+json" };
   if (allow !== undefined) headers["Allow"] = allow;
   return new NextResponse(
-    JSON.stringify(toProblemDetails(result.error, { instance: request.url })),
-    { status: httpStatusFor(result.error), headers },
+    JSON.stringify(toProblemDetails(result.errors, { instance: request.url })),
+    { status: httpStatusFor(result.errors), headers },
   );
 }
 ```
@@ -383,7 +389,7 @@ import { httpRequestFromFetch } from "@aahoughton/oav";
 
 const { httpRequest } = await httpRequestFromFetch(request);
 // Mutate httpRequest.body however you need, then:
-const err = validator.validateRequest(httpRequest);
+const result = validator.validateRequest(httpRequest);
 ```
 
 **Hono, cross-cutting alternative.** `app.use('*', mw)` can host
@@ -431,7 +437,7 @@ const request = new Request(upstreamUrl);
 const response = await fetch(request);
 const result = await validator.validateFetchResponse<PetList>(request, response);
 if (!result.ok) {
-  log.warn("upstream returned a response the spec doesn't declare", result.error);
+  log.warn("upstream returned a response the spec doesn't declare", result.errors);
 }
 // result.body is the parsed response body, typed as PetList on success.
 ```
@@ -633,8 +639,8 @@ client. Two override points are exposed: pass `detail` to
 ```ts
 import { httpStatusFor, toProblemDetails, type ValidationError } from "@aahoughton/oav";
 
-function safeProblemDetails(err: ValidationError, instance: string) {
-  const pd = toProblemDetails(err, { instance });
+function safeProblemDetails(errors: ValidationError[], instance: string) {
+  const pd = toProblemDetails(errors, { instance });
   return {
     ...pd,
     // Structural summary; nothing about the offending value reaches detail.
@@ -646,11 +652,11 @@ function safeProblemDetails(err: ValidationError, instance: string) {
 
 app.use(
   validateRequests(validator, {
-    onError: (err, ctx) => {
+    onError: (errors, ctx) => {
       ctx.res
-        .status(httpStatusFor(err))
+        .status(httpStatusFor(errors))
         .type("application/problem+json")
-        .json(safeProblemDetails(err, ctx.req.originalUrl));
+        .json(safeProblemDetails(errors, ctx.req.originalUrl));
     },
   }),
 );
@@ -671,14 +677,14 @@ starting point.
 Migrating an existing service may mean a documented client
 contract you can't change without breaking callers. Keep your
 envelope, fill it from `collectIssues` (per-issue path,
-message, code) plus `formatSummary` (top-level summary) plus
+message, code), an error count for the top-level summary, and
 `httpStatusFor` (status). Don't walk the tree by hand; the helpers
 already do the right thing for nested branches, route/method
 top-levels, and security/content-type leaves under `request` /
 `response` wrappers.
 
 ```ts
-import { collectIssues, formatSummary, httpStatusFor, type ValidationError } from "@aahoughton/oav";
+import { collectIssues, httpStatusFor, type ValidationError } from "@aahoughton/oav";
 
 // .. or whatever your clients already parse.
 type ClientError = {
@@ -686,10 +692,10 @@ type ClientError = {
   errors: Array<{ path: string; message: string; errorCode: string }>;
 };
 
-function toClientError(err: ValidationError): ClientError {
+function toClientError(errors: ValidationError[]): ClientError {
   return {
-    message: formatSummary(err),
-    errors: collectIssues(err).map((issue) => ({
+    message: `${errors.length} validation error(s)`,
+    errors: collectIssues(errors).map((issue) => ({
       path: issue.pointer, // RFC 6901, e.g. "/body/email"
       message: issue.message,
       errorCode: issue.code, // bare code, e.g. "required"
@@ -699,8 +705,8 @@ function toClientError(err: ValidationError): ClientError {
 
 app.use(
   validateRequests(validator, {
-    onError: (err, ctx) => {
-      ctx.res.status(httpStatusFor(err)).json(toClientError(err));
+    onError: (errors, ctx) => {
+      ctx.res.status(httpStatusFor(errors)).json(toClientError(errors));
     },
   }),
 );
@@ -711,7 +717,7 @@ and `email: "not-an-email"` (fails `format: email`), the response would be:
 
 ```json
 {
-  "message": "body.age must be <= 30",
+  "message": "2 validation error(s)",
   "errors": [
     {
       "path": "/body/age",
@@ -807,18 +813,18 @@ app.post("/avatar", upload.any(), async (req, res, next) => {
   const files = Object.fromEntries(
     ((req.files as Express.Multer.File[]) ?? []).map((f) => [f.fieldname, f.buffer]),
   );
-  const err = validator.validateRequest({
+  const result = validator.validateRequest({
     method: req.method,
     path: req.path,
     contentType: req.get("content-type"),
     headers: req.headers as Record<string, string | string[]>,
     body: { ...req.body, ...files },
   });
-  if (err !== null) {
+  if (!result.valid) {
     return res
-      .status(httpStatusFor(err))
+      .status(httpStatusFor(result.errors))
       .type("application/problem+json")
-      .json(toProblemDetails(err, { instance: req.originalUrl }));
+      .json(toProblemDetails(result.errors, { instance: req.originalUrl }));
   }
   // handler uses req.body + req.files as normal
 });
@@ -977,7 +983,7 @@ body shape you've already built:
 
 ```ts
 const body = await myCustomStreamingPipeline(request);
-const err = validator.validateRequest({
+const result = validator.validateRequest({
   method: request.method,
   path: new URL(request.url).pathname,
   contentType: request.headers.get("content-type") ?? undefined,
@@ -1009,12 +1015,12 @@ app.get("/pets/:id", async (req, res) => {
   const body = pet ?? { error: "not found" };
   const status = pet ? 200 : 404;
 
-  const err = validator.validateResponse(
+  const result = validator.validateResponse(
     { method: req.method, path: req.path },
     { status, contentType: "application/json", body },
   );
-  if (err !== null) {
-    log.warn("response validation failed", { path: req.path, err });
+  if (!result.valid) {
+    log.warn("response validation failed", { path: req.path, errors: result.errors });
   }
   res.status(status).json(body);
 });
@@ -1027,14 +1033,14 @@ auto-interception behavior for every response:
 app.use((req, res, next) => {
   const json = res.json.bind(res);
   res.json = (body) => {
-    const err = validator.validateResponse(
+    const result = validator.validateResponse(
       { method: req.method, path: req.path },
       { status: res.statusCode, contentType: "application/json", body },
     );
-    if (err !== null) {
+    if (!result.valid) {
       // Default: log + send anyway. See "Failure mode" below.
       res.setHeader("X-Response-Validation", "failed");
-      log.warn("response validation failed", { path: req.path, err });
+      log.warn("response validation failed", { path: req.path, errors: result.errors });
     }
     return json(body);
   };
@@ -1071,10 +1077,10 @@ budget burns for free.
    period, you can flip the policy in your `res.json` wrapper:
 
    ```ts
-   if (err !== null) {
-     log.error("response validation failed (hard)", { path: req.path, err });
+   if (!result.valid) {
+     log.error("response validation failed (hard)", { path: req.path, errors: result.errors });
      res.statusCode = 500;
-     return json(toProblemDetails(err, { instance: req.originalUrl }));
+     return json(toProblemDetails(result.errors, { instance: req.originalUrl }));
    }
    ```
 
@@ -1230,11 +1236,11 @@ back to the manual pattern:
 
 ```ts
 app.use(async (req, res, next) => {
-  const err = validator.validateRequest({
+  const result = validator.validateRequest({
     /* ... */
   });
-  if (err === null) return next();
-  if (err.code === "route") return next(); // unvalidated path, let routing continue
+  if (result.valid) return next();
+  if (result.errors.some((e) => e.code === "route")) return next(); // unvalidated path, let routing continue
   // ... 4xx response as usual
 });
 ```

--- a/docs/migration-v3.md
+++ b/docs/migration-v3.md
@@ -1,0 +1,184 @@
+# Migrating to v3
+
+v3 changes the zero-config defaults so a bare `compileSchema(schema)` (and
+`createValidator(spec)`) matches Ajv's out-of-the-box behaviour: a **flat**
+list of errors, stopping at the **first** one. The richer nested error tree
+and full error collection are one option away. This guide lists every
+breaking change and how to restore the v2 behaviour where you want it.
+
+If you only use the framework adapters with the default renderer, the upgrade
+is mostly transparent: keep passing the validator to `validateRequests`,
+problem-details responses still work. The breaking surface is for code that
+reads `validateRequest` results, calls `compileSchema` directly, or supplies a
+custom `onError`.
+
+## At a glance
+
+| Area                                   | v2                               | v3                                        |
+| -------------------------------------- | -------------------------------- | ----------------------------------------- |
+| `compileSchema` default result         | nested tree `{ valid, error? }`  | flat `{ valid, errors?, truncated }`      |
+| `compileSchema` default `maxErrors`    | uncapped                         | `1` (fast-fail)                           |
+| Mode selection                         | `flat: true` / `predicate: true` | `output: "flat" \| "tree" \| "predicate"` |
+| `validateRequest` / `validateResponse` | `ValidationError \| null`        | `{ valid, errors?, error?, truncated }`   |
+| Validator `maxErrors` default          | uncapped                         | `1`, as a per-call total                  |
+| Adapter `onError(err, ctx)`            | one `ValidationError`            | `onError(errors, ctx)` — a leaf list      |
+| `{ key: undefined }` presence          | counted as present               | treated as absent                         |
+
+## 1. The compiler's default result is flat
+
+`compileSchema(schema, { dialect })` now returns a flat result.
+
+```ts
+// v2
+const v = compileSchema(schema, { dialect });
+const r = v.validate(data);
+if (!r.valid) console.log(r.error); // nested ValidationError tree
+
+// v3 — same call, flat result
+const v = compileSchema(schema, { dialect });
+const r = v.validate(data);
+if (!r.valid) console.log(r.errors); // flat ValidationError[]
+```
+
+The result is a discriminated union on `valid`. On success it is exactly
+`{ valid: true }`; on failure it carries `errors` (a non-empty leaf list) and
+`truncated`. Reading `r.error` on the flat result is now a compile-time error
+in TypeScript, which catches the rename for you.
+
+**Keep the tree:** pass `output: "tree"`.
+
+```ts
+const v = compileSchema(schema, { dialect, output: "tree" });
+const r = v.validate(data);
+if (!r.valid) console.log(r.error); // nested tree, as before
+```
+
+## 2. The compiler defaults to `maxErrors: 1`
+
+The default validator stops at the first error. To collect every error, pass
+`maxErrors: Number.POSITIVE_INFINITY`. `output` and `maxErrors` are
+orthogonal: `output: "tree"` also defaults to `maxErrors: 1` (a nested tree
+holding the first error).
+
+```ts
+// every error, flat:
+compileSchema(schema, { dialect, maxErrors: Number.POSITIVE_INFINITY });
+// every error, nested tree (the v2 default behaviour):
+compileSchema(schema, { dialect, output: "tree", maxErrors: Number.POSITIVE_INFINITY });
+```
+
+`truncated` is `true` whenever the cap was reached (more problems may exist).
+Under the default `maxErrors: 1`, every rejection reports `truncated: true`.
+
+## 3. `output` replaces the `flat` / `predicate` booleans
+
+`output: "flat" | "tree" | "predicate"` is the single knob for the result
+shape. The `flat: true` and `predicate: true` booleans still work as
+deprecated aliases (removed in v4) and throw if combined with a conflicting
+`output`.
+
+```ts
+compileSchema(schema, { dialect, predicate: true }); // deprecated
+compileSchema(schema, { dialect, output: "predicate" }); // v3
+```
+
+## 4. Result type renames
+
+| v2                        | v3                                        |
+| ------------------------- | ----------------------------------------- |
+| `ValidationResult` (tree) | `TreeValidationResult`                    |
+| `FlatValidationResult`    | `ValidationResult` (now the flat default) |
+| `CompiledSchema` (tree)   | `CompiledTreeSchema`                      |
+| `CompiledFlatSchema`      | `CompiledSchema` (now the flat default)   |
+
+`FlatValidationResult` and `CompiledFlatSchema` remain as deprecated aliases
+of the new flat types for one major. If you imported `ValidationResult`
+expecting the tree shape, switch to `TreeValidationResult`.
+
+## 5. The validator returns a result object
+
+`createValidator` mirrors the compiler: same `output` / `maxErrors` options,
+same result types. `validateRequest` / `validateResponse` no longer return
+`ValidationError | null`.
+
+```ts
+// v2
+const err = validator.validateRequest(req);
+if (err !== null) renderProblemDetails(err, ctx);
+
+// v3 (flat default)
+const r = validator.validateRequest(req);
+if (!r.valid) renderProblemDetails(r.errors, ctx);
+```
+
+`createValidator` is overloaded on `output`, returning a `Validator` (flat),
+`TreeValidator`, or `PredicateValidator`. The validator's `maxErrors` is a
+**per-call total** across all locations (body, query, headers): the default
+`maxErrors: 1` yields a single error for the whole request.
+
+To keep the v2 nested-tree-or-null behaviour:
+
+```ts
+const validator = createValidator(spec, {
+  output: "tree",
+  maxErrors: Number.POSITIVE_INFINITY,
+});
+const r = validator.validateRequest(req);
+const err = r.valid ? null : r.error; // ValidationError | null, as before
+```
+
+## 6. Adapter `onError` receives a leaf list
+
+The framework adapters (`oav-express4`, `oav-express5`, `oav-fastify`) pass a
+flat `ValidationError[]` to `onError`, regardless of the validator's `output`
+(a tree validator's result is flattened first).
+
+```ts
+// v2
+validateRequests(validator, {
+  onError: (err, ctx) => {
+    /* err is one node */
+  },
+});
+
+// v3
+validateRequests(validator, {
+  onError: (errors, ctx) => {
+    /* errors is a list */
+  },
+});
+```
+
+A predicate-mode validator (`output: "predicate"`) can't render a
+problem-details body, so the adapters throw at construction if you pass one.
+Use `output: "flat"` (default) or `"tree"`.
+
+## 7. Problem-details and formatters accept a leaf list
+
+`httpStatusFor`, `allowHeaderFor`, `toProblemDetails`, `collectIssues`, and
+`formatText` now accept either a single `ValidationError` (tree) or a
+`ValidationError[]` (flat). Existing tree calls are unchanged; the new flat
+overload lets the same wiring serve either `output`.
+
+## 8. `undefined`-valued properties count as absent
+
+A property whose value is `undefined` is now treated as **absent** for
+`required`, `properties`, and the `dependent*` keywords, consistently. For
+parsed JSON this is a no-op (JSON has no `undefined`). For in-memory objects
+it matches `JSON.stringify`, which drops `undefined`-valued keys, so it is the
+wire-accurate answer; a validity verdict can change for such inputs.
+
+```ts
+// v2: `a` present -> passes `required: ["a"]`
+// v3: `a` absent  -> fails `required: ["a"]`
+validate({ a: undefined });
+```
+
+## A note on `maxErrors` and verdicts
+
+A finite `maxErrors` never changes a valid/invalid verdict. For schemas that
+use `unevaluatedProperties` / `unevaluatedItems`, the short-circuit is
+disabled and every error is collected (the cap is not enforced there),
+because capping mid-evaluation could otherwise suppress a real
+`unevaluated*` error. These keywords don't appear in OpenAPI specs, so the
+HTTP fast path is unaffected.

--- a/examples/basic-validation.ts
+++ b/examples/basic-validation.ts
@@ -22,7 +22,7 @@ const valid = v.validateRequest({
   contentType: "application/json",
   body: { name: "Fido", tag: "dog" },
 });
-console.log("valid request →", valid === null ? "ok" : "FAIL");
+console.log("valid request →", valid.valid ? "ok" : "FAIL");
 
 const bad = v.validateRequest({
   method: "POST",
@@ -30,12 +30,12 @@ const bad = v.validateRequest({
   contentType: "application/json",
   body: { tag: "dog" }, // missing required `name`
 });
-if (bad !== null) {
-  console.log("\ninvalid request:\n" + formatText(bad));
+if (!bad.valid) {
+  console.log("\ninvalid request:\n" + formatText(bad.errors));
 }
 
 const responseErr = v.validateResponse(
   { method: "POST", path: "/pets", body: { name: "Fido" }, contentType: "application/json" },
   { status: 201 },
 );
-console.log("\nresponse (201, no body) →", responseErr === null ? "ok" : "FAIL");
+console.log("\nresponse (201, no body) →", responseErr.valid ? "ok" : "FAIL");

--- a/examples/cross-field-validation.ts
+++ b/examples/cross-field-validation.ts
@@ -61,7 +61,7 @@ const ok = v.validateRequest({
   contentType: "application/json",
   body: { min: 3, max: 10 },
 });
-console.log("min=3 max=10  →", ok === null ? "ok" : "FAIL");
+console.log("min=3 max=10  →", ok.valid ? "ok" : "FAIL");
 
 const bad = v.validateRequest({
   method: "POST",
@@ -69,6 +69,6 @@ const bad = v.validateRequest({
   contentType: "application/json",
   body: { min: 10, max: 3 },
 });
-if (bad !== null) {
-  console.log("\nmin=10 max=3:\n" + formatText(bad));
+if (!bad.valid) {
+  console.log("\nmin=10 max=3:\n" + formatText(bad.errors));
 }

--- a/examples/custom-formats.ts
+++ b/examples/custom-formats.ts
@@ -29,7 +29,7 @@ const ok = v.validateRequest({
   contentType: "application/json",
   body: { phone: "+14155550123" },
 });
-console.log("+14155550123 →", ok === null ? "ok" : "FAIL");
+console.log("+14155550123 →", ok.valid ? "ok" : "FAIL");
 
 const bad = v.validateRequest({
   method: "POST",
@@ -37,6 +37,6 @@ const bad = v.validateRequest({
   contentType: "application/json",
   body: { phone: "415-555-0123" }, // not E.164
 });
-if (bad !== null) {
-  console.log("\n415-555-0123:\n" + formatText(bad));
+if (!bad.valid) {
+  console.log("\n415-555-0123:\n" + formatText(bad.errors));
 }

--- a/examples/custom-keywords.ts
+++ b/examples/custom-keywords.ts
@@ -36,7 +36,7 @@ const ok = v.validateRequest({
   contentType: "application/json",
   body: { tenantId: "t_acme", name: "Widget A" },
 });
-console.log("t_acme (active) →", ok === null ? "ok" : "FAIL");
+console.log("t_acme (active) →", ok.valid ? "ok" : "FAIL");
 
 const bad = v.validateRequest({
   method: "POST",
@@ -44,6 +44,6 @@ const bad = v.validateRequest({
   contentType: "application/json",
   body: { tenantId: "t_unknown", name: "Widget B" },
 });
-if (bad !== null) {
-  console.log("\nt_unknown:\n" + formatText(bad));
+if (!bad.valid) {
+  console.log("\nt_unknown:\n" + formatText(bad.errors));
 }

--- a/examples/max-errors.ts
+++ b/examples/max-errors.ts
@@ -9,7 +9,6 @@
  */
 
 import { fileURLToPath } from "node:url";
-import { collectLeaves } from "../packages/core/src/index.ts";
 import { createYamlFileReader } from "../packages/oav/src/yaml.ts";
 import { loadSpec } from "../packages/spec/src/index.ts";
 import { createValidator } from "../packages/validator/src/index.ts";
@@ -30,13 +29,13 @@ const runAndCount = (label: string, maxErrors: number | undefined): void => {
     body: bulk,
   });
   const ms = performance.now() - start;
-  const leafCount = err === null ? 0 : collectLeaves(err).length;
+  const leafCount = err.valid ? 0 : err.errors.length;
   console.log(
     `${label.padEnd(20)} leaves=${String(leafCount).padStart(3)}  time=${ms.toFixed(2)}ms`,
   );
 };
 
-runAndCount("uncapped (default)", undefined);
-runAndCount("fast-fail (1)", 1);
+runAndCount("fast-fail (default)", undefined);
 runAndCount("bounded (3)", 3);
 runAndCount("bounded (10)", 10);
+runAndCount("uncapped (Infinity)", Number.POSITIVE_INFINITY);

--- a/examples/overlay-petstore-endpoint.ts
+++ b/examples/overlay-petstore-endpoint.ts
@@ -54,7 +54,7 @@ const missing = v.validateRequest({
   body: { name: "Fido" },
 });
 console.log("POST /pets without X-Tenant:");
-if (missing !== null) console.log(formatText(missing));
+if (!missing.valid) console.log(formatText(missing.errors));
 
 // With the header: clean.
 const ok = v.validateRequest({
@@ -64,4 +64,4 @@ const ok = v.validateRequest({
   headers: { "x-tenant": "acme" },
   body: { name: "Fido" },
 });
-console.log("\nPOST /pets with X-Tenant →", ok === null ? "ok" : "FAIL");
+console.log("\nPOST /pets with X-Tenant →", ok.valid ? "ok" : "FAIL");

--- a/examples/overlay-petstore-schema.ts
+++ b/examples/overlay-petstore-schema.ts
@@ -52,7 +52,7 @@ const missing = v.validateRequest({
   body: { name: "Fido" },
 });
 console.log("POST /pets without `vaccinated`:");
-if (missing !== null) console.log(formatText(missing));
+if (!missing.valid) console.log(formatText(missing.errors));
 
 // With vaccinated: clean.
 const ok = v.validateRequest({
@@ -61,4 +61,4 @@ const ok = v.validateRequest({
   contentType: "application/json",
   body: { name: "Fido", vaccinated: true },
 });
-console.log("\nPOST /pets with `vaccinated: true` →", ok === null ? "ok" : "FAIL");
+console.log("\nPOST /pets with `vaccinated: true` →", ok.valid ? "ok" : "FAIL");

--- a/examples/overlay.ts
+++ b/examples/overlay.ts
@@ -42,7 +42,7 @@ const v = createValidator(merged);
 // Without the header — should fail.
 const missing = v.validateRequest({ method: "GET", path: "/pets" });
 console.log("without X-Request-Id:");
-if (missing !== null) console.log(formatText(missing));
+if (!missing.valid) console.log(formatText(missing.errors));
 
 // With the header — clean.
 const ok = v.validateRequest({
@@ -50,4 +50,4 @@ const ok = v.validateRequest({
   path: "/pets",
   headers: { "x-request-id": "abc-123" },
 });
-console.log("\nwith X-Request-Id →", ok === null ? "ok" : "FAIL");
+console.log("\nwith X-Request-Id →", ok.valid ? "ok" : "FAIL");

--- a/examples/versions.ts
+++ b/examples/versions.ts
@@ -32,7 +32,7 @@ console.log(
     path: "/pets",
     contentType: "application/json",
     body: { name: "Fido", tag: null },
-  }) === null
+  }).valid
     ? "ok"
     : "FAIL",
 );
@@ -45,7 +45,7 @@ console.log(
       contentType: "application/json",
       body: { name: "Fido", priority: 10 }, // exclusiveMaximum: true means must be < 10
     });
-    return e === null ? "ok (should fail!)" : "rejected (as expected)";
+    return e.valid ? "ok (should fail!)" : "rejected (as expected)";
   })(),
 );
 
@@ -59,7 +59,7 @@ console.log(
     path: "/pets",
     contentType: "application/json",
     body: { name: "Fido", tag: null },
-  }) === null
+  }).valid
     ? "ok"
     : "FAIL",
 );
@@ -73,4 +73,4 @@ const r = v32.validateRequest({
   contentType: "application/json",
   body: { filter: "cats" },
 });
-console.log("3.2.0  QUERY /search  →", r === null ? "ok" : "FAIL:\n" + formatText(r));
+console.log("3.2.0  QUERY /search  →", r.valid ? "ok" : "FAIL:\n" + formatText(r.errors));

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -203,29 +203,38 @@ export async function validateCommand(
     entry: args.spec,
     overlays: overlayDocs,
   });
-  const validator = createValidator(document);
+  // The CLI renders a nested error tree and reports every problem it
+  // finds, so it compiles in tree mode with uncapped error collection
+  // rather than the flat fail-fast default.
+  const validator = createValidator(document, {
+    output: "tree",
+    maxErrors: Number.POSITIVE_INFINITY,
+  });
 
   let err: ValidationError | null;
   if (args.mode.kind === "request") {
     const raw = await io.readText(args.mode.file);
     const req = parseHttpFile(raw);
-    err = validator.validateRequest(req);
+    const r = validator.validateRequest(req);
+    err = r.valid ? null : r.error;
   } else if (args.mode.kind === "bodyForPath") {
     const rawBody = await io.readText(args.mode.body);
     const body = tryJson(rawBody) as JsonValue | undefined;
-    err = validator.validateRequest({
+    const r = validator.validateRequest({
       method: args.mode.method,
       path: args.mode.path,
       contentType: "application/json",
       body,
     });
+    err = r.valid ? null : r.error;
   } else if (args.mode.kind === "responseForPath") {
     const rawBody = await io.readText(args.mode.body);
     const body = tryJson(rawBody) as JsonValue | undefined;
-    err = validator.validateResponse(
+    const r = validator.validateResponse(
       { method: args.mode.method, path: args.mode.path },
       { status: args.mode.status, contentType: "application/json", body },
     );
+    err = r.valid ? null : r.error;
   } else {
     io.stderr("validate: no action specified\n");
     return { exitCode: 3 };

--- a/packages/cli/src/emit-spec.ts
+++ b/packages/cli/src/emit-spec.ts
@@ -108,7 +108,16 @@ export function emitSpec(document: OpenAPIDocument, options: EmitSpecOptions = {
   const named = (schema: SchemaOrBoolean): string => {
     const existing = schemaNames.get(schema);
     if (existing !== undefined) return existing;
-    const c = compileSchema(schema, { dialect, refResolver, formats: builtInFormats });
+    // Mirror @oav/validator's runtime contract: the emitted module nests
+    // per-location error subtrees, so each schema compiles in tree mode
+    // with uncapped errors, independent of the v3 flat/maxErrors:1 default.
+    const c = compileSchema(schema, {
+      dialect,
+      refResolver,
+      formats: builtInFormats,
+      output: "tree",
+      maxErrors: Number.POSITIVE_INFINITY,
+    });
     const name = `S${compiled.length}`;
     compiled.push({ name, source: c.source });
     schemaNames.set(schema, name);

--- a/packages/cli/test/compile-spec.test.ts
+++ b/packages/cli/test/compile-spec.test.ts
@@ -125,7 +125,12 @@ function collectLeafCodes(err: ValidationError): string[] {
 
 describe("compile-spec: equivalence vs createValidator", () => {
   it("matches runtime output on the petstore matrix", async () => {
-    const runtime = createValidator(petstore);
+    // The emitted (AOT) module mirrors the validator's tree output, so
+    // compare against a tree-mode, uncapped runtime validator.
+    const runtime = createValidator(petstore, {
+      output: "tree",
+      maxErrors: Number.POSITIVE_INFINITY,
+    });
     const aot = await buildAot(petstore);
 
     const cases: Array<{ name: string; req: unknown }> = [
@@ -187,7 +192,8 @@ describe("compile-spec: equivalence vs createValidator", () => {
     ];
 
     for (const c of cases) {
-      const a = runtime.validateRequest(c.req as never);
+      const ra = runtime.validateRequest(c.req as never);
+      const a = ra.valid ? null : ra.error;
       const b = aot.validateRequest(c.req);
       if (!equivalent(a, b)) {
         console.error(

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -13,7 +13,10 @@ export interface FormatOptions {
 }
 
 /**
- * Render a {@link ValidationError} tree as an indented human-readable string.
+ * Render validation errors as an indented human-readable string.
+ * Accepts either a nested error tree (`output: "tree"`) or the flat leaf
+ * list the default validator returns; a flat list renders one line per
+ * leaf.
  *
  * @remarks
  * Every node renders as `<path> <message> [<code>]`. Children are indented
@@ -21,19 +24,22 @@ export interface FormatOptions {
  * programmatic consumption; use {@link toJsonObject} or
  * {@link formatSummary} for that.
  *
- * @param error - Root of the error tree.
+ * @param error - Root of the error tree, or a flat list of leaves.
  * @param options - Optional rendering settings.
  * @returns A multi-line string ready to print.
  *
  * @example
  * ```ts
- * const out = formatText(rootError);
- * console.error(out);
+ * const r = validator.validateRequest(httpRequest);
+ * if (!r.valid) console.error(formatText(r.errors));
  * ```
  *
  * @public
  */
-export function formatText(error: ValidationError, options: FormatOptions = {}): string {
+export function formatText(
+  error: ValidationError | readonly ValidationError[],
+  options: FormatOptions = {},
+): string {
   const indent = options.indent ?? "  ";
   const maxDepth = options.maxDepth ?? Number.POSITIVE_INFINITY;
   const lines: string[] = [];
@@ -48,7 +54,7 @@ export function formatText(error: ValidationError, options: FormatOptions = {}):
     lines.push(`${prefix}${pathPart}${node.message} [${node.code}]`);
     for (const child of node.children) render(child, depth + 1);
   };
-  render(error, 0);
+  for (const root of Array.isArray(error) ? error : [error as ValidationError]) render(root, 0);
   return lines.join("\n");
 }
 
@@ -223,59 +229,4 @@ export function countErrors(error: ValidationError): number {
     n += 1;
   });
   return n;
-}
-
-// ---------------------------------------------------------------------------
-// Deprecated: kept exported for source compatibility; absent from user-facing
-// docs. Behavior identical to the new canonical names. Removal in v3.
-// ---------------------------------------------------------------------------
-
-/**
- * @deprecated Use {@link toJsonObject}. Same return shape; the new name
- *   reflects that it returns an object, not a string. Removal in v3.
- *
- * @public
- */
-export function formatJson(error: ValidationError): ValidationError {
-  return toJsonObject(error);
-}
-
-/**
- * Options for the deprecated {@link summarize}. Use
- * {@link FormatSummaryOptions} instead.
- *
- * @deprecated Use {@link FormatSummaryOptions}. Removal in v3.
- *
- * @public
- */
-export interface SummarizeOptions {
-  /** @deprecated See {@link FormatSummaryOptions.select}. Removal in v3. */
-  select?: SummarizeSelect;
-}
-
-/**
- * @deprecated Use {@link FormatSummarySelect}. Note: the new type also
- *   accepts `"all"` for flat all-leaves output. Removal in v3.
- *
- * @public
- */
-export type SummarizeSelect = "first" | "deepest" | { byCode: readonly string[] };
-
-/**
- * @deprecated Use {@link formatSummary}. Same defaults and behavior.
- *   Removal in v3.
- *
- * @public
- */
-export function summarize(error: ValidationError, options: SummarizeOptions = {}): string {
-  return formatSummary(error, options);
-}
-
-/**
- * @deprecated Use `formatSummary(err, { select: "all" })`. Removal in v3.
- *
- * @public
- */
-export function formatFlat(error: ValidationError): string {
-  return formatSummary(error, { select: "all" });
 }

--- a/packages/core/src/http-status.ts
+++ b/packages/core/src/http-status.ts
@@ -69,16 +69,21 @@ export const DEFAULT_HTTP_STATUS_MAP: HttpStatusMap = {
  *
  * @public
  */
-export function httpStatusFor(err: ValidationError, overrides?: Partial<HttpStatusMap>): number {
+export function httpStatusFor(
+  err: ValidationError | readonly ValidationError[],
+  overrides?: Partial<HttpStatusMap>,
+): number {
   const map =
     overrides === undefined
       ? DEFAULT_HTTP_STATUS_MAP
       : { ...DEFAULT_HTTP_STATUS_MAP, ...overrides };
-  if (err.code === "route") return map.route;
-  if (err.code === "method") return map.method;
-  // Dive into the wrapper for codes that never appear at the top level.
-  // Priority order matches the HTTP gate ladder: 401 before 415 before 500.
-  const leaves = collectLeaves(err);
+  // Accepts either a nested error tree or the flat leaf list the default
+  // (flat) validator returns. Scan leaves in HTTP-gate priority order
+  // (404 -> 405 -> 415 -> 401 -> 500 -> 400); `route` / `method` fire as
+  // standalone leaves, the rest as leaves anywhere in the report.
+  const leaves = Array.isArray(err) ? err : collectLeaves(err as ValidationError);
+  if (leaves.some((l) => l.code === "route")) return map.route;
+  if (leaves.some((l) => l.code === "method")) return map.method;
   if (leaves.some((l) => l.code === "security")) return map.security;
   if (leaves.some((l) => l.code === "content-type")) return map["content-type"];
   if (leaves.some((l) => l.code === "status")) return map.status;
@@ -98,9 +103,13 @@ export function httpStatusFor(err: ValidationError, overrides?: Partial<HttpStat
  *
  * @public
  */
-export function allowHeaderFor(err: ValidationError): string | undefined {
-  if (err.code !== "method") return undefined;
-  const allowed = (err.params as { allowed?: unknown }).allowed;
+export function allowHeaderFor(
+  err: ValidationError | readonly ValidationError[],
+): string | undefined {
+  const leaves = Array.isArray(err) ? err : collectLeaves(err as ValidationError);
+  const method = leaves.find((l) => l.code === "method");
+  if (method === undefined) return undefined;
+  const allowed = (method.params as { allowed?: unknown }).allowed;
   if (!Array.isArray(allowed)) return undefined;
   return allowed.join(", ");
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,17 +17,12 @@ export {
 
 export {
   countErrors,
-  formatFlat,
-  formatJson,
   formatSummary,
   formatText,
-  summarize,
   toJsonObject,
   type FormatOptions,
   type FormatSummaryOptions,
   type FormatSummarySelect,
-  type SummarizeOptions,
-  type SummarizeSelect,
 } from "./format.js";
 
 export {

--- a/packages/core/src/problem-details.ts
+++ b/packages/core/src/problem-details.ts
@@ -98,8 +98,11 @@ export interface ProblemDetailsOptions {
  *
  * @public
  */
-export function collectIssues(error: ValidationError): ValidationIssue[] {
-  return collectLeaves(error).map((leaf) => ({
+export function collectIssues(
+  error: ValidationError | readonly ValidationError[],
+): ValidationIssue[] {
+  const leaves = Array.isArray(error) ? error : collectLeaves(error as ValidationError);
+  return leaves.map((leaf) => ({
     code: leaf.code,
     path: leaf.path,
     pointer: toJsonPointer(leaf.path),
@@ -144,15 +147,18 @@ export function collectIssues(error: ValidationError): ValidationIssue[] {
  * @public
  */
 export function toProblemDetails(
-  error: ValidationError,
+  error: ValidationError | readonly ValidationError[],
   options: ProblemDetailsOptions = {},
 ): ProblemDetails {
   const issues = collectIssues(error);
+  // `detail` summarises the first failing leaf. For a flat leaf list
+  // that's the list head; for a tree it's the first leaf in tree order.
+  const summarySource = Array.isArray(error) ? error[0] : (error as ValidationError);
   const result: ProblemDetails = {
     type: options.type ?? "about:blank",
     title: options.title ?? "Validation failed",
     status: options.status ?? 400,
-    detail: options.detail ?? formatSummary(error),
+    detail: options.detail ?? (summarySource !== undefined ? formatSummary(summarySource) : ""),
     issues,
   };
   if (options.instance !== undefined) result.instance = options.instance;

--- a/packages/core/test/format.test.ts
+++ b/packages/core/test/format.test.ts
@@ -1,14 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createBranchError, createLeafError, type ValidationError } from "../src/errors.js";
-import {
-  countErrors,
-  formatFlat,
-  formatJson,
-  formatSummary,
-  formatText,
-  summarize,
-  toJsonObject,
-} from "../src/format.js";
+import { countErrors, formatSummary, formatText, toJsonObject } from "../src/format.js";
 
 /** A realistic 4-level oneOf failure used by several formatter assertions. */
 function sampleTree(): ValidationError {
@@ -75,43 +67,6 @@ describe("formatText", () => {
   });
 });
 
-describe("formatJson", () => {
-  it("returns a tree that survives JSON.stringify → JSON.parse", () => {
-    const tree = sampleTree();
-    const roundTripped = JSON.parse(JSON.stringify(formatJson(tree)));
-    expect(roundTripped).toEqual(tree);
-  });
-
-  it("deep-copies children and params", () => {
-    const tree = sampleTree();
-    const cloned = formatJson(tree);
-    expect(cloned).not.toBe(tree);
-    expect(cloned.children).not.toBe(tree.children);
-    const firstChild = cloned.children[0];
-    if (firstChild === undefined) throw new Error("unreachable");
-    firstChild.message = "mutated";
-    expect(tree.children[0]?.message).not.toBe("mutated");
-  });
-});
-
-describe("formatFlat", () => {
-  it("emits exactly one line per leaf, not per branch", () => {
-    const out = formatFlat(sampleTree());
-    const lines = out.split("\n");
-    expect(lines).toHaveLength(2);
-    expect(lines[0]).toBe("body.purr must be boolean [type]");
-    expect(lines[1]).toBe('body must have required property "bark" [required]');
-  });
-
-  it("flattens deep nesting to a single leaf-per-line report", () => {
-    let node: ValidationError = createLeafError("type", ["deep", "x"], "bad");
-    for (let i = 0; i < 10; i += 1) {
-      node = createBranchError(`level-${i}`, [], "branch", [node]);
-    }
-    expect(formatFlat(node)).toBe("deep.x bad [type]");
-  });
-});
-
 describe("countErrors", () => {
   it("counts branches and leaves", () => {
     expect(countErrors(sampleTree())).toBe(6);
@@ -151,17 +106,12 @@ describe("formatSummary", () => {
     expect(formatSummary(tree, { select: "deepest" })).toBe("body.items[3].name must be string");
   });
 
-  it('"all" enumerates every leaf, one per line, in formatFlat shape', () => {
+  it('"all" enumerates every leaf, one per line', () => {
     const out = formatSummary(sampleTree(), { select: "all" });
     const lines = out.split("\n");
     expect(lines).toHaveLength(2);
     expect(lines[0]).toBe("body.purr must be boolean [type]");
     expect(lines[1]).toBe('body must have required property "bark" [required]');
-  });
-
-  it('"all" output is byte-identical to the deprecated formatFlat for the same tree', () => {
-    const tree = sampleTree();
-    expect(formatSummary(tree, { select: "all" })).toBe(formatFlat(tree));
   });
 
   it('"all" honors a custom separator', () => {
@@ -224,56 +174,9 @@ describe("formatSummary", () => {
   });
 });
 
-describe("summarize (deprecated)", () => {
-  it('defaults to "first" and picks the first leaf in tree-traversal order', () => {
-    expect(summarize(sampleTree())).toBe("body.purr must be boolean");
-  });
-
-  it('"deepest" picks the leaf with the longest path', () => {
-    // sampleTree's two leaves: body.purr (depth 2) vs body (depth 1).
-    // "deepest" prefers body.purr; "first" would also land here, so add
-    // a more discriminating fixture.
-    const tree = createBranchError("body", ["body"], "bad", [
-      createLeafError("required", ["body"], "missing name"),
-      createLeafError("type", ["body", "items", 3, "name"], "must be string"),
-    ]);
-    expect(summarize(tree, { select: "first" })).toBe("body missing name");
-    expect(summarize(tree, { select: "deepest" })).toBe("body.items[3].name must be string");
-  });
-
-  it('"deepest" tiebreaks on first-encountered when path lengths match', () => {
-    const tree = createBranchError("body", ["body"], "bad", [
-      createLeafError("required", ["body", "a"], "missing a"),
-      createLeafError("required", ["body", "b"], "missing b"),
-    ]);
-    expect(summarize(tree, { select: "deepest" })).toBe("body.a missing a");
-  });
-
-  it("byCode returns the first leaf matching the highest-priority listed code", () => {
-    const tree = createBranchError("request", [], "request invalid", [
-      createLeafError("type", ["body", "age"], "must be number"),
-      createLeafError("content-type", ["body"], 'Content-Type "text/plain" not accepted'),
-      createLeafError("required", ["body"], "missing name"),
-    ]);
-    // content-type wins over required even though required appears later.
-    expect(summarize(tree, { select: { byCode: ["content-type", "required"] } })).toBe(
-      'body Content-Type "text/plain" not accepted',
-    );
-    // Priority order matters: required first picks the required leaf.
-    expect(summarize(tree, { select: { byCode: ["required", "content-type"] } })).toBe(
-      "body missing name",
-    );
-  });
-
-  it('byCode falls back to "first" when no leaf matches any listed code', () => {
-    const tree = createLeafError("type", ["body", "age"], "must be number");
-    expect(summarize(tree, { select: { byCode: ["content-type", "security"] } })).toBe(
-      "body.age must be number",
-    );
-  });
-
+describe("formatSummary path-less leaf", () => {
   it("renders a path-less leaf as just the message", () => {
     const tree = createLeafError("route", [], "no matching route");
-    expect(summarize(tree)).toBe("no matching route");
+    expect(formatSummary(tree)).toBe("no matching route");
   });
 });

--- a/packages/oav-express4/README.md
+++ b/packages/oav-express4/README.md
@@ -78,10 +78,10 @@ A byte-size limit (`express.json({ limit })`) and a parse-boundary depth cap, ap
 
 Returns an Express 4 `RequestHandler`.
 
-| option          | type                                  | default                  |
-| --------------- | ------------------------------------- | ------------------------ |
-| `toHttpRequest` | `(req: Request) => HttpRequest`       | `httpRequestFromExpress` |
-| `onError`       | `(err, ctx) => void \| Promise<void>` | `renderProblemDetails`   |
+| option          | type                                                        | default                  |
+| --------------- | ----------------------------------------------------------- | ------------------------ |
+| `toHttpRequest` | `(req: Request) => HttpRequest`                             | `httpRequestFromExpress` |
+| `onError`       | `(errors: ValidationError[], ctx) => void \| Promise<void>` | `renderProblemDetails`   |
 
 `onError` may be async; the middleware awaits it. If it throws or rejects, the error is forwarded via `next(err)` so the host's error middleware sees it. The middleware does **not** call `next()` after `onError` returns; your callback owns the response (write to `ctx.res`, or call `ctx.next(err)` to delegate).
 
@@ -97,17 +97,21 @@ Header keys lowercased, path stripped of query string, cookies read from `req.co
 
 Use this when you want to compose your own middleware (e.g. validate inside an existing custom wrapper) without re-implementing the extraction.
 
-### `renderProblemDetails(err, ctx)`
+### `renderProblemDetails(errors, ctx)`
 
-The default `onError`. RFC 9457 `application/problem+json` body (via `toProblemDetails`), status from `httpStatusFor`, `Allow` header from `allowHeaderFor` on 405.
+The default `onError`. Takes the flat list of failing leaves and writes
+an RFC 9457 `application/problem+json` body (via `toProblemDetails`),
+status from `httpStatusFor`, `Allow` header from `allowHeaderFor` on 405.
+`onError` receives the same leaf list whatever `output` the validator
+uses (a tree validator's result is flattened first).
 
 Exported standalone so a custom `onError` can call it as the fallback path:
 
 ```ts
 validateRequests(validator, {
-  onError: (err, ctx) => {
-    if (err.code === "security") return ctx.res.status(401).end();
-    renderProblemDetails(err, ctx);
+  onError: (errors, ctx) => {
+    if (errors.some((e) => e.code === "security")) return ctx.res.status(401).end();
+    renderProblemDetails(errors, ctx);
   },
 });
 ```
@@ -192,10 +196,10 @@ app.use(validateRequests(validator));
 ```ts
 app.use(
   validateRequests(validator, {
-    onError: (err, ctx) => {
-      ctx.res.status(httpStatusFor(err)).json({
-        message: formatSummary(err),
-        errors: collectIssues(err),
+    onError: (errors, ctx) => {
+      ctx.res.status(httpStatusFor(errors)).json({
+        message: `${errors.length} validation error(s)`,
+        errors: collectIssues(errors),
       });
     },
   }),
@@ -207,7 +211,7 @@ app.use(
 ```ts
 app.use(
   validateRequests(validator, {
-    onError: (err, ctx) => ctx.next(new ValidationFailure(err)),
+    onError: (errors, ctx) => ctx.next(new ValidationFailure(errors)),
   }),
 );
 
@@ -227,9 +231,9 @@ Validation failures don't reach your registered Express error middleware by defa
 ```ts
 app.use(
   validateRequests(validator, {
-    onError: (err, ctx) => {
-      log.warn("validation failed", { path: ctx.req.path, code: err.code });
-      renderProblemDetails(err, ctx);
+    onError: (errors, ctx) => {
+      log.warn("validation failed", { path: ctx.req.path, codes: errors.map((e) => e.code) });
+      renderProblemDetails(errors, ctx);
     },
   }),
 );
@@ -242,9 +246,9 @@ Use this whenever your existing error pipeline (Sentry, structured logger, reque
 ```ts
 app.use(
   validateRequests(validator, {
-    onError: async (err, ctx) => {
-      await sentry.captureException(err);
-      renderProblemDetails(err, ctx);
+    onError: async (errors, ctx) => {
+      await sentry.captureException(errors);
+      renderProblemDetails(errors, ctx);
     },
   }),
 );

--- a/packages/oav-express4/src/middleware.ts
+++ b/packages/oav-express4/src/middleware.ts
@@ -1,6 +1,6 @@
 import type { Request, RequestHandler } from "express";
-import type { HttpRequest } from "@oav/core";
-import type { Validator } from "@oav/validator";
+import { collectLeaves, type HttpRequest, type ValidationError } from "@oav/core";
+import type { TreeValidator, Validator } from "@oav/validator";
 import { httpRequestFromExpress } from "./extract.js";
 import { renderProblemDetails } from "./render.js";
 import type { ErrorHandler, ExpressContext } from "./types.js";
@@ -69,9 +69,17 @@ export interface ValidateRequestsOptions {
  * @public
  */
 export function validateRequests(
-  validator: Validator,
+  validator: Validator | TreeValidator,
   options: ValidateRequestsOptions = {},
 ): RequestHandler {
+  // A predicate validator returns a bare boolean, so there are no errors
+  // to render. Fail loudly at construction rather than emitting empty 400s.
+  if (validator.output === "predicate") {
+    throw new Error(
+      'validateRequests: a predicate-mode validator (output: "predicate") cannot render ' +
+        'problem-details responses. Build the validator with output: "flat" (default) or "tree".',
+    );
+  }
   const toHttpRequest = options.toHttpRequest ?? httpRequestFromExpress;
   const onError = options.onError ?? renderProblemDetails;
 
@@ -83,16 +91,18 @@ export function validateRequests(
       next(e);
       return;
     }
-    const err = validator.validateRequest(httpReq);
-    if (err === null) {
+    const result = validator.validateRequest(httpReq);
+    if (result.valid) {
       next();
       return;
     }
+    const errors: ValidationError[] =
+      "errors" in result ? result.errors : collectLeaves(result.error);
     // onError may be sync or async. Awaiting a sync (void) return is
     // essentially free; awaiting a Promise lets handlers do async work
     // (remote logging, dynamic rendering config) before the response
     // settles. Promise rejection is forwarded to next(err) so the
     // host's error middleware sees it.
-    Promise.resolve(onError(err, { req, res, next })).catch(next);
+    Promise.resolve(onError(errors, { req, res, next })).catch(next);
   };
 }

--- a/packages/oav-express4/src/render.ts
+++ b/packages/oav-express4/src/render.ts
@@ -3,11 +3,10 @@ import type { ExpressContext } from "./types.js";
 
 /**
  * The default `onError` for {@link validateRequests}. Renders the
- * validation tree as an RFC 9457 `application/problem+json` response:
+ * failing leaves as an RFC 9457 `application/problem+json` response:
  * status from {@link httpStatusFor}, `Allow` header from
  * {@link allowHeaderFor} on a 405, body from {@link toProblemDetails}
- * (whose `detail` is the first failing leaf via
- * {@link formatSummary}).
+ * (whose `detail` is the first failing leaf).
  *
  * Exported standalone for two cases:
  *
@@ -20,11 +19,11 @@ import type { ExpressContext } from "./types.js";
  *
  * @public
  */
-export function renderProblemDetails(err: ValidationError, ctx: ExpressContext): void {
-  const allow = allowHeaderFor(err);
+export function renderProblemDetails(errors: ValidationError[], ctx: ExpressContext): void {
+  const allow = allowHeaderFor(errors);
   if (allow !== undefined) ctx.res.setHeader("Allow", allow);
   ctx.res
-    .status(httpStatusFor(err))
+    .status(httpStatusFor(errors))
     .type("application/problem+json")
-    .json(toProblemDetails(err, { instance: ctx.req.originalUrl }));
+    .json(toProblemDetails(errors, { instance: ctx.req.originalUrl }));
 }

--- a/packages/oav-express4/src/types.ts
+++ b/packages/oav-express4/src/types.ts
@@ -28,6 +28,10 @@ export interface ExpressContext {
  * loading per-tenant rendering config, etc.) can complete before the
  * middleware exits. Sync handlers pay no measurable overhead.
  *
+ * `errors` is the flat list of failing leaves, regardless of the
+ * validator's `output` mode (a tree validator's result is flattened
+ * before the handler is called).
+ *
  * @public
  */
-export type ErrorHandler<Ctx> = (err: ValidationError, ctx: Ctx) => void | Promise<void>;
+export type ErrorHandler<Ctx> = (errors: ValidationError[], ctx: Ctx) => void | Promise<void>;

--- a/packages/oav-express4/test/middleware.test.ts
+++ b/packages/oav-express4/test/middleware.test.ts
@@ -50,6 +50,11 @@ function fakeReq(overrides: Partial<Request>): Request {
 describe("validateRequests", () => {
   const v = createValidator(petSpec());
 
+  it("rejects a predicate-mode validator at construction", () => {
+    const predicate = createValidator(petSpec(), { output: "predicate" });
+    expect(() => validateRequests(predicate as never)).toThrow(/predicate-mode/);
+  });
+
   it("calls next() for a valid request without writing a response", () => {
     const mw = validateRequests(v);
     const res = fakeRes();
@@ -117,8 +122,9 @@ describe("validateRequests", () => {
       next,
     );
     expect(onError).toHaveBeenCalledTimes(1);
-    const [err, ctx] = onError.mock.calls[0]!;
-    expect((err as ValidationError).code).toBe("request");
+    const [errors, ctx] = onError.mock.calls[0]!;
+    expect(Array.isArray(errors)).toBe(true);
+    expect((errors as ValidationError[]).length).toBeGreaterThan(0);
     expect(ctx).toMatchObject({ res, next });
     expect(res.status).not.toHaveBeenCalled();
     expect(res.json).not.toHaveBeenCalled();

--- a/packages/oav-express5/README.md
+++ b/packages/oav-express5/README.md
@@ -76,10 +76,10 @@ A byte-size limit (`express.json({ limit })`) and a parse-boundary depth cap, ap
 
 Returns an Express 5 promise-returning `RequestHandler`.
 
-| option          | type                                  | default                  |
-| --------------- | ------------------------------------- | ------------------------ |
-| `toHttpRequest` | `(req: Request) => HttpRequest`       | `httpRequestFromExpress` |
-| `onError`       | `(err, ctx) => void \| Promise<void>` | `renderProblemDetails`   |
+| option          | type                                                        | default                  |
+| --------------- | ----------------------------------------------------------- | ------------------------ |
+| `toHttpRequest` | `(req: Request) => HttpRequest`                             | `httpRequestFromExpress` |
+| `onError`       | `(errors: ValidationError[], ctx) => void \| Promise<void>` | `renderProblemDetails`   |
 
 `onError` may be async; the middleware awaits it. Express 5 awaits the returned promise, so thrown extractor errors and rejected `onError` promises propagate to the host's error middleware automatically, no `try/catch` needed. The middleware does **not** call `next()` after `onError` returns; your callback owns the response (write to `ctx.res`, or call `ctx.next(err)` to delegate).
 
@@ -95,17 +95,21 @@ Header keys lowercased, path stripped of query string, cookies read from `req.co
 
 Use this when you want to compose your own middleware (e.g. validate inside an existing custom wrapper) without re-implementing the extraction.
 
-### `renderProblemDetails(err, ctx)`
+### `renderProblemDetails(errors, ctx)`
 
-The default `onError`. RFC 9457 `application/problem+json` body (via `toProblemDetails`), status from `httpStatusFor`, `Allow` header from `allowHeaderFor` on 405.
+The default `onError`. Takes the flat list of failing leaves and writes
+an RFC 9457 `application/problem+json` body (via `toProblemDetails`),
+status from `httpStatusFor`, `Allow` header from `allowHeaderFor` on 405.
+`onError` receives the same leaf list whatever `output` the validator
+uses (a tree validator's result is flattened first).
 
 Exported standalone so a custom `onError` can call it as the fallback path:
 
 ```ts
 validateRequests(validator, {
-  onError: (err, ctx) => {
-    if (err.code === "security") return ctx.res.status(401).end();
-    renderProblemDetails(err, ctx);
+  onError: (errors, ctx) => {
+    if (errors.some((e) => e.code === "security")) return ctx.res.status(401).end();
+    renderProblemDetails(errors, ctx);
   },
 });
 ```
@@ -139,10 +143,10 @@ app.use(validateRequests(validator));
 ```ts
 app.use(
   validateRequests(validator, {
-    onError: (err, ctx) => {
-      ctx.res.status(httpStatusFor(err)).json({
-        message: formatSummary(err),
-        errors: collectIssues(err),
+    onError: (errors, ctx) => {
+      ctx.res.status(httpStatusFor(errors)).json({
+        message: `${errors.length} validation error(s)`,
+        errors: collectIssues(errors),
       });
     },
   }),
@@ -154,7 +158,7 @@ app.use(
 ```ts
 app.use(
   validateRequests(validator, {
-    onError: (err, ctx) => ctx.next(new ValidationFailure(err)),
+    onError: (errors, ctx) => ctx.next(new ValidationFailure(errors)),
   }),
 );
 
@@ -174,9 +178,9 @@ Validation failures don't reach your registered Express error middleware by defa
 ```ts
 app.use(
   validateRequests(validator, {
-    onError: (err, ctx) => {
-      log.warn("validation failed", { path: ctx.req.path, code: err.code });
-      renderProblemDetails(err, ctx);
+    onError: (errors, ctx) => {
+      log.warn("validation failed", { path: ctx.req.path, codes: errors.map((e) => e.code) });
+      renderProblemDetails(errors, ctx);
     },
   }),
 );
@@ -189,9 +193,9 @@ Use this whenever your existing error pipeline (Sentry, structured logger, reque
 ```ts
 app.use(
   validateRequests(validator, {
-    onError: async (err, ctx) => {
-      await sentry.captureException(err);
-      renderProblemDetails(err, ctx);
+    onError: async (errors, ctx) => {
+      await sentry.captureException(errors);
+      renderProblemDetails(errors, ctx);
     },
   }),
 );

--- a/packages/oav-express5/src/middleware.ts
+++ b/packages/oav-express5/src/middleware.ts
@@ -1,6 +1,6 @@
 import type { Request, RequestHandler } from "express";
-import type { HttpRequest } from "@oav/core";
-import type { Validator } from "@oav/validator";
+import { collectLeaves, type HttpRequest, type ValidationError } from "@oav/core";
+import type { TreeValidator, Validator } from "@oav/validator";
 import { httpRequestFromExpress } from "./extract.js";
 import { renderProblemDetails } from "./render.js";
 import type { ErrorHandler, ExpressContext } from "./types.js";
@@ -69,22 +69,32 @@ export interface ValidateRequestsOptions {
  * @public
  */
 export function validateRequests(
-  validator: Validator,
+  validator: Validator | TreeValidator,
   options: ValidateRequestsOptions = {},
 ): RequestHandler {
+  // A predicate validator returns a bare boolean, so there are no errors
+  // to render. Fail loudly at construction rather than emitting empty 400s.
+  if (validator.output === "predicate") {
+    throw new Error(
+      'validateRequests: a predicate-mode validator (output: "predicate") cannot render ' +
+        'problem-details responses. Build the validator with output: "flat" (default) or "tree".',
+    );
+  }
   const toHttpRequest = options.toHttpRequest ?? httpRequestFromExpress;
   const onError = options.onError ?? renderProblemDetails;
 
   return async (req, res, next) => {
     const httpReq = toHttpRequest(req);
-    const err = validator.validateRequest(httpReq);
-    if (err === null) {
+    const result = validator.validateRequest(httpReq);
+    if (result.valid) {
       next();
       return;
     }
+    const errors: ValidationError[] =
+      "errors" in result ? result.errors : collectLeaves(result.error);
     // Express 5 awaits the returned promise; thrown errors and
     // rejected promises propagate to the host's error middleware.
     // Sync onError handlers complete inline; async ones get awaited.
-    await onError(err, { req, res, next });
+    await onError(errors, { req, res, next });
   };
 }

--- a/packages/oav-express5/src/render.ts
+++ b/packages/oav-express5/src/render.ts
@@ -3,11 +3,10 @@ import type { ExpressContext } from "./types.js";
 
 /**
  * The default `onError` for {@link validateRequests}. Renders the
- * validation tree as an RFC 9457 `application/problem+json` response:
+ * failing leaves as an RFC 9457 `application/problem+json` response:
  * status from {@link httpStatusFor}, `Allow` header from
  * {@link allowHeaderFor} on a 405, body from {@link toProblemDetails}
- * (whose `detail` is the first failing leaf via
- * {@link formatSummary}).
+ * (whose `detail` is the first failing leaf).
  *
  * Exported standalone for two cases:
  *
@@ -20,11 +19,11 @@ import type { ExpressContext } from "./types.js";
  *
  * @public
  */
-export function renderProblemDetails(err: ValidationError, ctx: ExpressContext): void {
-  const allow = allowHeaderFor(err);
+export function renderProblemDetails(errors: ValidationError[], ctx: ExpressContext): void {
+  const allow = allowHeaderFor(errors);
   if (allow !== undefined) ctx.res.setHeader("Allow", allow);
   ctx.res
-    .status(httpStatusFor(err))
+    .status(httpStatusFor(errors))
     .type("application/problem+json")
-    .json(toProblemDetails(err, { instance: ctx.req.originalUrl }));
+    .json(toProblemDetails(errors, { instance: ctx.req.originalUrl }));
 }

--- a/packages/oav-express5/src/types.ts
+++ b/packages/oav-express5/src/types.ts
@@ -27,6 +27,10 @@ export interface ExpressContext {
  * awaits the return; rejected promises propagate through Express 5's
  * native promise handling to the host's error middleware.
  *
+ * `errors` is the flat list of failing leaves, regardless of the
+ * validator's `output` mode (a tree validator's result is flattened
+ * before the handler is called).
+ *
  * @public
  */
-export type ErrorHandler<Ctx> = (err: ValidationError, ctx: Ctx) => void | Promise<void>;
+export type ErrorHandler<Ctx> = (errors: ValidationError[], ctx: Ctx) => void | Promise<void>;

--- a/packages/oav-express5/test/middleware.test.ts
+++ b/packages/oav-express5/test/middleware.test.ts
@@ -50,6 +50,11 @@ function fakeReq(overrides: Partial<Request>): Request {
 describe("validateRequests", () => {
   const v = createValidator(petSpec());
 
+  it("rejects a predicate-mode validator at construction", () => {
+    const predicate = createValidator(petSpec(), { output: "predicate" });
+    expect(() => validateRequests(predicate as never)).toThrow(/predicate-mode/);
+  });
+
   it("calls next() for a valid request without writing a response", async () => {
     const mw = validateRequests(v);
     const res = fakeRes();
@@ -108,8 +113,9 @@ describe("validateRequests", () => {
       next,
     );
     expect(onError).toHaveBeenCalledTimes(1);
-    const [err, ctx] = onError.mock.calls[0]!;
-    expect((err as ValidationError).code).toBe("request");
+    const [errors, ctx] = onError.mock.calls[0]!;
+    expect(Array.isArray(errors)).toBe(true);
+    expect((errors as ValidationError[]).length).toBeGreaterThan(0);
     expect(ctx).toMatchObject({ res, next });
     expect(res.status).not.toHaveBeenCalled();
     expect(next).not.toHaveBeenCalled();

--- a/packages/oav-fastify/README.md
+++ b/packages/oav-fastify/README.md
@@ -72,10 +72,10 @@ Mount on `preValidation` so oav sees the parsed body. If you also have per-route
 
 Returns a Fastify `preValidationHookHandler`.
 
-| option          | type                                       | default                  |
-| --------------- | ------------------------------------------ | ------------------------ |
-| `toHttpRequest` | `(request: FastifyRequest) => HttpRequest` | `httpRequestFromFastify` |
-| `onError`       | `(err, ctx) => void \| Promise<void>`      | `renderProblemDetails`   |
+| option          | type                                                        | default                  |
+| --------------- | ----------------------------------------------------------- | ------------------------ |
+| `toHttpRequest` | `(request: FastifyRequest) => HttpRequest`                  | `httpRequestFromFastify` |
+| `onError`       | `(errors: ValidationError[], ctx) => void \| Promise<void>` | `renderProblemDetails`   |
 
 `onError` may be async; the hook awaits it. Fastify awaits the returned promise, so thrown extractor errors and rejected `onError` promises propagate to Fastify's `setErrorHandler` automatically, no `try/catch` needed. The hook does **not** call `reply.send()` after `onError` returns; your callback owns the response (write to `ctx.reply`, or throw to delegate to Fastify's error handler).
 
@@ -91,17 +91,21 @@ Header keys passed through (Fastify already lowercases per HTTP spec), path stri
 
 Use this when you want to compose your own hook (e.g. validate inside a custom plugin) without re-implementing the extraction.
 
-### `renderProblemDetails(err, ctx)`
+### `renderProblemDetails(errors, ctx)`
 
-The default `onError`. RFC 9457 `application/problem+json` body (via `toProblemDetails`), status from `httpStatusFor`, `Allow` header from `allowHeaderFor` on 405.
+The default `onError`. Takes the flat list of failing leaves and writes
+an RFC 9457 `application/problem+json` body (via `toProblemDetails`),
+status from `httpStatusFor`, `Allow` header from `allowHeaderFor` on 405.
+`onError` receives the same leaf list whatever `output` the validator
+uses (a tree validator's result is flattened first).
 
 Exported standalone so a custom `onError` can call it as the fallback path:
 
 ```ts
 validateRequests(validator, {
-  onError: (err, ctx) => {
-    if (err.code === "security") return ctx.reply.code(401).send();
-    renderProblemDetails(err, ctx);
+  onError: (errors, ctx) => {
+    if (errors.some((e) => e.code === "security")) return ctx.reply.code(401).send();
+    renderProblemDetails(errors, ctx);
   },
 });
 ```
@@ -125,10 +129,10 @@ The check is shape-only: it confirms the declared credential is _present_, not t
 app.addHook(
   "preValidation",
   validateRequests(validator, {
-    onError: (err, ctx) => {
-      ctx.reply.code(httpStatusFor(err)).send({
-        message: formatSummary(err),
-        errors: collectIssues(err),
+    onError: (errors, ctx) => {
+      ctx.reply.code(httpStatusFor(errors)).send({
+        message: `${errors.length} validation error(s)`,
+        errors: collectIssues(errors),
       });
     },
   }),
@@ -143,8 +147,8 @@ Throw from `onError`; Fastify routes thrown errors to `setErrorHandler`:
 app.addHook(
   "preValidation",
   validateRequests(validator, {
-    onError: (err) => {
-      throw new ValidationFailure(err);
+    onError: (errors) => {
+      throw new ValidationFailure(errors);
     },
   }),
 );
@@ -166,9 +170,9 @@ Validation failures don't reach your registered `setErrorHandler` by default (th
 app.addHook(
   "preValidation",
   validateRequests(validator, {
-    onError: (err, ctx) => {
-      log.warn("validation failed", { url: ctx.request.url, code: err.code });
-      renderProblemDetails(err, ctx);
+    onError: (errors, ctx) => {
+      log.warn("validation failed", { url: ctx.request.url, codes: errors.map((e) => e.code) });
+      renderProblemDetails(errors, ctx);
     },
   }),
 );
@@ -182,9 +186,9 @@ Use this whenever your existing error pipeline (Sentry, structured logger, reque
 app.addHook(
   "preValidation",
   validateRequests(validator, {
-    onError: async (err, ctx) => {
-      await sentry.captureException(err);
-      renderProblemDetails(err, ctx);
+    onError: async (errors, ctx) => {
+      await sentry.captureException(errors);
+      renderProblemDetails(errors, ctx);
     },
   }),
 );

--- a/packages/oav-fastify/src/middleware.ts
+++ b/packages/oav-fastify/src/middleware.ts
@@ -1,6 +1,6 @@
 import type { FastifyRequest, preValidationHookHandler } from "fastify";
-import type { HttpRequest } from "@oav/core";
-import type { Validator } from "@oav/validator";
+import { collectLeaves, type HttpRequest, type ValidationError } from "@oav/core";
+import type { TreeValidator, Validator } from "@oav/validator";
 import { httpRequestFromFastify } from "./extract.js";
 import { renderProblemDetails } from "./render.js";
 import type { ErrorHandler, FastifyContext } from "./types.js";
@@ -72,20 +72,30 @@ export interface ValidateRequestsOptions {
  * @public
  */
 export function validateRequests(
-  validator: Validator,
+  validator: Validator | TreeValidator,
   options: ValidateRequestsOptions = {},
 ): preValidationHookHandler {
+  // A predicate validator returns a bare boolean, so there are no errors
+  // to render. Fail loudly at construction rather than emitting empty 400s.
+  if (validator.output === "predicate") {
+    throw new Error(
+      'validateRequests: a predicate-mode validator (output: "predicate") cannot render ' +
+        'problem-details responses. Build the validator with output: "flat" (default) or "tree".',
+    );
+  }
   const toHttpRequest = options.toHttpRequest ?? httpRequestFromFastify;
   const onError = options.onError ?? renderProblemDetails;
 
   return async (request, reply) => {
     const httpReq = toHttpRequest(request);
-    const err = validator.validateRequest(httpReq);
-    if (err === null) return;
+    const result = validator.validateRequest(httpReq);
+    if (result.valid) return;
+    const errors: ValidationError[] =
+      "errors" in result ? result.errors : collectLeaves(result.error);
     // Fastify awaits the returned promise; thrown errors / rejected
     // promises propagate to Fastify's error handler. The hook
     // returns once onError settles; Fastify treats a sent reply
     // as "we handled it, skip the route handler."
-    await onError(err, { request, reply });
+    await onError(errors, { request, reply });
   };
 }

--- a/packages/oav-fastify/src/render.ts
+++ b/packages/oav-fastify/src/render.ts
@@ -3,11 +3,10 @@ import type { FastifyContext } from "./types.js";
 
 /**
  * The default `onError` for {@link validateRequests}. Renders the
- * validation tree as an RFC 9457 `application/problem+json` response:
+ * failing leaves as an RFC 9457 `application/problem+json` response:
  * status from {@link httpStatusFor}, `Allow` header from
  * {@link allowHeaderFor} on a 405, body from {@link toProblemDetails}
- * (whose `detail` is the first failing leaf via
- * {@link formatSummary}).
+ * (whose `detail` is the first failing leaf).
  *
  * Exported standalone for two cases:
  *
@@ -23,11 +22,11 @@ import type { FastifyContext } from "./types.js";
  *
  * @public
  */
-export function renderProblemDetails(err: ValidationError, ctx: FastifyContext): void {
-  const allow = allowHeaderFor(err);
+export function renderProblemDetails(errors: ValidationError[], ctx: FastifyContext): void {
+  const allow = allowHeaderFor(errors);
   if (allow !== undefined) ctx.reply.header("Allow", allow);
   ctx.reply
-    .code(httpStatusFor(err))
+    .code(httpStatusFor(errors))
     .type("application/problem+json")
-    .send(toProblemDetails(err, { instance: ctx.request.url }));
+    .send(toProblemDetails(errors, { instance: ctx.request.url }));
 }

--- a/packages/oav-fastify/src/types.ts
+++ b/packages/oav-fastify/src/types.ts
@@ -31,6 +31,10 @@ export interface FastifyContext {
  * awaits the return; rejected promises propagate through Fastify's
  * native promise handling to its error handler.
  *
+ * `errors` is the flat list of failing leaves, regardless of the
+ * validator's `output` mode (a tree validator's result is flattened
+ * before the handler is called).
+ *
  * @public
  */
-export type ErrorHandler<Ctx> = (err: ValidationError, ctx: Ctx) => void | Promise<void>;
+export type ErrorHandler<Ctx> = (errors: ValidationError[], ctx: Ctx) => void | Promise<void>;

--- a/packages/oav-fastify/test/hook.test.ts
+++ b/packages/oav-fastify/test/hook.test.ts
@@ -50,6 +50,11 @@ function fakeRequest(overrides: Partial<FastifyRequest>): FastifyRequest {
 describe("validateRequests", () => {
   const v = createValidator(petSpec());
 
+  it("rejects a predicate-mode validator at construction", () => {
+    const predicate = createValidator(petSpec(), { output: "predicate" });
+    expect(() => validateRequests(predicate as never)).toThrow(/predicate-mode/);
+  });
+
   it("resolves without sending for a valid request", async () => {
     const hook = validateRequests(v);
     const reply = fakeReply();
@@ -105,8 +110,9 @@ describe("validateRequests", () => {
       () => {},
     );
     expect(onError).toHaveBeenCalledTimes(1);
-    const [err, ctx] = onError.mock.calls[0]!;
-    expect((err as ValidationError).code).toBe("request");
+    const [errors, ctx] = onError.mock.calls[0]!;
+    expect(Array.isArray(errors)).toBe(true);
+    expect((errors as ValidationError[]).length).toBeGreaterThan(0);
     expect(ctx).toMatchObject({ reply });
     expect(reply.code).not.toHaveBeenCalled();
     expect(reply.send).not.toHaveBeenCalled();

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -21,7 +21,7 @@ const { validate } = compileSchema(
 );
 
 validate({ name: "Fido" }); // { valid: true }
-validate({}); // { valid: false, error: { code: "required", ... } }
+validate({}); // { valid: false, errors: [{ code: "required", ... }], truncated: false }
 ```
 
 `compileSchema` returns `{ validate, source, stats }`. `validate(data,
@@ -29,6 +29,12 @@ startPath?)` runs the generated validator; `startPath` prepends segments
 to every error's `path` (used by the HTTP validator to prefix `"body"`,
 `"query"`, etc.). `source` is the generated JS, exposed for debugging;
 `stats.functionCount` is the number of helper functions emitted.
+
+By default `validate` returns a flat `errors` list and stops at the
+first problem (`maxErrors: 1`), matching Ajv's defaults. Pass
+`output: "tree"` for a nested error tree under `error`,
+`output: "predicate"` for a bare boolean, and
+`maxErrors: Number.POSITIVE_INFINITY` to collect every error.
 
 ## Dialects
 
@@ -107,15 +113,25 @@ you emit generated code directly.
 This is a contributor-facing surface; the full compile-context API and
 flag reference live in [`CLAUDE.md`](../../CLAUDE.md#how-to-add-a-new-keyword).
 
-## Error-collection modes
+## Output and error-collection modes
 
-`compileSchema(schema, { maxErrors: N })` caps the tree at N leaves and
-short-circuits hot loops once the budget is exhausted. `maxErrors: 1`
-is classic fast-fail; larger values bound CPU/memory on huge invalid
-payloads. Results carry `truncated: true` when the tree was capped.
-Omit the option for zero-overhead unlimited collection: codegen is
-specialized so uncapped callers emit plain `errors.push` with no
-budget checks.
+`output` selects the result shape: `"flat"` (default) returns
+`{ valid, errors, truncated }` with a de-nested leaf list; `"tree"`
+returns `{ valid, error, truncated }` with the nested error tree;
+`"predicate"` returns a bare boolean and builds no errors at all.
+
+`maxErrors` caps the leaves collected and short-circuits hot loops once
+the budget is exhausted. The default is `1` (classic fast-fail, matching
+Ajv); larger values bound CPU/memory on huge invalid payloads, and
+`Number.POSITIVE_INFINITY` collects everything with zero-overhead
+codegen (plain `errors.push`, no budget checks). A failing result
+carries `truncated: true` when the cap was reached.
+
+`output` and `maxErrors` are orthogonal. A finite `maxErrors` never
+changes a valid/invalid verdict; for schemas using
+`unevaluatedProperties` / `unevaluatedItems` the short-circuit is
+disabled (every error is collected) so the cap can't suppress a real
+`unevaluated*` error.
 
 ## `$ref` and cycles
 

--- a/packages/schema/src/compiler/compiler.ts
+++ b/packages/schema/src/compiler/compiler.ts
@@ -209,44 +209,75 @@ function runStrictLint(
 }
 
 /**
- * Result of compiling a JSON Schema 2020-12 document. The shape mirrors what
- * the user-facing validator in `@oav/validator` wants: a `{ valid, error? }`
- * object.
+ * Result of a default-mode `validate()` call: a flat list of leaf
+ * errors under `errors`. This is the v3 default (`output: "flat"`),
+ * shaped to match ajv's zero-config result. Every failing leaf keyword
+ * (`type`, `required`, `minimum`, …) is its own record, plus a childless
+ * marker leaf for each failed composition keyword (`anyOf` / `oneOf`);
+ * no `"schema"` branch wrappers. Each record is a {@link ValidationError}
+ * with an empty `children`, so the `@oav/core` renderers consume it
+ * unchanged. For the nested error tree, compile with `output: "tree"`
+ * and see {@link TreeValidationResult}.
+ *
+ * A discriminated union on `valid`: a successful result carries no error
+ * fields; a failing result always carries both `errors` (the flat leaf
+ * list, non-empty) and `truncated`. Narrow on `result.valid` to reach
+ * the error fields. The narrowing also makes a mistaken `result.error`
+ * access (the tree-mode field) a compile error rather than a silent
+ * `undefined`.
  *
  * @public
  */
-export interface ValidationResult {
-  valid: boolean;
-  error?: ValidationError;
-  /**
-   * `true` when at least one error was dropped because the configured
-   * `maxErrors` cap was hit. Only ever set on `{ valid: false }` results.
-   */
-  truncated?: boolean;
-}
+export type ValidationResult =
+  | { valid: true }
+  | {
+      valid: false;
+      /** The flat list of leaf errors. Always non-empty when `!valid`. */
+      errors: ValidationError[];
+      /**
+       * `true` when at least one error was dropped because the configured
+       * `maxErrors` cap was hit. The v3 default is `maxErrors: 1`, so a
+       * payload with more than one problem reports `truncated: true`;
+       * `false` when the list is complete.
+       */
+      truncated: boolean;
+    };
 
 /**
- * Result of a flat-mode (`flat: true`) `validate()` call. Where the
- * default mode returns a single nested {@link ValidationError} tree
- * under `error`, flat mode returns a de-nested list of leaf errors under
- * `errors`: every failing leaf keyword (`type`, `required`, `minimum`, …)
- * as its own record, plus a childless marker leaf for each failed
- * composition keyword (`anyOf` / `oneOf`). No `"schema"` branch
- * wrappers. Each record is a {@link ValidationError} with an empty
- * `children`, so the `@oav/core` renderers still consume it.
+ * Result of a tree-mode (`output: "tree"`) `validate()` call: a single
+ * nested {@link ValidationError} tree under `error`, with `"schema"`
+ * branch nodes mirroring the schema's composition structure. The opt-in
+ * counterpart to the flat {@link ValidationResult} default. The HTTP
+ * validator in `@oav/validator` compiles in this mode so it can nest
+ * per-location subtrees (`body`, `query`, …) under one root.
+ *
+ * A discriminated union on `valid`: a successful result carries no error
+ * fields; a failing result always carries both `error` (the tree root)
+ * and `truncated`.
  *
  * @public
  */
-export interface FlatValidationResult {
-  valid: boolean;
-  /** The flat list of leaf errors. Present (and non-empty) iff `!valid`. */
-  errors?: ValidationError[];
-  /**
-   * `true` when at least one error was dropped because the configured
-   * `maxErrors` cap was hit. Only ever set on `{ valid: false }` results.
-   */
-  truncated?: boolean;
-}
+export type TreeValidationResult =
+  | { valid: true }
+  | {
+      valid: false;
+      /** The root of the nested error tree. Always present when `!valid`. */
+      error: ValidationError;
+      /**
+       * `true` when at least one error was dropped because the configured
+       * `maxErrors` cap was hit; `false` when the tree is complete.
+       */
+      truncated: boolean;
+    };
+
+/**
+ * @deprecated Renamed to {@link ValidationResult} now that flat is the
+ * default error shape (v3). This alias is kept for one major and will be
+ * removed in v4. Update imports to `ValidationResult`.
+ *
+ * @public
+ */
+export type FlatValidationResult = ValidationResult;
 
 /**
  * Compile-time statistics about the generated validator. Exposed so
@@ -355,8 +386,25 @@ export type CompiledSchema = {
 };
 
 /**
- * The shape returned by {@link compileSchema} when `predicate: true` is
- * set. The validator collects no errors, allocates no tree, and
+ * The shape returned by {@link compileSchema} when `output: "tree"` is
+ * set. Same `validate(data, startPath?)` signature as
+ * {@link CompiledSchema}, but returns a {@link TreeValidationResult} (a
+ * single nested error tree) instead of the flat default. See
+ * {@link CompileOptions.output}.
+ *
+ * @public
+ */
+export type CompiledTreeSchema = {
+  validate: (data: unknown, startPath?: readonly PathSegment[]) => TreeValidationResult;
+  /** The generated source. Exposed for debugging/snapshot testing only. */
+  source: string;
+  /** Compile-time stats about the generated validator. */
+  stats: CompileStats;
+};
+
+/**
+ * The shape returned by {@link compileSchema} when `output: "predicate"`
+ * is set. The validator collects no errors, allocates no tree, and
  * returns a boolean: a true yes/no predicate. Use when consumers only
  * need to know whether the value conforms (e.g. routing, gating), not
  * why it doesn't.
@@ -372,21 +420,14 @@ export type CompiledPredicate = {
 };
 
 /**
- * The shape returned by {@link compileSchema} when `flat: true` is set.
- * Same `validate(data, startPath?)` signature as {@link CompiledSchema},
- * but returns a {@link FlatValidationResult} (a flat leaf list) instead
- * of a nested error tree. See {@link FlatValidationResult} for the
- * trade-off and {@link CompileOptions.flat}.
+ * @deprecated Flat is the default error shape now (v3), so the default
+ * {@link CompiledSchema} already returns a flat {@link ValidationResult}.
+ * This alias is kept for one major and will be removed in v4. Drop the
+ * `flat: true` option and use `CompiledSchema`.
  *
  * @public
  */
-export type CompiledFlatSchema = {
-  validate: (data: unknown, startPath?: readonly PathSegment[]) => FlatValidationResult;
-  /** The generated source. Exposed for debugging/snapshot testing only. */
-  source: string;
-  /** Compile-time stats about the generated validator. */
-  stats: CompileStats;
-};
+export type CompiledFlatSchema = CompiledSchema;
 
 /**
  * Options accepted by {@link compileSchema}.
@@ -397,9 +438,8 @@ export type CompiledFlatSchema = {
  *
  *   1. Compile essentials: `dialect`.
  *   2. Shared extension points: `formats`, `keywords`.
- *   3. Error-collection policy: `maxErrors`.
- *   4. Surface-specific extras last: here, `external`, `refResolver`,
- *      `predicate`.
+ *   3. Error-collection policy: `output`, `maxErrors`.
+ *   4. Surface-specific extras last: here, `external`, `refResolver`.
  *
  * Options common to both surfaces share names and positions so a
  * reader of one declaration can predict the other. When adding a new
@@ -444,22 +484,53 @@ export interface CompileOptions {
   // --- 3. Error-collection policy ---
 
   /**
+   * What `validate()` returns. Selects the result shape:
+   *
+   * - `"flat"` (default): a {@link ValidationResult}: `{ valid }` plus,
+   *   on failure, a de-nested `errors` leaf list and `truncated`. Shaped
+   *   to match ajv's zero-config output. With the default
+   *   `maxErrors: 1`, this is the fast-fail path that hits ajv-class
+   *   numbers on the rejection benchmark.
+   * - `"tree"`: a {@link TreeValidationResult}: `{ valid }` plus, on
+   *   failure, a single nested {@link ValidationError} tree under `error`
+   *   and `truncated`. The rich diagnostic shape; what `@oav/validator`
+   *   compiles in so it can nest per-location subtrees.
+   * - `"predicate"`: a {@link CompiledPredicate} whose `validate(data)`
+   *   returns a bare `boolean`. No {@link ValidationError} tree is ever
+   *   constructed, so consumers who only need a yes/no answer pay nothing
+   *   for error-reporting machinery (leaf allocation, path snapshot,
+   *   params object, message string).
+   *
+   * Defaults to `"flat"`. The deprecated `flat: true` / `predicate: true`
+   * booleans still work as aliases for `output: "flat"` / `"predicate"`;
+   * supplying both `output` and a conflicting legacy boolean throws.
+   *
+   * `output: "predicate"` is mutually exclusive with a finite
+   * {@link CompileOptions.maxErrors}: a predicate short-circuits at the
+   * first failure, so there is nothing to count. The compiler throws when
+   * both are supplied.
+   */
+  output?: "flat" | "tree" | "predicate";
+  /**
    * Cap on the number of leaf errors collected per `validate()` call.
-   * Defaults to `Number.POSITIVE_INFINITY` (collect everything).
+   * Defaults to `1` (fast-fail: stop at the first error), matching ajv's
+   * `allErrors: false` zero-config behaviour. Pass
+   * `Number.POSITIVE_INFINITY` to collect everything.
    *
    * When set to a finite value:
    * - Once the cap is reached, further errors are dropped and
-   *   {@link ValidationResult.truncated} is set on the returned result.
+   *   `truncated: true` is set on the returned result.
    * - Hot loops (array items, object properties, `allOf`/`anyOf`
    *   branches) short-circuit as soon as the budget is exhausted, so
    *   the CPU and memory cost of validating a huge payload is bounded.
    *
-   * `maxErrors: 1` is the classic fast-fail mode.
+   * `maxErrors: 1` is the default (classic fast-fail). To collect every
+   * error, pass `Number.POSITIVE_INFINITY`.
    *
    * Must be a positive integer (>= 1) when supplied. A cap of 0 is
    * effectively predicate mode (no errors collected, validation
-   * collapses to yes/no); for that, prefer
-   * {@link CompileOptions.predicate} which compiles a fully
+   * collapses to yes/no); for that, prefer `output: "predicate"`
+   * (see {@link CompileOptions.output}) which compiles a fully
    * specialized function with no error infrastructure at all.
    * `compileSchema` throws on `maxErrors <= 0`.
    */
@@ -509,40 +580,18 @@ export interface CompileOptions {
   /** Custom ref resolver; overrides the default (which resolves fragments within the root). */
   refResolver?: RefResolver;
   /**
-   * When `true`, compile a boolean predicate rather than an
-   * error-collecting validator. The returned {@link CompiledPredicate}'s
-   * `validate(data)` returns `boolean`: no {@link ValidationError}
-   * tree is ever constructed, so consumers who only need a yes/no
-   * answer pay nothing for error-reporting machinery (leaf allocation,
-   * path snapshot, params object, message string).
-   *
-   * Mutually exclusive with a finite {@link CompileOptions.maxErrors}.
-   * Predicate mode already short-circuits at the first failure;
-   * combining the two is meaningless, so the compiler throws when
-   * both are supplied.
+   * @deprecated Use `output: "predicate"` (see
+   * {@link CompileOptions.output}). `predicate: true` remains a working
+   * alias for one major and will be removed in v4. Supplying it together
+   * with a conflicting `output` throws.
    */
   predicate?: boolean;
   /**
-   * When `true`, compile a flat-collection validator. The returned
-   * {@link CompiledFlatSchema}'s `validate(data, startPath?)` returns a
-   * {@link FlatValidationResult}: a de-nested `ValidationError[]` of
-   * leaf errors (every failing leaf keyword as its own record, plus a
-   * childless marker leaf per failed `anyOf` / `oneOf`), with no
-   * `"schema"` branch wrappers. This produces ajv-class memory on large
-   * invalid payloads, where the default nested tree retains far more
-   * (branch nodes plus per-leaf path arrays). The records are still
-   * {@link ValidationError}s (empty `children`), so the `@oav/core`
-   * renderers keep working.
-   *
-   * Reach for it when you want *every* error on a very large invalid
-   * body cheaply. For merely bounding memory, {@link CompileOptions.maxErrors}
-   * already caps the tree; flat mode is for the "all errors, cheaply"
-   * case.
-   *
-   * Composes with `maxErrors` (the flat list is capped and
-   * {@link FlatValidationResult.truncated} is set). Mutually exclusive
-   * with {@link CompileOptions.predicate} (a predicate has no errors to
-   * flatten); the compiler throws when both are supplied.
+   * @deprecated Flat is the default error shape now (v3), so the bare
+   * `compileSchema(schema)` already returns a flat
+   * {@link ValidationResult}. `flat: true` remains a working alias for
+   * `output: "flat"` for one major and will be removed in v4. Supplying
+   * it together with a conflicting `output` throws.
    */
   flat?: boolean;
   /**
@@ -594,9 +643,17 @@ export interface CompileState {
   readonly graph: ResolvedGraph;
   readonly compileValidator: (schema: SchemaOrBoolean, mode: CompileMode) => string;
   /**
-   * `true` when a finite `maxErrors` was configured. Codegen uses this
-   * to emit the extra budget checks; when errors are uncapped we emit
-   * plain `errors.push` with no runtime overhead.
+   * `true` when the runtime error-budget short-circuit is active: a
+   * finite `maxErrors` was configured AND the schema does not track
+   * evaluated keys. Codegen uses this to emit the extra budget checks;
+   * otherwise we emit plain `errors.push` with no runtime overhead.
+   *
+   * The `unevaluated*` exclusion is a correctness guard, not an
+   * optimization: under a finite cap, an evaluated-key-harvesting
+   * sub-validator can exhaust the budget mid-evaluation, truncating its
+   * evaluated-key set or starving a real error, which flips an
+   * `unevaluatedProperties` / `unevaluatedItems` verdict. So schemas that
+   * use those keywords collect every error (the cap is not enforced).
    */
   readonly gated: boolean;
   /**
@@ -689,6 +746,35 @@ function schemaUsesUnevaluated(schema: SchemaOrBoolean): boolean {
 }
 
 /**
+ * Resolve the output mode from `output` plus the deprecated `flat` /
+ * `predicate` booleans. `output` is canonical and wins; a legacy boolean
+ * is accepted as an alias but throws if it disagrees with an explicit
+ * `output` (a contradiction the caller should resolve, not a default to
+ * paper over). Absent everything, the v3 default is `"flat"`.
+ */
+function resolveOutputMode(options: CompileOptions): "flat" | "tree" | "predicate" {
+  const legacyPredicate = options.predicate === true;
+  const legacyFlat = options.flat === true;
+  if (legacyPredicate && legacyFlat) {
+    throw new Error(
+      "compileSchema: `flat: true` is mutually exclusive with `predicate: true`. " +
+        "A predicate collects no errors, so there is nothing to return as a flat list.",
+    );
+  }
+  const legacy = legacyPredicate ? "predicate" : legacyFlat ? "flat" : undefined;
+  if (options.output !== undefined) {
+    if (legacy !== undefined && legacy !== options.output) {
+      throw new Error(
+        `compileSchema: \`output: "${options.output}"\` conflicts with the deprecated ` +
+          `\`${legacy === "predicate" ? "predicate" : "flat"}: true\`. Pass only \`output\`.`,
+      );
+    }
+    return options.output;
+  }
+  return legacy ?? "flat";
+}
+
+/**
  * Compile a JSON Schema 2020-12 document into an executable validator.
  *
  * @param schema - The schema (object or boolean) to compile.
@@ -699,31 +785,35 @@ function schemaUsesUnevaluated(schema: SchemaOrBoolean): boolean {
  * ```ts
  * const v = compileSchema({ type: "number" }, { dialect: jsonSchemaDialect });
  * v.validate(1.5); // { valid: true }
- * v.validate("x"); // { valid: false, error: { code: "type", ... } }
+ * v.validate("x"); // { valid: false, errors: [{ code: "type", ... }], truncated: false }
+ *
+ * // Opt into the nested error tree:
+ * const t = compileSchema({ type: "number" }, { dialect: jsonSchemaDialect, output: "tree" });
+ * t.validate("x"); // { valid: false, error: { code: "type", ... }, truncated: false }
  * ```
  *
  * @public
  */
 export function compileSchema(
   schema: SchemaOrBoolean,
-  options: CompileOptions & { predicate: true },
+  options: CompileOptions & ({ output: "predicate" } | { predicate: true }),
 ): CompiledPredicate;
 export function compileSchema(
   schema: SchemaOrBoolean,
-  options: CompileOptions & { flat: true; predicate?: false | undefined },
-): CompiledFlatSchema;
+  options: CompileOptions & { output: "tree" },
+): CompiledTreeSchema;
 export function compileSchema(
   schema: SchemaOrBoolean,
-  options: CompileOptions & { predicate?: false | undefined; flat?: false | undefined },
+  options: CompileOptions & { output?: "flat" | undefined; predicate?: false | undefined },
 ): CompiledSchema;
 export function compileSchema(
   schema: SchemaOrBoolean,
   options: CompileOptions,
-): CompiledSchema | CompiledPredicate | CompiledFlatSchema;
+): CompiledSchema | CompiledTreeSchema | CompiledPredicate;
 export function compileSchema(
   schema: SchemaOrBoolean,
   options: CompileOptions,
-): CompiledSchema | CompiledPredicate | CompiledFlatSchema {
+): CompiledSchema | CompiledTreeSchema | CompiledPredicate {
   const byKeyword = new Map<string, KeywordDefinition>();
   const ordered: KeywordDefinition[] = [];
   for (const vocab of options.dialect.vocabularies) {
@@ -746,21 +836,28 @@ export function compileSchema(
     }
   }
 
-  const maxErrors = options.maxErrors ?? Number.POSITIVE_INFINITY;
+  const mode = resolveOutputMode(options);
+  const predicate = mode === "predicate";
+  const flat = mode === "flat";
+
+  // v3 default: fast-fail (stop at the first error), matching ajv's
+  // `allErrors: false`. Predicate mode never counts errors, so its
+  // effective cap is irrelevant; keep it uncapped so the explicit-cap
+  // conflict check below only fires on a caller-supplied value.
+  const maxErrors = options.maxErrors ?? (predicate ? Number.POSITIVE_INFINITY : 1);
   if (
     options.maxErrors !== undefined &&
-    Number.isFinite(maxErrors) &&
-    (!Number.isInteger(maxErrors) || maxErrors < 1)
+    Number.isFinite(options.maxErrors) &&
+    (!Number.isInteger(options.maxErrors) || options.maxErrors < 1)
   ) {
     // Reject values that would silently neutralise validation. A cap
     // of 0 collects nothing and would return `valid: true` for invalid
-    // data; non-integers are likely a typo. Predicate mode is the
-    // explicit way to skip error collection entirely. `Infinity` is
-    // degenerate (equivalent to omitting the option) but harmless,
-    // and existing callers may pass it explicitly; accept it.
+    // data; non-integers are likely a typo. `output: "predicate"` is the
+    // explicit way to skip error collection entirely. `Infinity` is the
+    // uncapped escape hatch and is accepted explicitly.
     throw new Error(
       `compileSchema: \`maxErrors\` must be a positive integer (got ${String(options.maxErrors)}). ` +
-        "Use `predicate: true` if you want a yes/no validator with no error tree.",
+        'Use `output: "predicate"` if you want a yes/no validator with no error tree.',
     );
   }
   const maxDepth = options.maxDepth ?? Number.POSITIVE_INFINITY;
@@ -777,23 +874,13 @@ export function compileSchema(
         "Omit the option for uncapped recursion depth.",
     );
   }
-  const predicate = options.predicate === true;
-  if (predicate && Number.isFinite(maxErrors)) {
+  if (predicate && options.maxErrors !== undefined && Number.isFinite(options.maxErrors)) {
     // Predicate mode short-circuits at the first failure by design;
     // a finite maxErrors cap would be shadowed and callers would be
     // misled into thinking errors were being counted. Fail loudly.
     throw new Error(
-      "compileSchema: `predicate: true` is mutually exclusive with a finite `maxErrors`. " +
+      'compileSchema: `output: "predicate"` is mutually exclusive with a finite `maxErrors`. ' +
         "Predicate mode short-circuits on the first failure, so there is nothing to count.",
-    );
-  }
-  const flat = options.flat === true;
-  if (flat && predicate) {
-    // A predicate returns a boolean and collects no errors, so there is
-    // nothing to flatten. Fail loudly rather than silently ignoring one.
-    throw new Error(
-      "compileSchema: `flat: true` is mutually exclusive with `predicate: true`. " +
-        "A predicate collects no errors, so there is nothing to return as a flat list.",
     );
   }
   const deps = createDeps({ maxErrors, maxDepth, regexCompiler: options.regexCompiler });
@@ -844,7 +931,14 @@ export function compileSchema(
     refResolver,
     graph,
     nextFn: 0,
-    gated: Number.isFinite(maxErrors),
+    // The runtime error-budget short-circuit is unsafe when the schema
+    // tracks evaluated keys: a finite cap can exhaust mid-evaluation,
+    // truncating a sub-validator's evaluated-key set or starving a real
+    // error, which flips `unevaluatedProperties` / `unevaluatedItems`
+    // verdicts. So short-circuit only when nothing uses `unevaluated*`;
+    // those schemas collect every error (the cap is not enforced). They
+    // never appear in OpenAPI, so the HTTP fast path is unaffected.
+    gated: Number.isFinite(maxErrors) && !unevaluatedTracking,
     depthGated: Number.isFinite(maxDepth),
     compiling: new Set(),
     predicate,
@@ -892,21 +986,23 @@ export function compileSchema(
   }
   const factory = new Function(NAMES.DEPS, wholeSource) as (
     deps: ValidatorDeps,
-  ) => CompiledSchemaFactory;
+  ) => CompiledTreeSchemaFactory;
   const { validate } = factory(deps);
   return { validate, source: wholeSource, stats };
 }
 
-interface CompiledSchemaFactory {
+/** Flat-mode (default) runtime factory: `validate()` returns a {@link ValidationResult}. */
+interface CompiledFlatSchemaFactory {
   validate: (data: unknown, startPath?: readonly PathSegment[]) => ValidationResult;
+}
+
+/** Tree-mode (`output: "tree"`) runtime factory: returns a {@link TreeValidationResult}. */
+interface CompiledTreeSchemaFactory {
+  validate: (data: unknown, startPath?: readonly PathSegment[]) => TreeValidationResult;
 }
 
 interface CompiledPredicateFactory {
   validate: (data: unknown) => boolean;
-}
-
-interface CompiledFlatSchemaFactory {
-  validate: (data: unknown, startPath?: readonly PathSegment[]) => FlatValidationResult;
 }
 
 /** Per-mode slice of {@link CompileState.compiledFor}, created on demand. */
@@ -1266,7 +1362,7 @@ function assembleSource(state: CompileState, rootName: string): string {
         `  if (${NAMES.DEPS}.truncated) return { valid: false, errors: errs, truncated: true };`,
       );
     }
-    parts.push(`  return { valid: false, errors: errs };`);
+    parts.push(`  return { valid: false, errors: errs, truncated: false };`);
     parts.push(`}`);
   } else {
     parts.push(`function validate(${NAMES.DATA}, startPath) {`);
@@ -1288,7 +1384,7 @@ function assembleSource(state: CompileState, rootName: string): string {
         `  if (${NAMES.DEPS}.truncated) return { valid: false, error: err, truncated: true };`,
       );
     }
-    parts.push(`  return { valid: false, error: err };`);
+    parts.push(`  return { valid: false, error: err, truncated: false };`);
     parts.push(`}`);
   }
   parts.push("return { validate };");

--- a/packages/schema/src/compiler/index.ts
+++ b/packages/schema/src/compiler/index.ts
@@ -5,8 +5,10 @@ export {
   type CompiledFlatSchema,
   type CompiledPredicate,
   type CompiledSchema,
+  type CompiledTreeSchema,
   type FlatValidationResult,
   type StrictIssue,
+  type TreeValidationResult,
   type ValidationResult,
 } from "./compiler.js";
 export {

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -25,11 +25,13 @@ export {
   type CompiledPredicate,
   type CompiledRegex,
   type CompiledSchema,
+  type CompiledTreeSchema,
   type CompileOptions,
   type CompileStats,
   type FlatValidationResult,
   type RegexCompiler,
   type StrictIssue,
+  type TreeValidationResult,
   type Validator,
   type ValidationResult,
 } from "./compiler/index.js";

--- a/packages/schema/src/keywords/items.ts
+++ b/packages/schema/src/keywords/items.ts
@@ -97,7 +97,13 @@ export const containsKeyword: KeywordDefinition = {
   implements: ["minContains", "maxContains"],
   compile(ctx: KeywordCompileContext): void {
     const subSchema = ctx.schema as SchemaOrBoolean;
-    const fn = ctx.compileSubschema(subSchema);
+    // `contains` only reports its own count failure; the per-item match
+    // errors are never surfaced. Test membership with a predicate sub in
+    // every mode so failing items allocate no error tree and (critically)
+    // never decrement the shared `maxErrors` budget. Running the sub in
+    // error mode would consume the budget on thrown-away item errors and
+    // could starve a real sibling error, flipping a verdict under a cap.
+    const predFn = ctx.compileSubschema(subSchema, "predicate");
     const minLit =
       ctx.parentSchema.minContains === undefined
         ? "1"
@@ -121,7 +127,7 @@ export const containsKeyword: KeywordDefinition = {
         // exists only to populate `evaluatedItems` for any sibling
         // `unevaluatedItems`.
         g.forRange(i, len, (gi) => {
-          gi.if(`${fn}(${ctx.data}[${i}])`, (gii) => {
+          gi.if(`${predFn}(${ctx.data}[${i}])`, (gii) => {
             gii.line(`${count} += 1;`);
             if (ctx.evaluatedItemsVar !== null) {
               gii.line(`${ctx.evaluatedItemsVar}.add(${i});`);
@@ -132,19 +138,9 @@ export const containsKeyword: KeywordDefinition = {
         if (maxLit !== null) g.line(`if (${count} > ${maxLit}) return false;`);
         return;
       }
-      const matchedIdx = g.scope.name("matched");
-      g.const(matchedIdx, "[]");
       g.forRange(i, len, (gi) => {
-        const errVar = gi.scope.name("e");
-        // Function-call subschema: push/pop around the call so the
-        // callee sees the extended path via the shared array (avoids
-        // per-call allocation of `[...path, i]`).
-        gi.line(`${ctx.path}.push(${i});`);
-        gi.const(errVar, `${fn}(${ctx.data}[${i}], ${ctx.path})`);
-        gi.line(`${ctx.path}.pop();`);
-        gi.if(`${errVar} === null`, (gii) => {
+        gi.if(`${predFn}(${ctx.data}[${i}])`, (gii) => {
           gii.line(`${count} += 1;`);
-          gii.line(`${matchedIdx}.push(${i});`);
           if (ctx.evaluatedItemsVar !== null) {
             gii.line(`${ctx.evaluatedItemsVar}.add(${i});`);
           }

--- a/packages/schema/src/keywords/types.ts
+++ b/packages/schema/src/keywords/types.ts
@@ -164,8 +164,10 @@ export interface KeywordCompileContext {
   /** JS expression for the Set tracking evaluated items, or `null`. */
   readonly evaluatedItemsVar: string | null;
   /**
-   * `true` when a finite `maxErrors` cap was configured. Keyword
-   * authors usually don't need to read this directly; prefer
+   * `true` when the runtime error-budget short-circuit is active (a
+   * finite `maxErrors` was configured and the schema does not track
+   * evaluated keys; see the note on the compiler's `CompileState.gated`).
+   * Keyword authors usually don't need to read this directly; prefer
    * {@link KeywordCompileContext.emitError} /
    * {@link KeywordCompileContext.emitBudgetBreak} which inspect it.
    */

--- a/packages/schema/test/compiler-skeleton.test.ts
+++ b/packages/schema/test/compiler-skeleton.test.ts
@@ -19,7 +19,7 @@ describe("compileSchema", () => {
   });
 
   it("rejects everything when the schema is `false`", () => {
-    const v = compileSchema(false, { dialect: emptyDialect });
+    const v = compileSchema(false, { dialect: emptyDialect, output: "tree" });
     const result = v.validate(1);
     expect(result.valid).toBe(false);
     expect(result.error?.code).toBe("false");
@@ -44,20 +44,20 @@ describe("compileSchema", () => {
   });
 
   it("builds a path array at the root", () => {
-    const result = compileSchema(false, { dialect: emptyDialect }).validate(1);
+    const result = compileSchema(false, { dialect: emptyDialect, output: "tree" }).validate(1);
     expect(result.valid).toBe(false);
     expect(result.error?.path).toEqual([]);
   });
 
   it("prepends startPath to every error path", () => {
-    const v = compileSchema(false, { dialect: emptyDialect });
+    const v = compileSchema(false, { dialect: emptyDialect, output: "tree" });
     const result = v.validate(1, ["body"]);
     expect(result.valid).toBe(false);
     expect(result.error?.path).toEqual(["body"]);
   });
 
   it("does not mutate the caller's startPath", () => {
-    const v = compileSchema(false, { dialect: emptyDialect });
+    const v = compileSchema(false, { dialect: emptyDialect, output: "tree" });
     const prefix: (string | number)[] = ["body"];
     v.validate(1, prefix);
     expect(prefix).toEqual(["body"]);

--- a/packages/schema/test/default-output.test.ts
+++ b/packages/schema/test/default-output.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import { compileSchema } from "../src/compiler/compiler.js";
+import { jsonSchemaDialect } from "../src/keywords/vocabulary.js";
+
+const opts = { dialect: jsonSchemaDialect } as const;
+
+// The v3 zero-config contract: `compileSchema(schema, { dialect })` with
+// no other options is flat-shaped and fails fast (maxErrors: 1), matching
+// ajv's defaults. The richer tree and all-errors collection are opt-in.
+describe("v3 default output", () => {
+  it("defaults to the flat shape (errors array, no error tree)", () => {
+    const v = compileSchema({ type: "string" }, opts);
+    const r = v.validate(42);
+    expect(r.valid).toBe(false);
+    if (r.valid) return;
+    expect(Array.isArray(r.errors)).toBe(true);
+    expect(r.errors[0]?.code).toBe("type");
+    // The tree field must not be present on a flat result.
+    expect("error" in r).toBe(false);
+  });
+
+  it("a successful flat result carries no error fields", () => {
+    const v = compileSchema({ type: "string" }, opts);
+    expect(v.validate("ok")).toEqual({ valid: true });
+  });
+
+  it("defaults to maxErrors: 1 (fail-fast)", () => {
+    const v = compileSchema({ type: "object", required: ["a", "b", "c"] }, opts);
+    const r = v.validate({});
+    expect(r.valid).toBe(false);
+    if (r.valid) return;
+    expect(r.errors).toHaveLength(1);
+    expect(r.truncated).toBe(true);
+  });
+
+  it("reports truncated: false when the cap is not reached", () => {
+    // maxErrors above the actual error count -> budget never exhausted.
+    const v = compileSchema({ type: "object", required: ["a"] }, { ...opts, maxErrors: 10 });
+    const r = v.validate({});
+    expect(r.valid).toBe(false);
+    if (r.valid) return;
+    expect(r.errors).toHaveLength(1);
+    expect(r.truncated).toBe(false);
+  });
+
+  it('output: "tree" returns the nested tree (and also defaults to maxErrors: 1)', () => {
+    const v = compileSchema(
+      { type: "object", required: ["a", "b", "c"] },
+      {
+        ...opts,
+        output: "tree",
+      },
+    );
+    const r = v.validate({});
+    expect(r.valid).toBe(false);
+    if (r.valid) return;
+    // output and maxErrors are orthogonal: tree still fails fast by default.
+    expect(r.error.code).toBe("required");
+    expect(r.truncated).toBe(true);
+    expect("errors" in r).toBe(false);
+  });
+
+  it('output: "tree" with uncapped maxErrors returns every error nested', () => {
+    const v = compileSchema(
+      { type: "object", required: ["a", "b", "c"] },
+      { ...opts, output: "tree", maxErrors: Number.POSITIVE_INFINITY },
+    );
+    const r = v.validate({});
+    if (r.valid) return;
+    expect(r.error.code).toBe("schema");
+    expect(r.error.children).toHaveLength(3);
+    expect(r.truncated).toBe(false);
+  });
+
+  it('output: "predicate" returns a bare boolean', () => {
+    const v = compileSchema({ type: "string" }, { ...opts, output: "predicate" });
+    expect(v.validate("ok")).toBe(true);
+    expect(v.validate(42)).toBe(false);
+  });
+
+  it("explicit maxErrors overrides the default in flat mode", () => {
+    const v = compileSchema(
+      { type: "object", required: ["a", "b", "c"] },
+      { ...opts, maxErrors: Number.POSITIVE_INFINITY },
+    );
+    const r = v.validate({});
+    if (r.valid) return;
+    expect(r.errors).toHaveLength(3);
+    expect(r.truncated).toBe(false);
+  });
+
+  describe("deprecated boolean aliases", () => {
+    it("flat: true is an alias for output: flat", () => {
+      const v = compileSchema({ type: "string" }, { ...opts, flat: true });
+      const r = v.validate(42);
+      if (r.valid) return;
+      expect(r.errors[0]?.code).toBe("type");
+    });
+
+    it("predicate: true is an alias for output: predicate", () => {
+      const v = compileSchema({ type: "string" }, { ...opts, predicate: true });
+      expect(v.validate("ok")).toBe(true);
+      expect(v.validate(42)).toBe(false);
+    });
+
+    it("throws when output conflicts with a legacy boolean", () => {
+      expect(() => compileSchema({}, { ...opts, output: "tree", flat: true })).toThrow(
+        /conflicts with the deprecated/,
+      );
+      expect(() => compileSchema({}, { ...opts, output: "flat", predicate: true })).toThrow(
+        /conflicts with the deprecated/,
+      );
+    });
+  });
+
+  // A finite maxErrors must never change a valid/invalid verdict. Schemas
+  // that track evaluated keys collect every error (the cap is not enforced
+  // there) precisely so the short-circuit can't starve an
+  // unevaluatedProperties / unevaluatedItems error. See the gated note in
+  // the compiler.
+  it("maxErrors does not change the verdict for unevaluatedProperties + oneOf", () => {
+    const schema = {
+      type: "object",
+      oneOf: [
+        { properties: { foo: { type: "string" } }, required: ["foo"] },
+        { properties: { baz: { type: "integer" } }, required: ["baz"] },
+      ],
+      unevaluatedProperties: false,
+    };
+    const data = { foo: "ok", bar: 1 }; // bar is unevaluated -> invalid
+    expect(compileSchema(schema, { ...opts, maxErrors: 1 }).validate(data).valid).toBe(false);
+    expect(
+      compileSchema(schema, { ...opts, maxErrors: Number.POSITIVE_INFINITY }).validate(data).valid,
+    ).toBe(false);
+  });
+});

--- a/packages/schema/test/flat-mode.test.ts
+++ b/packages/schema/test/flat-mode.test.ts
@@ -8,10 +8,20 @@ import { jsonSchemaDialect } from "../src/keywords/vocabulary.js";
 type Opts = { maxErrors?: number };
 
 function tree(schema: unknown, opts: Opts = {}): ReturnType<typeof compileSchema> {
-  return compileSchema(schema as never, { dialect: jsonSchemaDialect, ...opts });
+  return compileSchema(schema as never, {
+    dialect: jsonSchemaDialect,
+    output: "tree",
+    maxErrors: Number.POSITIVE_INFINITY,
+    ...opts,
+  });
 }
 function flat(schema: unknown, opts: Opts = {}) {
-  return compileSchema(schema as never, { dialect: jsonSchemaDialect, flat: true, ...opts });
+  return compileSchema(schema as never, {
+    dialect: jsonSchemaDialect,
+    output: "flat",
+    maxErrors: Number.POSITIVE_INFINITY,
+    ...opts,
+  });
 }
 
 // Full-fidelity multiset key: a flat record and its tree-leaf counterpart

--- a/packages/schema/test/helpers.ts
+++ b/packages/schema/test/helpers.ts
@@ -6,13 +6,25 @@ import { jsonSchemaDialect } from "../src/keywords/vocabulary.js";
  * Compile a schema with the default JSON Schema 2020-12 dialect and
  * return the validator. Used by keyword tests so they don't repeat the
  * options boilerplate.
+ *
+ * Pins `output: "tree"` and uncapped `maxErrors` so the large body of
+ * keyword tests keeps asserting against the nested error tree and the
+ * full error set. The v3 zero-config defaults (flat shape, `maxErrors:
+ * 1`) are exercised by `default-output.test.ts`, `flat-mode.test.ts`,
+ * and the conformance suite, not here. Either default is overridable.
  */
 export function compile(
   schema: SchemaOrBoolean,
   overrides: Partial<CompileOptions> = {},
 ): ReturnType<typeof compileSchema> {
+  // Only inject the tree default when the caller hasn't picked a mode,
+  // so `compile(schema, { predicate: true })` / `{ flat: true }` /
+  // `{ output: ... }` don't collide with a forced `output: "tree"`.
+  const picksMode = "output" in overrides || "flat" in overrides || "predicate" in overrides;
   return compileSchema(schema, {
     dialect: jsonSchemaDialect,
+    maxErrors: Number.POSITIVE_INFINITY,
+    ...(picksMode ? {} : { output: "tree" as const }),
     ...overrides,
   });
 }

--- a/packages/schema/test/inlining.test.ts
+++ b/packages/schema/test/inlining.test.ts
@@ -10,7 +10,11 @@ import { compileSchema } from "../src/compiler/compiler.js";
 import { jsonSchemaDialect } from "../src/keywords/vocabulary.js";
 
 function compile(schema: unknown): ReturnType<typeof compileSchema> {
-  return compileSchema(schema as never, { dialect: jsonSchemaDialect });
+  return compileSchema(schema as never, {
+    dialect: jsonSchemaDialect,
+    output: "tree",
+    maxErrors: Number.POSITIVE_INFINITY,
+  });
 }
 
 describe("subschema inlining", () => {
@@ -91,7 +95,7 @@ describe("subschema inlining", () => {
   it("inlining respects maxErrors: allocated paths still wear the budget cap", () => {
     const v = compileSchema(
       { type: "array", items: { type: "number" } },
-      { dialect: jsonSchemaDialect, maxErrors: 3 },
+      { dialect: jsonSchemaDialect, output: "tree", maxErrors: 3 },
     );
     const r = v.validate(["a", "b", "c", "d", "e"]);
     expect(r.valid).toBe(false);

--- a/packages/schema/test/keyword-custom.test.ts
+++ b/packages/schema/test/keyword-custom.test.ts
@@ -25,7 +25,12 @@ describe("custom keywords", () => {
       typeof data !== "number" || data % (schemaValue as number) === 0;
     const compiled = compileSchema(
       { type: "integer", divisibleBy: 7 } as unknown as Record<string, unknown>,
-      { dialect: baseDialect, keywords: { divisibleBy } },
+      {
+        dialect: baseDialect,
+        output: "tree",
+        maxErrors: Number.POSITIVE_INFINITY,
+        keywords: { divisibleBy },
+      },
     );
     expect(compiled.validate(14).valid).toBe(true);
     expect(compiled.validate(21).valid).toBe(true);
@@ -53,7 +58,12 @@ describe("custom keywords", () => {
           b: { type: "string", myKw: { check: "b" } },
         },
       } as unknown as Record<string, unknown>,
-      { dialect: baseDialect, keywords: { myKw: recorder } },
+      {
+        dialect: baseDialect,
+        output: "tree",
+        maxErrors: Number.POSITIVE_INFINITY,
+        keywords: { myKw: recorder },
+      },
     );
     compiled.validate({ a: "x", b: "y" });
     expect(received).toHaveLength(2);
@@ -72,7 +82,12 @@ describe("custom keywords", () => {
     };
     const compiled = compileSchema(
       { type: "string", noSpaces: true } as unknown as Record<string, unknown>,
-      { dialect: baseDialect, keywords: { noSpaces: fn } },
+      {
+        dialect: baseDialect,
+        output: "tree",
+        maxErrors: Number.POSITIVE_INFINITY,
+        keywords: { noSpaces: fn },
+      },
     );
     expect(compiled.validate("ok").valid).toBe(true);
     const bad = compiled.validate("has spaces");
@@ -100,7 +115,7 @@ describe("custom keywords", () => {
         type: "array",
         items: { type: "string", alwaysBad: true },
       } as unknown as Record<string, unknown>,
-      { dialect: baseDialect, keywords: { alwaysBad: always }, maxErrors: 2 },
+      { dialect: baseDialect, output: "tree", keywords: { alwaysBad: always }, maxErrors: 2 },
     );
     const res = compiled.validate(["a", "b", "c", "d", "e"]);
     expect(res.valid).toBe(false);

--- a/packages/schema/test/keyword-string.test.ts
+++ b/packages/schema/test/keyword-string.test.ts
@@ -129,7 +129,11 @@ describe("string keywords", () => {
     const schema = await import("../src/index.js");
     const v = schema.compileSchema(
       { format: "email" },
-      { dialect: schema.openapi31Dialect, formats: { email: (s) => /@/.test(s) } },
+      {
+        dialect: schema.openapi31Dialect,
+        output: "tree",
+        formats: { email: (s) => /@/.test(s) },
+      },
     );
     expect(v.validate("x@y").valid).toBe(true);
     expect(v.validate("nope").valid).toBe(false);

--- a/packages/schema/test/max-errors.test.ts
+++ b/packages/schema/test/max-errors.test.ts
@@ -3,17 +3,24 @@ import { collectLeaves } from "@oav/core";
 import { compileSchema } from "../src/compiler/compiler.js";
 import { jsonSchemaDialect } from "../src/keywords/vocabulary.js";
 
+// Tree output so the assertions can walk `r.error`; `maxErrors`
+// uncapped unless a test pins it. (The zero-config default is
+// `maxErrors: 1`, covered in default-output.test.ts.)
 function compile(schema: unknown, maxErrors?: number): ReturnType<typeof compileSchema> {
-  return compileSchema(schema as never, { dialect: jsonSchemaDialect, maxErrors });
+  return compileSchema(schema as never, {
+    dialect: jsonSchemaDialect,
+    output: "tree",
+    maxErrors: maxErrors ?? Number.POSITIVE_INFINITY,
+  });
 }
 
 describe("maxErrors option", () => {
-  it("is uncapped by default", () => {
+  it("collects every error when uncapped", () => {
     const v = compile({ required: ["a", "b", "c", "d"] });
     const r = v.validate({});
     expect(r.valid).toBe(false);
     expect(collectLeaves(r.error!)).toHaveLength(4);
-    expect(r.truncated).toBeUndefined();
+    expect(r.truncated).toBe(false);
   });
 
   it("caps total leaf errors at the configured maxErrors", () => {
@@ -80,17 +87,19 @@ describe("maxErrors option", () => {
     expect(r.truncated).toBe(true);
   });
 
-  it("does not set truncated when everything fit in the budget", () => {
+  it("reports truncated: false when everything fit in the budget", () => {
     const v = compile({ required: ["a"] }, 10);
     const r = v.validate({});
     expect(collectLeaves(r.error!)).toHaveLength(1);
-    expect(r.truncated).toBeUndefined();
+    expect(r.truncated).toBe(false);
   });
 
   it("valid input never sets truncated even with a tight cap", () => {
     const v = compile({ type: "number" }, 1);
-    expect(v.validate(42).valid).toBe(true);
-    expect(v.validate(42).truncated).toBeUndefined();
+    const r = v.validate(42);
+    expect(r.valid).toBe(true);
+    // Discriminated union: the `valid: true` branch has no truncated field.
+    expect("truncated" in r).toBe(false);
   });
 
   it("rejects maxErrors: 0 at compile time", () => {
@@ -98,7 +107,7 @@ describe("maxErrors option", () => {
     // `valid: true` for invalid data, a correctness trap. Predicate
     // mode is the explicit way to skip error collection entirely.
     expect(() => compile({ type: "number" }, 0)).toThrow(
-      /must be a positive integer.*Use `predicate: true`/,
+      /must be a positive integer.*Use `output: "predicate"`/,
     );
   });
 

--- a/packages/schema/test/path-leak-probe.test.ts
+++ b/packages/schema/test/path-leak-probe.test.ts
@@ -25,7 +25,7 @@ describe("error paths survive path-array reuse", () => {
           required: ["x"],
         },
       },
-      { dialect: jsonSchemaDialect },
+      { dialect: jsonSchemaDialect, output: "tree", maxErrors: Number.POSITIVE_INFINITY },
     );
     const r = validate(["not-an-object", { x: "bad" }]);
     if (r.valid) throw new Error("unexpected valid");
@@ -45,7 +45,7 @@ describe("error paths survive path-array reuse", () => {
         type: "object",
         properties: { kind: { const: "Cat" } },
       },
-      { dialect: jsonSchemaDialect },
+      { dialect: jsonSchemaDialect, output: "tree", maxErrors: Number.POSITIVE_INFINITY },
     );
     const r = validate({ kind: "Dog" });
     if (r.valid) throw new Error("unexpected valid");
@@ -64,7 +64,7 @@ describe("error paths survive path-array reuse", () => {
         type: "object",
         properties: { fins: { type: "integer", minimum: 0 } },
       },
-      { dialect: jsonSchemaDialect },
+      { dialect: jsonSchemaDialect, output: "tree", maxErrors: Number.POSITIVE_INFINITY },
     );
     const r = validate({ fins: -1.5 });
     if (r.valid) throw new Error("unexpected valid");
@@ -96,7 +96,7 @@ describe("error paths survive path-array reuse", () => {
           },
         },
       },
-      { dialect: jsonSchemaDialect },
+      { dialect: jsonSchemaDialect, output: "tree", maxErrors: Number.POSITIVE_INFINITY },
     );
     const r = validate({ user: {} });
     if (r.valid) throw new Error("unexpected valid");

--- a/packages/schema/test/path-sharing.test.ts
+++ b/packages/schema/test/path-sharing.test.ts
@@ -19,7 +19,11 @@ import { compileSchema } from "../src/compiler/compiler.js";
 import { jsonSchemaDialect } from "../src/keywords/vocabulary.js";
 
 function compile(schema: unknown) {
-  return compileSchema(schema as never, { dialect: jsonSchemaDialect });
+  return compileSchema(schema as never, {
+    dialect: jsonSchemaDialect,
+    output: "tree",
+    maxErrors: Number.POSITIVE_INFINITY,
+  });
 }
 
 describe("path sharing: correctness under stress", () => {
@@ -171,6 +175,7 @@ describe("path sharing: correctness under stress", () => {
     // that DID get pushed must still be correct.
     const v = compileSchema({ type: "array", items: { type: "number" } } as never, {
       dialect: jsonSchemaDialect,
+      output: "tree",
       maxErrors: 3,
     });
     const r = v.validate(["a", "b", "c", "d", "e"]);

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -9,7 +9,7 @@ import { createValidator } from "@aahoughton/oav";
 
 const validator = createValidator(resolvedSpec);
 
-const requestErr = validator.validateRequest({
+const requestResult = validator.validateRequest({
   method: "POST",
   path: "/pets",
   query: { limit: "10" },
@@ -18,17 +18,19 @@ const requestErr = validator.validateRequest({
   body: { name: "Fido" },
 });
 
-const responseErr = validator.validateResponse(
+const responseResult = validator.validateResponse(
   { method: "GET", path: "/pets" },
   { status: 200, contentType: "application/json", body: [{ name: "Fido" }] },
 );
 ```
 
-Both methods return `null` on success or a `ValidationError` tree on
-failure. Errors are rooted at the HTTP frame (`["body", …]`,
-`["query", name, …]`, `["header", name, …]`, etc.) so downstream code
-can group by location. The top-level node's `code` (`"request"` vs
-`"response"`) distinguishes the leg.
+Both methods return `{ valid: true }` on success, or
+`{ valid: false, errors, truncated }` on failure. The default is a flat
+`errors` list that stops at the first problem (`maxErrors: 1`), matching
+Ajv; pass `output: "tree"` for a nested `error` tree, or
+`maxErrors: Number.POSITIVE_INFINITY` to collect every error. Errors are
+rooted at the HTTP frame (`["body", …]`, `["query", name, …]`,
+`["header", name, …]`, etc.) so downstream code can group by location.
 
 `validator.detectedVersion` reflects the `openapi` string that was
 detected on construction (or `undefined` if the field was missing or
@@ -76,8 +78,8 @@ the upstream test suites live in
 
 | Method                                        | Purpose                                                                                                                                                                   |
 | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `validateRequest(req)`                        | Check an `HttpRequest` against the spec. Returns `null` on success or a `ValidationError` tree.                                                                           |
-| `validateResponse(req, res)`                  | Check an `HttpResponse` against the spec (request is used only for method + path). Returns `null` or a tree.                                                              |
+| `validateRequest(req)`                        | Check an `HttpRequest` against the spec. Returns `{ valid: true }` or `{ valid: false, errors, truncated }` (flat by default; `output: "tree"` for a nested `error`).     |
+| `validateResponse(req, res)`                  | Check an `HttpResponse` against the spec (request is used only for method + path). Same result shape as `validateRequest`.                                                |
 | `validateFetchRequest<T>(request, opts?)`     | Convenience for Web Standards `Request`: reads URL, headers, body; returns a discriminated union with a typed body. See [docs/integration.md](../../docs/integration.md). |
 | `validateFetchResponse<T>(request, response)` | Symmetric Web Standards `Response` check. Useful for contract-testing an upstream.                                                                                        |
 | `getOperation({ method, path })`              | Startup-time introspection: returns the resolved, overlay-applied `OperationObject` + matched template for a (method, path) pair.                                         |
@@ -86,17 +88,18 @@ the upstream test suites live in
 
 ## Options
 
-| Option                  | Effect                                                                                                                                                                                         |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dialect`               | Force a specific {@link Dialect}, bypassing version detection.                                                                                                                                 |
-| `formats`               | Extra string format validators merged with `oav/formats`.                                                                                                                                      |
-| `keywords`              | User-registered schema keywords (see below).                                                                                                                                                   |
-| `maxErrors`             | Cap on leaf errors; `1` is fast-fail. Default: uncapped.                                                                                                                                       |
-| `strictQueryParameters` | Reject undeclared query parameters. Default `false`.                                                                                                                                           |
-| `validateSecurity`      | `"off"` (default), `"shape"` (check recognized schemes; pass on oauth2/oidc/mTLS), or `"strict"` (fail on unrecognized schemes). Boolean form deprecated; `true`->`"shape"`, `false`->`"off"`. |
-| `ignoreUndocumented`    | Return `null` on requests whose path the router can't match. Default `false`.                                                                                                                  |
-| `ignorePaths`           | `(path: string) => boolean` predicate that short-circuits validation when it returns `true` (runs before routing).                                                                             |
-| `onUnknownVersion`      | `"fallback31"` \| `"warn"` \| `"throw"` when `openapi` is missing or unsupported. Default `"fallback31"`.                                                                                      |
+| Option                  | Effect                                                                                                                           |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `dialect`               | Force a specific {@link Dialect}, bypassing version detection.                                                                   |
+| `formats`               | Extra string format validators merged with `oav/formats`.                                                                        |
+| `keywords`              | User-registered schema keywords (see below).                                                                                     |
+| `output`                | Result shape: `"flat"` (default), `"tree"`, or `"predicate"`. Mirrors `compileSchema`.                                           |
+| `maxErrors`             | Per-call total cap on leaf errors. Default `1` (fast-fail); `Number.POSITIVE_INFINITY` collects every error.                     |
+| `strictQueryParameters` | Reject undeclared query parameters. Default `false`.                                                                             |
+| `validateSecurity`      | `"off"` (default), `"shape"` (check recognized schemes; pass on oauth2/oidc/mTLS), or `"strict"` (fail on unrecognized schemes). |
+| `ignoreUndocumented`    | Return `null` on requests whose path the router can't match. Default `false`.                                                    |
+| `ignorePaths`           | `(path: string) => boolean` predicate that short-circuits validation when it returns `true` (runs before routing).               |
+| `onUnknownVersion`      | `"fallback31"` \| `"warn"` \| `"throw"` when `openapi` is missing or unsupported. Default `"fallback31"`.                        |
 
 ## Custom keywords
 
@@ -128,14 +131,16 @@ an end-to-end.
 ## Fast-fail / bounded error collection
 
 ```ts
-createValidator(spec, { maxErrors: 1 }); // stop after first leaf
+createValidator(spec); // default: stop after the first error
 createValidator(spec, { maxErrors: 10 }); // cap while still getting useful feedback
+createValidator(spec, { maxErrors: Number.POSITIVE_INFINITY }); // every error
 ```
 
-Hot loops (array items, object properties, `allOf` / `anyOf` branches)
-short-circuit once the budget is exhausted, so a 10 MB invalid payload
-doesn't cost proportional CPU or memory. Results carry `truncated:
-true` when the tree was capped.
+`maxErrors` is a per-call total across all locations (body, query,
+headers). Hot loops (array items, object properties, `allOf` / `anyOf`
+branches) short-circuit once the budget is exhausted, so a 10 MB invalid
+payload doesn't cost proportional CPU or memory. A failing result
+carries `truncated: true` when the cap was reached.
 
 ## Handling unknown `openapi` versions
 

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -16,6 +16,8 @@
 
 export {
   createValidator,
+  type PredicateValidator,
+  type TreeValidator,
   type Validator,
   type ValidatorOptions,
   type ValidatorStats,

--- a/packages/validator/src/operation-cache.ts
+++ b/packages/validator/src/operation-cache.ts
@@ -8,7 +8,7 @@ import type {
 } from "@oav/core";
 import { resolveJsonPointer } from "@oav/core";
 import type { RouteMatch } from "@oav/router";
-import type { CompiledSchema } from "@oav/schema";
+import type { CompiledTreeSchema } from "@oav/schema";
 import type { BodyDirection } from "./body-schema-transform.js";
 import type { CompiledSecurity } from "./security.js";
 
@@ -20,10 +20,10 @@ import type { CompiledSecurity } from "./security.js";
  * @internal
  */
 export interface OperationCache {
-  pathParamValidators: Map<string, CompiledSchema>;
-  queryParamValidators: Map<string, CompiledSchema>;
-  headerParamValidators: Map<string, CompiledSchema>;
-  cookieParamValidators: Map<string, CompiledSchema>;
+  pathParamValidators: Map<string, CompiledTreeSchema>;
+  queryParamValidators: Map<string, CompiledTreeSchema>;
+  headerParamValidators: Map<string, CompiledTreeSchema>;
+  cookieParamValidators: Map<string, CompiledTreeSchema>;
   parameters: ParameterObject[];
   /**
    * Names of every declared `in: "query"` parameter, precomputed for
@@ -32,7 +32,7 @@ export interface OperationCache {
    */
   knownQueryParameters: Set<string>;
   requestBody: RequestBodyObject | undefined;
-  bodyValidators: Map<string, CompiledSchema>;
+  bodyValidators: Map<string, CompiledTreeSchema>;
   responses: Map<string, ResponseCompiled>;
   /**
    * Pre-compiled shape-only security check, or `undefined` when the
@@ -63,8 +63,8 @@ export interface ResponseCompiled {
   /** Header schemas keyed by lowercased name; compiled lazily. */
   headerSchemas: Map<string, SchemaOrBoolean>;
   /** Memoization caches for the lazy compiles. */
-  bodyValidators: Map<string, CompiledSchema>;
-  headerValidators: Map<string, CompiledSchema>;
+  bodyValidators: Map<string, CompiledTreeSchema>;
+  headerValidators: Map<string, CompiledTreeSchema>;
 }
 
 /**
@@ -77,8 +77,8 @@ export interface ResponseCompiled {
  */
 export interface OperationCacheDeps {
   resolveRef: <T>(value: T | ReferenceObject | undefined) => T | undefined;
-  compile: (schema: SchemaOrBoolean) => CompiledSchema;
-  compileForDirection: (schema: SchemaOrBoolean, direction: BodyDirection) => CompiledSchema;
+  compile: (schema: SchemaOrBoolean) => CompiledTreeSchema;
+  compileForDirection: (schema: SchemaOrBoolean, direction: BodyDirection) => CompiledTreeSchema;
 }
 
 /**
@@ -128,10 +128,10 @@ export function buildOperationCache(
     if (p.in === "query") knownQueryParameters.add(p.name);
   }
 
-  const pathParamValidators = new Map<string, CompiledSchema>();
-  const queryParamValidators = new Map<string, CompiledSchema>();
-  const headerParamValidators = new Map<string, CompiledSchema>();
-  const cookieParamValidators = new Map<string, CompiledSchema>();
+  const pathParamValidators = new Map<string, CompiledTreeSchema>();
+  const queryParamValidators = new Map<string, CompiledTreeSchema>();
+  const headerParamValidators = new Map<string, CompiledTreeSchema>();
+  const cookieParamValidators = new Map<string, CompiledTreeSchema>();
 
   for (const p of parameters) {
     const contentSchema = firstContentSchema(p);
@@ -149,7 +149,7 @@ export function buildOperationCache(
     target.set(p.name, v);
   }
 
-  const bodyValidators = new Map<string, CompiledSchema>();
+  const bodyValidators = new Map<string, CompiledTreeSchema>();
   const requestBody = deps.resolveRef<RequestBodyObject>(pathMatch.operation.requestBody);
   if (requestBody?.content) {
     for (const [mt, mto] of Object.entries(requestBody.content)) {

--- a/packages/validator/src/validate-step.ts
+++ b/packages/validator/src/validate-step.ts
@@ -5,7 +5,7 @@ import {
   type ValidationError,
 } from "@oav/core";
 import type { RouteMatch } from "@oav/router";
-import type { CompiledSchema } from "@oav/schema";
+import type { CompiledTreeSchema } from "@oav/schema";
 import { deserialize, matchMediaType } from "./deserialize.js";
 import type { OperationCache } from "./operation-cache.js";
 import { assembleObjectQueryParam } from "./query-assembly.js";
@@ -52,7 +52,7 @@ export function validateParameter(
   cache: OperationCache,
 ): ValidationError | null {
   let raw: string | string[] | undefined;
-  let validator: CompiledSchema | undefined;
+  let validator: CompiledTreeSchema | undefined;
   let pathPrefix: (string | number)[];
   let code: string;
 

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -1,5 +1,6 @@
 import {
   classifyUnknownVersion,
+  collectLeaves,
   createBranchError,
   createLeafError,
   detectOpenAPIVersion,
@@ -22,12 +23,14 @@ import {
   oas30Dialect,
   openapi31Dialect,
   resolve,
-  type CompiledSchema,
+  type CompiledTreeSchema,
   type CustomKeywordValidator,
   type Dialect,
   type RefResolver,
   type RegexCompiler,
   type StrictIssue,
+  type TreeValidationResult,
+  type ValidationResult,
 } from "@oav/schema";
 import { deserialize, matchMediaType, matchResponseKey } from "./deserialize.js";
 import {
@@ -49,20 +52,16 @@ import { checkSecurity, compileOperationSecurity, type SecurityMode } from "./se
 import { checkBodyContentType, validateBody, validateParameter } from "./validate-step.js";
 
 /**
- * Coerce {@link ValidatorOptions.validateSecurity} (boolean | enum
- * string | undefined) to the `"off" | "shape" | "strict"` value the
- * security compiler reads. `true` aliases `"shape"`; `false` and
- * `undefined` alias `"off"`. The boolean form is deprecated and will
- * be removed in v3.
+ * Coerce {@link ValidatorOptions.validateSecurity} (enum string |
+ * undefined) to the `"off" | "shape" | "strict"` value the security
+ * compiler reads. `undefined` defaults to `"off"`.
  *
  * @internal
  */
 function normalizeSecurityMode(
-  value: boolean | "off" | "shape" | "strict" | undefined,
+  value: "off" | "shape" | "strict" | undefined,
 ): "off" | SecurityMode {
-  if (value === true) return "shape";
-  if (value === false || value === undefined) return "off";
-  return value;
+  return value ?? "off";
 }
 
 /**
@@ -84,9 +83,80 @@ function dialectFor(version: OpenAPIVersion): Dialect {
 }
 
 /**
- * The HTTP validator: after being built from a (resolved) OpenAPI document,
- * `validateRequest` / `validateResponse` each return a full
- * {@link ValidationError} tree (or `null`).
+ * Depth-first prune of an error tree to at most `max` leaves, dropping
+ * branches that become empty. Returns the trimmed root. Used to enforce
+ * the per-call `maxErrors` total in tree output.
+ */
+function trimTreeToLeaves(root: ValidationError, max: number): ValidationError {
+  let remaining = max;
+  const visit = (node: ValidationError): ValidationError | null => {
+    if (node.children.length === 0) {
+      if (remaining <= 0) return null;
+      remaining -= 1;
+      return node;
+    }
+    const kept: ValidationError[] = [];
+    for (const child of node.children) {
+      const v = visit(child);
+      if (v !== null) kept.push(v);
+    }
+    if (kept.length === 0) return null;
+    return { ...node, children: kept };
+  };
+  return visit(root) ?? root;
+}
+
+/**
+ * Reshape the validator's internal error tree (`ValidationError | null`)
+ * into the requested output, applying the per-call `maxErrors` total.
+ * `truncated` reports that the cap was reached (more problems may exist).
+ */
+function reshapeResult(
+  tree: ValidationError | null,
+  output: "flat" | "tree" | "predicate",
+  maxErrors: number,
+): ValidationResult | TreeValidationResult | boolean {
+  if (output === "predicate") return tree === null;
+  if (tree === null) return { valid: true };
+  const finite = Number.isFinite(maxErrors);
+  const leaves = collectLeaves(tree);
+  const truncated = finite && leaves.length >= maxErrors;
+  if (output === "tree") {
+    const error = finite && leaves.length > maxErrors ? trimTreeToLeaves(tree, maxErrors) : tree;
+    return { valid: false, error, truncated };
+  }
+  return { valid: false, errors: finite ? leaves.slice(0, maxErrors) : leaves, truncated };
+}
+
+/**
+ * Map a reshaped validation result onto the Fetch-wrapper return shape:
+ * `{ ok: true, body }` on success, or `{ ok: false }` plus the failure
+ * fields (`errors`/`error` + `truncated`, or nothing in predicate mode).
+ */
+function toFetchResult<T>(
+  result: ValidationResult | TreeValidationResult | boolean,
+  body: unknown,
+): {
+  ok: boolean;
+  body?: T;
+  errors?: ValidationError[];
+  error?: ValidationError;
+  truncated?: boolean;
+} {
+  if (result === true) return { ok: true, body: body as T };
+  if (result === false) return { ok: false };
+  if (result.valid) return { ok: true, body: body as T };
+  const { valid: _valid, ...failure } = result;
+  return { ok: false, ...failure };
+}
+
+/**
+ * The HTTP validator (flat output, the default). `validateRequest` /
+ * `validateResponse` return a {@link @aahoughton/oav/schema!ValidationResult}:
+ * `{ valid: true }` or `{ valid: false, errors, truncated }` with a flat
+ * list of leaf errors. Compile with `output: "tree"` for a
+ * {@link TreeValidator} (nested {@link ValidationError} tree) or
+ * `output: "predicate"` for a {@link PredicateValidator} (bare boolean).
  *
  * - **Per-call HTTP validation**: {@link Validator.validateRequest},
  *   {@link Validator.validateResponse}.
@@ -104,43 +174,46 @@ function dialectFor(version: OpenAPIVersion): Dialect {
  */
 export interface Validator {
   /**
-   * Validate one HTTP request against the spec. Returns `null` when the
-   * request matches the operation declared at its method + path,
-   * including parameters, headers, cookies, body, and content type;
-   * returns a {@link ValidationError} tree otherwise.
+   * Validate one HTTP request against the spec. Returns `{ valid: true }`
+   * when the request matches the operation declared at its method + path
+   * (parameters, headers, cookies, body, and content type); otherwise
+   * `{ valid: false, errors, truncated }` with a flat list of leaf
+   * errors.
    *
-   * The returned tree's top-level `code` is `"request"` for any failure,
-   * with branch children under `body`, `query.<name>`, `header.<name>`,
-   * `cookie.<name>`, `path-param.<name>`, or `security`. Route and
-   * method mismatches surface as top-level `"route"` / `"method"`
-   * codes; see {@link httpStatusFor} for the canonical status mapping.
+   * Each error's `path` is prefixed with its HTTP location: `["body",
+   * …]`, `["query", name]`, `["header", name]`, `["cookie", name]`,
+   * `["path-param", name]`, or `["security"]`. Route and method
+   * mismatches surface as `route` / `method` leaves; see
+   * {@link httpStatusFor} for the canonical status mapping.
+   *
+   * `truncated` is `true` when the `maxErrors` cap (default 1) was
+   * reached, so more problems may exist; raise `maxErrors` to collect
+   * them.
    *
    * Does not mutate `req`. Synchronous: parameter deserialization,
-   * content-type matching, and schema validation all run inline. Per
-   * `req` cost is dominated by the schema validation; bodies that
-   * pass validation incur a single tree walk and no allocation.
+   * content-type matching, and schema validation all run inline.
    *
    * Paths the spec doesn't declare are treated according to
    * {@link ValidatorOptions.ignoreUndocumented} and
    * {@link ValidatorOptions.ignorePaths}: by default an undeclared
-   * path returns a `"route"` error; configure to bypass the validator
+   * path returns a `route` error; configure to bypass the validator
    * entirely.
    *
    * @see {@link Validator.validateResponse} for the response-side pair.
    * @see {@link Validator.validateFetchRequest} for the Web Standards convenience wrapper.
    * @see {@link Validator.getOperation} to look up the matched operation without validating.
    */
-  validateRequest(req: HttpRequest): ValidationError | null;
+  validateRequest(req: HttpRequest): ValidationResult;
   /**
    * Validate one HTTP response against the spec, given the request it
-   * answers. Returns `null` when the response status, content type,
-   * headers, and body all match the responses declared on the operation
-   * `req` resolves to; returns a {@link ValidationError} tree otherwise.
+   * answers. Returns `{ valid: true }` when the response status, content
+   * type, headers, and body all match the responses declared on the
+   * operation `req` resolves to; otherwise `{ valid: false, errors,
+   * truncated }`.
    *
-   * The returned tree's top-level `code` is `"response"`, with branch
-   * children under `body`, `header.<name>`, or `status`. The `req`
-   * argument is used only to locate the operation; its body isn't
-   * read.
+   * Each error's `path` is prefixed with `["body", …]`, `["header",
+   * name]`, or `["status"]`. The `req` argument is used only to locate
+   * the operation; its body isn't read.
    *
    * Response-body schemas compile lazily on first use per `(status,
    * mediaType)` pairing; {@link ValidatorStats.responseBodiesCompiled}
@@ -152,7 +225,7 @@ export interface Validator {
    * @see {@link Validator.validateRequest} for the request-side pair.
    * @see {@link Validator.validateFetchResponse} for the Web Standards convenience wrapper.
    */
-  validateResponse(req: HttpRequest, res: HttpResponse): ValidationError | null;
+  validateResponse(req: HttpRequest, res: HttpResponse): ValidationResult;
   /**
    * Parse a Web Standards {@link Request} and validate it in one call.
    * Convenient for route handlers in frameworks that expose `Request`
@@ -162,8 +235,8 @@ export interface Validator {
    * Returns a discriminated union. On success, `body` is the parsed
    * request body, narrowed to the generic type the caller supplies
    * (validation has already confirmed the shape, so the cast is safe
-   * in practice). On failure, `error` is the same
-   * {@link ValidationError} tree `validateRequest` would return.
+   * in practice). On failure, `errors` / `truncated` are the same
+   * fields `validateRequest` would return.
    *
    * Body parsing recognizes `application/json` (and `*+json`),
    * `application/x-www-form-urlencoded`, `multipart/form-data`
@@ -181,7 +254,7 @@ export interface Validator {
    * ```ts
    * export async function POST(request: Request) {
    *   const r = await validator.validateFetchRequest<CreatePet>(request);
-   *   if (!r.ok) return problemResponse(r.error);
+   *   if (!r.ok) return problemResponse(r.errors);
    *   // r.body is typed as CreatePet
    * }
    * ```
@@ -189,7 +262,7 @@ export interface Validator {
   validateFetchRequest<T = unknown>(
     request: Request,
     options?: FetchRequestOptions,
-  ): Promise<{ ok: true; body: T } | { ok: false; error: ValidationError }>;
+  ): Promise<{ ok: true; body: T } | { ok: false; errors: ValidationError[]; truncated: boolean }>;
   /**
    * Validate a Web Standards {@link Response} against the operation
    * the {@link Request} resolves to. Mirrors
@@ -211,13 +284,13 @@ export interface Validator {
    * ```ts
    * const response = await fetch(upstreamUrl, init);
    * const r = await validator.validateFetchResponse<PetList>(req, response);
-   * if (!r.ok) log.warn("upstream returned malformed response", r.error);
+   * if (!r.ok) log.warn("upstream returned malformed response", r.errors);
    * ```
    */
   validateFetchResponse<T = unknown>(
     request: Request,
     response: Response,
-  ): Promise<{ ok: true; body: T } | { ok: false; error: ValidationError }>;
+  ): Promise<{ ok: true; body: T } | { ok: false; errors: ValidationError[]; truncated: boolean }>;
   /**
    * Look up the effective operation declaration for a method + path.
    * Returns the resolved (`$ref`s followed) and overlay-applied
@@ -255,6 +328,13 @@ export interface Validator {
    */
   readonly detectedVersion: OpenAPIVersion | undefined;
   /**
+   * The output shape this validator was built with (see
+   * {@link ValidatorOptions.output}): `"flat"` (default), `"tree"`, or
+   * `"predicate"`. Lets consumers (e.g. the framework adapters) branch
+   * on the result shape without a trial call.
+   */
+  readonly output: "flat" | "tree" | "predicate";
+  /**
    * Warnings collected during `createValidator`. Populated when
    * `onUnknownVersion: "warn"` fires, or when the `dialect` escape
    * hatch suppresses a category error that would otherwise throw
@@ -286,6 +366,57 @@ export interface Validator {
    * through indirect signals (throwing test schemas, source grepping).
    */
   readonly stats: ValidatorStats;
+}
+
+/** The four validation methods whose return type tracks `output`. */
+type OutputDependentMethods =
+  | "validateRequest"
+  | "validateResponse"
+  | "validateFetchRequest"
+  | "validateFetchResponse";
+
+/**
+ * The HTTP validator built with `output: "tree"`. Identical to
+ * {@link Validator} except `validateRequest` / `validateResponse` return
+ * a {@link @aahoughton/oav/schema!TreeValidationResult} (a nested
+ * {@link ValidationError} tree under `error`) instead of the flat default.
+ *
+ * @public
+ */
+export interface TreeValidator extends Omit<Validator, OutputDependentMethods> {
+  validateRequest(req: HttpRequest): TreeValidationResult;
+  validateResponse(req: HttpRequest, res: HttpResponse): TreeValidationResult;
+  validateFetchRequest<T = unknown>(
+    request: Request,
+    options?: FetchRequestOptions,
+  ): Promise<{ ok: true; body: T } | { ok: false; error: ValidationError; truncated: boolean }>;
+  validateFetchResponse<T = unknown>(
+    request: Request,
+    response: Response,
+  ): Promise<{ ok: true; body: T } | { ok: false; error: ValidationError; truncated: boolean }>;
+}
+
+/**
+ * The HTTP validator built with `output: "predicate"`. `validateRequest`
+ * / `validateResponse` return a bare `boolean` (no errors are ever
+ * constructed). The Fetch wrappers narrow the body on success and carry
+ * no error payload on failure. A predicate validator cannot render a
+ * problem-details response, so the framework adapters reject it at
+ * construction; use it for gating where only the yes/no answer matters.
+ *
+ * @public
+ */
+export interface PredicateValidator extends Omit<Validator, OutputDependentMethods> {
+  validateRequest(req: HttpRequest): boolean;
+  validateResponse(req: HttpRequest, res: HttpResponse): boolean;
+  validateFetchRequest<T = unknown>(
+    request: Request,
+    options?: FetchRequestOptions,
+  ): Promise<{ ok: true; body: T } | { ok: false }>;
+  validateFetchResponse<T = unknown>(
+    request: Request,
+    response: Response,
+  ): Promise<{ ok: true; body: T } | { ok: false }>;
 }
 
 /**
@@ -325,7 +456,8 @@ export interface ValidatorStats {
  * - **Dialect override**: {@link ValidatorOptions.dialect}.
  * - **Schema extension**: {@link ValidatorOptions.formats},
  *   {@link ValidatorOptions.keywords}.
- * - **Error budget**: {@link ValidatorOptions.maxErrors}.
+ * - **Output shape + error budget**: {@link ValidatorOptions.output},
+ *   {@link ValidatorOptions.maxErrors}.
  * - **Strict-mode linting**: {@link ValidatorOptions.strict}.
  * - **Security gating**: {@link ValidatorOptions.validateSecurity}.
  * - **Path filtering**: {@link ValidatorOptions.ignoreUndocumented},
@@ -340,7 +472,7 @@ export interface ValidatorStats {
  *
  *   1. Compile essentials: `dialect`.
  *   2. Shared extension points: `formats`, `keywords`.
- *   3. Error-collection policy: `maxErrors`.
+ *   3. Error-collection policy: `output`, `maxErrors`.
  *   4. Surface-specific extras last: here, `strictQueryParameters`,
  *      `onUnknownVersion`, `warn`.
  *
@@ -398,19 +530,35 @@ export interface ValidatorOptions {
   // --- 3. Error-collection policy ---
 
   /**
-   * Cap on the number of leaf schema errors collected per
-   * `validateRequest` / `validateResponse` call. Defaults to uncapped.
+   * What `validateRequest` / `validateResponse` return. Mirrors
+   * {@link @aahoughton/oav/schema!CompileOptions.output}:
    *
-   * Set to `1` for fast-fail semantics, or to a small number (say 10)
-   * to bound CPU and memory on validation of very large payloads
-   * (e.g. a 10 MB array where every element has the same structural
-   * error). When the cap is hit, the returned error tree is marked
-   * with a `truncated: true` param on the root so consumers can tell
-   * the report was shortened.
+   * - `"flat"` (default): a
+   *   {@link @aahoughton/oav/schema!ValidationResult}: `{ valid }` plus,
+   *   on failure, a flat `errors` leaf list and `truncated`. The
+   *   constructed validator has type {@link Validator}.
+   * - `"tree"`: a {@link @aahoughton/oav/schema!TreeValidationResult}: a
+   *   nested {@link ValidationError} tree under `error`. Type
+   *   {@link TreeValidator}.
+   * - `"predicate"`: a bare `boolean`. Type {@link PredicateValidator};
+   *   the framework adapters reject it (it can't render a 400 body).
+   *
+   * Defaults to `"flat"`.
+   */
+  output?: "flat" | "tree" | "predicate";
+  /**
+   * Cap on the number of leaf schema errors collected per
+   * `validateRequest` / `validateResponse` call, across all locations
+   * (body, parameters, headers). Defaults to `1` (fast-fail: the first
+   * error). Pass `Number.POSITIVE_INFINITY` to collect every error.
+   *
+   * When the cap is reached the result's `truncated` is `true`, so
+   * consumers can tell more problems may exist. A small cap also bounds
+   * CPU and memory on validation of very large invalid payloads (e.g. a
+   * 10 MB array where every element has the same structural error).
    *
    * Must be a positive integer (>= 1). `createValidator` throws on
-   * non-integer or zero/negative values; the compiler surfaces the
-   * error eagerly at construction time.
+   * non-integer or zero/negative values.
    */
   maxErrors?: number;
   /**
@@ -484,13 +632,8 @@ export interface ValidatorOptions {
    * auth layer only decorates `req` without rejecting unauthenticated
    * traffic. None of the modes substitute for actual credential
    * verification.
-   *
-   * The boolean form is a deprecated alias preserved for compatibility:
-   * `true` aliases `"shape"`, `false` aliases `"off"`. Both will be
-   * removed in v3 alongside the other deprecations queued for that
-   * release. New code should use the strings.
    */
-  validateSecurity?: boolean | "off" | "shape" | "strict";
+  validateSecurity?: "off" | "shape" | "strict";
   /** When `true`, reject unknown query parameters (default: `false`). */
   strictQueryParameters?: boolean;
   /**
@@ -578,7 +721,26 @@ export interface ValidatorOptions {
  * @see {@link ValidatorOptions}
  * @public
  */
-export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions = {}): Validator {
+export function createValidator(
+  spec: OpenAPIDocument,
+  options: ValidatorOptions & { output: "tree" },
+): TreeValidator;
+export function createValidator(
+  spec: OpenAPIDocument,
+  options: ValidatorOptions & { output: "predicate" },
+): PredicateValidator;
+export function createValidator(
+  spec: OpenAPIDocument,
+  options?: ValidatorOptions & { output?: "flat" },
+): Validator;
+export function createValidator(
+  spec: OpenAPIDocument,
+  options?: ValidatorOptions,
+): Validator | TreeValidator | PredicateValidator;
+export function createValidator(
+  spec: OpenAPIDocument,
+  options: ValidatorOptions = {},
+): Validator | TreeValidator | PredicateValidator {
   if (
     options.maxErrors !== undefined &&
     Number.isFinite(options.maxErrors) &&
@@ -589,7 +751,7 @@ export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions
     // would silently break validation: 0, negatives, non-integers.
     throw new Error(
       `createValidator: \`maxErrors\` must be a positive integer (got ${String(options.maxErrors)}). ` +
-        "Use `maxErrors: 1` for fast-fail, or omit the option for uncapped error collection.",
+        "Omit the option for fast-fail (1), or pass `Number.POSITIVE_INFINITY` to collect every error.",
     );
   }
   if (
@@ -602,6 +764,12 @@ export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions
         "Omit the option for uncapped recursion depth.",
     );
   }
+  // Resolved output shape + per-call error budget. Both mirror
+  // `compileSchema`: flat output and `maxErrors: 1` by default. Each
+  // per-location sub-validator is capped at `maxErrors` (bounds the work
+  // per location); `reshapeResult` then enforces the per-call total.
+  const outputMode = options.output ?? "flat";
+  const maxErrors = options.maxErrors ?? 1;
   const paths = spec.paths ?? {};
   const router: Router = createRouter(paths);
   const formats = { ...builtInFormats, ...options.formats };
@@ -674,18 +842,25 @@ export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions
     strictIssues,
   };
 
-  const compiledCache = new Map<SchemaOrBoolean, CompiledSchema>();
+  const compiledCache = new Map<SchemaOrBoolean, CompiledTreeSchema>();
   const compile = (
     schema: SchemaOrBoolean,
     resolver: RefResolver = refResolver,
-  ): CompiledSchema => {
+  ): CompiledTreeSchema => {
     const cached = compiledCache.get(schema);
     if (cached !== undefined) return cached;
     const c = compileSchema(schema, {
       dialect,
       formats,
       refResolver: resolver,
-      maxErrors: options.maxErrors,
+      // The validator builds a nested per-location tree internally and
+      // reshapes it to the requested `output` at the boundary, so the
+      // sub-validators always compile in tree mode. Each is capped at the
+      // per-call `maxErrors` (a per-location bound that prevents a single
+      // huge location from running away); `reshapeResult` then enforces
+      // the per-call total across all locations.
+      output: "tree",
+      maxErrors,
       maxDepth: options.maxDepth,
       keywords: options.keywords,
       strict: options.strict,
@@ -711,7 +886,10 @@ export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions
     request: createDirectionResolver(refResolver, "request", directionTransformCache.request),
     response: createDirectionResolver(refResolver, "response", directionTransformCache.response),
   };
-  const compileForDirection = (schema: SchemaOrBoolean, direction: BodyDirection): CompiledSchema =>
+  const compileForDirection = (
+    schema: SchemaOrBoolean,
+    direction: BodyDirection,
+  ): CompiledTreeSchema =>
     compile(
       transformBodySchemaForDirection(
         schema,
@@ -728,11 +906,11 @@ export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions
   // get the "response" transform (writeOnly properties forbidden);
   // response headers are direction-agnostic.
   const getResponseValidator = (
-    cache: Map<string, CompiledSchema>,
+    cache: Map<string, CompiledTreeSchema>,
     schemas: Map<string, SchemaOrBoolean>,
     key: string,
     direction?: BodyDirection,
-  ): CompiledSchema | undefined => {
+  ): CompiledTreeSchema | undefined => {
     const hit = cache.get(key);
     if (hit !== undefined) return hit;
     const schema = schemas.get(key);
@@ -766,7 +944,7 @@ export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions
     return cache;
   };
 
-  const validateRequest = (req: HttpRequest): ValidationError | null => {
+  const validateRequestTree = (req: HttpRequest): ValidationError | null => {
     if (options.ignorePaths?.(req.path) === true) return null;
     const match = router.match(req.method, req.path);
     if (match === undefined) {
@@ -854,7 +1032,7 @@ export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions
     );
   };
 
-  const validateResponse = (req: HttpRequest, res: HttpResponse): ValidationError | null => {
+  const validateResponseTree = (req: HttpRequest, res: HttpResponse): ValidationError | null => {
     if (options.ignorePaths?.(req.path) === true) return null;
     const match = router.match(req.method, req.path);
     if (match === undefined) {
@@ -970,29 +1148,29 @@ export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions
     );
   };
 
-  const validateFetchRequest = async <T>(
-    request: Request,
-    options?: FetchRequestOptions,
-  ): Promise<{ ok: true; body: T } | { ok: false; error: ValidationError }> => {
-    const { httpRequest, body } = await httpRequestFromFetch(request, options);
-    const error = validateRequest(httpRequest);
-    if (error === null) return { ok: true, body: body as T };
-    return { ok: false, error };
+  // Public, output-shaped entry points: build the internal tree, then
+  // reshape to the requested output and per-call error budget.
+  const validateRequest = (req: HttpRequest): ValidationResult | TreeValidationResult | boolean =>
+    reshapeResult(validateRequestTree(req), outputMode, maxErrors);
+  const validateResponse = (
+    req: HttpRequest,
+    res: HttpResponse,
+  ): ValidationResult | TreeValidationResult | boolean =>
+    reshapeResult(validateResponseTree(req, res), outputMode, maxErrors);
+
+  const validateFetchRequest = async <T>(request: Request, fetchOptions?: FetchRequestOptions) => {
+    const { httpRequest, body } = await httpRequestFromFetch(request, fetchOptions);
+    return toFetchResult<T>(validateRequest(httpRequest), body);
   };
 
-  const validateFetchResponse = async <T>(
-    request: Request,
-    response: Response,
-  ): Promise<{ ok: true; body: T } | { ok: false; error: ValidationError }> => {
+  const validateFetchResponse = async <T>(request: Request, response: Response) => {
     // Build an HttpRequest from the fetch Request without reading its
     // body; we only need method + path to match the operation.
     const url = new URL(request.url);
     const method = request.method.toUpperCase();
     const httpRequest: HttpRequest = { method, path: url.pathname };
     const { httpResponse, body } = await httpResponseFromFetch(response);
-    const error = validateResponse(httpRequest, httpResponse);
-    if (error === null) return { ok: true, body: body as T };
-    return { ok: false, error };
+    return toFetchResult<T>(validateResponse(httpRequest, httpResponse), body);
   };
 
   const getOperation = (req: {
@@ -1016,6 +1194,10 @@ export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions
     ? Object.freeze(lintResolvedSpec(spec))
     : [];
 
+  // The runtime methods return the `output`-dependent union; the
+  // overloads above resolve the precise interface for callers. The cast
+  // bridges the two: `outputMode` determines the real shape, which TS
+  // can't track from the value back to the literal overload.
   return {
     validateRequest,
     validateResponse,
@@ -1023,8 +1205,9 @@ export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions
     validateFetchResponse,
     getOperation,
     detectedVersion,
+    output: outputMode,
     warnings,
     specHygieneIssues,
     stats,
-  };
+  } as unknown as Validator | TreeValidator | PredicateValidator;
 }

--- a/packages/validator/test/custom-keywords.test.ts
+++ b/packages/validator/test/custom-keywords.test.ts
@@ -1,7 +1,7 @@
 import { collectLeaves, type OpenAPIDocument, type ValidationError } from "@oav/core";
 import { describe, expect, it } from "vitest";
 import type { CustomKeywordValidator } from "../src/index.js";
-import { createValidator } from "../src/validator.js";
+import { createValidator } from "./fixtures.js";
 
 describe("custom keywords via createValidator", () => {
   function sku(): OpenAPIDocument {

--- a/packages/validator/test/error-codes.test.ts
+++ b/packages/validator/test/error-codes.test.ts
@@ -5,7 +5,7 @@ import {
   type ValidationError,
 } from "@oav/core";
 import { describe, expect, it } from "vitest";
-import { createValidator } from "../src/index.js";
+import { createValidator } from "./fixtures.js";
 
 /**
  * Cross-check between actual emitted error codes and the documented

--- a/packages/validator/test/fetch-validators.test.ts
+++ b/packages/validator/test/fetch-validators.test.ts
@@ -215,7 +215,7 @@ describe("validator.validateFetchRequest", () => {
     const result = await v.validateFetchRequest(req);
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error.code).toBe("request");
+      expect(result.errors[0]?.path[0]).toBe("body");
     }
   });
 
@@ -223,7 +223,7 @@ describe("validator.validateFetchRequest", () => {
     const req = new Request("https://example.com/nope", { method: "DELETE" });
     const result = await v.validateFetchRequest(req);
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.error.code).toBe("route");
+    if (!result.ok) expect(result.errors[0]?.code).toBe("route");
   });
 
   it("accepts a multipart upload body", async () => {
@@ -420,7 +420,7 @@ describe("validator.validateFetchResponse", () => {
     });
     const result = await v.validateFetchResponse(req, res);
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.error.code).toBe("response");
+    if (!result.ok) expect(result.errors[0]?.path[0]).toBe("body");
   });
 
   it("flags an undeclared status code", async () => {
@@ -428,7 +428,7 @@ describe("validator.validateFetchResponse", () => {
     const res = new Response(null, { status: 500 });
     const result = await v.validateFetchResponse(req, res);
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.error.code).toBe("response");
+    if (!result.ok) expect(result.errors[0]?.code).toBe("status");
   });
 
   it("flags unknown routes at the request level", async () => {
@@ -436,7 +436,7 @@ describe("validator.validateFetchResponse", () => {
     const res = new Response(null, { status: 200 });
     const result = await v.validateFetchResponse(req, res);
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.error.code).toBe("route");
+    if (!result.ok) expect(result.errors[0]?.code).toBe("route");
   });
 
   it("doesn't read the request body", async () => {

--- a/packages/validator/test/fixtures.ts
+++ b/packages/validator/test/fixtures.ts
@@ -1,11 +1,48 @@
-import type { OpenAPIDocument, ValidationError } from "@oav/core";
+import type { HttpRequest, HttpResponse, OpenAPIDocument, ValidationError } from "@oav/core";
 import { collectLeaves } from "@oav/core";
+import {
+  createValidator as createValidatorRaw,
+  type TreeValidator,
+  type ValidatorOptions,
+} from "../src/index.js";
 
 /**
  * Shared test helpers for the validator test suite. Extracted so the
  * request / response / custom-keywords / lazy-compile test files can
  * share a minimal vocabulary without each one inlining its own spec.
  */
+
+/**
+ * Test shim: a tree-mode, uncapped validator whose
+ * `validateRequest` / `validateResponse` return `ValidationError | null`.
+ * The logic-focused suites assert error codes, paths, and counts, all of
+ * which are output-shape-independent, so this shim lets them keep doing
+ * that without threading the v3 result object through every case. The
+ * `output` knob, the flat default, and reshaping/budget behavior are
+ * covered directly by `output-modes.test.ts`.
+ */
+export type TreeShim = Omit<TreeValidator, "validateRequest" | "validateResponse"> & {
+  validateRequest(req: HttpRequest): ValidationError | null;
+  validateResponse(req: HttpRequest, res: HttpResponse): ValidationError | null;
+};
+
+export function createValidator(spec: OpenAPIDocument, options: ValidatorOptions = {}): TreeShim {
+  const v = createValidatorRaw(spec, {
+    output: "tree",
+    maxErrors: Number.POSITIVE_INFINITY,
+    ...options,
+  });
+  return Object.assign(Object.create(null) as object, v, {
+    validateRequest: (req: HttpRequest): ValidationError | null => {
+      const r = v.validateRequest(req);
+      return r.valid ? null : r.error;
+    },
+    validateResponse: (req: HttpRequest, res: HttpResponse): ValidationError | null => {
+      const r = v.validateResponse(req, res);
+      return r.valid ? null : r.error;
+    },
+  }) as TreeShim;
+}
 
 export function leafCodes(err: ValidationError | null | undefined): string[] {
   return err === null || err === undefined ? [] : collectLeaves(err).map((l) => l.code);

--- a/packages/validator/test/max-depth.test.ts
+++ b/packages/validator/test/max-depth.test.ts
@@ -1,6 +1,6 @@
 import { collectLeaves, httpStatusFor, type OpenAPIDocument } from "@oav/core";
 import { describe, expect, it } from "vitest";
-import { createValidator } from "../src/validator.js";
+import { createValidator } from "./fixtures.js";
 
 // A spec whose request body is a self-recursive `Node` (tree shape).
 function treeSpec(): OpenAPIDocument {

--- a/packages/validator/test/output-modes.test.ts
+++ b/packages/validator/test/output-modes.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { createValidator } from "../src/validator.js";
+import { petSpec } from "./fixtures.js";
+
+// These exercise the real (un-shimmed) validator: the `output` knob, the
+// flat default, and the per-call `maxErrors` total. The shimmed
+// `createValidator` in fixtures.ts is for the logic-focused suites.
+
+const badPost = {
+  method: "POST",
+  path: "/pets",
+  contentType: "application/json",
+  // missing required X-Tenant header AND missing required body `name`:
+  // at least two problems, in two different locations.
+  body: { age: -1 },
+} as const;
+
+describe("validator output modes", () => {
+  it("defaults to flat output", () => {
+    const v = createValidator(petSpec());
+    const r = v.validateRequest(badPost);
+    expect(r.valid).toBe(false);
+    if (r.valid) return;
+    expect(Array.isArray(r.errors)).toBe(true);
+    expect("error" in r).toBe(false);
+    expect(v.output).toBe("flat");
+  });
+
+  it("defaults to maxErrors: 1 as a per-call total across locations", () => {
+    const v = createValidator(petSpec());
+    const r = v.validateRequest(badPost);
+    if (r.valid) return;
+    expect(r.errors).toHaveLength(1);
+    expect(r.truncated).toBe(true);
+  });
+
+  it("collects every location's errors when uncapped", () => {
+    const v = createValidator(petSpec(), { maxErrors: Number.POSITIVE_INFINITY });
+    const r = v.validateRequest(badPost);
+    if (r.valid) return;
+    // header + body problems both present.
+    expect(r.errors.length).toBeGreaterThan(1);
+    expect(r.truncated).toBe(false);
+  });
+
+  it("caps the per-call total at an explicit maxErrors", () => {
+    const v = createValidator(petSpec(), { maxErrors: 2 });
+    const r = v.validateRequest(badPost);
+    if (r.valid) return;
+    expect(r.errors.length).toBeLessThanOrEqual(2);
+  });
+
+  it("a valid request is { valid: true } with no error fields", () => {
+    const v = createValidator(petSpec());
+    const r = v.validateRequest({
+      method: "POST",
+      path: "/pets",
+      contentType: "application/json",
+      headers: { "x-tenant": "acme" },
+      body: { name: "Fido" },
+    });
+    expect(r).toEqual({ valid: true });
+  });
+
+  describe('output: "tree"', () => {
+    it("returns a nested tree under error", () => {
+      const v = createValidator(petSpec(), {
+        output: "tree",
+        maxErrors: Number.POSITIVE_INFINITY,
+      });
+      const r = v.validateRequest(badPost);
+      expect(r.valid).toBe(false);
+      if (r.valid) return;
+      expect(r.error.code).toBe("request");
+      expect(r.error.children.length).toBeGreaterThan(0);
+      expect("errors" in r).toBe(false);
+      expect(v.output).toBe("tree");
+    });
+  });
+
+  describe('output: "predicate"', () => {
+    it("returns a bare boolean", () => {
+      const v = createValidator(petSpec(), { output: "predicate" });
+      expect(v.validateRequest(badPost)).toBe(false);
+      expect(
+        v.validateRequest({
+          method: "POST",
+          path: "/pets",
+          contentType: "application/json",
+          headers: { "x-tenant": "acme" },
+          body: { name: "Fido" },
+        }),
+      ).toBe(true);
+      expect(v.output).toBe("predicate");
+    });
+  });
+
+  it("flat leaves carry their HTTP location in the path prefix", () => {
+    const v = createValidator(petSpec(), { maxErrors: Number.POSITIVE_INFINITY });
+    const r = v.validateRequest(badPost);
+    if (r.valid) return;
+    const locations = new Set(r.errors.map((e) => e.path[0]));
+    // body problems land under ["body", ...]; header problems elsewhere.
+    expect(locations.has("body")).toBe(true);
+  });
+
+  it("a route miss is a single route leaf in flat mode", () => {
+    const v = createValidator(petSpec());
+    const r = v.validateRequest({ method: "POST", path: "/nope" });
+    if (r.valid) return;
+    expect(r.errors).toHaveLength(1);
+    expect(r.errors[0]?.code).toBe("route");
+  });
+});

--- a/packages/validator/test/refs.test.ts
+++ b/packages/validator/test/refs.test.ts
@@ -9,7 +9,7 @@
 import { describe, expect, it } from "vitest";
 import type { OpenAPIDocument } from "@oav/core";
 import { createMemoryReader, resolveSpec } from "@oav/spec";
-import { createValidator } from "../src/validator.js";
+import { createValidator } from "./fixtures.js";
 
 describe("operation-level $ref resolution", () => {
   it("resolves requestBody $ref", () => {

--- a/packages/validator/test/regex-compiler.test.ts
+++ b/packages/validator/test/regex-compiler.test.ts
@@ -102,6 +102,7 @@ describe("createValidator forwards regexCompiler", () => {
       contentType: "application/json",
       body: { sku: "OAV-42" },
     });
-    expect(err).not.toBeNull();
+    expect(err.valid).toBe(false);
+    if (!err.valid) expect(err.errors.some((e) => e.code === "pattern")).toBe(true);
   });
 });

--- a/packages/validator/test/request.test.ts
+++ b/packages/validator/test/request.test.ts
@@ -1,7 +1,6 @@
 import { collectLeaves, httpStatusFor, type OpenAPIDocument } from "@oav/core";
 import { describe, expect, it } from "vitest";
-import { createValidator } from "../src/validator.js";
-import { leafAt, leafCodes, petSpec } from "./fixtures.js";
+import { createValidator, leafAt, leafCodes, petSpec } from "./fixtures.js";
 
 describe("validateRequest", () => {
   const v = createValidator(petSpec());

--- a/packages/validator/test/response.test.ts
+++ b/packages/validator/test/response.test.ts
@@ -1,7 +1,6 @@
 import type { OpenAPIDocument } from "@oav/core";
 import { describe, expect, it } from "vitest";
-import { createValidator } from "../src/validator.js";
-import { leafAt, leafCodes, petSpec } from "./fixtures.js";
+import { createValidator, leafAt, leafCodes, petSpec } from "./fixtures.js";
 
 describe("validateResponse", () => {
   const v = createValidator(petSpec());

--- a/packages/validator/test/security.test.ts
+++ b/packages/validator/test/security.test.ts
@@ -1,6 +1,6 @@
 import type { ErrorParamsFor, OpenAPIDocument, ValidationError } from "@oav/core";
 import { describe, expect, it } from "vitest";
-import { createValidator } from "../src/validator.js";
+import { createValidator } from "./fixtures.js";
 
 /**
  * Shape-only security validation coverage: bearer / basic / apiKey.
@@ -39,7 +39,7 @@ function firstLeaf(err: ValidationError | null): ValidationError | null {
 
 describe("security validation: bearer (http / bearer)", () => {
   const spec = specWith({ bearerAuth: { type: "http", scheme: "bearer" } }, [{ bearerAuth: [] }]);
-  const v = createValidator(spec, { validateSecurity: true });
+  const v = createValidator(spec, { validateSecurity: "shape" });
 
   it("accepts Authorization: Bearer <token>", () => {
     expect(
@@ -91,7 +91,7 @@ describe("security validation: bearer (http / bearer)", () => {
 
 describe("security validation: basic (http / basic)", () => {
   const spec = specWith({ basicAuth: { type: "http", scheme: "basic" } }, [{ basicAuth: [] }]);
-  const v = createValidator(spec, { validateSecurity: true });
+  const v = createValidator(spec, { validateSecurity: "shape" });
 
   it("accepts a well-formed Basic credential", () => {
     const creds = Buffer.from("user:pass").toString("base64");
@@ -134,7 +134,7 @@ describe("security validation: apiKey", () => {
     const spec = specWith({ apiKeyAuth: { type: "apiKey", in: "header", name: "X-API-Key" } }, [
       { apiKeyAuth: [] },
     ]);
-    const v = createValidator(spec, { validateSecurity: true });
+    const v = createValidator(spec, { validateSecurity: "shape" });
     expect(v.validateRequest({ method: "GET", path: "/ping" })?.code).toBe("request");
     expect(
       v.validateRequest({ method: "GET", path: "/ping", headers: { "x-api-key": "abc" } }),
@@ -145,7 +145,7 @@ describe("security validation: apiKey", () => {
     const spec = specWith({ apiKeyAuth: { type: "apiKey", in: "header", name: "X-API-Key" } }, [
       { apiKeyAuth: [] },
     ]);
-    const v = createValidator(spec, { validateSecurity: true });
+    const v = createValidator(spec, { validateSecurity: "shape" });
     const err = v.validateRequest({
       method: "GET",
       path: "/ping",
@@ -158,7 +158,7 @@ describe("security validation: apiKey", () => {
     const spec = specWith({ apiKeyAuth: { type: "apiKey", in: "query", name: "api_key" } }, [
       { apiKeyAuth: [] },
     ]);
-    const v = createValidator(spec, { validateSecurity: true });
+    const v = createValidator(spec, { validateSecurity: "shape" });
     expect(v.validateRequest({ method: "GET", path: "/ping" })?.code).toBe("request");
     expect(
       v.validateRequest({ method: "GET", path: "/ping", query: { api_key: "abc" } }),
@@ -169,7 +169,7 @@ describe("security validation: apiKey", () => {
     const spec = specWith({ apiKeyAuth: { type: "apiKey", in: "cookie", name: "session" } }, [
       { apiKeyAuth: [] },
     ]);
-    const v = createValidator(spec, { validateSecurity: true });
+    const v = createValidator(spec, { validateSecurity: "shape" });
     expect(v.validateRequest({ method: "GET", path: "/ping" })?.code).toBe("request");
     expect(
       v.validateRequest({ method: "GET", path: "/ping", cookies: { session: "abc" } }),
@@ -185,7 +185,7 @@ describe("security validation: OR across alternatives, AND within", () => {
     },
     [{ bearerAuth: [] }, { apiKeyAuth: [] }],
   );
-  const v = createValidator(spec, { validateSecurity: true });
+  const v = createValidator(spec, { validateSecurity: "shape" });
 
   it("either scheme on its own satisfies the operation", () => {
     expect(
@@ -220,7 +220,7 @@ describe("security validation: OR across alternatives, AND within", () => {
       },
       [{ bearerAuth: [], apiKeyAuth: [] }],
     );
-    const andV = createValidator(andSpec, { validateSecurity: true });
+    const andV = createValidator(andSpec, { validateSecurity: "shape" });
 
     // Only the bearer is present; AND fails.
     const err = andV.validateRequest({
@@ -248,7 +248,7 @@ describe("security validation: top-level vs operation-level", () => {
       [], // explicit opt-out on the operation
       [{ bearerAuth: [] }], // top-level requirement
     );
-    const v = createValidator(spec, { validateSecurity: true });
+    const v = createValidator(spec, { validateSecurity: "shape" });
     expect(v.validateRequest({ method: "GET", path: "/ping" })).toBeNull();
   });
 
@@ -258,17 +258,17 @@ describe("security validation: top-level vs operation-level", () => {
       undefined, // operation omits the field
       [{ bearerAuth: [] }],
     );
-    const v = createValidator(spec, { validateSecurity: true });
+    const v = createValidator(spec, { validateSecurity: "shape" });
     expect(v.validateRequest({ method: "GET", path: "/ping" })?.code).toBe("request");
   });
 });
 
 describe("security validation: configuration", () => {
-  it("defaults to off: security is not enforced unless validateSecurity: true is set", () => {
+  it("defaults to off: security is not enforced unless validateSecurity is set", () => {
     // The default reflects the "auth middleware runs upstream" reality:
     // by the time the validator sees a request, the credential has
     // already been verified (or rejected) by the host app's auth layer.
-    // Opt in with `true` for dev / prototyping without auth middleware
+    // Opt in with `"shape"` for dev / prototyping without auth middleware
     // or for decorator-only auth that doesn't reject unauthenticated.
     const spec = specWith({ bearerAuth: { type: "http", scheme: "bearer" } }, [{ bearerAuth: [] }]);
     const v = createValidator(spec);
@@ -277,7 +277,7 @@ describe("security validation: configuration", () => {
 
   it("an undeclared scheme name fails the check (fail-closed, no silent pass)", () => {
     const spec = specWith({ bearerAuth: { type: "http", scheme: "bearer" } }, [{ typoAuth: [] }]);
-    const v = createValidator(spec, { validateSecurity: true });
+    const v = createValidator(spec, { validateSecurity: "shape" });
     const err = v.validateRequest({ method: "GET", path: "/ping" });
     expect(firstLeaf(err)?.code).toBe("security");
   });
@@ -306,7 +306,7 @@ describe("security validation: configuration", () => {
         },
       },
     };
-    const v = createValidator(doc, { validateSecurity: true });
+    const v = createValidator(doc, { validateSecurity: "shape" });
     const err = v.validateRequest({
       method: "POST",
       path: "/echo",
@@ -329,7 +329,7 @@ describe("security validation: configuration", () => {
       },
       [{ oauth: ["read"] }],
     );
-    const v = createValidator(spec, { validateSecurity: true });
+    const v = createValidator(spec, { validateSecurity: "shape" });
     // No headers / query; oauth2 isn't shape-checked, so pass.
     expect(v.validateRequest({ method: "GET", path: "/ping" })).toBeNull();
   });
@@ -422,32 +422,6 @@ describe("security validation: configuration", () => {
           method: "GET",
           path: "/ping",
           headers: { authorization: "Bearer abc" },
-        }),
-      ).toBeNull();
-    });
-
-    it('boolean form: `true` aliases "shape", `false` aliases "off"', () => {
-      const spec = specWith(
-        {
-          oauth: {
-            type: "oauth2",
-            flows: { implicit: { authorizationUrl: "https://example.com/auth", scopes: {} } },
-          },
-        },
-        [{ oauth: ["read"] }],
-      );
-      // `true` -> "shape": oauth2 silently passes.
-      expect(
-        createValidator(spec, { validateSecurity: true }).validateRequest({
-          method: "GET",
-          path: "/ping",
-        }),
-      ).toBeNull();
-      // `false` -> "off": no check at all (same as default).
-      expect(
-        createValidator(spec, { validateSecurity: false }).validateRequest({
-          method: "GET",
-          path: "/ping",
         }),
       ).toBeNull();
     });

--- a/packages/validator/test/versioning.test.ts
+++ b/packages/validator/test/versioning.test.ts
@@ -12,7 +12,7 @@
 import { describe, expect, it } from "vitest";
 import type { OpenAPIDocument } from "@oav/core";
 import { jsonSchemaDialect } from "@oav/schema";
-import { createValidator } from "../src/validator.js";
+import { createValidator } from "./fixtures.js";
 
 function spec32(): OpenAPIDocument {
   return {

--- a/performance/README.md
+++ b/performance/README.md
@@ -222,54 +222,53 @@ format warnings don't flood stdout.
 once, outside the timed loop. The hot path is literally
 `validator(sample)` — no closures, no cursor math, no per-iteration
 setup. One representative sample each for the valid and invalid
-paths so neither side wins by short-circuiting. `allErrors: true` on
-ajv for parity with oav's always-collect-everything default.
+paths so neither side wins by short-circuiting.
+
+The bench runs five validators so each comparison is apples-to-apples:
+`oav` is the zero-config default (flat, `maxErrors: 1`) and pairs with
+`ajv-fast` (`allErrors: false`); `oav-all` collects every error and
+pairs with `ajv` (`allErrors: true`); `oav-predicate` is the boolean
+fast path.
 
 ## Interpreting the results
 
 - **Compile-hot workloads.** Per-request or per-tenant validator
-  construction. oav wins across the board in the current numbers,
+  construction. oav is faster across the board in the current numbers,
   by one to two orders of magnitude against ajv.
 - **Steady-state validate on the same payload shape.** Call
-  `compile` once at boot, validate many times. ajv and oav trade the
-  lead by shape:
-  - **At or near ajv parity** on scalar, flat-object, and recursive
-    `$ref` shapes (within ~10–35% on the bench spec).
-  - **Behind ajv** on the applicator-heavy shapes: ~2–3× on large
-    arrays, ~3–4× on `oneOf`/`allOf` composition (the largest
-    remaining gap; see the structural note below). Predicate mode
-    closes most of the composition gap.
-  - **Ahead of ajv** on two shapes: `uniqueItems` arrays (oav's
-    primitive fast path vs ajv's pairwise scan), and length-bounded
-    strings. On the latter, `minLength` / `maxLength` decide from the
-    string's `.length` before walking code points, so a large valid
-    body costs O(1) where ajv walks the whole string (oav is
-    ~thousands× faster on that shape's valid path).
+  `compile` once at boot, validate many times. Comparing matched
+  defaults (`oav` vs `ajv-fast`, both fail-fast):
+  - **Within ~25%** on scalar, flat-object, recursive `$ref`, and
+    large-array shapes. ajv is a little ahead on the rejection path.
+  - **Behind ajv** on `oneOf` / `allOf` rejection (~2.5×, larger when
+    collecting all errors): oav materialises the composition error
+    where ajv stops at the first failure. `output: "predicate"` reaches
+    parity (see the structural note below).
+  - **Ahead of ajv** on `uniqueItems` arrays (~1.6–3×; oav's primitive
+    fast path vs ajv's pairwise scan). `minLength` / `maxLength` also
+    decide from the string's `.length` before walking code points, so a
+    large valid body costs O(1).
 
-  `maxErrors: 1` closes the gap on invalid payloads (apples-to-apples
-  with ajv's default fail-fast behavior).
-
-- **Predicate mode (`predicate: true`).** When consumers only need a
+- **Predicate mode (`output: "predicate"`).** When consumers only need a
   yes/no answer — routing, gating, hot-path filtering — `oav-predicate`
-  brings oav onto parity with ajv's default (fail-fast) mode on invalid
-  paths and typically edges it out on valid paths. The compiler drops
-  error-tree construction entirely: no leaf-allocation, no path
-  snapshot, no params object, no message string, no wrapper. Every
-  failure short-circuits to `return false;`. The mode cannot be
-  combined with `maxErrors` (the two options are semantically
-  incompatible; the compiler throws).
+  brings oav to parity with ajv's fail-fast mode on invalid paths and
+  typically edges it out on valid paths. The compiler drops error-tree
+  construction entirely: no leaf-allocation, no path snapshot, no params
+  object, no message string, no wrapper. Every failure short-circuits to
+  `return false;`. The mode cannot be combined with a finite `maxErrors`
+  (the two are semantically incompatible; the compiler throws).
 - **Hyperjump**'s validate throughput sits roughly two orders of
   magnitude below ajv / oav. It's the 2020-12 reference
   implementation, not a speed target.
 - **`@oav/schema`**'s remaining validate overhead vs ajv comes from
   two structural choices: schemas that contain applicators
-  (`properties` / `items` / `allOf` / ...) compile to a function
-  call rather than inlining into the enclosing body (V8 monomorphizes
-  hot-loop calls better than massive inline bodies); and oav collects
-  complete error trees by default, while ajv defaults to
-  `allErrors: false`. Set `maxErrors: 1` on oav for apples-to-apples
-  fast-fail semantics, or `predicate: true` to shed the error
-  infrastructure entirely.
+  (`properties` / `items` / `allOf` / ...) compile to a function call
+  rather than inlining into the enclosing body (V8 monomorphizes
+  hot-loop calls better than massive inline bodies); and on the
+  rejection path oav still builds a structured leaf for the failing
+  keyword. oav's default already matches ajv's fail-fast (flat,
+  `maxErrors: 1`); `output: "predicate"` sheds the error infrastructure
+  entirely for the cases that only need a yes/no answer.
 
 ## Results file
 

--- a/performance/run.ts
+++ b/performance/run.ts
@@ -38,7 +38,7 @@ const specPath = specArg?.slice("--spec=".length);
 type Result = {
   schema: string;
   metric: "compile" | "validate";
-  lib: "ajv" | "ajv-fast" | "hyperjump" | "oav" | "oav-predicate";
+  lib: "ajv" | "ajv-fast" | "hyperjump" | "oav" | "oav-all" | "oav-predicate";
   hz: number; // ops/sec
   mean: number; // µs/op
   variant?: string; // full task name (e.g. "oav validate (valid)")
@@ -149,15 +149,24 @@ async function benchSchema(s: PerfSchema): Promise<void> {
   registerSchema(s.schema, hjUri);
   const hjV = await hjValidate(hjUri);
 
+  // oav's zero-config default: flat output, maxErrors 1 (fail-fast). The
+  // apples-to-apples partner for ajv-fast (allErrors: false).
   const oav = compileSchema(s.schema as never, {
     dialect: jsonSchemaDialect,
     formats: builtInFormats,
   });
 
+  // oav collecting every error: the partner for ajv (allErrors: true).
+  const oavAll = compileSchema(s.schema as never, {
+    dialect: jsonSchemaDialect,
+    formats: builtInFormats,
+    maxErrors: Number.POSITIVE_INFINITY,
+  });
+
   const oavPredicate = compileSchema(s.schema as never, {
     dialect: jsonSchemaDialect,
     formats: builtInFormats,
-    predicate: true,
+    output: "predicate",
   });
 
   // Measure both the happy path (valid) and the failure path (invalid)
@@ -191,6 +200,12 @@ async function benchSchema(s: PerfSchema): Promise<void> {
     })
     .add("oav validate (invalid)", () => {
       oav.validate(invalidSample);
+    })
+    .add("oav-all validate (valid)", () => {
+      oavAll.validate(validSample);
+    })
+    .add("oav-all validate (invalid)", () => {
+      oavAll.validate(invalidSample);
     })
     .add("oav-predicate validate (valid)", () => {
       oavPredicate.validate(validSample);
@@ -403,6 +418,7 @@ if (specPath !== undefined) {
       "ajv-fast".padEnd(10) +
       "hyperjump".padEnd(12) +
       "oav".padEnd(8) +
+      "oav-all".padEnd(9) +
       "oav-pred",
   );
   console.log("-".repeat(80));
@@ -421,6 +437,7 @@ if (specPath !== undefined) {
     const ajvFast = row["ajv-fast"] ?? 0;
     const hj = row["hyperjump"] ?? 0;
     const oav = row["oav"] ?? 0;
+    const oavAll = row["oav-all"] ?? 0;
     const oavPred = row["oav-predicate"] ?? 0;
     const base = ajv || 1;
     const fmt = (n: number) => (n === 0 ? "—" : (n / base).toFixed(2));
@@ -431,6 +448,7 @@ if (specPath !== undefined) {
         fmt(ajvFast).padEnd(10) +
         fmt(hj).padEnd(12) +
         fmt(oav).padEnd(8) +
+        fmt(oavAll).padEnd(9) +
         fmt(oavPred),
     );
   }


### PR DESCRIPTION
## v3: flat error output and `maxErrors: 1` as zero-config defaults

`compileSchema(schema)` and `createValidator(spec)` now match Ajv's out-of-the-box behaviour: a flat list of errors that stops at the first problem. The richer nested error tree and full error collection become opt-in. The goal is that a drive-by evaluator running zero-config sees Ajv-class numbers; the nested tree is there when you ask for it.

### API changes

- **`output: "flat" | "tree" | "predicate"`** selects the result shape. The `flat` / `predicate` booleans become deprecated aliases that throw on conflict. **`maxErrors` defaults to `1`** and is orthogonal to `output`.
- **Result types renamed:** `ValidationResult` is now the flat shape, `TreeValidationResult` the tree; `CompiledSchema` / `CompiledTreeSchema` likewise. `FlatValidationResult` / `CompiledFlatSchema` kept as deprecated aliases. Both are discriminated unions on `valid`.
- **`createValidator` mirrors the compiler:** same `output` / `maxErrors` options, overloaded into `Validator` / `TreeValidator` / `PredicateValidator`. `maxErrors` is a per-call total across locations.
- **Adapters** (express4 / express5 / fastify) flatten any result to a `ValidationError[]` leaf list for `onError` (signature now `(errors, ctx)`), and reject a predicate-mode validator at construction.
- **`@oav/core`** `httpStatusFor` / `allowHeaderFor` / `toProblemDetails` / `collectIssues` / `formatText` accept a single `ValidationError` or a `ValidationError[]`.

### Correctness fix the `maxErrors: 1` default forced

A finite `maxErrors` must never flip a valid/invalid verdict. `contains` now tests membership with a predicate sub-validator (never charging the budget for discarded per-item errors), and the budget short-circuit is disabled whenever a schema uses `unevaluated*`. Swept the full JSON Schema Test Suite (1448 cases): **0 verdict flips** between `maxErrors: 1` and uncapped.

### Also in the batch

- `undefined`-valued object properties now count as absent for `required` / `properties` / `dependent*` (#343, now flagged BREAKING).
- Removed the v3-deprecated `formatJson` / `summarize` / `formatFlat` formatters and the `validateSecurity` boolean form.
- CLI stays tree + uncapped; examples updated to the flat default.
- Benchmark refresh: added an `oav-all` task (flat, uncapped) so comparisons are apples-to-apples against Ajv `allErrors:true`.
- Docs: new `docs/migration-v3.md`; updated README, configuration, integration, comparison, extending, all package READMEs.

### Verification

typecheck · 1176 unit tests · 30 framework integration tests · lint/fmt · JSON Schema conformance baseline (default **and** `OAV_FLAT=1`, 1270/1290) · 32/32 OpenAPI cases.

### Release

This carries a `feat!:` + `BREAKING CHANGE:` footer, so release-please will bump the group to **3.0.0**. Hold the release-please PR unmerged until the v3 architectural-review backlog (tracked separately) is addressed.

See `docs/migration-v3.md` for the full v2 to v3 migration guide.
