### PR TITLE
test(schema): pin flat/tree leaf parity under finite maxErrors

### DIFF
--- a/packages/schema/test/flat-mode.test.ts
+++ b/packages/schema/test/flat-mode.test.ts
@@ -128,6 +128,29 @@ describe("flat mode: leaf-set parity with the tree (non-composition schemas)", (
   }
 });
 
+describe("flat mode: finite-maxErrors leaf-set parity with the tree (non-composition)", () => {
+  // The budget short-circuit drops errors mid-evaluation. Flat codegen and
+  // tree codegen run the identical keyword dispatch under the identical gated
+  // counter, so a finite cap must drop the SAME leaves in both modes: the flat
+  // list and collectLeaves(tree) stay equal, and truncated agrees. Nothing else
+  // forces these two flat-list producers equal under a budget (the Infinity
+  // block above only exercises the un-gated path).
+  for (const { name, schema, data } of LEAF_CASES) {
+    for (const maxErrors of [1, 2, 3]) {
+      it(`${name} @ maxErrors=${maxErrors}`, () => {
+        const t = tree(schema, { maxErrors }).validate(data);
+        const f = flat(schema, { maxErrors }).validate(data);
+        expect(t.valid).toBe(false);
+        expect(f.valid).toBe(false);
+        expect(bag(f.errors!)).toEqual(bag(collectLeaves(t.error!)));
+        expect(f.errors!.length).toBeLessThanOrEqual(maxErrors);
+        expect(f.truncated).toBe(t.truncated);
+        for (const e of f.errors!) expect(e.children).toEqual([]);
+      });
+    }
+  }
+});
+
 describe("flat mode: composition markers", () => {
   it("anyOf all-fail: branch leaves plus one anyOf marker", () => {
     const r = flat({ anyOf: [{ type: "string" }, { type: "number" }] }).validate(true);
@@ -206,12 +229,18 @@ describe("flat mode: validity agreement with the tree", () => {
     { schema: recursive, data: { value: 1, children: [{ value: "bad" }, { extra: true }] } },
   ];
 
+  // Run each case un-gated AND under finite budgets. A finite maxErrors must
+  // never flip a valid/invalid verdict (it only caps how many errors are
+  // reported); pinning flat.valid === tree.valid across caps guards that v3
+  // claim at the compiler's public boundary, composition/refs/recursion incl.
   for (const [i, { schema, data }] of AGREEMENT.entries()) {
-    it(`case ${i}: flat.valid === tree.valid`, () => {
-      const t = tree(schema).validate(data);
-      const f = flat(schema).validate(data);
-      expect(f.valid).toBe(t.valid);
-    });
+    for (const maxErrors of [1, 2, Number.POSITIVE_INFINITY]) {
+      it(`case ${i} @ maxErrors=${maxErrors}: flat.valid === tree.valid`, () => {
+        const t = tree(schema, { maxErrors }).validate(data);
+        const f = flat(schema, { maxErrors }).validate(data);
+        expect(f.valid).toBe(t.valid);
+      });
+    }
   }
 });
 


### PR DESCRIPTION
## Pin flat/tree leaf parity under a finite `maxErrors`

P2#1 from the v3 architectural-review backlog.

The compiler has two producers of the flat leaf list:

1. the **flat codegen** path (`output: "flat"`), and
2. **`collectLeaves`** of the **tree codegen** (`output: "tree"`) — the form the validator reshapes at its public boundary.

`flat-mode.test.ts` already pinned these equal, but only un-gated (`maxErrors: Infinity`). The budget short-circuit drops errors mid-evaluation, so a **finite cap** is exactly where the two paths could silently diverge, and nothing forced them equal there. Conformance `OAV_FLAT=1` only checks `.valid`, so it wouldn't catch a leaf-set drift either.

### What this adds

- **Finite-maxErrors leaf-set parity** (`LEAF_CASES` x `maxErrors ∈ {1,2,3}`): the flat list equals `collectLeaves(tree)`, the cap is respected, and `truncated` agrees. Both modes run identical keyword dispatch under the identical gated counter, so the same leaves drop in both — this locks that in against a future codegen change.
- **Validity agreement under finite budgets** (`{1,2}` added to the existing corpus): asserts the core v3 claim — a finite `maxErrors` never flips a valid/invalid verdict — at the compiler's public boundary, across composition / refs / recursion, not just un-gated.

Composition stays out of strict bag-equality by design: flat mode synthesizes an `anyOf`/`oneOf` marker record with no `collectLeaves` counterpart, so those cases are covered by the existing marker + validity assertions.

### Verification

`flat-mode.test.ts`: 137 passed (was ~58). Lint/fmt clean. Test-only change; no production code touched.

Rides into the held 3.0.0 release.
