### PR TITLE
chore: drop two phantom workspace dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,9 +189,9 @@ package's README covers its responsibilities. The non-obvious nugget
 per package:
 
 - **`@oav/core`**: the shared error-tree model and HTTP/format
-  helpers. Everything depends on it; it depends on nothing. Legacy
-  formatter aliases (`formatJson` / `formatFlat` / `summarize`) are
-  deprecated, removal in v3.
+  helpers. Every package except the leaf `@oav/formats` depends on it;
+  it depends on nothing. Legacy formatter aliases (`formatJson` /
+  `formatFlat` / `summarize`) are deprecated, removal in v3.
 - **`@oav/schema`**: the JSON Schema 2020-12 compiler; walks a schema,
   dispatches each keyword via `KeywordDefinition.compile(ctx)`, and
   `eval`s the generated source through `new Function(deps, src)`.
@@ -200,7 +200,8 @@ per package:
   mechanics live behind the `oav/schema/internals` subpath (not
   semver-covered; reach for them only when a plugin truly needs them).
 - **`@oav/formats`**: pure string validators, a `Record<string, (s:
-string) => boolean>` shaped for `compileSchema`'s `formats` option.
+string) => boolean>` shaped for `compileSchema`'s `formats` option. A
+  leaf alongside `core`: no workspace dependencies.
 - **`@oav/spec`**: `DocumentReader` (file/http/memory/composite) plus
   `resolveSpec()`, which inlines external `$ref`s and leaves circular
   ones as internal refs. `applyOverlays()` is the extension system.
@@ -231,7 +232,7 @@ string) => boolean>` shaped for `compileSchema`'s `formats` option.
 ```
 cli           → validator → router
                          → spec → core
-                         → formats → core
+                         → formats
                          → schema → core
                          → core
               → spec → core

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@oav/core": "workspace:*",
     "@oav/formats": "workspace:*",
-    "@oav/router": "workspace:*",
     "@oav/schema": "workspace:*",
     "@oav/spec": "workspace:*",
     "@oav/validator": "workspace:*",

--- a/packages/formats/package.json
+++ b/packages/formats/package.json
@@ -12,9 +12,6 @@
       "import": "./src/index.ts"
     }
   },
-  "dependencies": {
-    "@oav/core": "workspace:*"
-  },
   "engines": {
     "node": ">=20"
   }

--- a/packages/formats/tsconfig.json
+++ b/packages/formats/tsconfig.json
@@ -5,6 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "node_modules", "src/**/*.test.ts"],
-  "references": [{ "path": "../core" }]
+  "exclude": ["dist", "node_modules", "src/**/*.test.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       '@oav/formats':
         specifier: workspace:*
         version: link:../formats
-      '@oav/router':
-        specifier: workspace:*
-        version: link:../router
       '@oav/schema':
         specifier: workspace:*
         version: link:../schema
@@ -62,11 +59,7 @@ importers:
 
   packages/core: {}
 
-  packages/formats:
-    dependencies:
-      '@oav/core':
-        specifier: workspace:*
-        version: link:../core
+  packages/formats: {}
 
   packages/oav:
     dependencies:


### PR DESCRIPTION
## Drop two phantom workspace dependencies

Part of P3#7 from the v3 architectural-review backlog. Both deps are declared but never imported, so the declared package graph overstated the real import graph.

### `@oav/cli` → `@oav/router`

`cli/src` has zero imports of `@oav/router` / `createRouter`. The cli only emits `createRouter` as a **string literal** in generated code that imports from `@oav/validator/internals`; the end user's `@oav/validator` install carries router transitively. The cli's `tsconfig` references already omit router, so this just aligns `package.json` with them.

### `@oav/formats` → `@oav/core`

`formats/src` imports nothing from `@oav/core`. (The only `@oav/schema` mentions in its source are TSDoc `{@link ...}` targets, not imports.) `@oav/formats` is a pure-utility **leaf** with no workspace dependencies, so I dropped the dep and its `tsconfig` project reference to match `@oav/core`'s leaf shape.

Updated the CLAUDE.md dependency graph: `formats` is now a leaf alongside `core`.

### Out of scope (the other half of P3#7)

The review also suggested an **import-cycle lint rule**. oxlint has no such rule, so that needs a tooling decision (new devDependency vs. a small dependency-free package-graph script). Tracking separately so this stays a clean, dependency-free cleanup.

### Verification

clean `tsc -b` · 1260 unit tests · `pnpm build` (formats bundles with no core dep) · lint/fmt · `pnpm install --frozen-lockfile` consistent.

Rides into the held 3.0.0 release.
