### PR TITLE
docs: post-v3 cleanup of stale deprecation notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,8 +190,7 @@ per package:
 
 - **`@oav/core`**: the shared error-tree model and HTTP/format
   helpers. Every package except the leaf `@oav/formats` depends on it;
-  it depends on nothing. Legacy formatter aliases (`formatJson` /
-  `formatFlat` / `summarize`) are deprecated, removal in v3.
+  it depends on nothing.
 - **`@oav/schema`**: the JSON Schema 2020-12 compiler; walks a schema,
   dispatches each keyword via `KeywordDefinition.compile(ctx)`, and
   `eval`s the generated source through `new Function(deps, src)`.

--- a/packages/schema/src/compiler/compiler.ts
+++ b/packages/schema/src/compiler/compiler.ts
@@ -255,6 +255,11 @@ export type ValidationResult =
  * fields; a failing result always carries both `error` (the tree root)
  * and `truncated`.
  *
+ * Migrating from v2: this nested shape was the v2 default and was named
+ * `ValidationResult`. v3 makes flat the default, so the name
+ * `ValidationResult` now refers to the flat shape and the tree moved
+ * here. (`FlatValidationResult` aliases the new flat default, not this.)
+ *
  * @public
  */
 export type TreeValidationResult =


### PR DESCRIPTION
## Post-v3 cleanup of stale deprecation notes (P3#4 + doc hygiene)

Two stragglers from the v3 batch.

### P3#4: migration breadcrumb on `TreeValidationResult`

v2 callers know the nested error-tree shape as `ValidationResult`. v3 reassigned that name to the flat default and moved the tree to `TreeValidationResult`. A v2 reader searching for their old type lands on... nothing pointing them forward: the `FlatValidationResult` deprecation alias points the *other* way (at the new flat default), so it does not serve a v2 reader. This adds one TSDoc paragraph on `TreeValidationResult` naming the rename explicitly.

### Doc hygiene: drop a note describing an action already taken

CLAUDE.md's `@oav/core` bullet still said the legacy formatter aliases (`formatJson` / `formatFlat` / `summarize`) are "deprecated, removal in v3." They were **removed** in the v3 batch (confirmed gone from `packages/core/src`), so the note described a pending action that already happened.

### Stacking

> Based on `chore-drop-phantom-deps` (#346), which edits the same `@oav/core` CLAUDE.md bullet. Will retarget to `main` once #346 merges. The compiler.ts breadcrumb is independent.

### Verification

Doc-only (TSDoc + markdown). typecheck clean, lint/fmt clean.

Rides into the held 3.0.0 release.
