### PR TITLE
refactor(schema): derive compiled artifact variants from CompiledSchema

### DIFF
--- a/packages/schema/src/compiler/compiler.ts
+++ b/packages/schema/src/compiler/compiler.ts
@@ -390,16 +390,13 @@ export type CompiledSchema = {
  * set. Same `validate(data, startPath?)` signature as
  * {@link CompiledSchema}, but returns a {@link TreeValidationResult} (a
  * single nested error tree) instead of the flat default. See
- * {@link CompileOptions.output}.
+ * {@link CompileOptions.output}. Carries the same `source` / `stats` as
+ * {@link CompiledSchema}; only the `validate` return type differs.
  *
  * @public
  */
-export type CompiledTreeSchema = {
+export type CompiledTreeSchema = Omit<CompiledSchema, "validate"> & {
   validate: (data: unknown, startPath?: readonly PathSegment[]) => TreeValidationResult;
-  /** The generated source. Exposed for debugging/snapshot testing only. */
-  source: string;
-  /** Compile-time stats about the generated validator. */
-  stats: CompileStats;
 };
 
 /**
@@ -407,16 +404,13 @@ export type CompiledTreeSchema = {
  * is set. The validator collects no errors, allocates no tree, and
  * returns a boolean: a true yes/no predicate. Use when consumers only
  * need to know whether the value conforms (e.g. routing, gating), not
- * why it doesn't.
+ * why it doesn't. Carries the same `source` / `stats` as
+ * {@link CompiledSchema}; only the `validate` return type differs.
  *
  * @public
  */
-export type CompiledPredicate = {
+export type CompiledPredicate = Omit<CompiledSchema, "validate"> & {
   validate: (data: unknown) => boolean;
-  /** The generated source. Exposed for debugging/snapshot testing only. */
-  source: string;
-  /** Compile-time stats about the generated validator. */
-  stats: CompileStats;
 };
 
 /**


### PR DESCRIPTION
## Derive compiled artifact variants from `CompiledSchema` (P3#5)

`CompiledSchema`, `CompiledTreeSchema`, and `CompiledPredicate` each re-declared the same `source: string` and `stats: CompileStats` fields with identical TSDoc; only the `validate` signature varied. Three copies of the field docs drift independently.

Keep `CompiledSchema` (the flat default) as the canonical carrier of `source` / `stats` and derive the other two:

```ts
export type CompiledTreeSchema = Omit<CompiledSchema, "validate"> & {
  validate: (data: unknown, startPath?: readonly PathSegment[]) => TreeValidationResult;
};
export type CompiledPredicate = Omit<CompiledSchema, "validate"> & {
  validate: (data: unknown) => boolean;
};
```

The `source` / `stats` contract now lives in one place. This mirrors the validator side, where `TreeValidator` / `PredicateValidator` extend `Omit<Validator, OutputDependentMethods>`.

Type-level only: the runtime artifact (`{ validate, source, stats }`) is unchanged, and the `compileSchema` overloads keep their concrete per-mode return types.

### Verification

clean `tsc -b` · 509 schema tests · 1176 total unit tests · lint/fmt clean.

Rides into the held 3.0.0 release.
