### PR TITLE
test(ci): harden pack-smoke adapter checks and fix stale v2 assertions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,9 +217,8 @@ jobs:
               },
             },
           });
-          if (v.validateRequest({ method: "POST", path: "/x", contentType: "application/json", body: {} }) === null) {
-            throw new Error("expected invalid");
-          }
+          const reqResult = v.validateRequest({ method: "POST", path: "/x", contentType: "application/json", body: {} });
+          if (reqResult.valid) throw new Error("expected invalid (missing required 'a')");
           const { validate } = compileSchema({ type: "integer" }, { dialect: jsonSchemaDialect });
           if (!validate(42).valid) throw new Error("expected valid");
           // oav-core's JSON-only reader should refuse .yaml paths with an install-hint error.
@@ -271,9 +270,8 @@ jobs:
               },
             },
           });
-          if (v.validateRequest({ method: "POST", path: "/x", contentType: "application/json", body: {} }) === null) {
-            throw new Error("expected invalid");
-          }
+          const reqResult = v.validateRequest({ method: "POST", path: "/x", contentType: "application/json", body: {} });
+          if (reqResult.valid) throw new Error("expected invalid (missing required 'a')");
           const { validate } = compileSchema({ type: "integer" }, { dialect: jsonSchemaDialect });
           if (!validate(42).valid) throw new Error("expected valid");
           const parsed = parseYamlString("openapi: 3.1.0\ninfo: { title: t, version: '1' }\npaths: {}");
@@ -308,6 +306,7 @@ jobs:
           npm init -y > /dev/null
           npm install express@4 "$CORE_TGZ" "$E4_TGZ"
           cat > smoke.mjs <<'EOF'
+          import { createValidator } from "@aahoughton/oav-core";
           import {
             httpRequestFromExpress,
             renderProblemDetails,
@@ -316,6 +315,19 @@ jobs:
           if (typeof validateRequests !== "function") throw new Error("validateRequests missing");
           if (typeof httpRequestFromExpress !== "function") throw new Error("httpRequestFromExpress missing");
           if (typeof renderProblemDetails !== "function") throw new Error("renderProblemDetails missing");
+          // Exercise the cross-package boundary: build a validator from the
+          // published core and hand it to the published adapter. This forces
+          // the adapter's rewritten `@aahoughton/oav-core/core` imports to
+          // load and proves a published-core validator is consumable. A leaked
+          // `@oav/*` import would fail resolution here.
+          const handler = validateRequests(
+            createValidator({
+              openapi: "3.1.0",
+              info: { title: "t", version: "1" },
+              paths: { "/x": { post: { responses: { "200": { description: "ok" } } } } },
+            }),
+          );
+          if (typeof handler !== "function") throw new Error("validateRequests did not return a handler");
           console.log("oav-express4 smoke ok");
           EOF
           node smoke.mjs
@@ -328,6 +340,7 @@ jobs:
           npm init -y > /dev/null
           npm install express@5 "$CORE_TGZ" "$E5_TGZ"
           cat > smoke.mjs <<'EOF'
+          import { createValidator } from "@aahoughton/oav-core";
           import {
             httpRequestFromExpress,
             renderProblemDetails,
@@ -336,6 +349,19 @@ jobs:
           if (typeof validateRequests !== "function") throw new Error("validateRequests missing");
           if (typeof httpRequestFromExpress !== "function") throw new Error("httpRequestFromExpress missing");
           if (typeof renderProblemDetails !== "function") throw new Error("renderProblemDetails missing");
+          // Exercise the cross-package boundary: build a validator from the
+          // published core and hand it to the published adapter. This forces
+          // the adapter's rewritten `@aahoughton/oav-core/core` imports to
+          // load and proves a published-core validator is consumable. A leaked
+          // `@oav/*` import would fail resolution here.
+          const handler = validateRequests(
+            createValidator({
+              openapi: "3.1.0",
+              info: { title: "t", version: "1" },
+              paths: { "/x": { post: { responses: { "200": { description: "ok" } } } } },
+            }),
+          );
+          if (typeof handler !== "function") throw new Error("validateRequests did not return a handler");
           console.log("oav-express5 smoke ok");
           EOF
           node smoke.mjs
@@ -348,6 +374,7 @@ jobs:
           npm init -y > /dev/null
           npm install fastify@5 "$CORE_TGZ" "$F_TGZ"
           cat > smoke.mjs <<'EOF'
+          import { createValidator } from "@aahoughton/oav-core";
           import {
             httpRequestFromFastify,
             renderProblemDetails,
@@ -356,6 +383,19 @@ jobs:
           if (typeof validateRequests !== "function") throw new Error("validateRequests missing");
           if (typeof httpRequestFromFastify !== "function") throw new Error("httpRequestFromFastify missing");
           if (typeof renderProblemDetails !== "function") throw new Error("renderProblemDetails missing");
+          // Exercise the cross-package boundary: build a validator from the
+          // published core and hand it to the published adapter. This forces
+          // the adapter's rewritten `@aahoughton/oav-core/core` imports to
+          // load and proves a published-core validator is consumable. A leaked
+          // `@oav/*` import would fail resolution here.
+          const hook = validateRequests(
+            createValidator({
+              openapi: "3.1.0",
+              info: { title: "t", version: "1" },
+              paths: { "/x": { post: { responses: { "200": { description: "ok" } } } } },
+            }),
+          );
+          if (typeof hook !== "function") throw new Error("validateRequests did not return a hook");
           console.log("oav-fastify smoke ok");
           EOF
           node smoke.mjs


### PR DESCRIPTION
## Harden pack-smoke adapter checks; fix stale v2 assertions

Prompted by a Codex review that flagged the published adapter `dist` importing private `@oav/*`. That finding **did not reproduce against the actual tarball**: the reviewer read the gitignored `tsc -b` output (`dist/middleware.js`), not the `clean: true` tsup `prepack` output that ships. Packing all three adapters confirms the shipped `index.js` imports `@aahoughton/oav-core/core` (the declared dep) and the `.d.ts` inlines the oav-core types. The existing pack-smoke job already installs each adapter with only its declared runtime + peer deps and imports it, so a real leak would already fail resolution there.

Two real gaps it surfaced, fixed here:

### 1. Stale v2 assertions in the core / oav smokes

The `@aahoughton/oav-core` and `@aahoughton/oav` smoke scripts asserted:

```js
if (v.validateRequest(...) === null) throw new Error("expected invalid");
```

That's the **v2** contract. Post-v3 `validateRequest` returns a result object and never `null`, so the condition is always false and the assertion was dead, it could no longer catch a false-valid regression. Now:

```js
const reqResult = v.validateRequest(...);
if (reqResult.valid) throw new Error("expected invalid (missing required 'a')");
```

### 2. Adapter smokes only `typeof`-checked

The three adapter smokes asserted exports were functions but never exercised the cross-package boundary. They now build a validator from the **published** core and hand it to the **published** adapter:

```js
const handler = validateRequests(createValidator({ /* minimal spec */ }));
if (typeof handler !== "function") throw new Error("validateRequests did not return a handler");
```

This forces the adapter's rewritten `@aahoughton/oav-core/core` imports to load and proves a published-core validator is consumable by the published adapter, the exact boundary the review was nervous about.

### Verification

Packed core + all three adapters, installed each into a temp project with only declared deps, ran the updated smoke scripts:

```
oav-core smoke ok; reqResult.valid = false
oav-express4 smoke ok
oav-express5 smoke ok
oav-fastify smoke ok
```

`yq` confirms the workflow still parses. Rides into the held 3.0.0 release.
