### PR TITLE
docs: sweep stale v2 result-shape and pre-maxDepth language

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,11 +389,12 @@ validation, response interception, upload helpers), see
   see ["Hardening against untrusted regex patterns"
   ](./docs/configuration.md#hardening-against-untrusted-regex-patterns).
 - Recursive schemas validate by recursing on the JavaScript call
-  stack, with no depth limit. A deeply nested payload (a few thousand
-  levels, only a few KB on the wire) can exhaust the stack and throw
-  `RangeError: Maximum call stack size exceeded`. The framework
-  adapters surface this as a 500 rather than a crash, but for
-  untrusted input cap nesting depth at the parse boundary; see
+  stack. Unbounded, a deeply nested payload (a few thousand levels,
+  only a few KB on the wire) can exhaust the stack and throw
+  `RangeError: Maximum call stack size exceeded`. Set the `maxDepth`
+  option (`CompileOptions` / `ValidatorOptions`) to bound recursion at
+  the validator: a payload past the cap fails as a `depth` error (HTTP 400) instead of crashing. For untrusted input set `maxDepth`, and
+  optionally cap nesting at the parse boundary as a backstop; see
   ["Guarding against deeply nested payloads"
   ](./docs/configuration.md#guarding-against-deeply-nested-payloads).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,8 +15,8 @@ this page is a recipe-oriented overview.
 | `strict`                | Compile-time schema lint mode: `"off"`, `"warn-partial"` (default), or `"strict"`. Issues surface via `validator.stats.strictIssues`.                                        |
 | `strictQueryParameters` | Reject undeclared query parameters. Default `false`.                                                                                                                         |
 | `validateSecurity`      | `"off"` (default), `"shape"` (check recognized schemes; pass on oauth2/oidc/mTLS), or `"strict"` (fail on unrecognized schemes).                                             |
-| `ignoreUndocumented`    | Return `null` on requests whose path the router can't match. Default `false`.                                                                                                |
-| `ignorePaths`           | Predicate `(path) => boolean`; returning `true` short-circuits validation to `null` before routing.                                                                          |
+| `ignoreUndocumented`    | Treat requests whose path the router can't match as valid (`{ valid: true }`) instead of a `route` error. Default `false`.                                                   |
+| `ignorePaths`           | Predicate `(path) => boolean`; returning `true` short-circuits validation to a valid result (`{ valid: true }`) before routing.                                              |
 | `onUnknownVersion`      | Policy for specs with missing/unsupported `openapi`: `"fallback31"` (default), `"warn"`, or `"throw"`.                                                                       |
 | `regexCompiler`         | Compiler for `pattern` keywords and `format: "regex"`. Defaults to `new RegExp(p, "u")` with a non-u fallback. Plug in `re2` or a safe-regex check for hardening; see below. |
 

--- a/docs/migration-from-eov.md
+++ b/docs/migration-from-eov.md
@@ -76,16 +76,16 @@ makes sense for your API.
 
 ### Request validation
 
-| eov option                          | oav equivalent                                                                                             |
-| ----------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `validateRequests: true`            | `validator.validateRequest(...)` in your middleware, or `validateRequests(validator)` from `oav-express4`. |
-| `validateRequests.allErrors`        | Default; `oav` always collects every leaf. Bound cost with `maxErrors: N`.                                 |
-| `validateRequests.coerceTypes`      | Query scalars coerced by default; body coercion not supported (see recipe).                                |
-| `validateRequests.removeAdditional` | Not supported. `additionalProperties: false` rejects; there is no silent-drop mode.                        |
-| `validateRequests.discriminator`    | Native, always on for OpenAPI specs.                                                                       |
-| `serDes`                            | Not supported. Pre- or post-transform the payload in your handler if you need `Date` / `ObjectId` / etc.   |
-| `ignorePaths` (regex/fn)            | `createValidator(spec, { ignorePaths: (p) => ... })`: predicate that short-circuits before routing.        |
-| `ignoreUndocumented`                | `createValidator(spec, { ignoreUndocumented: true })`: returns `null` on paths the router doesn't match.   |
+| eov option                          | oav equivalent                                                                                                                |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `validateRequests: true`            | `validator.validateRequest(...)` in your middleware, or `validateRequests(validator)` from `oav-express4`.                    |
+| `validateRequests.allErrors`        | `maxErrors: Number.POSITIVE_INFINITY`. oav defaults to `maxErrors: 1` (fast-fail, like Ajv); raise it to collect more leaves. |
+| `validateRequests.coerceTypes`      | Query scalars coerced by default; body coercion not supported (see recipe).                                                   |
+| `validateRequests.removeAdditional` | Not supported. `additionalProperties: false` rejects; there is no silent-drop mode.                                           |
+| `validateRequests.discriminator`    | Native, always on for OpenAPI specs.                                                                                          |
+| `serDes`                            | Not supported. Pre- or post-transform the payload in your handler if you need `Date` / `ObjectId` / etc.                      |
+| `ignorePaths` (regex/fn)            | `createValidator(spec, { ignorePaths: (p) => ... })`: predicate that short-circuits before routing.                           |
+| `ignoreUndocumented`                | `createValidator(spec, { ignoreUndocumented: true })`: reports paths the router doesn't match as valid (`{ valid: true }`).   |
 
 ### Response validation
 

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -2,8 +2,10 @@
 
 JSON Schema 2020-12 compiler. Walks the schema once at construction
 time and emits a JavaScript function via code generation, with no
-schema-walking on the hot path. Compiled validators return
-`{ valid, error? }` where `error` is a `ValidationError` tree.
+schema-walking on the hot path. Compiled validators return `{ valid }`
+plus, on failure, a flat `errors` list and `truncated` (the
+`output: "flat"` default, matching Ajv); `output: "tree"` swaps in a
+nested `error` tree.
 
 Use this module directly when you want schema validation without the
 HTTP layer (REST-less RPC bodies, config files, test fixtures, etc.).

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -97,7 +97,7 @@ the upstream test suites live in
 | `maxErrors`             | Per-call total cap on leaf errors. Default `1` (fast-fail); `Number.POSITIVE_INFINITY` collects every error.                     |
 | `strictQueryParameters` | Reject undeclared query parameters. Default `false`.                                                                             |
 | `validateSecurity`      | `"off"` (default), `"shape"` (check recognized schemes; pass on oauth2/oidc/mTLS), or `"strict"` (fail on unrecognized schemes). |
-| `ignoreUndocumented`    | Return `null` on requests whose path the router can't match. Default `false`.                                                    |
+| `ignoreUndocumented`    | Treat requests whose path the router can't match as valid (`{ valid: true }`). Default `false`.                                  |
 | `ignorePaths`           | `(path: string) => boolean` predicate that short-circuits validation when it returns `true` (runs before routing).               |
 | `onUnknownVersion`      | `"fallback31"` \| `"warn"` \| `"throw"` when `openapi` is missing or unsupported. Default `"fallback31"`.                        |
 

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -638,7 +638,8 @@ export interface ValidatorOptions {
   strictQueryParameters?: boolean;
   /**
    * When `true`, an unmatched path no longer produces a `route` error;
-   * `validateRequest` / `validateResponse` return `null`. Mirrors
+   * `validateRequest` / `validateResponse` report the request as valid
+   * (`{ valid: true }`). Mirrors
    * `express-openapi-validator`'s `ignoreUndocumented`. Does not affect
    * the `method` code: a path that matched but whose verb wasn't
    * declared still surfaces (that's a 405, not an "undocumented route").
@@ -647,7 +648,8 @@ export interface ValidatorOptions {
   /**
    * Predicate for finer control than {@link ValidatorOptions.ignoreUndocumented}.
    * Runs before route matching; when it returns `true` for the request's
-   * `path`, the validator short-circuits and returns `null`. Useful for
+   * `path`, the validator short-circuits to a valid result
+   * (`{ valid: true }`). Useful for
    * per-prefix allowlists ("skip anything under `/internal/`"),
    * regex-driven exclusions, or keeping parts of the surface out of
    * spec validation for staged rollout.


### PR DESCRIPTION
## Sweep stale v2 result-shape and pre-`maxDepth` language

Addresses the two HIGH findings from the Codex documentation review. I verified each claim against the source before fixing (the prior architecture review's HIGH turned out to be a false positive, so these were checked the same way) — both reproduce.

### Result-shape drift (review HIGH #1)

The public library API returns the v3 result object; several docs still described the v2 shapes. One nuance worth flagging: the review said the `ignorePaths`/`ignoreUndocumented` bypass "still returns `null` in the implementation." That's the *internal* helper (`validateRequestTree`); the **public** method reshapes it to `{ valid: true }` (`reshapeResult`, validator.ts:120). So this is a pure docs/TSDoc bug, no code change.

Fixed:
- **`packages/schema/README.md`** intro said compiled validators return `{ valid, error? }` (the v2 tree) — contradicting the flat default shown 20 lines down. Now states the flat default, tree opt-in.
- **`docs/migration-from-eov.md`** said `oav` "always collects every leaf" by default; v3 defaults to `maxErrors: 1`. Remapped eov `allErrors` → `maxErrors: Number.POSITIVE_INFINITY`.
- The **`ignoreUndocumented`/`ignorePaths` bypass** was documented as returning `null` in `configuration.md`, `validator/README.md`, `migration-from-eov.md`, and the `ValidatorOptions` TSDoc. It reports the request as valid (`{ valid: true }`), never `null`. Corrected all four.

### `maxDepth` contradiction (review HIGH #2)

The root **README** known-limitation bullet said recursive schemas have "no depth limit" and recommended only a parse-boundary cap, omitting the `maxDepth` validator-level guard the adapter READMEs and `configuration.md` already teach. Now leads with `maxDepth` (a `depth` error / HTTP 400 past the cap), parse-boundary cap as a backstop.

### Deliberately *not* changed

`packages/cli/README.md`'s "return `null`" for the `--requests-only` response stub is **correct**: the CLI's generated standalone module uses its own documented `null | ValidationError` (tree-or-null) contract, distinct from the library's v3 result object (`emit-spec.ts:684`). That divergence is a design choice, not drift.

### Scope

Codex Mediums #4 (package README links) and #5 (`modules.md`) are already tracked as #352 / #353. The organizational Mediums (README overloaded, repetition) and the voice nit are deferred as non-release-relevant.

### Verification

Doc-only plus two TSDoc comment lines. `pnpm test` (1260), `typecheck`, `lint` all green. Rides into the held 3.0.0 release.
