### PR TITLE
feat(cli)!: compile-spec result-shape parity with createValidator

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -65,6 +65,8 @@ below for the expected shape.
 | `--dialect 2020-12\|openapi-3.1\|openapi-3.0` | compile-schema / compile-spec     | Schema dialect. Defaults: 2020-12 (compile-schema), auto-detect from `openapi` field (compile-spec). |
 | `--requests-only`                             | compile-spec                      | Skip response-validator emit. Smaller output.                                                        |
 | `--only <method-path...>`                     | compile-spec                      | Repeatable; restrict emit to given ops, e.g. `--only "POST /pets"`.                                  |
+| `--output-mode flat\|tree\|predicate`         | compile-spec                      | Result shape of the emitted validators. Default `flat`. Mirrors `output`.                            |
+| `--max-errors <n>`                            | compile-spec                      | Leaf-error cap baked in: a positive integer or `all`. Default `1`. Mirrors `maxErrors`.              |
 | `-o <file>`                                   | all                               | Write output to a file instead of stdout.                                                            |
 | `--quiet`                                     | resolve / validate                | Exit code only, no stdout.                                                                           |
 
@@ -101,6 +103,13 @@ same surface as `createValidator(document)`: `validateRequest`,
 parameter / body / response schemas are pre-compiled and inlined.
 esbuild bundles everything; the resulting module has zero imports.
 
+The emitted `validate*` return the same result shapes as the library:
+`{ valid: true }` or `{ valid: false, errors, truncated }`, stopping at
+the first error by default (flat + `maxErrors: 1`), the same zero-config
+behaviour as `createValidator`. `--output-mode` and `--max-errors`
+(below) tune the shape, exactly mirroring the `output` / `maxErrors`
+options.
+
 Consumers who were running `createValidator(await loadSpec(...))` at
 application boot get the same behavior with no YAML parse, no
 `$ref` walk, no schema compilation at load time. Target use cases:
@@ -122,11 +131,20 @@ application boot get the same behavior with no YAML parse, no
   time. Same semantics as `oav resolve`.
 - **`--dialect <name>`**: forces a specific schema dialect. Default
   is auto-detected from the spec's `openapi` field.
+- **`--output-mode flat|tree|predicate`**: result shape of the emitted
+  validators, mirroring `createValidator`'s `output`. Default `flat`
+  (a de-nested `errors` list); `tree` for the nested `error` tree;
+  `predicate` for a bare boolean.
+- **`--max-errors <n>`**: leaf-error cap baked into the validators,
+  mirroring `maxErrors`. A positive integer or `all` (unbounded).
+  Default `1` (fast-fail). A failing result sets `truncated: true`
+  when the cap was reached.
 - **`--requests-only`**: skips response-validator emit.
-  `validateResponse` / `validateFetchResponse` are still exported
-  but return `null`. Output shrinks significantly on response-heavy
-  specs (rough rule of thumb: ~50% smaller on Stripe-shape, ~20–30%
-  on petstore-shape).
+  `validateResponse` / `validateFetchResponse` are still exported but
+  report every response as valid (a passing result in the configured
+  output mode). Output shrinks significantly on response-heavy specs
+  (rough rule of thumb: ~50% smaller on Stripe-shape, ~20–30% on
+  petstore-shape).
 - **`--only "METHOD PATH"`** (repeatable): restricts emit to
   specified operations. OR-combined across multiple flags. Paths not
   matching any `--only` are dropped from the router. Methods dropped

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -213,6 +213,16 @@ export function buildProgram(options: BuildProgramOptions = {}): Command {
       collectOnly,
       [],
     )
+    .option(
+      "--output-mode <mode>",
+      "result shape of the emitted validators: flat | tree | predicate (default: flat)",
+      parseOutputMode,
+    )
+    .option(
+      "--max-errors <n>",
+      'leaf-error cap baked into the validators: a positive integer or "all" (default: 1)',
+      parseMaxErrors,
+    )
     .option("-o, --output <file>", "write output to a file instead of stdout")
     .action(
       async (
@@ -222,6 +232,8 @@ export function buildProgram(options: BuildProgramOptions = {}): Command {
           dialect?: StandaloneDialect;
           requestsOnly?: boolean;
           only: Array<{ method: string; path: string }>;
+          outputMode?: "flat" | "tree" | "predicate";
+          maxErrors?: number;
           output?: string;
         },
       ) => {
@@ -233,6 +245,8 @@ export function buildProgram(options: BuildProgramOptions = {}): Command {
             dialect: opts.dialect,
             requestsOnly: opts.requestsOnly === true,
             only: opts.only,
+            outputMode: opts.outputMode,
+            maxErrors: opts.maxErrors,
           },
           io,
         );
@@ -256,6 +270,24 @@ function collectOnly(
 
 function collectOverlays(value: string, previous: string[]): string[] {
   return [...previous, value];
+}
+
+function parseOutputMode(value: string): "flat" | "tree" | "predicate" {
+  if (value !== "flat" && value !== "tree" && value !== "predicate") {
+    throw new Error(`--output-mode must be flat | tree | predicate, got ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+function parseMaxErrors(value: string): number {
+  if (value === "all" || value === "infinity") return Number.POSITIVE_INFINITY;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error(
+      `--max-errors must be a positive integer or "all", got ${JSON.stringify(value)}`,
+    );
+  }
+  return n;
 }
 
 function deriveMode(opts: {

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -388,6 +388,10 @@ export async function compileSpecCommand(
     requestsOnly?: boolean;
     /** `{ method, path }` include-list; empty = all ops. */
     only?: Array<{ method: string; path: string }>;
+    /** Result shape of the emitted validators. Default `"flat"`. */
+    outputMode?: "flat" | "tree" | "predicate";
+    /** Leaf-error cap baked into the emitted validators. Default `1`. */
+    maxErrors?: number;
     /** Test-only: rewrite emit imports to `@oav` so the workspace resolves. */
     importPrefix?: string;
     /** Test-only: override esbuild's resolveDir for in-workspace bundle. */
@@ -417,6 +421,8 @@ export async function compileSpecCommand(
       dialect: args.dialect,
       requestsOnly: args.requestsOnly === true,
       only: args.only,
+      outputMode: args.outputMode,
+      maxErrors: args.maxErrors,
       importPrefix: args.importPrefix,
     });
   } catch (err) {

--- a/packages/cli/src/emit-spec.ts
+++ b/packages/cli/src/emit-spec.ts
@@ -5,7 +5,11 @@
  * `validateFetchRequest`, `validateFetchResponse`, `getOperation`,
  * `detectedVersion`, `warnings`, but with every operation's schemas
  * already compiled into the module. After bundling through esbuild the
- * module has zero imports.
+ * module has zero imports. The emitted `validate*` return the same
+ * result shapes as `createValidator` (`{ valid, errors?/error?,
+ * truncated }` or a predicate boolean), tuned by `outputMode` /
+ * `maxErrors`; each builds the nested tree internally and reshapes at
+ * the boundary via the shared `reshapeResult` / `toFetchResult`.
  *
  * Consumers who were doing `createValidator(await loadSpec(...))` at
  * runtime get the same behavior with no YAML parse, no `$ref`
@@ -66,6 +70,17 @@ export interface EmitSpecOptions {
    * resolves against the workspace aliases.
    */
   importPrefix?: string;
+  /**
+   * Result shape of the emitted `validate*` exports, matching
+   * `createValidator`'s `output` option. Default `"flat"`.
+   */
+  outputMode?: "flat" | "tree" | "predicate";
+  /**
+   * Per-call leaf-error cap baked into the emitted validators, matching
+   * `createValidator`'s `maxErrors`. Default `1` (fast-fail);
+   * `Number.POSITIVE_INFINITY` collects every error.
+   */
+  maxErrors?: number;
 }
 
 const DIALECT_MAP: Record<StandaloneDialect, Dialect> = {
@@ -82,6 +97,12 @@ const DIALECT_MAP: Record<StandaloneDialect, Dialect> = {
  */
 export function emitSpec(document: OpenAPIDocument, options: EmitSpecOptions = {}): string {
   const importPrefix = options.importPrefix ?? "@aahoughton/oav";
+  const outputMode = options.outputMode ?? "flat";
+  const maxErrors = options.maxErrors ?? 1;
+  // Bake the cap as a JS literal; Infinity has no JSON form.
+  const maxErrorsLiteral = Number.isFinite(maxErrors)
+    ? String(maxErrors)
+    : "Number.POSITIVE_INFINITY";
   const warnings: string[] = [];
   const dialect = resolveDialect(document, options.dialect, warnings);
   const graph = resolve(document as unknown as SchemaOrBoolean);
@@ -214,7 +235,7 @@ export function emitSpec(document: OpenAPIDocument, options: EmitSpecOptions = {
     `import { createLeafError, createBranchError, createError } from "${importPrefix}/core";`,
     `import { createDeps, deepEqual, typeOf, wrapErrors } from "${importPrefix}/schema/internals";`,
     `import { builtInFormats } from "${importPrefix}/formats";`,
-    `import { deserialize, matchMediaType, matchResponseKey, httpRequestFromFetch, httpResponseFromFetch, checkSecurity, compileOperationSecurity, resolveOperationRef, createRouter } from "${importPrefix}/validator/internals";`,
+    `import { deserialize, matchMediaType, matchResponseKey, httpRequestFromFetch, httpResponseFromFetch, checkSecurity, compileOperationSecurity, resolveOperationRef, createRouter, reshapeResult, toFetchResult } from "${importPrefix}/validator/internals";`,
     "",
     "void createBranchError; void createError; void deepEqual; void typeOf; void wrapErrors;",
     "void resolveOperationRef;",
@@ -266,13 +287,17 @@ export function emitSpec(document: OpenAPIDocument, options: EmitSpecOptions = {
     `export const detectedVersion = ${JSON.stringify(detectVersionBucket(document))};`,
     `export const warnings = Object.freeze(${JSON.stringify(warnings)});`,
     "",
-    renderValidateRequest(),
+    "// ---- output shape (from --output-mode / --max-errors) ----",
+    "// Each validate* builds the nested error tree internally, then",
+    "// reshapeResult / toFetchResult shape it to match createValidator.",
+    `const __outputMode = ${JSON.stringify(outputMode)};`,
+    `const __maxErrors = ${maxErrorsLiteral};`,
     "",
-    options.requestsOnly === true ? renderValidateResponseNoop() : renderValidateResponse(),
+    renderValidateRequestTree(),
     "",
-    renderValidateFetchRequest(),
+    options.requestsOnly === true ? renderValidateResponseTreeNoop() : renderValidateResponseTree(),
     "",
-    renderValidateFetchResponse(),
+    renderPublicValidators(),
     "",
     renderGetOperation(),
     "",
@@ -553,13 +578,15 @@ function resolveDialect(
 
 const HTTP_METHODS = ["get", "put", "post", "delete", "options", "head", "patch", "trace", "query"];
 
-function renderValidateRequest(): string {
-  // Mirrors validator.ts's validateRequest closely. Differences:
+function renderValidateRequestTree(): string {
+  // Mirrors validator.ts's validateRequestTree closely. Differences:
   //   - state comes from the `ops` table, keyed on
   //     `${pathPattern}::${method}`, rather than cacheFor+WeakMap
   //   - security is pre-compiled at module load (op.compiledSecurity)
   //   - no strict-query-parameter option surfaced yet
-  return `export function validateRequest(req) {
+  // Returns the nested error tree (or null when valid); the exported
+  // validateRequest wrapper reshapes it to the configured output.
+  return `function __validateRequestTree(req) {
   const method = (req.method ?? "GET").toUpperCase();
   const match = router.match(method, req.path);
   if (match === undefined) {
@@ -680,16 +707,16 @@ function __readParamRaw(p, req, match) {
 `;
 }
 
-function renderValidateResponseNoop(): string {
-  return `export function validateResponse(_req, _res) {
+function renderValidateResponseTreeNoop(): string {
+  return `function __validateResponseTree(_req, _res) {
   // compile-spec was run with --requests-only; responses are a pass-through.
   return null;
 }
 `;
 }
 
-function renderValidateResponse(): string {
-  return `export function validateResponse(req, res) {
+function renderValidateResponseTree(): string {
+  return `function __validateResponseTree(req, res) {
   const method = (req.method ?? "GET").toUpperCase();
   const match = router.match(method, req.path);
   if (match === undefined) {
@@ -759,23 +786,30 @@ function renderValidateResponse(): string {
 `;
 }
 
-function renderValidateFetchRequest(): string {
-  return `export async function validateFetchRequest(request, options) {
-  const { httpRequest, bodyPresent: _bp, bodyValue } = await httpRequestFromFetch(request, options);
-  const error = validateRequest(httpRequest);
-  if (error !== null) return { ok: false, error };
-  return { ok: true, body: bodyValue };
-}
-`;
+/**
+ * The exported validate* surface. Each builds the nested tree via the
+ * internal __validate*Tree helper, then reshapes to the configured
+ * output (`__outputMode` / `__maxErrors`) exactly as validator.ts does
+ * at its public boundary, so the AOT output matches `createValidator`.
+ */
+function renderPublicValidators(): string {
+  return `export function validateRequest(req) {
+  return reshapeResult(__validateRequestTree(req), __outputMode, __maxErrors);
 }
 
-function renderValidateFetchResponse(): string {
-  return `export async function validateFetchResponse(request, response) {
+export function validateResponse(req, res) {
+  return reshapeResult(__validateResponseTree(req, res), __outputMode, __maxErrors);
+}
+
+export async function validateFetchRequest(request, options) {
+  const { httpRequest, bodyValue } = await httpRequestFromFetch(request, options);
+  return toFetchResult(validateRequest(httpRequest), bodyValue);
+}
+
+export async function validateFetchResponse(request, response) {
   const requestHttp = await httpRequestFromFetch(request);
   const { httpResponse, bodyValue } = await httpResponseFromFetch(response);
-  const error = validateResponse(requestHttp.httpRequest, httpResponse);
-  if (error !== null) return { ok: false, error };
-  return { ok: true, body: bodyValue };
+  return toFetchResult(validateResponse(requestHttp.httpRequest, httpResponse), bodyValue);
 }
 `;
 }

--- a/packages/cli/test/compile-spec.test.ts
+++ b/packages/cli/test/compile-spec.test.ts
@@ -65,9 +65,20 @@ const petstore: OpenAPIDocument = {
   },
 };
 
+/**
+ * The emitted validate* return the same v3 result shapes as
+ * `createValidator`: `{ valid: true }` or `{ valid: false, ... }` (flat
+ * carries `errors`, tree carries `error`), or a bare boolean in predicate
+ * mode.
+ */
+type AotResult =
+  | boolean
+  | { valid: true }
+  | { valid: false; errors?: ValidationError[]; error?: ValidationError; truncated: boolean };
+
 interface AotValidator {
-  validateRequest: (req: unknown) => ValidationError | null;
-  validateResponse: (req: unknown, res: unknown) => ValidationError | null;
+  validateRequest: (req: unknown) => AotResult;
+  validateResponse: (req: unknown, res: unknown) => AotResult;
   getOperation: (req: {
     method: string;
     path: string;
@@ -76,11 +87,25 @@ interface AotValidator {
   warnings: readonly string[];
 }
 
+/** The nested error tree of a tree-mode result, or null when valid. */
+function treeOf(r: AotResult): ValidationError | null {
+  if (typeof r === "boolean" || r.valid) return null;
+  return r.error ?? null;
+}
+
+/** The flat leaf list of a flat-mode result, or [] when valid. */
+function flatErrors(r: AotResult): ValidationError[] {
+  if (typeof r === "boolean" || r.valid) return [];
+  return r.errors ?? [];
+}
+
 async function buildAot(
   document: OpenAPIDocument,
   extra: {
     requestsOnly?: boolean;
     only?: Array<{ method: string; path: string }>;
+    outputMode?: "flat" | "tree" | "predicate";
+    maxErrors?: number;
   } = {},
 ): Promise<AotValidator> {
   const mem = memoryIo([["spec.json", document]]);
@@ -93,6 +118,8 @@ async function buildAot(
       resolveDir: RESOLVE_DIR,
       requestsOnly: extra.requestsOnly,
       only: extra.only,
+      outputMode: extra.outputMode,
+      maxErrors: extra.maxErrors,
     },
     mem.io,
   );
@@ -131,7 +158,10 @@ describe("compile-spec: equivalence vs createValidator", () => {
       output: "tree",
       maxErrors: Number.POSITIVE_INFINITY,
     });
-    const aot = await buildAot(petstore);
+    const aot = await buildAot(petstore, {
+      outputMode: "tree",
+      maxErrors: Number.POSITIVE_INFINITY,
+    });
 
     const cases: Array<{ name: string; req: unknown }> = [
       {
@@ -194,7 +224,7 @@ describe("compile-spec: equivalence vs createValidator", () => {
     for (const c of cases) {
       const ra = runtime.validateRequest(c.req as never);
       const a = ra.valid ? null : ra.error;
-      const b = aot.validateRequest(c.req);
+      const b = treeOf(aot.validateRequest(c.req));
       if (!equivalent(a, b)) {
         console.error(
           `${c.name}\n  runtime: ${a === null ? "ok" : `${a.code} / ${collectLeafCodes(a).join(",")}`}\n  aot:     ${b === null ? "ok" : `${b.code} / ${collectLeafCodes(b).join(",")}`}`,
@@ -263,13 +293,13 @@ describe("compile-spec: equivalence vs createValidator", () => {
 });
 
 describe("compile-spec --requests-only", () => {
-  it("emits a validateResponse that passes through (returns null)", async () => {
+  it("emits a validateResponse that passes through (valid)", async () => {
     const aot = await buildAot(petstore, { requestsOnly: true });
     const r = aot.validateResponse(
       { method: "GET", path: "/pets" },
       { status: 999, contentType: "application/json", body: [{ shape: "wrong" }] },
     );
-    expect(r).toBe(null);
+    expect(r).toEqual({ valid: true });
   });
 
   it("still validates requests correctly", async () => {
@@ -281,7 +311,7 @@ describe("compile-spec --requests-only", () => {
       headers: { "x-tenant": "acme" },
       body: { name: "Fido" },
     });
-    expect(valid).toBe(null);
+    expect(valid).toEqual({ valid: true });
   });
 });
 
@@ -318,10 +348,60 @@ describe("compile-spec --only", () => {
       headers: { "x-tenant": "acme" },
       body: { name: "Fido" },
     });
-    expect(included).toBe(null);
+    expect(included).toEqual({ valid: true });
 
     // GET /pets dropped → route miss (404)
     const dropped = aot.validateRequest({ method: "GET", path: "/pets" });
-    expect(dropped?.code).toBe("route");
+    expect(flatErrors(dropped)[0]?.code).toBe("route");
+  });
+});
+
+describe("compile-spec --output-mode / --max-errors (result-shape parity)", () => {
+  // Two independent problems: missing required X-Tenant header AND a body
+  // whose `name` violates minLength:1. Params validate before body, so the
+  // uncapped leaf order is [header-param, minLength].
+  const twoProblems = {
+    method: "POST",
+    path: "/pets",
+    contentType: "application/json",
+    body: { name: "" },
+  };
+  const validReq = {
+    method: "POST",
+    path: "/pets",
+    contentType: "application/json",
+    headers: { "x-tenant": "acme" },
+    body: { name: "Fido" },
+  };
+
+  it("defaults to flat + maxErrors:1 (matches createValidator's zero-config)", async () => {
+    const aot = await buildAot(petstore);
+    const r = aot.validateRequest(twoProblems);
+    expect(r).toMatchObject({ valid: false, truncated: true });
+    expect(flatErrors(r)).toHaveLength(1);
+    expect(aot.validateRequest(validReq)).toEqual({ valid: true });
+  });
+
+  it("--max-errors all collects every leaf (truncated: false)", async () => {
+    const aot = await buildAot(petstore, { maxErrors: Number.POSITIVE_INFINITY });
+    const r = aot.validateRequest(twoProblems);
+    expect(r).toMatchObject({ valid: false, truncated: false });
+    expect(flatErrors(r).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("--output-mode tree returns the nested error tree", async () => {
+    const aot = await buildAot(petstore, {
+      outputMode: "tree",
+      maxErrors: Number.POSITIVE_INFINITY,
+    });
+    const r = aot.validateRequest(twoProblems);
+    expect(r).toMatchObject({ valid: false });
+    expect(treeOf(r)?.code).toBe("request");
+  });
+
+  it("--output-mode predicate returns a bare boolean", async () => {
+    const aot = await buildAot(petstore, { outputMode: "predicate" });
+    expect(aot.validateRequest(twoProblems)).toBe(false);
+    expect(aot.validateRequest(validReq)).toBe(true);
   });
 });

--- a/packages/validator/src/internals.ts
+++ b/packages/validator/src/internals.ts
@@ -59,3 +59,13 @@ export { checkSecurity, compileOperationSecurity } from "./security.js";
 // `oav/validator/internals` so the emitted module only
 // has to reach into one subpath.
 export { createRouter, type RouteMatch, type Router } from "@oav/router";
+
+// Result reshaping. The validator builds a nested error tree internally
+// and reshapes it to the requested `output` / `maxErrors` at the public
+// boundary; `oav compile-spec`'s emitted module reuses the same two
+// functions so its AOT output's result shape matches `createValidator`
+// exactly (`reshapeResult` for `validate{Request,Response}`,
+// `toFetchResult` for the `validateFetch*` wrappers). Sourced from the
+// standalone `./reshape.js` so re-exporting here doesn't pull the
+// validator's `node:fs`-bearing graph into the compile-spec bundle.
+export { reshapeResult, toFetchResult } from "./reshape.js";

--- a/packages/validator/src/reshape.ts
+++ b/packages/validator/src/reshape.ts
@@ -1,0 +1,94 @@
+/**
+ * Result reshaping, factored out of `validator.ts` so it can be
+ * re-exported through `@oav/validator/internals` without dragging the
+ * validator's full module graph (`@oav/spec` -> `node:fs`, etc.) into
+ * `oav compile-spec`'s standalone esbuild bundle. The only runtime
+ * dependency here is `@oav/core`'s `collectLeaves`.
+ *
+ * The validator builds a nested error tree internally and reshapes it to
+ * the requested `output` / `maxErrors` at its public boundary; the emitted
+ * standalone module reuses these same functions so its AOT output's result
+ * shape stays identical to `createValidator`.
+ */
+import { collectLeaves, type ValidationError } from "@oav/core";
+import type { TreeValidationResult, ValidationResult } from "@oav/schema";
+
+/**
+ * Depth-first prune of an error tree to at most `max` leaves, dropping
+ * branches that become empty. Returns the trimmed root. Used to enforce
+ * the per-call `maxErrors` total in tree output.
+ */
+function trimTreeToLeaves(root: ValidationError, max: number): ValidationError {
+  let remaining = max;
+  const visit = (node: ValidationError): ValidationError | null => {
+    if (node.children.length === 0) {
+      if (remaining <= 0) return null;
+      remaining -= 1;
+      return node;
+    }
+    const kept: ValidationError[] = [];
+    for (const child of node.children) {
+      const v = visit(child);
+      if (v !== null) kept.push(v);
+    }
+    if (kept.length === 0) return null;
+    return { ...node, children: kept };
+  };
+  return visit(root) ?? root;
+}
+
+/**
+ * Reshape the validator's internal error tree (`ValidationError | null`)
+ * into the requested output, applying the per-call `maxErrors` total.
+ * `truncated` reports that the cap was reached (more problems may exist).
+ *
+ * Exported through `@oav/validator/internals` so `oav compile-spec`'s
+ * emitted standalone module reshapes its hand-built tree the same way,
+ * keeping the AOT output's result shape identical to this validator's.
+ *
+ * @internal
+ */
+export function reshapeResult(
+  tree: ValidationError | null,
+  output: "flat" | "tree" | "predicate",
+  maxErrors: number,
+): ValidationResult | TreeValidationResult | boolean {
+  if (output === "predicate") return tree === null;
+  if (tree === null) return { valid: true };
+  const finite = Number.isFinite(maxErrors);
+  const leaves = collectLeaves(tree);
+  const truncated = finite && leaves.length >= maxErrors;
+  if (output === "tree") {
+    const error = finite && leaves.length > maxErrors ? trimTreeToLeaves(tree, maxErrors) : tree;
+    return { valid: false, error, truncated };
+  }
+  return { valid: false, errors: finite ? leaves.slice(0, maxErrors) : leaves, truncated };
+}
+
+/**
+ * Map a reshaped validation result onto the Fetch-wrapper return shape:
+ * `{ ok: true, body }` on success, or `{ ok: false }` plus the failure
+ * fields (`errors`/`error` + `truncated`, or nothing in predicate mode).
+ *
+ * Exported through `@oav/validator/internals` for the `oav compile-spec`
+ * emitted module's `validateFetch*` wrappers (same reason as
+ * {@link reshapeResult}).
+ *
+ * @internal
+ */
+export function toFetchResult<T>(
+  result: ValidationResult | TreeValidationResult | boolean,
+  body: unknown,
+): {
+  ok: boolean;
+  body?: T;
+  errors?: ValidationError[];
+  error?: ValidationError;
+  truncated?: boolean;
+} {
+  if (result === true) return { ok: true, body: body as T };
+  if (result === false) return { ok: false };
+  if (result.valid) return { ok: true, body: body as T };
+  const { valid: _valid, ...failure } = result;
+  return { ok: false, ...failure };
+}

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -1,6 +1,5 @@
 import {
   classifyUnknownVersion,
-  collectLeaves,
   createBranchError,
   createLeafError,
   detectOpenAPIVersion,
@@ -33,6 +32,7 @@ import {
   type ValidationResult,
 } from "@oav/schema";
 import { deserialize, matchMediaType, matchResponseKey } from "./deserialize.js";
+import { reshapeResult, toFetchResult } from "./reshape.js";
 import {
   createDirectionResolver,
   transformBodySchemaForDirection,
@@ -80,74 +80,6 @@ function dialectFor(version: OpenAPIVersion): Dialect {
     case "3.0":
       return oas30Dialect;
   }
-}
-
-/**
- * Depth-first prune of an error tree to at most `max` leaves, dropping
- * branches that become empty. Returns the trimmed root. Used to enforce
- * the per-call `maxErrors` total in tree output.
- */
-function trimTreeToLeaves(root: ValidationError, max: number): ValidationError {
-  let remaining = max;
-  const visit = (node: ValidationError): ValidationError | null => {
-    if (node.children.length === 0) {
-      if (remaining <= 0) return null;
-      remaining -= 1;
-      return node;
-    }
-    const kept: ValidationError[] = [];
-    for (const child of node.children) {
-      const v = visit(child);
-      if (v !== null) kept.push(v);
-    }
-    if (kept.length === 0) return null;
-    return { ...node, children: kept };
-  };
-  return visit(root) ?? root;
-}
-
-/**
- * Reshape the validator's internal error tree (`ValidationError | null`)
- * into the requested output, applying the per-call `maxErrors` total.
- * `truncated` reports that the cap was reached (more problems may exist).
- */
-function reshapeResult(
-  tree: ValidationError | null,
-  output: "flat" | "tree" | "predicate",
-  maxErrors: number,
-): ValidationResult | TreeValidationResult | boolean {
-  if (output === "predicate") return tree === null;
-  if (tree === null) return { valid: true };
-  const finite = Number.isFinite(maxErrors);
-  const leaves = collectLeaves(tree);
-  const truncated = finite && leaves.length >= maxErrors;
-  if (output === "tree") {
-    const error = finite && leaves.length > maxErrors ? trimTreeToLeaves(tree, maxErrors) : tree;
-    return { valid: false, error, truncated };
-  }
-  return { valid: false, errors: finite ? leaves.slice(0, maxErrors) : leaves, truncated };
-}
-
-/**
- * Map a reshaped validation result onto the Fetch-wrapper return shape:
- * `{ ok: true, body }` on success, or `{ ok: false }` plus the failure
- * fields (`errors`/`error` + `truncated`, or nothing in predicate mode).
- */
-function toFetchResult<T>(
-  result: ValidationResult | TreeValidationResult | boolean,
-  body: unknown,
-): {
-  ok: boolean;
-  body?: T;
-  errors?: ValidationError[];
-  error?: ValidationError;
-  truncated?: boolean;
-} {
-  if (result === true) return { ok: true, body: body as T };
-  if (result === false) return { ok: false };
-  if (result.valid) return { ok: true, body: body as T };
-  const { valid: _valid, ...failure } = result;
-  return { ok: false, ...failure };
 }
 
 /**


### PR DESCRIPTION
## `compile-spec` result-shape parity with `createValidator`

The `oav compile-spec` standalone output returned the v2-era `null | error-tree` shape, diverging from both the library's v3 result object *and* the schema standalone emit (`compileSchema` → standalone already returns `{ valid, ... }`). This gives `compile-spec` full parity, with the same knobs as the library.

### What changes

- The emitted `validateRequest` / `validateResponse` / `validateFetch*` now return the same shapes as `createValidator`: `{ valid: true }` / `{ valid: false, errors|error, truncated }`, or a bare boolean in predicate mode.
- **New flags**, mirroring the library options:
  - `--output-mode flat|tree|predicate` (default `flat`)
  - `--max-errors <n|all>` (default `1`)

```
oav compile-spec api.yaml --output-mode tree --max-errors all -o validator.js
```

### How

The emit already builds the full nested tree (embedded schema validators stay `tree` + uncapped), so honoring the flags is just a reshape at the boundary, exactly as `validator.ts` does. The emitted module **reuses the library's `reshapeResult` / `toFetchResult`** via `@oav/validator/internals` (guaranteed parity, zero duplication).

Those two functions moved from `validator.ts` into a new **`reshape.ts`** (deps: only `@oav/core`). Without that split, re-exporting them from `validator.ts` dragged its `node:fs`-bearing graph (`@oav/spec`) into the zero-import esbuild bundle and broke `compile-spec` (caught by the existing bundle tests).

### Tests

`compile-spec.test.ts`: the equivalence matrix now compares result objects; new cases assert the default flat+`maxErrors:1` shape, `--max-errors all`, `--output-mode tree`, and `--output-mode predicate` (each emits → esbuild-bundles → imports → executes). 59 CLI tests pass; 1264 total; typecheck + lint clean.

### Breaking

`oav compile-spec` output now returns the v3 result object instead of `ValidationError | null`, and defaults to flat + `maxErrors: 1`. Consumers reading the old null/tree shape read `result.valid` / `result.errors` (or pass `--output-mode tree` for the nested `error`). Appropriate for the 3.0.0 major; rides into the held release.
