### PR TITLE
docs: drop "matching Ajv" framing from the defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ handles local YAML, remote JSON / YAML, and local JSON transparently.
 `validateRequest` / `validateResponse` return `{ valid: true }` on
 success, or `{ valid: false, errors, truncated }` on failure. The
 zero-config default is a flat `errors` list that stops at the first
-problem (`maxErrors: 1`), matching Ajv's defaults; raise `maxErrors` to
-collect more, or pass `output: "tree"` for a nested error tree under
+problem (`maxErrors: 1`); raise `maxErrors` to collect more, or pass
+`output: "tree"` for a nested error tree under
 `error` (or `output: "predicate"` for a bare boolean). Every error
 carries a stable `code` (e.g. `"type"`, `"required"`, `"content-type"`,
 `"oneOf"`), a `path` rooted at the HTTP frame (e.g. `["body", "pets", 3,

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -182,7 +182,7 @@ type: "string" }` to `{ type: ["string", "number", "boolean",
   predicate mode compiles to a different function entirely.
 - **Explicit error budget.** `maxErrors: N` caps the errors collected
   and short-circuits hot loops when the budget is exhausted. The default
-  is `1` (fast-fail, like Ajv's `allErrors: false`); Ajv has
+  is `1` (fast-fail); Ajv has
   `allErrors: true | false` but no explicit count budget. Pass
   `Number.POSITIVE_INFINITY` for zero-overhead uncapped collection
   (codegen emits plain `errors.push` with no budget checks).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,8 +40,8 @@ return-shape contract (boolean, error object, or array of errors).
 
 ## Error budget
 
-The validator stops at the first error by default (`maxErrors: 1`),
-matching Ajv's zero-config behaviour. The cap is a per-call total
+The validator stops at the first error by default (`maxErrors: 1`).
+The cap is a per-call total
 across every location (body, query, headers).
 
 ```ts

--- a/docs/migration-from-eov.md
+++ b/docs/migration-from-eov.md
@@ -76,16 +76,16 @@ makes sense for your API.
 
 ### Request validation
 
-| eov option                          | oav equivalent                                                                                                                |
-| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `validateRequests: true`            | `validator.validateRequest(...)` in your middleware, or `validateRequests(validator)` from `oav-express4`.                    |
-| `validateRequests.allErrors`        | `maxErrors: Number.POSITIVE_INFINITY`. oav defaults to `maxErrors: 1` (fast-fail, like Ajv); raise it to collect more leaves. |
-| `validateRequests.coerceTypes`      | Query scalars coerced by default; body coercion not supported (see recipe).                                                   |
-| `validateRequests.removeAdditional` | Not supported. `additionalProperties: false` rejects; there is no silent-drop mode.                                           |
-| `validateRequests.discriminator`    | Native, always on for OpenAPI specs.                                                                                          |
-| `serDes`                            | Not supported. Pre- or post-transform the payload in your handler if you need `Date` / `ObjectId` / etc.                      |
-| `ignorePaths` (regex/fn)            | `createValidator(spec, { ignorePaths: (p) => ... })`: predicate that short-circuits before routing.                           |
-| `ignoreUndocumented`                | `createValidator(spec, { ignoreUndocumented: true })`: reports paths the router doesn't match as valid (`{ valid: true }`).   |
+| eov option                          | oav equivalent                                                                                                              |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `validateRequests: true`            | `validator.validateRequest(...)` in your middleware, or `validateRequests(validator)` from `oav-express4`.                  |
+| `validateRequests.allErrors`        | `maxErrors: Number.POSITIVE_INFINITY`. oav defaults to `maxErrors: 1` (fast-fail); raise it to collect more leaves.         |
+| `validateRequests.coerceTypes`      | Query scalars coerced by default; body coercion not supported (see recipe).                                                 |
+| `validateRequests.removeAdditional` | Not supported. `additionalProperties: false` rejects; there is no silent-drop mode.                                         |
+| `validateRequests.discriminator`    | Native, always on for OpenAPI specs.                                                                                        |
+| `serDes`                            | Not supported. Pre- or post-transform the payload in your handler if you need `Date` / `ObjectId` / etc.                    |
+| `ignorePaths` (regex/fn)            | `createValidator(spec, { ignorePaths: (p) => ... })`: predicate that short-circuits before routing.                         |
+| `ignoreUndocumented`                | `createValidator(spec, { ignoreUndocumented: true })`: reports paths the router doesn't match as valid (`{ valid: true }`). |
 
 ### Response validation
 

--- a/docs/migration-v3.md
+++ b/docs/migration-v3.md
@@ -1,8 +1,8 @@
 # Migrating to v3
 
-v3 changes the zero-config defaults so a bare `compileSchema(schema)` (and
-`createValidator(spec)`) matches Ajv's out-of-the-box behaviour: a **flat**
-list of errors, stopping at the **first** one. The richer nested error tree
+v3 changes the zero-config defaults: a bare `compileSchema(schema)` (and
+`createValidator(spec)`) now returns a **flat** list of errors, stopping
+at the **first** one. The richer nested error tree
 and full error collection are one option away. This guide lists every
 breaking change and how to restore the v2 behaviour where you want it.
 

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -4,7 +4,7 @@ JSON Schema 2020-12 compiler. Walks the schema once at construction
 time and emits a JavaScript function via code generation, with no
 schema-walking on the hot path. Compiled validators return `{ valid }`
 plus, on failure, a flat `errors` list and `truncated` (the
-`output: "flat"` default, matching Ajv); `output: "tree"` swaps in a
+`output: "flat"` default); `output: "tree"` swaps in a
 nested `error` tree.
 
 Use this module directly when you want schema validation without the
@@ -33,7 +33,7 @@ to every error's `path` (used by the HTTP validator to prefix `"body"`,
 `stats.functionCount` is the number of helper functions emitted.
 
 By default `validate` returns a flat `errors` list and stops at the
-first problem (`maxErrors: 1`), matching Ajv's defaults. Pass
+first problem (`maxErrors: 1`). Pass
 `output: "tree"` for a nested error tree under `error`,
 `output: "predicate"` for a bare boolean, and
 `maxErrors: Number.POSITIVE_INFINITY` to collect every error.
@@ -123,8 +123,8 @@ returns `{ valid, error, truncated }` with the nested error tree;
 `"predicate"` returns a bare boolean and builds no errors at all.
 
 `maxErrors` caps the leaves collected and short-circuits hot loops once
-the budget is exhausted. The default is `1` (classic fast-fail, matching
-Ajv); larger values bound CPU/memory on huge invalid payloads, and
+the budget is exhausted. The default is `1` (classic fast-fail); larger
+values bound CPU/memory on huge invalid payloads, and
 `Number.POSITIVE_INFINITY` collects everything with zero-overhead
 codegen (plain `errors.push`, no budget checks). A failing result
 carries `truncated: true` when the cap was reached.

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -26,8 +26,8 @@ const responseResult = validator.validateResponse(
 
 Both methods return `{ valid: true }` on success, or
 `{ valid: false, errors, truncated }` on failure. The default is a flat
-`errors` list that stops at the first problem (`maxErrors: 1`), matching
-Ajv; pass `output: "tree"` for a nested `error` tree, or
+`errors` list that stops at the first problem (`maxErrors: 1`); pass
+`output: "tree"` for a nested `error` tree, or
 `maxErrors: Number.POSITIVE_INFINITY` to collect every error. Errors are
 rooted at the HTTP frame (`["body", …]`, `["query", name, …]`,
 `["header", name, …]`, etc.) so downstream code can group by location.

--- a/performance/README.md
+++ b/performance/README.md
@@ -266,7 +266,7 @@ fast path.
   rather than inlining into the enclosing body (V8 monomorphizes
   hot-loop calls better than massive inline bodies); and on the
   rejection path oav still builds a structured leaf for the failing
-  keyword. oav's default already matches ajv's fail-fast (flat,
+  keyword. oav's default is already fail-fast (flat,
   `maxErrors: 1`); `output: "predicate"` sheds the error infrastructure
   entirely for the cases that only need a yes/no answer.
 


### PR DESCRIPTION
## Drop "matching Ajv" framing from the defaults

Several docs justified the v3 zero-config defaults (flat output, `maxErrors: 1`) by saying they "match Ajv" / are "like Ajv's". We make our own choices; state the default directly.

Reworded the defaults-framing in:
- `README.md`, `packages/schema/README.md`, `packages/validator/README.md`
- `docs/configuration.md`, `docs/migration-v3.md`, `docs/migration-from-eov.md`
- `performance/README.md`

Example: "stops at the first problem (`maxErrors: 1`), matching Ajv's defaults" → "stops at the first problem (`maxErrors: 1`)".

### Left untouched (honest comparison, not copy-framing)

- `docs/comparison.md`'s feature map and the README "How it compares" table + perf numbers (comparing to Ajv is their job).
- The README "start with Ajv if you only need generic JSON Schema validation" pointer.
- `fromAjvFormats` (an actual API name) and `ajv.compile()` references in the `compile-spec` "Relationship to Ajv's standaloneCode" section.
- `comparison.md`'s "Ajv has `allErrors: true | false` but no explicit count budget" (a factual feature comparison; only the "like Ajv's allErrors:false" justification of *our* default was removed).

Verified with a multiline-aware sweep (`(matching|matches|like)\s+Ajv`): zero remaining in authored docs. Doc-only; lint/fmt clean. Rides into the held 3.0.0 release.
