### PR TITLE
perf(schema): emit direct property checks for small required arrays

### DIFF
--- a/packages/schema/src/keywords/object-validation.ts
+++ b/packages/schema/src/keywords/object-validation.ts
@@ -141,6 +141,37 @@ export const requiredKeyword: KeywordDefinition = {
   compile(ctx: KeywordCompileContext): void {
     const required = ctx.schema as string[];
     if (required.length === 0) return;
+    if (required.length <= 8) {
+      const emitCheck = (name: string): void => {
+        const keyLit = quoteString(name);
+        ctx.gen.if(propertyAbsent(ctx.data, keyLit, name), () => {
+          ctx.emitError(
+            "leaf",
+            ctx.leafErrorExpr(
+              quoteString("required"),
+              JSON.stringify(`must have required property "${name}"`),
+              `{ missing: ${keyLit} }`,
+              [keyLit],
+            ),
+          );
+          ctx.emitBudgetBreak();
+        });
+      };
+      ctx.gen.if(objectGuardVar(ctx), (g) => {
+        if (ctx.predicate) {
+          for (const name of required) emitCheck(name);
+          return;
+        }
+        // Keep emitBudgetBreak() valid without paying iterator/dynamic
+        // lookup overhead for the common small fixed-list case.
+        g.line("do {");
+        g.indent();
+        for (const name of required) emitCheck(name);
+        g.dedent();
+        g.line("} while (false);");
+      });
+      return;
+    }
     const requiredVar = ctx.hoistConstant(JSON.stringify(required), "required");
     // The loop variable is dynamic, but the set of names is fixed at
     // compile time: if none of them is an inherited `Object.prototype`


### PR DESCRIPTION
## Direct property checks for small `required` arrays

For a fixed `required` list of **≤ 8** names, emit one literal absence check per name instead of hoisting the array and looping:

```js
// before: hoist + loop over a dynamic _req
for (const _req of required_0) { if (data[_req] === undefined) { ... } }

// after: literal checks
if (data["id"] === undefined)   { ...emit... }
if (data["name"] === undefined) { ...emit... }
```

The name set is fixed at compile time, so the iterator and dynamic keyed access buy nothing for the common small case. Literal checks give V8 a simpler monomorphic path and fold the message/param work into compile-time literals. Lists > 8 keep the hoisted loop.

### Correctness

- Reuses the existing `propertyAbsent(data, key, name)` helper, so an `Object.prototype` name (`toString`, `constructor`, …) still falls back to `hasOwnProperty` rather than the unsound `=== undefined`.
- Predicate mode emits the checks directly; flat/tree wrap them in `do { ... } while (false)` so `emitBudgetBreak()` can still `break` without changing `maxErrors` semantics.

Verified: full unit suite (**1264**), JSON Schema conformance **1270/1290** in both default and `OAV_FLAT=1`, **32/32** OpenAPI. The new path is exercised by existing tests (required-with-prototype-name in `property-presence`, multi-error flat/tree parity in `flat-mode`, truncation in `max-errors`).

### Performance

Baseline vs. this change, validate throughput (single run each, so the extremes are noise-amplified, but the direction is consistent and matches the mechanism):

| schema | validate gain |
|---|---|
| composition | +40% to +120% (most `required` work) |
| array-heavy | +4% to +25% |
| tree | +3% to +20% |
| petstore | +6% to +17% |
| tiny | flat (±1-2%, one required field) |
| compile (all) | flat (±1-4%, validate-focused change) |

No regressions.

Rides into a 3.x. (Original change by Codex; reviewed, verified, and benchmarked here.)
