### PR TITLE
chore: refresh dev tooling and example run docs for v3

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ uses, so the example code translates 1:1 into production use.
 From the repo root, after `pnpm install`:
 
 ```bash
-pnpm tsx examples/<example>.ts
+pnpm dlx tsx examples/<example>.ts
 ```
 
 The examples import from `packages/*/src` directly so they work without

--- a/performance/dump-compiled.ts
+++ b/performance/dump-compiled.ts
@@ -34,30 +34,41 @@ for (const s of perfSchemas) {
     dialect: jsonSchemaDialect,
     formats: builtInFormats,
   });
-  writeFileSync(join(OUT, `${s.name}.oav.js`), "// oav (full error tree)\n" + oav.source + "\n");
+  writeFileSync(
+    join(OUT, `${s.name}.oav-flat.js`),
+    "// oav (flat, maxErrors: 1)\n" + oav.source + "\n",
+  );
+
+  const oavAll = compileSchema(s.schema, {
+    dialect: jsonSchemaDialect,
+    formats: builtInFormats,
+    maxErrors: Number.POSITIVE_INFINITY,
+  });
+  writeFileSync(
+    join(OUT, `${s.name}.oav-all.js`),
+    "// oav (flat, all errors)\n" + oavAll.source + "\n",
+  );
+
+  const oavTree = compileSchema(s.schema, {
+    dialect: jsonSchemaDialect,
+    formats: builtInFormats,
+    output: "tree",
+  });
+  writeFileSync(join(OUT, `${s.name}.oav-tree.js`), "// oav (tree)\n" + oavTree.source + "\n");
 
   const oavPred = compileSchema(s.schema, {
     dialect: jsonSchemaDialect,
     formats: builtInFormats,
-    predicate: true,
+    output: "predicate",
   });
   writeFileSync(
     join(OUT, `${s.name}.oav-predicate.js`),
     "// oav (predicate mode)\n" + oavPred.source + "\n",
   );
 
-  const oavFast = compileSchema(s.schema, {
-    dialect: jsonSchemaDialect,
-    formats: builtInFormats,
-    maxErrors: 1,
-  });
-  writeFileSync(
-    join(OUT, `${s.name}.oav-fast.js`),
-    "// oav (maxErrors: 1)\n" + oavFast.source + "\n",
-  );
-
   console.log(
     `${s.name}: ajv ${ajvFn.toString().length} B, ajv-fast ${ajvFastFn.toString().length} B, ` +
-      `oav ${oav.source.length} B, oav-pred ${oavPred.source.length} B, oav-fast ${oavFast.source.length} B`,
+      `oav-flat ${oav.source.length} B, oav-all ${oavAll.source.length} B, ` +
+      `oav-tree ${oavTree.source.length} B, oav-pred ${oavPred.source.length} B`,
   );
 }


### PR DESCRIPTION
## Refresh dev tooling and example run docs for v3

Two dev-facing, non-shipping cleanups.

### `performance/dump-compiled.ts`
- Dump generated validators per output mode: `.oav-flat`, `.oav-all`, `.oav-tree`, `.oav-predicate` (previously a single `.oav.js` + a separate `.oav-fast.js`).
- Migrate the deprecated `predicate: true` to `output: "predicate"`.
- Fix the stale label that called the default flat output "full error tree" — the default is flat now. Verified it runs clean (exit 0) and reports per-mode sizes.

### `examples/README.md`
The documented run command was `pnpm tsx examples/<example>.ts`, but `tsx` is **not** a workspace dependency (it's deliberately isolated to the `conformance/` / `performance/` / `framework-tests/` sub-roots), so that command fails with `Command "tsx" not found` for anyone without a global `tsx`. Switched to `pnpm dlx tsx` — no install, keeps `tsx` out of the main lockfile, consistent with the repo's lean-main-install stance.

Separately confirmed all 10 examples still **run** (not just typecheck) and emit correct v3 output.
