### PR TITLE
docs: correct stale README claims against code

### DIFF
--- a/packages/formats/README.md
+++ b/packages/formats/README.md
@@ -29,7 +29,12 @@ replace them.
 - **IP**: `ipv4`, `ipv6`
 - **URI**: `uri`, `uri-reference`, `iri`, `iri-reference`, `uri-template`
 - **JSON Pointer**: `json-pointer`, `relative-json-pointer`
-- **Misc**: `regex`, `uuid`
+- **Misc**: `uuid`
+
+`regex` also works as a `format`, but it isn't a key in `builtInFormats`:
+`oav/schema` registers it inside `createDeps` so it routes through the
+same compile path as the `pattern` keyword (and honors `regexCompiler`).
+The standalone `validateRegex` predicate is still exported for direct use.
 
 ## Registering a custom format
 

--- a/packages/oav-express4/README.md
+++ b/packages/oav-express4/README.md
@@ -4,7 +4,7 @@ Express 4 adapter for [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav
 
 Thin: this package re-exports nothing from oav-core. You install both. The adapter declares oav-core as a regular dependency, so a single `npm install @aahoughton/oav-express4` pulls oav-core along; or install [`oav`](https://www.npmjs.com/package/@aahoughton/oav) instead if you want YAML readers and the CLI.
 
-Sibling packages: [`oav-express5`](../oav-express5/README.md), [`oav-fastify`](../oav-fastify/README.md). Same export names, option shapes, and defaults; only the framework-typed argument differs.
+Sibling packages: [`oav-express5`](../oav-express5/README.md), [`oav-fastify`](../oav-fastify/README.md). Identical option shapes and defaults; `validateRequests` and `renderProblemDetails` share names across the family, while the `httpRequestFrom*` extractor and `*Context` type carry framework-native names.
 
 > **Migrating from `express-openapi-validator`?** See [docs/migration-from-eov.md](../../docs/migration-from-eov.md) for behavior differences (path-label `/params/` → `/path/`, `errorCode` namespacing, status mapping) and a worked porting walkthrough.
 

--- a/packages/oav-express5/README.md
+++ b/packages/oav-express5/README.md
@@ -4,7 +4,7 @@ Express 5 adapter for [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav
 
 Same shape as the [`oav-express4`](../oav-express4/README.md) sibling; only the framework-typed argument and the async semantics differ. Express 5's promise-native middleware means thrown errors and rejected promises propagate to the host's error middleware automatically, with no `try/catch` wrapper.
 
-Sibling packages: [`oav-express4`](../oav-express4/README.md), [`oav-fastify`](../oav-fastify/README.md). Same export names, option shapes, and defaults; only the framework-typed argument differs.
+Sibling packages: [`oav-express4`](../oav-express4/README.md), [`oav-fastify`](../oav-fastify/README.md). Identical option shapes and defaults; `validateRequests` and `renderProblemDetails` share names across the family, while the `httpRequestFrom*` extractor and `*Context` type carry framework-native names.
 
 > **Migrating from `express-openapi-validator`?** See [docs/migration-from-eov.md](../../docs/migration-from-eov.md) for behavior differences (path-label `/params/` → `/path/`, `errorCode` namespacing, status mapping) and a worked porting walkthrough.
 

--- a/packages/oav-fastify/README.md
+++ b/packages/oav-fastify/README.md
@@ -4,7 +4,7 @@ Fastify adapter for [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-c
 
 Same shape as the Express siblings ([`oav-express4`](../oav-express4/README.md), [`oav-express5`](../oav-express5/README.md)); only the framework-typed argument and Fastify's hook-vs-middleware distinction differ. Fastify is async-native, so thrown errors and rejected promises propagate to Fastify's error handler automatically, with no `try/catch` wrapper.
 
-Sibling packages: [`oav-express4`](../oav-express4/README.md), [`oav-express5`](../oav-express5/README.md). Same export names, option shapes, and defaults; only the framework-typed argument differs.
+Sibling packages: [`oav-express4`](../oav-express4/README.md), [`oav-express5`](../oav-express5/README.md). Identical option shapes and defaults; `validateRequests` and `renderProblemDetails` share names across the family, while the `httpRequestFrom*` extractor and `*Context` type carry framework-native names.
 
 ## Install
 

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -6,8 +6,9 @@
 > contributors navigating the monorepo. Third-party consumers get the
 > router's functionality transparently via `createValidator`.
 
-Trie-based OpenAPI path matcher. Resolves `method + path` to the
-matching `OperationObject` in the spec.
+OpenAPI path matcher: a specificity-sorted route list, scanned
+linearly per request. Resolves `method + path` to the matching
+`OperationObject` in the spec.
 
 ```ts
 // Internal usage inside the monorepo


### PR DESCRIPTION
Fix four README claims that the source contradicts:

- **router**: matcher is a specificity-sorted linear scan, not a trie.
- **formats**: `regex` isn't a `builtInFormats` key (the schema compiler registers it); note where it comes from instead.
- **adapters** (express4/5, fastify): only `validateRequests`/`renderProblemDetails` share names across siblings; `httpRequestFrom*` and `*Context` are framework-named.

Docs-only. Found while checking whether the router's "trie" line was accurate.