### PR TITLE
chore: pre-3.1.0 docs and build-hygiene polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ validator for JavaScript and TypeScript services. Two primary drivers:
   application-side patches. `applyOverlays` rewrites the document
   at load time. Custom keywords, formats, and dialects plug into
   the compiler the same way, so per-tenant validation rules don't
-  require forking. See [docs/overlays.md](./docs/overlays.md).
+  require forking. See [docs/overlays.md](https://github.com/aahoughton/oav/blob/main/docs/overlays.md).
 - **Validators that fit in microservice runners.** `oav compile-spec
 openapi.yaml` emits a single zero-dependency ES module exposing
   the full validator surface. Targets Cloudflare Workers, Vercel
@@ -28,7 +28,7 @@ If you only need generic JSON Schema validation across many drafts,
 start with Ajv. If you want a one-line Express middleware with file
 upload and auth handler conveniences built in, start with
 `express-openapi-validator`. See
-[docs/comparison.md](./docs/comparison.md) for the feature map.
+[docs/comparison.md](https://github.com/aahoughton/oav/blob/main/docs/comparison.md) for the feature map.
 
 ## Install
 
@@ -61,7 +61,7 @@ npm install @aahoughton/oav-fastify    # Fastify adapter
 `/spec`, `/overlay-spec`, `/formats`, `/core`); on the lean package,
 substitute `oav-core` in imports that don't touch the YAML readers
 (`createYamlFileReader`, `createSmartHttpReader`) or the CLI. See
-[`docs/modules.md`](./docs/modules.md) for what each subpath exports.
+[`docs/modules.md`](https://github.com/aahoughton/oav/blob/main/docs/modules.md) for what each subpath exports.
 
 ## Quick start
 
@@ -89,7 +89,7 @@ app.post("/pets", (req, res) => res.json({ ok: true }));
 Invalid requests receive an `application/problem+json` response.
 Valid requests continue to your route handlers. Express 4 uses the
 same shape with `oav-express4`; Fastify uses `oav-fastify` as a
-`preValidation` hook. See [docs/integration.md](./docs/integration.md).
+`preValidation` hook. See [docs/integration.md](https://github.com/aahoughton/oav/blob/main/docs/integration.md).
 
 ### Framework-agnostic
 
@@ -129,7 +129,7 @@ carries a stable `code` (e.g. `"type"`, `"required"`, `"content-type"`,
 "name"]`), a human-readable `message`, and a machine-readable `params`
 object whose shape per code is documented in `BuiltInErrorParams`.
 
-Runnable end-to-end demos in [`examples/`](./examples/README.md):
+Runnable end-to-end demos in [`examples/`](https://github.com/aahoughton/oav/blob/main/examples/README.md):
 custom formats, custom keywords, cross-field constraints, error
 budgets, version differences, overlays, and spec-derived middleware
 config.
@@ -180,19 +180,19 @@ const validator = createValidator(patched);
 
 The full verb surface (component-bucket fan-out, predicate iterators,
 operation-level metadata) is documented in
-[`docs/overlays.md`](./docs/overlays.md); cross-cutting integration
-shapes live in [`docs/integration.md`](./docs/integration.md).
+[`docs/overlays.md`](https://github.com/aahoughton/oav/blob/main/docs/overlays.md); cross-cutting integration
+shapes live in [`docs/integration.md`](https://github.com/aahoughton/oav/blob/main/docs/integration.md).
 
 ## Where to go next
 
-| Task                                      | Read                                                                   |
-| ----------------------------------------- | ---------------------------------------------------------------------- |
-| Wire into Express, Fastify, Next.js, Hono | [docs/integration.md](./docs/integration.md)                           |
-| Patch a spec you do not own               | [docs/overlays.md](./docs/overlays.md)                                 |
-| Emit standalone validators                | [packages/cli/README.md](./packages/cli/README.md#compile-spec-output) |
-| Compare against Ajv and other tools       | [docs/comparison.md](./docs/comparison.md)                             |
-| Migrate from express-openapi-validator    | [docs/migration-from-eov.md](./docs/migration-from-eov.md)             |
-| Use custom formats, keywords, or limits   | [docs/configuration.md](./docs/configuration.md)                       |
+| Task                                      | Read                                                                                                             |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Wire into Express, Fastify, Next.js, Hono | [docs/integration.md](https://github.com/aahoughton/oav/blob/main/docs/integration.md)                           |
+| Patch a spec you do not own               | [docs/overlays.md](https://github.com/aahoughton/oav/blob/main/docs/overlays.md)                                 |
+| Emit standalone validators                | [packages/cli/README.md](https://github.com/aahoughton/oav/blob/main/packages/cli/README.md#compile-spec-output) |
+| Compare against Ajv and other tools       | [docs/comparison.md](https://github.com/aahoughton/oav/blob/main/docs/comparison.md)                             |
+| Migrate from express-openapi-validator    | [docs/migration-from-eov.md](https://github.com/aahoughton/oav/blob/main/docs/migration-from-eov.md)             |
+| Use custom formats, keywords, or limits   | [docs/configuration.md](https://github.com/aahoughton/oav/blob/main/docs/configuration.md)                       |
 
 ## How it compares
 
@@ -201,11 +201,11 @@ Ajv for JSON Schema, `express-openapi-validator` for Express,
 `openapi-backend` for operationId routing plus validation, and smaller
 request/response validators for custom stacks. oav is aimed at
 HTTP-aware validation with structured errors, overlays, and standalone
-OpenAPI validator output. See [docs/comparison.md](./docs/comparison.md)
-for the feature map, and [docs/migration-from-eov.md](./docs/migration-from-eov.md)
+OpenAPI validator output. See [docs/comparison.md](https://github.com/aahoughton/oav/blob/main/docs/comparison.md)
+for the feature map, and [docs/migration-from-eov.md](https://github.com/aahoughton/oav/blob/main/docs/migration-from-eov.md)
 if you are migrating from `express-openapi-validator`.
 
-Numbers below are from the [`performance/`](./performance/README.md)
+Numbers below are from the [`performance/`](https://github.com/aahoughton/oav/blob/main/performance/README.md)
 benchmark on AWS c7i.large (Intel Sapphire Rapids, Node 22). Your
 hardware will vary.
 
@@ -236,18 +236,18 @@ For typical HTTP workloads (1k–10k req/sec × ~1 validation per
 request), the difference is invisible. For validation-heavy code
 (millions of validations per second), measure your own shapes.
 
-Full per-shape breakdown: [`docs/comparison.md`](./docs/comparison.md). Raw
+Full per-shape breakdown: [`docs/comparison.md`](https://github.com/aahoughton/oav/blob/main/docs/comparison.md). Raw
 benchmark data and methodology:
-[`performance/README.md`](./performance/README.md).
+[`performance/README.md`](https://github.com/aahoughton/oav/blob/main/performance/README.md).
 
 ## Conformance
 
-The [`conformance/`](./conformance/README.md) sub-package drives the
+The [`conformance/`](https://github.com/aahoughton/oav/blob/main/conformance/README.md) sub-package drives the
 compiler and CLI against the upstream JSON Schema 2020-12 Test Suite,
 a set of OpenAPI 3.0 / 3.1 / 3.2 petstore scenarios, and a handful of
 real-world specs (Stripe, GitHub, DigitalOcean, Twilio, Asana, Box,
 Adyen) that have to load and compile without error. See
-[`conformance/REPORT.md`](./conformance/REPORT.md) for pass / fail
+[`conformance/REPORT.md`](https://github.com/aahoughton/oav/blob/main/conformance/REPORT.md) for pass / fail
 counts by category.
 
 Categories oav does not aim to cover:
@@ -261,7 +261,7 @@ Categories oav does not aim to cover:
 
 OpenAPI specs hand-authored or generated for typical APIs rarely
 touch any of these. If they matter for your use case, the
-[report](./conformance/REPORT.md) lays out which tests fail and why.
+[report](https://github.com/aahoughton/oav/blob/main/conformance/REPORT.md) lays out which tests fail and why.
 
 ## CLI
 
@@ -278,7 +278,7 @@ Flags: `--format text|json|flat`, `--depth n`, `--overlay file`
 (repeatable), `-o file`, `--quiet`, `--dialect` (compile-schema /
 compile-spec), `--requests-only` (compile-spec), `--only METHOD PATH`
 (compile-spec, repeatable). See
-[packages/cli/README.md](./packages/cli/README.md) for the full
+[packages/cli/README.md](https://github.com/aahoughton/oav/blob/main/packages/cli/README.md) for the full
 surface, the `.http` file format, and both compile commands' output
 contracts.
 
@@ -313,7 +313,7 @@ npx swagger2openapi swagger.json -o openapi.json
 `createValidator(spec, options)` accepts options for dialect override,
 custom formats and keywords, error budget, strict-mode lint, security
 shape-checking, ignored paths, and version-mismatch policy. See
-[`docs/configuration.md`](./docs/configuration.md) for the option
+[`docs/configuration.md`](https://github.com/aahoughton/oav/blob/main/docs/configuration.md) for the option
 table, custom-keyword recipe, and bounded-error-collection details.
 The canonical contract is the `ValidatorOptions` TSDoc.
 
@@ -351,15 +351,15 @@ the flat `errors` list or a tree `error`, so this wiring is the same
 whichever `output` the validator uses.
 
 Companion adapter packages cover common request-validation wiring:
-[`oav-express4`](./packages/oav-express4/README.md),
-[`oav-express5`](./packages/oav-express5/README.md), and
-[`oav-fastify`](./packages/oav-fastify/README.md). They share export
+[`oav-express4`](https://github.com/aahoughton/oav/blob/main/packages/oav-express4/README.md),
+[`oav-express5`](https://github.com/aahoughton/oav/blob/main/packages/oav-express5/README.md), and
+[`oav-fastify`](https://github.com/aahoughton/oav/blob/main/packages/oav-fastify/README.md). They share export
 names and option shapes; only the framework type differs.
 
 For Next.js, Hono, Bun, Deno, and custom frameworks, use the
 framework-agnostic `validateRequest` / `validateResponse` calls or the
 Fetch helpers (`validateFetchRequest`, `validateFetchResponse`). See
-[docs/integration.md](./docs/integration.md) for body parsing,
+[docs/integration.md](https://github.com/aahoughton/oav/blob/main/docs/integration.md) for body parsing,
 response validation, uploads, security, ignored paths, and custom error
 envelopes.
 
@@ -376,7 +376,7 @@ on request) rather than framework-specific error classes.
 Runtime behavior corners. For feature-scope tradeoffs against Ajv and
 OpenAPI middleware packages (draft versions, `$data`, async
 validation, response interception, upload helpers), see
-[docs/comparison.md](./docs/comparison.md).
+[docs/comparison.md](https://github.com/aahoughton/oav/blob/main/docs/comparison.md).
 
 - `$dynamicRef` behaves like `$ref` with anchor lookup; no runtime dynamic-scope traversal.
 - `style: deepObject` query parameters support only single-level nesting (`obj[key]=value`); OpenAPI 3.0–3.2 don't define nested semantics.
@@ -387,7 +387,7 @@ validation, response interception, upload helpers), see
   string the validator checks. Pass a `regexCompiler` to
   `createValidator` to plug in `re2` or a complexity-checking engine;
   see ["Hardening against untrusted regex patterns"
-  ](./docs/configuration.md#hardening-against-untrusted-regex-patterns).
+  ](https://github.com/aahoughton/oav/blob/main/docs/configuration.md#hardening-against-untrusted-regex-patterns).
 - Recursive schemas validate by recursing on the JavaScript call
   stack. Unbounded, a deeply nested payload (a few thousand levels,
   only a few KB on the wire) can exhaust the stack and throw
@@ -396,15 +396,15 @@ validation, response interception, upload helpers), see
   the validator: a payload past the cap fails as a `depth` error (HTTP 400) instead of crashing. For untrusted input set `maxDepth`, and
   optionally cap nesting at the parse boundary as a backstop; see
   ["Guarding against deeply nested payloads"
-  ](./docs/configuration.md#guarding-against-deeply-nested-payloads).
+  ](https://github.com/aahoughton/oav/blob/main/docs/configuration.md#guarding-against-deeply-nested-payloads).
 
 ## Contributing
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for branch / PR / release flow.
+See [CONTRIBUTING.md](https://github.com/aahoughton/oav/blob/main/CONTRIBUTING.md) for branch / PR / release flow.
 Development workflow (lint / typecheck / test / build) and the
 conformance and performance sub-packages are described there and in
-[CLAUDE.md](./CLAUDE.md).
+[CLAUDE.md](https://github.com/aahoughton/oav/blob/main/CLAUDE.md).
 
 ## License
 
-MIT. See [LICENSE](./LICENSE).
+MIT. See [LICENSE](https://github.com/aahoughton/oav/blob/main/LICENSE).

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,14 +1,15 @@
 # Modules
 
-The package publishes a small root and five subpath entrypoints.
-`oav-core` exposes the same six entrypoints; substitute
+The package publishes a root entry and five public subpath
+entrypoints (plus the not-semver-covered `*/internals` subpaths listed
+further down). `oav-core` mirrors the same paths; substitute
 `oav-core/...` to import from the lean package.
 
 | Import                         | Surface                                                                         |
 | ------------------------------ | ------------------------------------------------------------------------------- |
 | `@aahoughton/oav`              | `createValidator`, error helpers, formatters, types                             |
 | `@aahoughton/oav/schema`       | `compileSchema`, dialects, vocabularies, custom keywords                        |
-| `@aahoughton/oav/spec`         | `loadSpec`, `resolveSpec`, `applyOverlays`, readers                             |
+| `@aahoughton/oav/spec`         | `loadSpec`, `loadSpecSync`, `resolveSpec`, `applyOverlays`, readers             |
 | `@aahoughton/oav/overlay-spec` | `translateOverlay`, `applySpecOverlay`: OpenAPI Overlay 1.0 → typed SpecOverlay |
 | `@aahoughton/oav/formats`      | Built-in string format validators                                               |
 | `@aahoughton/oav/core`         | Error tree model, shared OpenAPI / HTTP types                                   |
@@ -17,6 +18,20 @@ The package publishes a small root and five subpath entrypoints.
 (HTTP reader that handles both JSON and YAML by inspecting
 `Content-Type`), and `parseYamlString` at the root entry, and ships
 the `oav` CLI as a `bin`.
+
+## Internal subpaths (not covered by semver)
+
+Each public package also exposes lower-level primitives behind a
+`/internals` path. They exist for advanced plugins, tooling, and
+tests, and sit deliberately outside the semver contract: compare
+against the public barrel before reaching for them. `oav-core` mirrors
+each at the matching `oav-core/...` path.
+
+| Import                                | Surface                                                                                           |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `@aahoughton/oav/schema/internals`    | Codegen mechanics, runtime helpers, and resolve internals below the keyword-author API            |
+| `@aahoughton/oav/spec/internals`      | Synchronous resolver primitives (`resolveSpecSync`, `createFileReaderSync`, `composeReadersSync`) |
+| `@aahoughton/oav/validator/internals` | Parameter deserialization, query assembly, and the operation-level `$ref` resolver                |
 
 ## Companion adapter packages
 

--- a/packages/oav-express4/README.md
+++ b/packages/oav-express4/README.md
@@ -4,9 +4,9 @@ Express 4 adapter for [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav
 
 Thin: this package re-exports nothing from oav-core. You install both. The adapter declares oav-core as a regular dependency, so a single `npm install @aahoughton/oav-express4` pulls oav-core along; or install [`oav`](https://www.npmjs.com/package/@aahoughton/oav) instead if you want YAML readers and the CLI.
 
-Sibling packages: [`oav-express5`](../oav-express5/README.md), [`oav-fastify`](../oav-fastify/README.md). Identical option shapes and defaults; `validateRequests` and `renderProblemDetails` share names across the family, while the `httpRequestFrom*` extractor and `*Context` type carry framework-native names.
+Sibling packages: [`oav-express5`](https://github.com/aahoughton/oav/blob/main/packages/oav-express5/README.md), [`oav-fastify`](https://github.com/aahoughton/oav/blob/main/packages/oav-fastify/README.md). Identical option shapes and defaults; `validateRequests` and `renderProblemDetails` share names across the family, while the `httpRequestFrom*` extractor and `*Context` type carry framework-native names.
 
-> **Migrating from `express-openapi-validator`?** See [docs/migration-from-eov.md](../../docs/migration-from-eov.md) for behavior differences (path-label `/params/` → `/path/`, `errorCode` namespacing, status mapping) and a worked porting walkthrough.
+> **Migrating from `express-openapi-validator`?** See [docs/migration-from-eov.md](https://github.com/aahoughton/oav/blob/main/docs/migration-from-eov.md) for behavior differences (path-label `/params/` → `/path/`, `errorCode` namespacing, status mapping) and a worked porting walkthrough.
 
 ## Install
 
@@ -293,5 +293,5 @@ For per-route inline multer (validator called from inside the route handler) and
 
 - [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core): `createValidator`, `ValidatorOptions`, `formatSummary`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
 - [`oav`](https://www.npmjs.com/package/@aahoughton/oav): oav-core plus YAML readers and the `oav` CLI.
-- The repo-root [`docs/integration.md`](../../docs/integration.md): broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
-- The repo-root [`docs/migration-from-eov.md`](../../docs/migration-from-eov.md): porting from `express-openapi-validator`.
+- The repo-root [`docs/integration.md`](https://github.com/aahoughton/oav/blob/main/docs/integration.md): broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
+- The repo-root [`docs/migration-from-eov.md`](https://github.com/aahoughton/oav/blob/main/docs/migration-from-eov.md): porting from `express-openapi-validator`.

--- a/packages/oav-express5/README.md
+++ b/packages/oav-express5/README.md
@@ -2,11 +2,11 @@
 
 Express 5 adapter for [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core): a promise-native middleware factory plus standalone helpers (`httpRequestFromExpress`, `renderProblemDetails`) for callers composing their own middleware.
 
-Same shape as the [`oav-express4`](../oav-express4/README.md) sibling; only the framework-typed argument and the async semantics differ. Express 5's promise-native middleware means thrown errors and rejected promises propagate to the host's error middleware automatically, with no `try/catch` wrapper.
+Same shape as the [`oav-express4`](https://github.com/aahoughton/oav/blob/main/packages/oav-express4/README.md) sibling; only the framework-typed argument and the async semantics differ. Express 5's promise-native middleware means thrown errors and rejected promises propagate to the host's error middleware automatically, with no `try/catch` wrapper.
 
-Sibling packages: [`oav-express4`](../oav-express4/README.md), [`oav-fastify`](../oav-fastify/README.md). Identical option shapes and defaults; `validateRequests` and `renderProblemDetails` share names across the family, while the `httpRequestFrom*` extractor and `*Context` type carry framework-native names.
+Sibling packages: [`oav-express4`](https://github.com/aahoughton/oav/blob/main/packages/oav-express4/README.md), [`oav-fastify`](https://github.com/aahoughton/oav/blob/main/packages/oav-fastify/README.md). Identical option shapes and defaults; `validateRequests` and `renderProblemDetails` share names across the family, while the `httpRequestFrom*` extractor and `*Context` type carry framework-native names.
 
-> **Migrating from `express-openapi-validator`?** See [docs/migration-from-eov.md](../../docs/migration-from-eov.md) for behavior differences (path-label `/params/` → `/path/`, `errorCode` namespacing, status mapping) and a worked porting walkthrough.
+> **Migrating from `express-openapi-validator`?** See [docs/migration-from-eov.md](https://github.com/aahoughton/oav/blob/main/docs/migration-from-eov.md) for behavior differences (path-label `/params/` → `/path/`, `errorCode` namespacing, status mapping) and a worked porting walkthrough.
 
 ## Install
 
@@ -225,5 +225,5 @@ A migrating consumer's `import { validateRequests } from "@aahoughton/oav-expres
 
 - [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core): `createValidator`, `ValidatorOptions`, `formatSummary`, `collectIssues`, `httpStatusFor`, `toProblemDetails`.
 - [`oav`](https://www.npmjs.com/package/@aahoughton/oav): oav-core plus YAML readers and the `oav` CLI.
-- The repo-root [`docs/integration.md`](../../docs/integration.md): broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
-- The repo-root [`docs/migration-from-eov.md`](../../docs/migration-from-eov.md): porting from `express-openapi-validator`.
+- The repo-root [`docs/integration.md`](https://github.com/aahoughton/oav/blob/main/docs/integration.md): broader recipes (security, file uploads, response validation, status mapping, type coercion, ignoring paths).
+- The repo-root [`docs/migration-from-eov.md`](https://github.com/aahoughton/oav/blob/main/docs/migration-from-eov.md): porting from `express-openapi-validator`.

--- a/packages/oav-fastify/README.md
+++ b/packages/oav-fastify/README.md
@@ -2,9 +2,9 @@
 
 Fastify adapter for [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core): a `preValidation` hook factory plus standalone helpers (`httpRequestFromFastify`, `renderProblemDetails`) for callers composing their own hooks.
 
-Same shape as the Express siblings ([`oav-express4`](../oav-express4/README.md), [`oav-express5`](../oav-express5/README.md)); only the framework-typed argument and Fastify's hook-vs-middleware distinction differ. Fastify is async-native, so thrown errors and rejected promises propagate to Fastify's error handler automatically, with no `try/catch` wrapper.
+Same shape as the Express siblings ([`oav-express4`](https://github.com/aahoughton/oav/blob/main/packages/oav-express4/README.md), [`oav-express5`](https://github.com/aahoughton/oav/blob/main/packages/oav-express5/README.md)); only the framework-typed argument and Fastify's hook-vs-middleware distinction differ. Fastify is async-native, so thrown errors and rejected promises propagate to Fastify's error handler automatically, with no `try/catch` wrapper.
 
-Sibling packages: [`oav-express4`](../oav-express4/README.md), [`oav-express5`](../oav-express5/README.md). Identical option shapes and defaults; `validateRequests` and `renderProblemDetails` share names across the family, while the `httpRequestFrom*` extractor and `*Context` type carry framework-native names.
+Sibling packages: [`oav-express4`](https://github.com/aahoughton/oav/blob/main/packages/oav-express4/README.md), [`oav-express5`](https://github.com/aahoughton/oav/blob/main/packages/oav-express5/README.md). Identical option shapes and defaults; `validateRequests` and `renderProblemDetails` share names across the family, while the `httpRequestFrom*` extractor and `*Context` type carry framework-native names.
 
 ## Install
 

--- a/packages/oav/README.md
+++ b/packages/oav/README.md
@@ -41,7 +41,7 @@ surface changes.
   `loadSpec`. Its default reader covers `.yaml` / `.yml` and `.json`
   on disk, so a single call resolves a YAML spec and its cross-file
   `$ref`s. JSON-only callers can use `oav-core`'s `loadSpecSync` from
-  `oav/spec`; see [the loader docs](../spec/README.md#synchronous-loading)
+  `oav/spec`; see [the loader docs](https://github.com/aahoughton/oav/blob/main/packages/spec/README.md#synchronous-loading)
   for the blocking caveat and the load-or-skip pattern.
 
   ```ts
@@ -53,43 +53,43 @@ surface changes.
 
 - **The `oav` CLI binary**: `oav resolve`, `oav validate`,
   `oav compile-schema`, `oav compile-spec`. See
-  [`packages/cli/README.md`](../cli/README.md) for commands and
+  [`packages/cli/README.md`](https://github.com/aahoughton/oav/blob/main/packages/cli/README.md) for commands and
   flags.
 
 Everything else (`createValidator`, `compileSchema`, error helpers,
 formatters, `formatSummary`, `toProblemDetails`, HTTP-status helpers, …)
 is re-exported from `oav-core`. Documentation for those lives in:
 
-- [`packages/core/README.md`](../core/README.md): error tree,
+- [`packages/core/README.md`](https://github.com/aahoughton/oav/blob/main/packages/core/README.md): error tree,
   formatters, HTTP helpers.
-- [`packages/validator/README.md`](../validator/README.md): the
+- [`packages/validator/README.md`](https://github.com/aahoughton/oav/blob/main/packages/validator/README.md): the
   HTTP validator.
-- [`packages/schema/README.md`](../schema/README.md): the JSON
+- [`packages/schema/README.md`](https://github.com/aahoughton/oav/blob/main/packages/schema/README.md): the JSON
   Schema compiler.
-- [`packages/spec/README.md`](../spec/README.md): multi-file
+- [`packages/spec/README.md`](https://github.com/aahoughton/oav/blob/main/packages/spec/README.md): multi-file
   loader, resolver, overlays.
-- [`packages/overlay-spec/README.md`](../overlay-spec/README.md):
+- [`packages/overlay-spec/README.md`](https://github.com/aahoughton/oav/blob/main/packages/overlay-spec/README.md):
   OpenAPI Overlay 1.0 spec-format translator.
-- [`packages/formats/README.md`](../formats/README.md): built-in
+- [`packages/formats/README.md`](https://github.com/aahoughton/oav/blob/main/packages/formats/README.md): built-in
   string format validators.
 
 ## Framework integration
 
 `oav` is a validator, not a middleware package. Companion adapter
 packages cover the framework wiring:
-[`oav-express4`](../oav-express4/README.md),
-[`oav-express5`](../oav-express5/README.md),
-[`oav-fastify`](../oav-fastify/README.md). See
-[`docs/integration.md`](../../docs/integration.md) for adapter recipes plus
+[`oav-express4`](https://github.com/aahoughton/oav/blob/main/packages/oav-express4/README.md),
+[`oav-express5`](https://github.com/aahoughton/oav/blob/main/packages/oav-express5/README.md),
+[`oav-fastify`](https://github.com/aahoughton/oav/blob/main/packages/oav-fastify/README.md). See
+[`docs/integration.md`](https://github.com/aahoughton/oav/blob/main/docs/integration.md) for adapter recipes plus
 manual integration patterns for Next.js, Hono, Bun, and Deno via
 the Web Standards adapter.
 
 ## See also
 
-- [Top-level `README.md`](../../README.md): full rationale, install
+- [Top-level `README.md`](https://github.com/aahoughton/oav/blob/main/README.md): full rationale, install
   matrix, comparison.
-- [`docs/integration.md`](../../docs/integration.md): adapter recipes,
+- [`docs/integration.md`](https://github.com/aahoughton/oav/blob/main/docs/integration.md): adapter recipes,
   security wiring, response validation, file uploads, migration.
-- [`docs/overlays.md`](../../docs/overlays.md): extending an externally-owned
+- [`docs/overlays.md`](https://github.com/aahoughton/oav/blob/main/docs/overlays.md): extending an externally-owned
   base spec at load time.
-- [`docs/comparison.md`](../../docs/comparison.md): feature comparison vs Ajv.
+- [`docs/comparison.md`](https://github.com/aahoughton/oav/blob/main/docs/comparison.md): feature comparison vs Ajv.

--- a/test/alias-parity.test.ts
+++ b/test/alias-parity.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { workspaceAliases } from "../workspace-aliases.js";
+
+// Parity guard for the hand-maintained `@oav/*` -> path tables. Adding a
+// subpath export (a new `*/internals`, a new package) means updating
+// three places; missing one surfaces as a confusing resolve failure
+// (tests pass but the build breaks, or vice versa) rather than a clear
+// error. This asserts the tables agree, with an explicit allowlist for
+// the entries the `oav` bundle legitimately doesn't reference.
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const onlyOav = (k: string): boolean => k.startsWith("@oav/");
+
+function aliasKeys(): string[] {
+  return Object.keys(workspaceAliases(root)).filter(onlyOav).sort();
+}
+
+function tsconfigPathKeys(): string[] {
+  const json = JSON.parse(readFileSync(resolve(root, "tsconfig.build.json"), "utf8")) as {
+    compilerOptions: { paths: Record<string, unknown> };
+  };
+  return Object.keys(json.compilerOptions.paths).filter(onlyOav).sort();
+}
+
+function tsupRewriteKeys(): string[] {
+  // packages/oav/tsup.config.ts can't be imported here (it reads
+  // `__dirname` at module load, which is undefined under ESM), so read
+  // it as text and extract the quoted `@oav/*` keys of its rewrite and
+  // bundle maps. Values are `@aahoughton/oav-core/...` and comments use
+  // backticks, so a quoted `@oav/...` literal is always a map key.
+  const src = readFileSync(resolve(root, "packages/oav/tsup.config.ts"), "utf8");
+  const keys = new Set<string>();
+  for (const m of src.matchAll(/["'](@oav\/[^"']+)["']/g)) keys.add(m[1]!);
+  return [...keys].sort();
+}
+
+// The oav bundle re-exports oav-core's surface and bundles the CLI +
+// router; it never imports itself or the framework adapters, so these
+// four keys appear in the resolution tables but not the tsup rewrite
+// map. Update this list when adding or removing a published package.
+const NOT_IN_OAV_BUNDLE = [
+  "@oav/oav",
+  "@oav/oav-express4",
+  "@oav/oav-express5",
+  "@oav/oav-fastify",
+].sort();
+
+describe("@oav/* alias parity across resolution tables", () => {
+  it("workspace-aliases.ts and tsconfig.build.json cover the same @oav/* keys", () => {
+    expect(aliasKeys()).toEqual(tsconfigPathKeys());
+  });
+
+  it("the oav tsup rewrite map matches the alias set minus the bundle's non-deps", () => {
+    const aliases = new Set(aliasKeys());
+    const tsup = new Set(tsupRewriteKeys());
+    // Every tsup key must be a known alias (no typo or stale entry).
+    expect([...tsup].filter((k) => !aliases.has(k))).toEqual([]);
+    // The only aliases absent from tsup are the documented non-deps.
+    expect([...aliases].filter((k) => !tsup.has(k)).sort()).toEqual(NOT_IN_OAV_BUNDLE);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     alias: workspaceAliases(__dirname),
   },
   test: {
-    include: ["packages/*/test/**/*.test.ts", "packages/*/src/**/*.test.ts"],
+    include: ["packages/*/test/**/*.test.ts", "packages/*/src/**/*.test.ts", "test/**/*.test.ts"],
     environment: "node",
     globals: false,
     passWithNoTests: true,


### PR DESCRIPTION
Three independent, low-churn cleanups for the 3.1.0 cut. Each is its own revertable commit; happy to split into separate PRs if preferred.

### `docs(modules)`: document the `*/internals` subpaths and fix the count (closes #353)
`docs/modules.md` omitted the not-semver-covered `*/internals` subpaths and the "five/six entrypoints" wording ignored them. Adds an internals section with a stability note, reconciles the count to "five public subpaths plus internals", and adds `loadSpecSync` to the spec row.

### `test(build)`: assert `@oav/*` alias parity across resolution tables (closes #329)
The `@oav/*` -> path mappings are hand-maintained in three places (`workspace-aliases.ts`, `tsconfig.build.json` paths, `packages/oav/tsup.config.ts`). Adding a subpath export means updating all three; missing one fails as a confusing resolve error rather than a clear one (the sync-loader work just added `@oav/spec/internals` to all three by hand). A parity test now asserts the two full tables cover the same keys, and the tsup rewrite map equals that set minus an explicit allowlist of the four keys the `oav` bundle never imports.

### `docs`: absolutize cross-doc links in published-package READMEs (closes #352)
Published tarballs ship only `dist`/`README`/`LICENSE`, so relative cross-doc links (`../sibling/README.md`, `../../docs/*`) 404 from npm. Rewrites them to absolute `…/blob/main/…` URLs in the five READMEs that publish (root `oav-core`, `oav`, the three adapters), fragments preserved. Private `@oav/*` package READMEs stay relative (repo-only, where relative is correct and better for navigation). Also scopes the package names in the `oav` comparison table.

Links anchor to `main` and can drift for old versions. That is the deliberate, norm-aligned choice for prose cross-links: npm already rewrites relative links to `main`, the closest comparable monorepo (Changesets) does the same, and version-accurate alternatives mean either release-time link tooling or a versioned docs site. Neither is worth it here.

All checks green: lint, dep-graph, and the full suite (1293 tests, including the new parity test).