### PR TITLE
perf: publishable benchmark harness + host-stamped c7i.large numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,40 +205,22 @@ OpenAPI validator output. See [docs/comparison.md](https://github.com/aahoughton
 for the feature map, and [docs/migration-from-eov.md](https://github.com/aahoughton/oav/blob/main/docs/migration-from-eov.md)
 if you are migrating from `express-openapi-validator`.
 
-Numbers below are from the [`performance/`](https://github.com/aahoughton/oav/blob/main/performance/README.md)
-benchmark on AWS c7i.large (Intel Sapphire Rapids, Node 22). Your
-hardware will vary.
+On raw speed, oav wins some and loses some against Ajv, and for most
+services the difference is immaterial. oav compiles schemas far faster
+(tens of microseconds against milliseconds), validates competitively on
+typical request bodies, and carries a slightly smaller steady-state
+memory footprint than `express-openapi-validator`. Ajv is faster on
+fast-fail validation of some ordinary object shapes. At normal request
+volumes (a validation or two per request, thousands of requests per
+second) these gaps are nanoseconds per call and vanish into everything
+else a handler does. They only start to matter if you validate at
+extreme volume or against pathological shapes (very large `uniqueItems`
+arrays, very long length-bounded strings).
 
-**Compile: oav is meaningfully faster.**
-
-|                                            | Ajv     | oav       |
-| ------------------------------------------ | ------- | --------- |
-| Single synthetic schema (varies by shape)  | ~2.7 ms | 15–200 µs |
-| Real-world spec (petstore-31, ~10 schemas) | 27 ms   | 1.6 ms    |
-
-Ajv compile is essentially constant overhead per schema; oav scales
-with shape, running 20–175× faster across the synthetic shapes and
-~5–8× on real-world specs (Stripe, Adyen). The advantage shows up
-wherever validator construction sits in the hot path: per-request,
-per-tenant, per-test, edge cold-start, AOT module emit.
-
-**Validate: close on typical shapes at matched defaults.**
-
-Comparing each library's zero-config default (oav flat + `maxErrors: 1`
-against Ajv `allErrors: false`, both stopping at the first error): the
-two are within ~25% on typical request bodies (small objects, recursive
-trees, large arrays). Ajv leads by ~2.5× on `oneOf` / `allOf` rejection,
-where oav materialises the composition error; oav's `predicate` mode
-(`compileSchema(..., { output: "predicate" })`) reaches parity there.
-oav leads ~1.6–3× on `uniqueItems` arrays.
-
-For typical HTTP workloads (1k–10k req/sec × ~1 validation per
-request), the difference is invisible. For validation-heavy code
-(millions of validations per second), measure your own shapes.
-
-Full per-shape breakdown: [`docs/comparison.md`](https://github.com/aahoughton/oav/blob/main/docs/comparison.md). Raw
-benchmark data and methodology:
-[`performance/README.md`](https://github.com/aahoughton/oav/blob/main/performance/README.md).
+For the host-stamped per-shape numbers, the memory comparison, and the
+methodology, see [docs/comparison.md](https://github.com/aahoughton/oav/blob/main/docs/comparison.md).
+Raw benchmark data lives in
+[`performance/`](https://github.com/aahoughton/oav/blob/main/performance/README.md).
 
 ## Conformance
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -35,34 +35,108 @@ comes down to the shape of integration you want.
 
 This document is about behavior and capabilities. For raw numbers
 and methodology see [`performance/README.md`](../performance/README.md);
-the shape of the trade-off is sketched below.
+the host-stamped per-shape numbers are below.
 
-## Performance sketch
+## Performance
 
-The numbers below compare matched defaults: oav's zero-config output
-(flat, `maxErrors: 1`) against Ajv's zero-config `allErrors: false`.
-Both stop at the first error. Validate ratios are oav ÷ Ajv, so `1.00`
-is parity, above is oav faster, below is Ajv faster. Synthetic bench,
-one machine; treat them as orders of magnitude, not exact figures.
+- **Host:** AWS c7i.large, Intel Xeon Platinum 8488C (Sapphire Rapids),
+  x86_64, 2 vCPU, Linux
+- **Runtime:** Node v22.22.3, Ajv 8.20.0
+- **Method:** synthetic shape suite, 1000 ms/task, 500 ms cooldown,
+  median of 3 runs; commit `2754996`, 2026-06-09
 
-| Workload                                            | oav ÷ Ajv | Notes                                                                                                                     |
-| --------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------- |
-| Validate, small objects (tiny / petstore)           | 0.75–1.0  | Within ~25%; Ajv a little ahead on the rejection path                                                                     |
-| Validate, recursive tree                            | ~1.0      | Tied                                                                                                                      |
-| Validate, large array of small objects              | 0.86–0.99 | Within ~15%                                                                                                               |
-| Validate, `oneOf` / `allOf` rejection               | ~0.4      | Ajv ~2.5× faster: oav materialises the composition error (more when collecting all). `output: "predicate"` reaches parity |
-| Validate, `uniqueItems` arrays                      | 1.6–3.2   | oav faster                                                                                                                |
-| Validate, predicate mode (vs Ajv `allErrors:false`) | 0.9–3.2   | At or above parity across shapes                                                                                          |
-| Compile, synthetic (per shape)                      | 20–175×   | oav faster                                                                                                                |
-| Compile, real-world OpenAPI spec                    | ~5–8×     | oav faster: ~8× on Stripe (886 schemas), ~5.5× on Adyen (44 schemas)                                                      |
+The harness measures five configurations: Ajv fast-fail
+(`allErrors: false`), Ajv full-collect (`allErrors: true`), oav fast-fail
+(flat, `maxErrors: 1`, the zero-config default), oav full-collect
+(`maxErrors: Infinity`), and oav predicate (`output: "predicate"`).
+Validate is compared against the matched Ajv mode: oav fast-fail vs Ajv
+fast-fail, oav full-collect vs Ajv full-collect, oav predicate vs Ajv
+fast-fail.
 
-The shape of the trade-off: on validate throughput the two are close on
-typical request bodies, Ajv leads on `oneOf` / `allOf` rejection, and
-oav leads on `uniqueItems` and predicate-mode checks. oav's larger and
-more consistent advantage is compile time, which matters wherever
-validator construction is in the hot path (per-request, per-tenant,
-per-test, edge cold-start, AOT module emit). Full methodology, raw
-numbers, and the benchmark harness live in
+### Compile
+
+oav's clearest, most consistent win. Ajv's compile is near-constant
+per-schema overhead; oav scales with shape and runs an order of
+magnitude or two faster. This matters wherever validator construction
+is in the hot path (per-request, per-tenant, per-test, edge cold-start,
+AOT module emit).
+
+| shape               | Ajv     | oav      | speedup |
+| ------------------- | ------- | -------- | ------- |
+| `tiny`              | 9.38 ms | 32.7 µs  | 287×    |
+| `petstore`          | 7.96 ms | 160.2 µs | 50×     |
+| `tree`              | 8.00 ms | 81.2 µs  | 99×     |
+| `composition`       | 8.13 ms | 358.2 µs | 23×     |
+| `array-heavy`       | 7.66 ms | 117.6 µs | 65×     |
+| `unique-primitives` | 7.01 ms | 46.7 µs  | 150×    |
+| `long-string`       | 7.12 ms | 85.3 µs  | 83×     |
+
+### Validate
+
+Each cell is oav's throughput as a percent of the matched Ajv mode:
+`100%` is parity, above is oav faster, below is Ajv faster. On typical
+request bodies the absolute per-call gaps are tens of nanoseconds, so
+these percentages move real numbers only at extreme validation volume.
+
+Valid input:
+
+| shape               | oav fast-fail | oav full-collect | oav predicate |
+| ------------------- | ------------- | ---------------- | ------------- |
+| `tiny`              | 144%          | 149%             | 149%          |
+| `petstore`          | 74%           | 101%             | 107%          |
+| `tree`              | 99%           | 103%             | 121%          |
+| `composition`       | 139%          | 170%             | 183%          |
+| `array-heavy`       | 111%          | 115%             | 211%          |
+| `unique-primitives` | 159%          | 162%             | 161%          |
+| `long-string`       | >1000×†       | >1000×†          | >1000×†       |
+
+Invalid input (averaged across failure-position fixtures):
+
+| shape               | oav fast-fail | oav full-collect | oav predicate |
+| ------------------- | ------------- | ---------------- | ------------- |
+| `tiny`              | 81%           | 104%             | 123%          |
+| `petstore`          | 61%           | 93%              | 147%          |
+| `tree`              | 87%           | 115%             | 189%          |
+| `composition`       | 97%           | 75%              | 228%          |
+| `array-heavy`       | 106%          | 78%              | 208%          |
+| `unique-primitives` | 313%          | 295%             | 316%          |
+| `long-string`       | 42%           | 89%              | >1000×†       |
+
+The trade-off: oav fast-fail trails Ajv fast-fail on plain object
+rejection (`petstore` 61–74%), trades places on the other shapes, and
+leads clearly on `uniqueItems`. oav full-collect stays close to Ajv
+full-collect: ahead on most accept-path shapes, mixed on rejection
+(trailing on `composition` and `array-heavy`, where collecting every
+error costs more). oav predicate mode, which skips error
+materialisation, is at or above parity everywhere.
+
+† `long-string` is a pathological shape. On the accept path oav is
+roughly three to four thousand times faster than Ajv (capped here to
+`>1000×`), because Ajv's handling of very long length-bounded strings is
+expensive on this input while oav short-circuits. The reject path is
+noisier and swings the other way for fast-fail (oav at 42%). Read this
+row as a shape-specific signal, not a typical result.
+
+### Memory
+
+Steady-state HTTP-server footprint over 50,000 requests, oav vs
+`express-openapi-validator` (which wraps Ajv), both Express 4 against the
+same 40-schema spec and identical traffic:
+
+| metric                          | oav      | eov + Ajv |
+| ------------------------------- | -------- | --------- |
+| Baseline RSS                    | 75.6 MB  | 72.4 MB   |
+| Steady-state RSS (avg)          | 102.5 MB | 106.6 MB  |
+| Steady-state heap used (avg)    | 12.8 MB  | 14.7 MB   |
+| Post-idle RSS                   | 102.3 MB | 106.8 MB  |
+| Throughput (ms / 500-req batch) | 525 ms   | 578 ms    |
+
+oav settles a few percent lighter on RSS, carries less heap, and turns
+the same workload over a little faster. Neither footprint is large; the
+gap is unlikely to decide a deployment.
+
+Full methodology, the synthetic shape definitions, the `--spec` mode for
+real-world OpenAPI documents, and the raw host-stamped JSON live in
 [`performance/README.md`](../performance/README.md).
 
 ## Where Ajv (+ express-openapi-validator) does more
@@ -240,9 +314,9 @@ Pick oav when you want a structured error tree, overlays over specs you
 don't own, an OpenAPI 3.0 dialect built into the validator, explicit
 control over where validation runs in your HTTP stack, or standalone
 OpenAPI HTTP validator output for edge/serverless deployments. It also
-fits compile-heavy workloads: current benchmarks show one to two orders
-of magnitude faster schema compile than Ajv, including 8× on Stripe's
-real-world spec; see the performance sketch above.
+fits compile-heavy workloads: the benchmarks show one to two orders
+of magnitude faster schema compile than Ajv; see the Performance
+section above.
 
 For benchmark numbers rather than feature comparisons, see
 [`performance/README.md`](../performance/README.md).

--- a/performance/README.md
+++ b/performance/README.md
@@ -1,8 +1,7 @@
 # @oav-dev/performance
 
 Cross-library benchmarks for `@oav/schema` vs
-[ajv](https://github.com/ajv-validator/ajv) (2020-12 dialect) vs
-[@hyperjump/json-schema](https://github.com/hyperjump-io/json-schema).
+[ajv](https://github.com/ajv-validator/ajv) (2020-12 dialect).
 Two benchmark entry points, two use cases.
 
 ## Bootstrap
@@ -23,8 +22,27 @@ pnpm bench                                      # default 500ms per task
 pnpm bench:long                                 # 1500ms per task
 pnpm bench -- --filter=petstore                 # one schema only
 pnpm bench -- --time=250                        # quick smoke
+pnpm bench -- --cooldown=500                    # fallow sleep after each task
 pnpm bench -- --spec=path/to/openapi.yaml       # real spec mode
 ```
+
+Each run writes a timestamped JSON file under `./results/` (gitignored;
+numbers are host-dependent). The file carries a `meta` block (host CPU,
+arch, Node and ajv versions, git commit, time-per-task, cooldown) so a
+table can never drift away from the machine it was measured on. Render
+the latest run (or a given file) into markdown tables with:
+
+```bash
+pnpm bench:render                               # newest results file
+pnpm bench:render results/<timestamp>.json      # a specific run
+```
+
+`render.ts` emits three tables, one concern each: **compile** (ajv vs
+oav), **validate / valid input**, and **validate / invalid input** (each
+across the five configs: ajv fast-fail, ajv full-collect, oav fast-fail,
+oav full-collect, oav predicate). `--cooldown` adds a fallow sleep after
+every task; set it for publishable runs to limit thermal / GC cross-talk
+between tasks.
 
 Two modes, one script:
 
@@ -39,7 +57,7 @@ Two modes, one script:
 
 - **`--spec=<path>` (real-world).** Loads the given OpenAPI entry via
   [`@apidevtools/json-schema-ref-parser`](https://github.com/APIDevTools/json-schema-ref-parser)
-  (to keep the input identical across all three libraries), extracts
+  (to keep the input identical across both libraries), extracts
   every unique request- and response-body schema, and times each
   library's compile across the whole set with plain
   `performance.now()`. Validate is skipped in this mode: real-world
@@ -99,7 +117,7 @@ retention.
 
 | You want to know...                                                    | Use                                                                       |
 | ---------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| Is oav competitive with ajv / hyperjump on shape X?                    | `run.ts` (synthetic, pick the matching schema in `schemas.ts` or add one) |
+| Is oav competitive with ajv on shape X?                                | `run.ts` (synthetic, pick the matching schema in `schemas.ts` or add one) |
 | How does library choice scale across a real spec's schemas?            | `run.ts --spec=<path>`                                                    |
 | Does this real spec load cleanly through oav's pipeline?               | `bench-real-world.mjs`                                                    |
 | How long does oav take from spec-on-disk to "first validated request"? | `bench-real-world.mjs`                                                    |
@@ -113,7 +131,6 @@ retention.
 === petstore — object with required + scalar properties; realistic small API payload ===
 compile:
   ajv compile                  356 ops/s       2.85ms / op
-  hyperjump compile           5.9K ops/s     189.94µs / op
   oav compile                17.1K ops/s      67.49µs / op
 validate:
   ajv validate (valid)              23.7M ops/s      42.95ns / op
@@ -122,7 +139,9 @@ validate:
 
 Per-library line per task. `ops/s` is tinybench's measured throughput,
 `/ op` is mean latency per call. Bigger ops/s = faster. The relative
-table at the end normalizes against ajv as baseline.
+table at the end normalizes against ajv as baseline. For the publishable
+markdown tables, run `pnpm bench:render` against the JSON instead of
+reading this console output.
 
 ### Spec mode
 
@@ -131,7 +150,6 @@ table at the end normalizes against ajv as baseline.
 277 unique request/response body schemas.
 compile (per library, aggregated across every schema):
   ajv         total  3858.40ms   mean    13.93ms   p95    41.17ms   max    54.78ms
-  hyperjump   total  1337.84ms   mean     4.83ms   p95    17.01ms   max    22.35ms
   oav         total    336.77ms   mean     1.22ms   p95     3.86ms   max     5.92ms
 ```
 
@@ -206,23 +224,32 @@ library's work:
 - **ajv**: `new Ajv({allErrors, strict:false}).compile(schema)`. The
   instance construction stays in — it's part of the cold-start cost
   for a consumer that doesn't already have an Ajv around.
-- **hyperjump**: `registerSchema(schema, uri)` then `await validate(uri)`
-  then `unregisterSchema(uri)`. URIs come from a pre-generated pool
-  so no string construction is in the hot loop; the unregister keeps
-  registry size bounded.
 - **oav**: `compileSchema(schema, opts)` with pre-built `opts`.
 
 **Compile (spec mode).** Same per-library semantics, one iteration
-per schema. Hyperjump gets an explicit `https://json-schema.org/draft/2020-12/schema`
-dialect URI passed to `registerSchema` (spec-derived schemas don't
-carry `$schema`). Ajv runs with `logger: false` so OAS-specific
-format warnings don't flood stdout.
+per schema. Ajv runs with `logger: false` so OAS-specific format
+warnings don't flood stdout.
 
 **Validate (synthetic).** Every library pre-compiles its validator
 once, outside the timed loop. The hot path is literally
 `validator(sample)` — no closures, no cursor math, no per-iteration
-setup. One representative sample each for the valid and invalid
-paths so neither side wins by short-circuiting.
+setup; each task validates one fixed payload.
+
+The **valid** path uses one representative sample per shape. The
+**invalid** path runs one task per authored invalid fixture, because
+where and how badly a payload fails dominates the number: a `uniqueItems`
+duplicate near the start vs. the end, a first- vs. last-element array
+failure, a cheap early reject vs. an expensive late one. Each fixture is
+its own pure-loop task; `render.ts` reports the median across them with
+the min–max range, so the published invalid number spans the
+failure-position spread rather than a single cherry-picked point. The
+fixtures in `schemas.ts` are deliberately authored to cover that spread
+(early / mid / deep / late / many-errors).
+
+Before any timing, a pre-flight pass validates every authored input
+under all five configs and asserts the verdict matches its label —
+catching a mislabeled fixture or an ajv/oav disagreement that would
+otherwise silently time the wrong path.
 
 The bench runs five validators so each comparison is apples-to-apples:
 `oav` is the zero-config default (flat, `maxErrors: 1`) and pairs with
@@ -285,8 +312,15 @@ type RunOutput = {
     timestamp: string; // ISO 8601
     commitSha: string;
     nodeVersion: string;
+    platform: string; // os.platform()
+    arch: string; // os.arch()
+    cpu: string; // os.cpus()[0].model
+    cpuCount: number;
+    ajvVersion: string; // resolved ajv version compared against
     timePerTaskMs: number;
+    cooldownMs: number;
     mode: "synthetic" | "spec";
+    specPath: string | null;
   };
   results: Result[];
 };
@@ -294,7 +328,8 @@ type RunOutput = {
 type Result = {
   schema: string; // schema name or spec path
   metric: "compile" | "validate";
-  lib: "ajv" | "ajv-fast" | "hyperjump" | "oav" | "oav-predicate";
+  lib: "ajv" | "ajv-fast" | "oav" | "oav-all" | "oav-predicate";
+  validity?: "valid" | "invalid"; // validate only
   hz: number; // ops/sec
   mean: number; // µs per op
   variant?: string; // e.g. "oav-predicate validate (valid)"

--- a/performance/mem-bench/server-oav.mjs
+++ b/performance/mem-bench/server-oav.mjs
@@ -44,7 +44,7 @@ app.get("/__memory", (req, res) => {
 // Validator adapter.
 app.use(async (req, res, next) => {
   if (req.path === "/__memory") return next();
-  const err = validator.validateRequest({
+  const result = validator.validateRequest({
     method: req.method,
     path: req.path,
     query: req.query,
@@ -52,13 +52,14 @@ app.use(async (req, res, next) => {
     contentType: req.get("content-type") ?? undefined,
     body: req.body,
   });
-  if (err === null) return next();
-  const allow = allowHeaderFor(err);
+  if (result.valid) return next();
+  const errors = result.errors;
+  const allow = allowHeaderFor(errors);
   if (allow !== undefined) res.setHeader("Allow", allow);
   res
-    .status(httpStatusFor(err))
+    .status(httpStatusFor(errors))
     .type("application/problem+json")
-    .json(toProblemDetails(err, { instance: req.originalUrl }));
+    .json(toProblemDetails(errors, { instance: req.originalUrl }));
 });
 
 // Business handlers.

--- a/performance/package.json
+++ b/performance/package.json
@@ -2,18 +2,18 @@
   "name": "@oav-dev/performance",
   "version": "0.0.0",
   "private": true,
-  "description": "Benchmarks: @oav/schema compile + validate performance vs ajv (2020) and @hyperjump/json-schema.",
+  "description": "Benchmarks: @oav/schema compile + validate performance vs ajv (2020-12).",
   "type": "module",
   "scripts": {
     "bench": "tsx run.ts",
     "bench:long": "tsx run.ts --time=1500",
+    "bench:render": "tsx render.ts",
     "bench:mem": "tsx mem.ts",
     "bench:large": "tsx large-payload.ts",
     "bench:anatomy": "node --expose-gc --import tsx error-tree-anatomy.ts"
   },
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "^15.3.5",
-    "@hyperjump/json-schema": "^1.17.6",
     "ajv": "^8.20.0",
     "tinybench": "^6.0.2",
     "tsx": "^4.22.4",

--- a/performance/pnpm-lock.yaml
+++ b/performance/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '9.0'
 
 settings:
-  autoInstallPeers: false
+  autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
@@ -10,10 +10,7 @@ importers:
     devDependencies:
       '@apidevtools/json-schema-ref-parser':
         specifier: ^15.3.5
-        version: 15.3.5
-      '@hyperjump/json-schema':
-        specifier: ^1.17.6
-        version: 1.17.6
+        version: 15.3.5(@types/json-schema@7.0.15)
       ajv:
         specifier: ^8.20.0
         version: 8.20.0
@@ -191,32 +188,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@hyperjump/json-pointer@1.1.2':
-    resolution: {integrity: sha512-zPNgu1zdhtjQHFNLGzvEsLDsLOEvhRj6u6ktIQmlz7YPESv5uF8SnAe3Dq0oL6gZ6OGWSLq2n7pphRNF6Hpg6w==}
-
-  '@hyperjump/json-schema-formats@1.0.1':
-    resolution: {integrity: sha512-qvcIxysnMfcPxyPSFFzzo28o2BN1CNT5b0tQXNUP0kaFpvptQNDg8SCLvlnMg2sYxuiuqna8+azGBaBthiskAw==}
-
-  '@hyperjump/json-schema@1.17.6':
-    resolution: {integrity: sha512-m0QggWCn58IACqLi3fqI9cuUrFju79DVAxjkDENo+xgE26963rudPMwKwwlkZkB+JqAgu+OGvJAMfE1toevfGw==}
-    peerDependencies:
-      '@hyperjump/browser': ^1.1.0
-
-  '@hyperjump/pact@1.4.0':
-    resolution: {integrity: sha512-01Q7VY6BcAkp9W31Fv+ciiZycxZHGlR2N6ba9BifgyclHYHdbaZgITo0U6QMhYRlem4k8pf8J31/tApxvqAz8A==}
-
-  '@hyperjump/uri@1.3.3':
-    resolution: {integrity: sha512-rUqeUdL2aW7lzvSnCL6yUetXYzqxhsBEw9Z7Y1bEhgiRzcfO3kjY0UdD6c4H/bzxe0fXIjYuocjWQzinio8JTQ==}
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
-
-  content-type@1.0.5:
-    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
-    engines: {node: '>= 0.6'}
 
   esbuild@0.28.0:
     resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
@@ -234,26 +213,12 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  idn-hostname@15.1.8:
-    resolution: {integrity: sha512-MmLwddtSVyMtzYxx+xs2IFEbfyg/facubL/mEaAoJX/XIfjt1ly5QhPByihf4yrxZYbkQfRZVEnBgISv/e2ZWw==}
-
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
-
-  json-stringify-deterministic@1.0.13:
-    resolution: {integrity: sha512-Gm2hkhXlhD69QplkQGmY30S8Ps5noSFzruJKbgmD/nkYIXimS/Q0P1YIbJkWe2nbWDIzERmtp+hWGzC3Vk3bZg==}
-    engines: {node: '>= 4'}
-
-  just-curry-it@5.3.0:
-    resolution: {integrity: sha512-silMIRiFjUWlfaDhkgSzpuAyQ6EX/o09Eu8ZBfmFwQMbax7+LQzeIU2CBrICT6Ne4l86ITCGvUCBpCubWYy0Yw==}
-
-  punycode@2.3.1:
-    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
-    engines: {node: '>=6'}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -273,14 +238,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  uuid@14.0.0:
-    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
-    hasBin: true
-
 snapshots:
 
-  '@apidevtools/json-schema-ref-parser@15.3.5':
+  '@apidevtools/json-schema-ref-parser@15.3.5(@types/json-schema@7.0.15)':
     dependencies:
+      '@types/json-schema': 7.0.15
       js-yaml: 4.1.1
 
   '@esbuild/aix-ppc64@0.28.0':
@@ -361,27 +323,7 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
-  '@hyperjump/json-pointer@1.1.2': {}
-
-  '@hyperjump/json-schema-formats@1.0.1':
-    dependencies:
-      '@hyperjump/uri': 1.3.3
-      idn-hostname: 15.1.8
-
-  '@hyperjump/json-schema@1.17.6':
-    dependencies:
-      '@hyperjump/json-pointer': 1.1.2
-      '@hyperjump/json-schema-formats': 1.0.1
-      '@hyperjump/pact': 1.4.0
-      '@hyperjump/uri': 1.3.3
-      content-type: 1.0.5
-      json-stringify-deterministic: 1.0.13
-      just-curry-it: 5.3.0
-      uuid: 14.0.0
-
-  '@hyperjump/pact@1.4.0': {}
-
-  '@hyperjump/uri@1.3.3': {}
+  '@types/json-schema@7.0.15': {}
 
   ajv@8.20.0:
     dependencies:
@@ -391,8 +333,6 @@ snapshots:
       require-from-string: 2.0.2
 
   argparse@2.0.1: {}
-
-  content-type@1.0.5: {}
 
   esbuild@0.28.0:
     optionalDependencies:
@@ -430,21 +370,11 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  idn-hostname@15.1.8:
-    dependencies:
-      punycode: 2.3.1
-
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
 
   json-schema-traverse@1.0.0: {}
-
-  json-stringify-deterministic@1.0.13: {}
-
-  just-curry-it@5.3.0: {}
-
-  punycode@2.3.1: {}
 
   require-from-string@2.0.2: {}
 
@@ -457,5 +387,3 @@ snapshots:
       fsevents: 2.3.3
 
   typescript@5.9.3: {}
-
-  uuid@14.0.0: {}

--- a/performance/render.ts
+++ b/performance/render.ts
@@ -1,0 +1,248 @@
+/**
+ * Render a benchmark results JSON (written by run.ts) into markdown
+ * tables.
+ *
+ *   - Compile: one combined table (absolute + the `N×` oav speedup).
+ *   - Validate, valid input: an absolute table + a relative table.
+ *   - Validate, invalid input: an absolute table (average with the
+ *     min–max range across the failure-position fixtures) + a relative
+ *     table (average speed vs the baseline).
+ *
+ * Splitting absolute from relative keeps every cell to a single value.
+ * Absolute tables are latency (lower is faster) and list every config;
+ * relative tables show each oav config against the ajv mode doing the
+ * same job (fast-fail vs fast-fail, full-collect vs full-collect), so
+ * 100% = same and higher is faster (large speedups render as `N×`).
+ *
+ * Usage:
+ *   pnpm bench:render [path/to/results.json]
+ *
+ * With no path, the most recent file under ./results/ is used. The
+ * provenance header records the host the numbers came from, so a table
+ * pasted into the README can't drift away from where it was measured.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+type Result = {
+  schema: string;
+  metric: "compile" | "validate";
+  lib: "ajv" | "ajv-fast" | "oav" | "oav-all" | "oav-predicate";
+  validity?: "valid" | "invalid";
+  mean: number; // µs/op
+};
+type Meta = Record<string, unknown>;
+
+const perfDir = dirname(fileURLToPath(import.meta.url));
+
+function latestResults(): string {
+  const dir = resolve(perfDir, "results");
+  const files = readdirSync(dir)
+    // run.ts outputs are `<ISO>.json`; skip `mem-*.json` and other
+    // sibling-bench outputs, which have a different shape.
+    .filter((f) => /^\d{4}-\d{2}-\d{2}T.*\.json$/.test(f))
+    .sort(); // ISO timestamps sort chronologically
+  const last = files.at(-1);
+  if (last === undefined)
+    throw new Error(`no run.ts result files in ${dir}; run \`pnpm bench\` first`);
+  return join(dir, last);
+}
+
+function fmtUs(us: number): string {
+  if (us < 1) return (us * 1000).toFixed(1) + "ns";
+  if (us < 1000) return us.toFixed(2) + "µs";
+  return (us / 1000).toFixed(2) + "ms";
+}
+
+function avg(xs: number[]): number {
+  return xs.reduce((a, b) => a + b, 0) / xs.length;
+}
+
+// Unique schema names in first-seen order: keeps the README's shape
+// ordering stable instead of reshuffling on Object key iteration.
+function schemaOrder(results: Result[]): string[] {
+  const seen = new Set<string>();
+  const order: string[] = [];
+  for (const r of results) {
+    if (!seen.has(r.schema)) {
+      seen.add(r.schema);
+      order.push(r.schema);
+    }
+  }
+  return order;
+}
+
+function table(header: string[], rows: string[][]): string {
+  const head = `| ${header.join(" | ")} |`;
+  const sep = `| ${header.map(() => "---").join(" | ")} |`;
+  const body = rows.map((r) => `| ${r.join(" | ")} |`).join("\n");
+  return [head, sep, body].join("\n");
+}
+
+const path = process.argv[2] ?? latestResults();
+const { meta, results } = JSON.parse(readFileSync(path, "utf8")) as {
+  meta: Meta;
+  results: Result[];
+};
+const shapes = schemaOrder(results);
+
+function pickMean(
+  schema: string,
+  lib: Result["lib"],
+  metric: "compile" | "validate",
+  validity?: "valid" | "invalid",
+): number | null {
+  const r = results.find(
+    (x) =>
+      x.schema === schema &&
+      x.metric === metric &&
+      x.lib === lib &&
+      (validity === undefined || x.validity === validity),
+  );
+  return r ? r.mean : null;
+}
+
+function invalidStats(
+  schema: string,
+  lib: Result["lib"],
+): { avg: number; min: number; max: number } | null {
+  const means = results
+    .filter(
+      (r) =>
+        r.schema === schema && r.metric === "validate" && r.validity === "invalid" && r.lib === lib,
+    )
+    .map((r) => r.mean);
+  if (means.length === 0) return null;
+  return { avg: avg(means), min: Math.min(...means), max: Math.max(...means) };
+}
+
+// Speed of a cell relative to its row's baseline (the first column):
+// baseline latency / cell latency. 100% = same speed, >100% faster,
+// <100% slower. Large compile speedups render as an `N×` multiplier
+// rather than an unwieldy four-digit percentage.
+function rel(baseline: number | null, value: number | null): string {
+  if (baseline === null || value === null || value === 0) return "—";
+  const r = baseline / value;
+  if (r >= 10) return `${r.toFixed(0)}×`;
+  const pct = r * 100;
+  return pct < 1 ? "<1%" : `${pct.toFixed(0)}%`;
+}
+
+const COLS: { label: string; lib: Result["lib"] }[] = [
+  { label: "ajv fast-fail", lib: "ajv-fast" },
+  { label: "ajv full-collect", lib: "ajv" },
+  { label: "oav fast-fail", lib: "oav" },
+  { label: "oav full-collect", lib: "oav-all" },
+  { label: "oav predicate", lib: "oav-predicate" },
+];
+const COL_LABELS = COLS.map((c) => c.label);
+
+// Relative tables pair each oav config with the ajv mode doing the same
+// job, so the comparison is like-for-like (full-collect against
+// full-collect, not against fast-fail). ajv has no boolean-only mode, so
+// predicate is measured against ajv's fastest path, fast-fail.
+const MATCHED: { label: string; oav: Result["lib"]; ajv: Result["lib"] }[] = [
+  { label: "oav fast-fail", oav: "oav", ajv: "ajv-fast" },
+  { label: "oav full-collect", oav: "oav-all", ajv: "ajv" },
+  { label: "oav predicate", oav: "oav-predicate", ajv: "ajv-fast" },
+];
+const MATCHED_LABELS = MATCHED.map((p) => p.label);
+const MATCHED_NOTE =
+  "_Each oav config vs the matched ajv mode (fast-fail→fast-fail, " +
+  "full-collect→full-collect, predicate→fast-fail). 100% = same, higher is faster._";
+
+const m = (k: string): string => String(meta[k] ?? "?");
+const sha = m("commitSha");
+console.log(`### Benchmark results\n`);
+console.log(
+  [
+    `- **Host:** ${m("cpu")} (${m("arch")}, ${m("cpuCount")} vCPU, ${m("platform")})`,
+    `- **Runtime:** Node ${m("nodeVersion")}, ajv ${m("ajvVersion")}`,
+    `- **Run:** ${m("mode")} mode, ${m("timePerTaskMs")}ms/task, ${m("cooldownMs")}ms cooldown`,
+    `- **Commit:** \`${sha === "?" ? sha : sha.slice(0, 12)}\` · ${m("timestamp")}`,
+    meta["specPath"] ? `- **Spec:** ${m("specPath")}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n"),
+);
+
+// --- Compile (combined: absolute + oav speedup) ---------------------------
+const compileRows = shapes
+  .filter((s) => results.some((r) => r.schema === s && r.metric === "compile"))
+  .map((s) => {
+    const ajv = pickMean(s, "ajv", "compile");
+    const oav = pickMean(s, "oav", "compile");
+    return [
+      `\`${s}\``,
+      ajv === null ? "—" : fmtUs(ajv),
+      oav === null ? "—" : `${fmtUs(oav)} / ${rel(ajv, oav)}`,
+    ];
+  });
+console.log(`\n#### Compile (ajv vs oav)\n`);
+console.log(
+  `_Mean per schema. oav's \`N×\` is its speedup over the ajv baseline; higher is faster._\n`,
+);
+console.log(table(["shape", "ajv", "oav (vs ajv)"], compileRows));
+
+// --- Validate, valid input ------------------------------------------------
+if (results.some((r) => r.metric === "validate" && r.validity === "valid")) {
+  const validShapes = shapes.filter((s) =>
+    results.some((r) => r.schema === s && r.metric === "validate" && r.validity === "valid"),
+  );
+  const absRows = validShapes.map((s) => [
+    `\`${s}\``,
+    ...COLS.map((c) => {
+      const v = pickMean(s, c.lib, "validate", "valid");
+      return v === null ? "—" : fmtUs(v);
+    }),
+  ]);
+  const relRows = validShapes.map((s) => [
+    `\`${s}\``,
+    ...MATCHED.map((p) =>
+      rel(pickMean(s, p.ajv, "validate", "valid"), pickMean(s, p.oav, "validate", "valid")),
+    ),
+  ]);
+
+  console.log(`\n#### Validate — valid input · absolute\n`);
+  console.log(`_Mean latency per op. Lower is faster._\n`);
+  console.log(table(["shape", ...COL_LABELS], absRows));
+
+  console.log(`\n#### Validate — valid input · oav vs matched ajv mode\n`);
+  console.log(`${MATCHED_NOTE}\n`);
+  console.log(table(["shape", ...MATCHED_LABELS], relRows));
+}
+
+// --- Validate, invalid input ----------------------------------------------
+if (results.some((r) => r.metric === "validate" && r.validity === "invalid")) {
+  const invalidShapes = shapes.filter((s) =>
+    results.some((r) => r.schema === s && r.metric === "validate" && r.validity === "invalid"),
+  );
+  const absRows = invalidShapes.map((s) => [
+    `\`${s}\``,
+    ...COLS.map((c) => {
+      const st = invalidStats(s, c.lib);
+      if (st === null) return "—";
+      return st.min === st.max
+        ? fmtUs(st.avg)
+        : `${fmtUs(st.avg)} (${fmtUs(st.min)}–${fmtUs(st.max)})`;
+    }),
+  ]);
+  const relRows = invalidShapes.map((s) => [
+    `\`${s}\``,
+    ...MATCHED.map((p) =>
+      rel(invalidStats(s, p.ajv)?.avg ?? null, invalidStats(s, p.oav)?.avg ?? null),
+    ),
+  ]);
+
+  console.log(`\n#### Validate — invalid input · absolute\n`);
+  console.log(
+    `_Average per op with the min–max range across the failure-position fixtures. Lower is faster._\n`,
+  );
+  console.log(table(["shape", ...COL_LABELS], absRows));
+
+  console.log(`\n#### Validate — invalid input · oav vs matched ajv mode\n`);
+  console.log(`${MATCHED_NOTE}\n`);
+  console.log(table(["shape", ...MATCHED_LABELS], relRows));
+}

--- a/performance/run.ts
+++ b/performance/run.ts
@@ -1,44 +1,65 @@
 /**
- * Cross-library benchmarks for @oav/schema vs ajv (2020) vs
- * @hyperjump/json-schema (2020-12).
+ * Cross-library benchmarks for @oav/schema vs ajv (2020-12 dialect).
  *
  * Two modes:
  *
  *   - Synthetic (default): iterate over ./schemas.ts and measure
  *     compile + validate with hand-authored valid/invalid inputs.
- *   - Spec (--spec <path>): load an OpenAPI document, extract every
- *     unique request/response body schema, and measure each
- *     library's compile time across the set. Validate is skipped in
- *     this mode because real-world schemas come without paired
- *     valid/invalid fixtures.
+ *   - Spec (--spec=<path>): load an OpenAPI document, extract every
+ *     unique request/response body schema, and measure each library's
+ *     compile time across the set. Validate is skipped in this mode
+ *     because real-world schemas come without paired valid/invalid
+ *     fixtures.
  *
- * See ./README.md for details.
+ * Output is a timestamped JSON file under ./results/ (gitignored;
+ * numbers are host-dependent). Render it into markdown tables with
+ * `pnpm bench:render`. See ./README.md for details.
+ *
+ * Flags:
+ *   --time=<ms>      tinybench time budget per task (default 500)
+ *   --cooldown=<ms>  fallow sleep after each task to limit cross-talk
+ *                    (default 0; set it for publishable runs)
+ *   --filter=<name>  run only schemas whose name includes <name>
+ *   --spec=<path>    real-world spec compile mode
  */
 
+import { execSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { cpus, arch, platform } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import $RefParser from "@apidevtools/json-schema-ref-parser";
 import { Bench } from "tinybench";
 import Ajv from "ajv/dist/2020.js";
-import {
-  registerSchema,
-  unregisterSchema,
-  validate as hjValidate,
-} from "@hyperjump/json-schema/draft-2020-12";
 import { compileSchema, jsonSchemaDialect } from "../packages/schema/src/index.ts";
 import { builtInFormats } from "../packages/formats/src/index.ts";
 import { perfSchemas, type PerfSchema } from "./schemas.ts";
 
 const args = process.argv.slice(2);
+const numArg = (name: string, dflt: number): number => {
+  const a = args.find((x) => x.startsWith(`--${name}=`));
+  return a ? Number.parseInt(a.slice(name.length + 3), 10) : dflt;
+};
 const filterArg = args.find((a) => a.startsWith("--filter="));
 const filter = filterArg?.slice("--filter=".length);
-const timeArg = args.find((a) => a.startsWith("--time="));
-const time = timeArg ? Number.parseInt(timeArg.slice("--time=".length), 10) : 500;
+const time = numArg("time", 500);
+const cooldown = numArg("cooldown", 0);
 const specArg = args.find((a) => a.startsWith("--spec="));
 const specPath = specArg?.slice("--spec=".length);
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+// Fallow period after every task so thermal / GC state from one task
+// doesn't bleed into the next. Applied as a tinybench per-task afterAll
+// hook; tasks run sequentially, so this spaces the whole sweep.
+const taskOpts = cooldown > 0 ? { afterAll: () => sleep(cooldown) } : {};
 
 type Result = {
   schema: string;
   metric: "compile" | "validate";
-  lib: "ajv" | "ajv-fast" | "hyperjump" | "oav" | "oav-all" | "oav-predicate";
+  lib: "ajv" | "ajv-fast" | "oav" | "oav-all" | "oav-predicate";
+  validity?: "valid" | "invalid";
   hz: number; // ops/sec
   mean: number; // µs/op
   variant?: string; // full task name (e.g. "oav validate (valid)")
@@ -73,46 +94,40 @@ function taskErrorMessage(t: { result?: unknown }): string | undefined {
   return r?.error?.message;
 }
 
+function validityOf(taskName: string): "valid" | "invalid" | undefined {
+  if (taskName.includes("(valid)")) return "valid";
+  if (taskName.includes("(invalid")) return "invalid";
+  return undefined;
+}
+
 async function benchSchema(s: PerfSchema): Promise<void> {
   console.log(`\n=== ${s.name} — ${s.description} ===`);
 
-  // Pre-allocate per-iteration scratch that is NOT part of what we want
-  // to measure so the hot loop reduces to the library's work.
-  // - Hyperjump caches compiled validators per URI, so we need a fresh
-  //   URI per iteration; pre-generate the pool.
-  // - Compile options for oav / ajv are identical each iteration, so
-  //   hoist them.
-  const URI_POOL = 50_000;
-  const hjCompileUris = Array.from({ length: URI_POOL }, (_, i) => `bench://c-${s.name}-${i}`);
-  let hjCompileIdx = 0;
+  // Compile options for oav / ajv are identical each iteration, so hoist
+  // them; the hot loop reduces to the library's work.
   const oavOpts = { dialect: jsonSchemaDialect, formats: builtInFormats };
   const ajvFactory = () => new Ajv({ allErrors: true, strict: false });
 
   // COMPILE BENCH: each task turns a fresh schema object into a callable
   // validator. For ajv that includes `new Ajv()` (it's part of the
   // cold-start cost — a pool of compiled schemas still needs an instance
-  // to own them). For hyperjump, `registerSchema` + `validate(uri)`.
+  // to own them).
   const compileBench = new Bench({ time });
   compileBench
-    .add("ajv compile", () => {
-      ajvFactory().compile(s.schema);
-    })
-    .add("hyperjump compile", async () => {
-      const uri = hjCompileUris[hjCompileIdx];
-      hjCompileIdx += 1;
-      if (uri === undefined) throw new Error("uri pool exhausted; raise URI_POOL");
-      registerSchema(s.schema, uri);
-      try {
-        await hjValidate(uri);
-      } finally {
-        // Registry doesn't need to grow across iterations — unregister keeps
-        // registerSchema's cost stable instead of degrading as we add entries.
-        unregisterSchema(uri);
-      }
-    })
-    .add("oav compile", () => {
-      compileSchema(s.schema as never, oavOpts);
-    });
+    .add(
+      "ajv compile",
+      () => {
+        ajvFactory().compile(s.schema);
+      },
+      taskOpts,
+    )
+    .add(
+      "oav compile",
+      () => {
+        compileSchema(s.schema as never, oavOpts);
+      },
+      taskOpts,
+    );
 
   await compileBench.run();
 
@@ -136,18 +151,14 @@ async function benchSchema(s: PerfSchema): Promise<void> {
   // no modulo, no cursor math — so what we measure is as close as
   // possible to the real production cost of "I already loaded the spec;
   // now validate this one payload".
+
+  // ajv collecting every error (allErrors: true): full-collect.
   const ajv = new Ajv({ allErrors: true, strict: false });
   const ajvValidate = ajv.compile(s.schema);
 
-  // ajv's default (fail-fast) mode — the fair comparison for oav's
-  // predicate mode. Both stop at the first failure and report
-  // yes/no-style rather than building a full error tree.
+  // ajv's fail-fast mode (allErrors: false): stops at the first failure.
   const ajvFast = new Ajv({ allErrors: false, strict: false });
   const ajvValidateFast = ajvFast.compile(s.schema);
-
-  const hjUri = `bench://validate-${s.name}`;
-  registerSchema(s.schema, hjUri);
-  const hjV = await hjValidate(hjUri);
 
   // oav's zero-config default: flat output, maxErrors 1 (fail-fast). The
   // apples-to-apples partner for ajv-fast (allErrors: false).
@@ -163,56 +174,72 @@ async function benchSchema(s: PerfSchema): Promise<void> {
     maxErrors: Number.POSITIVE_INFINITY,
   });
 
+  // oav predicate mode: boolean only, no error materialization.
   const oavPredicate = compileSchema(s.schema as never, {
     dialect: jsonSchemaDialect,
     formats: builtInFormats,
     output: "predicate",
   });
 
-  // Measure both the happy path (valid) and the failure path (invalid)
-  // so nobody gets to win by short-circuiting. Pick one representative
-  // sample of each up front — no per-iteration selection work.
-  const validSample = s.validInputs[0];
-  const invalidSample = s.invalidInputs[0];
+  // Each config: how to run it (timed) and its boolean verdict (used by
+  // the pre-flight check). Flat / full-collect return `{ valid }`;
+  // predicate and ajv return a bare boolean.
+  const configs: {
+    lib: Result["lib"];
+    run: (x: unknown) => void;
+    verdict: (x: unknown) => boolean;
+  }[] = [
+    { lib: "ajv", run: (x) => void ajvValidate(x), verdict: (x) => ajvValidate(x) === true },
+    {
+      lib: "ajv-fast",
+      run: (x) => void ajvValidateFast(x),
+      verdict: (x) => ajvValidateFast(x) === true,
+    },
+    {
+      lib: "oav",
+      run: (x) => void oav.validate(x),
+      verdict: (x) => (oav.validate(x) as { valid: boolean }).valid,
+    },
+    {
+      lib: "oav-all",
+      run: (x) => void oavAll.validate(x),
+      verdict: (x) => (oavAll.validate(x) as { valid: boolean }).valid,
+    },
+    {
+      lib: "oav-predicate",
+      run: (x) => void oavPredicate.validate(x),
+      verdict: (x) => oavPredicate.validate(x) === true,
+    },
+  ];
 
-  const validateBench = new Bench({ time });
-  validateBench
-    .add("ajv validate (valid)", () => {
-      ajvValidate(validSample);
-    })
-    .add("ajv validate (invalid)", () => {
-      ajvValidate(invalidSample);
-    })
-    .add("ajv-fast validate (valid)", () => {
-      ajvValidateFast(validSample);
-    })
-    .add("ajv-fast validate (invalid)", () => {
-      ajvValidateFast(invalidSample);
-    })
-    .add("hyperjump validate (valid)", () => {
-      hjV(validSample);
-    })
-    .add("hyperjump validate (invalid)", () => {
-      hjV(invalidSample);
-    })
-    .add("oav validate (valid)", () => {
-      oav.validate(validSample);
-    })
-    .add("oav validate (invalid)", () => {
-      oav.validate(invalidSample);
-    })
-    .add("oav-all validate (valid)", () => {
-      oavAll.validate(validSample);
-    })
-    .add("oav-all validate (invalid)", () => {
-      oavAll.validate(invalidSample);
-    })
-    .add("oav-predicate validate (valid)", () => {
-      oavPredicate.validate(validSample);
-    })
-    .add("oav-predicate validate (invalid)", () => {
-      oavPredicate.validate(invalidSample);
+  // Pre-flight: every authored input must validate as labeled under
+  // every config. This both confirms fixtures are correctly labeled and
+  // that ajv and oav agree on the verdict; a mismatch means a timed task
+  // would measure the wrong path, so fail loudly before timing.
+  for (const c of configs) {
+    s.validInputs.forEach((x, i) => {
+      if (!c.verdict(x)) throw new Error(`${s.name}: ${c.lib} rejects validInputs[${i}]`);
     });
+    s.invalidInputs.forEach((x, i) => {
+      if (c.verdict(x)) throw new Error(`${s.name}: ${c.lib} accepts invalidInputs[${i}]`);
+    });
+  }
+
+  // Valid path: one representative sample per config. Invalid path: one
+  // task per authored fixture per config, so the published invalid
+  // number spans the failure-position spread instead of a single point.
+  // Each task still validates ONE fixed payload — pure hot loop, no
+  // per-iteration selection.
+  const validSample = s.validInputs[0];
+  const validateBench = new Bench({ time });
+  for (const c of configs) {
+    validateBench.add(`${c.lib} validate (valid)`, () => c.run(validSample), taskOpts);
+  }
+  for (const c of configs) {
+    s.invalidInputs.forEach((sample, i) => {
+      validateBench.add(`${c.lib} validate (invalid #${i})`, () => c.run(sample), taskOpts);
+    });
+  }
   await validateBench.run();
 
   console.log("validate:");
@@ -231,13 +258,12 @@ async function benchSchema(s: PerfSchema): Promise<void> {
       schema: s.name,
       metric: "validate",
       lib,
+      validity: validityOf(t.name),
       hz: stats.hz,
       mean: stats.mean,
       variant: t.name,
     });
   }
-
-  unregisterSchema(hjUri);
 }
 
 /**
@@ -276,9 +302,9 @@ function extractBodySchemas(doc: unknown): unknown[] {
 
 async function benchSpec(path: string): Promise<void> {
   // Use @apidevtools/json-schema-ref-parser to produce a fully
-  // dereferenced document. That isolates compile-time comparisons
-  // from any resolver differences between libraries and gives ajv /
-  // hyperjump / oav an identical input.
+  // dereferenced document. That isolates compile-time comparisons from
+  // any resolver differences between libraries and gives ajv / oav an
+  // identical input.
   const doc = await $RefParser.dereference(path);
   const schemas = extractBodySchemas(doc);
   console.log(`\n=== Real-world spec: ${path} ===`);
@@ -289,10 +315,8 @@ async function benchSpec(path: string): Promise<void> {
   // warmup + iteration machinery is overkill at ms scale and across
   // 100+ schemas it blows past anything resembling a reasonable run time.
   const ajvTimes: number[] = [];
-  const hjTimes: number[] = [];
   const oavTimes: number[] = [];
   const ajvErrors: string[] = [];
-  const hjErrors: string[] = [];
   const oavErrors: string[] = [];
 
   for (let i = 0; i < schemas.length; i += 1) {
@@ -302,40 +326,12 @@ async function benchSpec(path: string): Promise<void> {
       const t0 = performance.now();
       // `logger: false` suppresses "unknown format X" warnings that
       // would otherwise flood the output; the schemas use OAS-specific
-      // formats (`duration`, `float`) that neither ajv nor
-      // ajv-formats recognize by default.
+      // formats (`duration`, `float`) that neither ajv nor ajv-formats
+      // recognize by default.
       new Ajv({ allErrors: true, strict: false, logger: false }).compile(schema as never);
       ajvTimes.push(performance.now() - t0);
     } catch (err) {
       ajvErrors.push(err instanceof Error ? err.message : String(err));
-    }
-
-    const uri = `bench://spec-${i}`;
-    // Spec-derived schemas don't declare `$schema`. Pin 2020-12
-    // explicitly so hyperjump doesn't refuse on dialect detection.
-    // OAS 3.0 keywords (`nullable`, etc.) will still trip it; those
-    // show up as per-schema compile failures, which is accurate: the
-    // benchmark is measuring what the library can actually do with
-    // the input, not what it could do with a hand-crafted fixture.
-    //
-    // Hyperjump prints unknown-format warnings to stdout on register.
-    // Swallow them so the bench output stays readable.
-    const origLog = console.log;
-    console.log = () => {};
-    try {
-      registerSchema(schema as never, uri, "https://json-schema.org/draft/2020-12/schema");
-      const t0 = performance.now();
-      await hjValidate(uri);
-      hjTimes.push(performance.now() - t0);
-    } catch (err) {
-      hjErrors.push(err instanceof Error ? err.message : String(err));
-    } finally {
-      console.log = origLog;
-      try {
-        unregisterSchema(uri);
-      } catch {
-        // registry state may already be clean; ignore.
-      }
     }
 
     try {
@@ -369,14 +365,9 @@ async function benchSpec(path: string): Promise<void> {
 
   console.log("compile (per library, aggregated across every schema):");
   row("ajv", ajvTimes, ajvErrors);
-  row("hyperjump", hjTimes, hjErrors);
   row("oav", oavTimes, oavErrors);
 
-  for (const [lib, errs] of [
-    ["ajv", ajvErrors] as const,
-    ["hyperjump", hjErrors] as const,
-    ["oav", oavErrors] as const,
-  ]) {
+  for (const [lib, errs] of [["ajv", ajvErrors] as const, ["oav", oavErrors] as const]) {
     if (errs.length === 0) continue;
     console.log(`\n${lib} compile errors:`);
     const counts = new Map<string, number>();
@@ -387,7 +378,7 @@ async function benchSpec(path: string): Promise<void> {
     if (counts.size > 5) console.log(`  … and ${counts.size - 5} other distinct error(s)`);
   }
 
-  const pushSpec = (lib: "ajv" | "hyperjump" | "oav", times: number[]): void => {
+  const pushSpec = (lib: "ajv" | "oav", times: number[]): void => {
     if (times.length === 0) return;
     const total = times.reduce((a, b) => a + b, 0);
     results.push({
@@ -399,7 +390,6 @@ async function benchSpec(path: string): Promise<void> {
     });
   };
   pushSpec("ajv", ajvTimes);
-  pushSpec("hyperjump", hjTimes);
   pushSpec("oav", oavTimes);
 }
 
@@ -413,18 +403,16 @@ if (specPath !== undefined) {
   console.log("\n=== Relative throughput (vs ajv = 1.00) ===");
   console.log(
     "schema".padEnd(14) +
-      "metric".padEnd(22) +
+      "task".padEnd(22) +
       "ajv".padEnd(8) +
       "ajv-fast".padEnd(10) +
-      "hyperjump".padEnd(12) +
       "oav".padEnd(8) +
       "oav-all".padEnd(9) +
       "oav-pred",
   );
-  console.log("-".repeat(80));
+  console.log("-".repeat(72));
   const byKey = new Map<string, Record<string, number>>();
   for (const r of results) {
-    // Distinguish validate-valid vs validate-invalid when we have variants.
     const variantLabel = r.variant ? r.variant.replace(/^\S+\s+/, "") : r.metric;
     const key = `${r.schema}|${variantLabel}`;
     const row = byKey.get(key) ?? {};
@@ -432,10 +420,9 @@ if (specPath !== undefined) {
     byKey.set(key, row);
   }
   for (const [key, row] of byKey) {
-    const [schema, metric] = key.split("|");
+    const [schema, task] = key.split("|");
     const ajv = row["ajv"] ?? 0;
     const ajvFast = row["ajv-fast"] ?? 0;
-    const hj = row["hyperjump"] ?? 0;
     const oav = row["oav"] ?? 0;
     const oavAll = row["oav-all"] ?? 0;
     const oavPred = row["oav-predicate"] ?? 0;
@@ -443,21 +430,15 @@ if (specPath !== undefined) {
     const fmt = (n: number) => (n === 0 ? "—" : (n / base).toFixed(2));
     console.log(
       (schema ?? "").padEnd(14) +
-        (metric ?? "").padEnd(22) +
+        (task ?? "").padEnd(22) +
         "1.00".padEnd(8) +
         fmt(ajvFast).padEnd(10) +
-        fmt(hj).padEnd(12) +
         fmt(oav).padEnd(8) +
         fmt(oavAll).padEnd(9) +
         fmt(oavPred),
     );
   }
 }
-
-import { mkdirSync, writeFileSync } from "node:fs";
-import { resolve, dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { execSync } from "node:child_process";
 
 const perfDir = dirname(fileURLToPath(import.meta.url));
 
@@ -471,13 +452,29 @@ function gitSha(): string {
   }
 }
 
+function ajvVersion(): string {
+  try {
+    return (createRequire(import.meta.url)("ajv/package.json") as { version: string }).version;
+  } catch {
+    return "unknown";
+  }
+}
+
 const timestamp = new Date().toISOString();
+const cpuList = cpus();
 const meta = {
   timestamp,
   commitSha: gitSha(),
   nodeVersion: process.version,
+  platform: platform(),
+  arch: arch(),
+  cpu: cpuList[0]?.model ?? "unknown",
+  cpuCount: cpuList.length,
+  ajvVersion: ajvVersion(),
   timePerTaskMs: time,
+  cooldownMs: cooldown,
   mode: specPath !== undefined ? "spec" : "synthetic",
+  specPath: specPath ?? null,
 } as const;
 const payload = JSON.stringify({ meta, results }, null, 2);
 
@@ -488,3 +485,4 @@ const outPath = join(historyDir, `${fileSafeTs}.json`);
 writeFileSync(outPath, payload);
 
 console.log(`\nRaw numbers written to ${outPath}`);
+console.log(`Render a table with:  pnpm bench:render ${outPath}`);

--- a/performance/schemas.ts
+++ b/performance/schemas.ts
@@ -51,11 +51,15 @@ const petstore: PerfSchema = {
     { id: 1, name: "Fido" },
     { id: 2, name: "Whiskers", tag: "cat", status: "available", price: 12.5 },
   ],
+  // Failure positions span early (required) → mid (a prop constraint) →
+  // deep (a nested numeric bound) → late (additionalProperties, only
+  // after every declared property is checked) → many (several at once).
   invalidInputs: [
-    { name: "Missing id" },
-    { id: 1, name: "" },
-    { id: 1, name: "Fido", extra: true },
-    { id: 1, name: "Fido", price: -1 },
+    { name: "Missing id" }, // early: required `id`
+    { id: 1, name: "" }, // mid: name minLength
+    { id: 1, name: "Fido", price: -1 }, // deep: a property's numeric minimum
+    { id: 1, name: "Fido", extra: true }, // late: additionalProperties
+    { id: 0, name: "", status: "nope", price: -5, extra: 1 }, // many: five errors at once
   ],
 };
 
@@ -89,10 +93,17 @@ const tree: PerfSchema = {
       ],
     },
   ],
+  // Failure depth spread: root-required → shallow type → one level deep
+  // → three levels into the recursion (stresses the recursive call path
+  // before failing).
   invalidInputs: [
-    { value: "not a number" },
-    { value: 1, children: [{ value: "bad" }] },
-    { label: "missing value" },
+    { label: "missing value" }, // early: required `value` at the root
+    { value: "not a number" }, // shallow: root value type
+    { value: 1, children: [{ value: "bad" }] }, // one level deep
+    {
+      value: 1,
+      children: [{ value: 2, children: [{ value: 3, children: [{ value: "deep" }] }] }],
+    }, // deep: failure three levels into the recursion
   ],
 };
 
@@ -127,11 +138,16 @@ const composition: PerfSchema = {
     { kind: "Dog", bark: "woof" },
     { kind: "Fish", fins: 2 },
   ],
+  // Spread across the oneOf dispatch: missing discriminator (fails the
+  // allOf earliest) → no branch matches → matched branch missing a
+  // required field → matched branch wrong type → matched branch deep
+  // numeric bound.
   invalidInputs: [
-    { kind: "Cat" },
-    { kind: "Lizard" },
-    { kind: "Dog", bark: 42 },
-    { kind: "Fish", fins: -1 },
+    {}, // earliest: allOf required `kind` missing
+    { kind: "Lizard" }, // no oneOf branch's const matches
+    { kind: "Cat" }, // matches Cat const, missing required `purr`
+    { kind: "Dog", bark: 42 }, // matches Dog const, wrong type for `bark`
+    { kind: "Fish", fins: -1 }, // matches Fish const, fails `fins` minimum
   ],
 };
 
@@ -148,7 +164,13 @@ const uniquePrimitives: PerfSchema = {
     items: { type: "string" },
   },
   validInputs: [makeUniqueStrings(500)],
-  invalidInputs: [makeDuplicateStrings(500)],
+  // Vary where the duplicate sits so the scan detects it early, mid, or
+  // only after a full pass.
+  invalidInputs: [
+    makeDuplicateStrings(500, 1), // early: duplicate near the start
+    makeDuplicateStrings(500, 250), // middle
+    makeDuplicateStrings(500, 499), // late: duplicate at the end (full scan)
+  ],
 };
 
 function makeUniqueStrings(n: number): string[] {
@@ -157,11 +179,11 @@ function makeUniqueStrings(n: number): string[] {
   return out;
 }
 
-function makeDuplicateStrings(n: number): string[] {
+function makeDuplicateStrings(n: number, dupAt: number): string[] {
   const out = makeUniqueStrings(n);
-  // Put the duplicate in the middle so the scan can't trivially
-  // short-circuit on the first pair.
-  out[Math.floor(n / 2)] = out[0]!;
+  // Collide out[dupAt] with out[0] so the second occurrence (the
+  // earliest point a scan can detect the duplicate) sits at `dupAt`.
+  out[dupAt] = out[0]!;
   return out;
 }
 
@@ -183,7 +205,14 @@ const arrayHeavy: PerfSchema = {
     },
   },
   validInputs: [makeValidArray(100)],
-  invalidInputs: [makeInvalidArray(100)],
+  // First-element vs last-element failure separates fast-fail (exits at
+  // the first bad item) from the cost of walking to a late failure;
+  // every-element-fails stresses full-collect (100 errors gathered).
+  invalidInputs: [
+    makeInvalidArrayAt(100, 0), // early: first element fails
+    makeInvalidArrayAt(100, 99), // late: last element fails
+    makeAllInvalidArray(100), // many: every element fails
+  ],
 };
 
 // 7. Large strings with length bounds — exercises minLength / maxLength
@@ -205,7 +234,14 @@ const longString: PerfSchema = {
     },
   },
   validInputs: [{ title: "Hello", body: makeAscii(100_000) }],
-  invalidInputs: [{ title: "", body: makeAscii(2_500_000) }],
+  // Separates a cheap early failure (empty title, body never inspected)
+  // from the expensive one (title fine, so the big maxLength count on a
+  // 2.5M-char body has to run) and the both-fail case.
+  invalidInputs: [
+    { title: "", body: makeAscii(100_000) }, // cheap/early: title minLength fails first
+    { title: "ok", body: makeAscii(2_500_000) }, // expensive: body overshoots maxLength
+    { title: "", body: makeAscii(2_500_000) }, // both fail
+  ],
 };
 
 function makeAscii(n: number): string {
@@ -220,9 +256,15 @@ function makeValidArray(n: number): Array<Record<string, unknown>> {
   return out;
 }
 
-function makeInvalidArray(n: number): Array<Record<string, unknown>> {
+function makeInvalidArrayAt(n: number, idx: number): Array<Record<string, unknown>> {
   const out = makeValidArray(n);
-  (out[n - 1] as Record<string, unknown>).id = -1;
+  (out[idx] as Record<string, unknown>).id = -1;
+  return out;
+}
+
+function makeAllInvalidArray(n: number): Array<Record<string, unknown>> {
+  const out = makeValidArray(n);
+  for (const item of out) (item as Record<string, unknown>).id = -1;
   return out;
 }
 


### PR DESCRIPTION
Refactors the `performance/` harness for reproducible, publishable runs, fixes a stale mem-bench fixture surfaced while running it, and refreshes the public perf docs from a single host-stamped run.

## Commits
- `chore(perf)`: benchmark harness refactor (drops hyperjump; ajv vs oav matrix; timestamped JSON with full provenance baked in; `render.ts` -> markdown tables). Already reviewed.
- `fix(perf)`: mem-bench oav fixture used the old `ValidationError | null` contract and crashed in `collectLeaves` on the first validation request. Now mirrors the shipped oav-express4 adapter (`result.valid` / `result.errors`). Dev-only fixture, not type-checked in CI, which is why the drift went unnoticed.
- `docs`: rebuild the perf comparison from one host-stamped run.

## The run
- **Host:** AWS c7i.large, Intel Xeon Platinum 8488C (Sapphire Rapids), 2 vCPU, Linux
- **Runtime:** Node v22.22.3, ajv 8.20.0
- **Method:** synthetic shape suite, 1000ms/task, 500ms cooldown, median of 3 runs; commit 2754996

This makes the README's long-standing `c7i.large` attribution true again: the table had been refreshed from a local machine while still claiming AWS. The harness now stamps the real host into every results JSON so the published numbers can't be mislabeled.

## Numbers (median of 3)
- **Compile:** oav 23x-287x faster than ajv across shapes.
- **Validate:** a wash in nanoseconds on typical shapes; oav fast-fail trails ajv on plain object rejection (`petstore` 61-74%), leads on `uniqueItems` (~3x), predicate mode at/above parity everywhere. `long-string` is a pathological >1000x accept-path outlier, capped and annotated.
- **Memory:** oav ~4% lighter steady-state RSS (102.5 vs 106.6 MB) and ~9% faster throughput than express-openapi-validator.

## Docs changes
- README `## How it compares`: tables replaced with a short, general note (wins some / loses some / immaterial at normal volume), pointing to the per-shape detail.
- `docs/comparison.md`: host-stamped compile / validate / memory tables; stale Stripe/Adyen compile figures (measured on a different host) dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)