### PR TITLE
feat(validator): routes accessor for spec introspection

### DIFF
--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -2,6 +2,7 @@ export {
   createRouter,
   parseTemplate,
   type MethodNotAllowed,
+  type RouteInfo,
   type RouteMatch,
   type Router,
   type Segment,

--- a/packages/router/src/matcher.ts
+++ b/packages/router/src/matcher.ts
@@ -81,6 +81,24 @@ export interface MethodNotAllowed {
 }
 
 /**
+ * A single declared operation, surfaced by {@link Router.routes}.
+ * `method` is uppercased (`"GET"`); `pathPattern` is the template
+ * exactly as declared in the spec (`"/pets/{id}"`).
+ *
+ * Lists operations actually declared on each `PathItem`; the implicit
+ * HEAD that any GET resource also answers (RFC 9110 §9.3.2) is a
+ * match-time fallback, not a declaration, so it is not enumerated here.
+ *
+ * @public
+ */
+export interface RouteInfo {
+  /** Uppercased HTTP method (e.g. `"GET"`). */
+  method: string;
+  /** Path template as declared in the spec (e.g. `"/pets/{id}"`). */
+  pathPattern: string;
+}
+
+/**
  * The router interface. `match` returns:
  *
  * - `RouteMatch`: the path matched and the method is declared on it.
@@ -93,6 +111,14 @@ export interface MethodNotAllowed {
  */
 export interface Router {
   match(method: string, path: string): RouteMatch | MethodNotAllowed | undefined;
+  /**
+   * Every declared (method, pathPattern) pair, in the router's
+   * specificity sort order (more literal segments first). Static for
+   * the router's lifetime; the same frozen array is returned each call.
+   * Used for spec introspection and cross-router overlap checks (see
+   * `@oav/validator`'s `combineValidators`).
+   */
+  routes(): readonly RouteInfo[];
 }
 
 // HTTP methods to scan on a `PathItem` when collecting `allowed` for a
@@ -292,7 +318,21 @@ export function createRouter(paths: Record<string, PathItem>): Router {
     return a.pathPattern.localeCompare(b.pathPattern);
   });
 
+  // Enumerate declared operations once, in sort order. Frozen so the
+  // accessor can hand the same array out repeatedly without copying.
+  const routeList: readonly RouteInfo[] = Object.freeze(
+    routes.flatMap((route) =>
+      ALL_METHODS.filter((m) => route.pathItem[m] !== undefined).map((m) => ({
+        method: m.toUpperCase(),
+        pathPattern: route.pathPattern,
+      })),
+    ),
+  );
+
   return {
+    routes() {
+      return routeList;
+    },
     match(method, path) {
       const normMethod = method.toLowerCase() as HttpMethod;
       const stripped = path.split("?")[0] ?? path;

--- a/packages/router/test/router.test.ts
+++ b/packages/router/test/router.test.ts
@@ -62,6 +62,31 @@ describe("router", () => {
     expect(m?.operation.operationId).toBe("mine");
   });
 
+  it("enumerates declared (method, pathPattern) pairs, uppercased, in sort order", () => {
+    const list = r.routes();
+    // Sort: more literal segments first (mine and .../tags/... both have
+    // 2), then longer paths first, then ALL_METHODS order (get before
+    // put/post) within a path.
+    expect(list).toEqual([
+      { method: "GET", pathPattern: "/pets/{id}/tags/{tag}" },
+      { method: "GET", pathPattern: "/pets/mine" },
+      { method: "GET", pathPattern: "/pets/{id}" },
+      { method: "PUT", pathPattern: "/pets/{id}" },
+      { method: "GET", pathPattern: "/pets" },
+      { method: "POST", pathPattern: "/pets" },
+    ]);
+  });
+
+  it("does not synthesize HEAD for a GET-only path", () => {
+    const getOnly = createRouter({ "/ping": { get: op("ping") } });
+    expect(getOnly.routes()).toEqual([{ method: "GET", pathPattern: "/ping" }]);
+  });
+
+  it("returns a frozen, stable array across calls", () => {
+    expect(Object.isFrozen(r.routes())).toBe(true);
+    expect(r.routes()).toBe(r.routes());
+  });
+
   it("matches methods independently on the same path", () => {
     expect(r.match("get", "/pets")?.kind).toBe("match");
     expect(r.match("post", "/pets")?.kind).toBe("match");

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -83,6 +83,7 @@ the upstream test suites live in
 | `validateFetchRequest<T>(request, opts?)`     | Convenience for Web Standards `Request`: reads URL, headers, body; returns a discriminated union with a typed body. See [docs/integration.md](../../docs/integration.md). |
 | `validateFetchResponse<T>(request, response)` | Symmetric Web Standards `Response` check. Useful for contract-testing an upstream.                                                                                        |
 | `getOperation({ method, path })`              | Startup-time introspection: returns the resolved, overlay-applied `OperationObject` + matched template for a (method, path) pair.                                         |
+| `routes`                                      | `readonly RouteInfo[]`: every declared `{ method, pathPattern }` pair (uppercased method), in route-specificity order. Frozen at construction.                            |
 | `detectedVersion`                             | The `openapi` string detected on construction, or `undefined` for an unrecognised / missing version (see `onUnknownVersion`).                                             |
 | `warnings`                                    | `readonly string[]`: warnings accumulated at construction time (`onUnknownVersion: "warn"` or `dialect`-suppressed category error). Empty when neither path fires.        |
 

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -22,6 +22,10 @@ export {
   type ValidatorOptions,
   type ValidatorStats,
 } from "./validator.js";
+// Re-exported from `@oav/router` so consumers of the validator surface
+// get the `Validator.routes` element type without reaching across into
+// the router package.
+export type { RouteInfo } from "@oav/router";
 export {
   httpRequestFromFetch,
   httpResponseFromFetch,

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -14,7 +14,7 @@ import {
   type ValidationError,
 } from "@oav/core";
 import { builtInFormats } from "@oav/formats";
-import { createRouter, type RouteMatch, type Router } from "@oav/router";
+import { createRouter, type RouteInfo, type RouteMatch, type Router } from "@oav/router";
 import { lintResolvedSpec, type SpecHygieneIssue } from "@oav/spec";
 import {
   compileSchema,
@@ -252,6 +252,21 @@ export interface Validator {
     pathItem: PathItem;
     operation: OperationObject;
   } | null;
+  /**
+   * Every operation the spec declares, as `{ method, pathPattern }`
+   * pairs in route-specificity order (more literal segments first).
+   * `method` is uppercased (`"GET"`); `pathPattern` is the template as
+   * declared (`"/pets/{id}"`). The implicit HEAD that a GET resource
+   * also answers (RFC 9110 §9.3.2) is a match-time fallback, not a
+   * declaration, so it is not listed.
+   *
+   * Startup-time introspection over the same route table the validator
+   * matches against, frozen at `createValidator` time. Useful for
+   * mounting per-route middleware, generating coverage reports, or
+   * asserting two specs are route-disjoint before
+   * {@link combineValidators} stacks them.
+   */
+  readonly routes: readonly RouteInfo[];
   /**
    * The OpenAPI version detected from the spec's `openapi` field, or
    * `undefined` when the field was missing/malformed and the validator
@@ -1138,6 +1153,7 @@ export function createValidator(
     validateFetchRequest,
     validateFetchResponse,
     getOperation,
+    routes: router.routes(),
     detectedVersion,
     output: outputMode,
     warnings,

--- a/packages/validator/test/routes.test.ts
+++ b/packages/validator/test/routes.test.ts
@@ -1,0 +1,57 @@
+import type { OpenAPIDocument } from "@oav/core";
+import { describe, expect, it } from "vitest";
+import { createValidator } from "../src/validator.js";
+
+/**
+ * `Validator.routes` is startup-time introspection over the same route
+ * table the validator matches against: every declared `{ method,
+ * pathPattern }` pair, frozen at `createValidator` time. Consumers use
+ * it to mount per-route middleware, build coverage reports, or assert
+ * two specs are route-disjoint before `combineValidators` stacks them.
+ */
+
+function spec(): OpenAPIDocument {
+  return {
+    openapi: "3.1.0",
+    info: { title: "routes", version: "1" },
+    paths: {
+      "/pets": {
+        get: { operationId: "listPets", responses: { "200": { description: "ok" } } },
+        post: { operationId: "createPet", responses: { "201": { description: "ok" } } },
+      },
+      "/pets/{id}": {
+        get: { operationId: "getPet", responses: { "200": { description: "ok" } } },
+      },
+    },
+  };
+}
+
+describe("Validator.routes", () => {
+  it("lists every declared (method, pathPattern) pair, uppercased", () => {
+    const v = createValidator(spec());
+    expect(
+      [...v.routes].sort((a, b) =>
+        (a.method + a.pathPattern).localeCompare(b.method + b.pathPattern),
+      ),
+    ).toEqual([
+      { method: "GET", pathPattern: "/pets" },
+      { method: "GET", pathPattern: "/pets/{id}" },
+      { method: "POST", pathPattern: "/pets" },
+    ]);
+  });
+
+  it("does not list the implicit HEAD that a GET resource answers", () => {
+    const v = createValidator(spec());
+    expect(v.routes.some((r) => r.method === "HEAD")).toBe(false);
+  });
+
+  it("is empty for a spec with no paths", () => {
+    const v = createValidator({ openapi: "3.1.0", info: { title: "empty", version: "1" } });
+    expect(v.routes).toEqual([]);
+  });
+
+  it("is frozen", () => {
+    const v = createValidator(spec());
+    expect(Object.isFrozen(v.routes)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Adds a `readonly routes` accessor to the `Validator` surface: every declared `{ method, pathPattern }` pair (uppercased method), in route-specificity order, frozen at construction.

```ts
const v = createValidator(spec);
v.routes; // [{ method: "GET", pathPattern: "/pets/{id}" }, { method: "POST", pathPattern: "/pets" }, ...]
```

## Why

Two motivations:

1. **Spec introspection.** Mount per-route middleware, build coverage reports, or otherwise enumerate the operation surface without re-parsing the document. Complements `getOperation`, which answers a single (method, path) lookup.
2. **Foundation for `combineValidators`.** The upcoming multi-spec composite needs each member's full route set at construction to assert the specs are route-disjoint (an opt-in `onOverlap: "error"` startup guard) and to keep 405 fidelity across the union. `getOperation` alone can't enumerate, and folds method-not-allowed into `null`.

## Shape

- New `Router.routes()` enumeration over the same sorted route table the matcher scans, so introspection and matching share one source of truth.
- Element type `RouteInfo { method, pathPattern }` defined in `@oav/router`, re-exported from `@oav/validator` (and flows through the `oav` umbrella via `export *`).
- The implicit HEAD a GET resource answers (RFC 9110 §9.3.2) is a match-time fallback, not a declaration, so it is **not** listed. Documented on both the `Router.routes` and `Validator.routes` TSDoc.

Minimal `{ method, pathPattern }` shape per the design discussion; the record widens additively later if a consumer needs the `operation` object.

## Tests

- Router: enumeration order (specificity + ALL_METHODS), no synthetic HEAD, frozen/stable array.
- Validator: declared pairs surfaced, no HEAD, empty for path-less spec, frozen.

Fully additive. No behavior change to existing paths.

First of three related PRs (this, then `combineValidators` stacked on it, then `validateResponses` #357 independently).