### PR TITLE
feat(validator): combineValidators for multi-spec validation

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -35,6 +35,7 @@ frameworks:
 - [Security / authentication](#security--authentication)
 - [Type coercion on body fields](#type-coercion-on-body-fields)
 - [Ignoring paths not in the spec](#ignoring-paths-not-in-the-spec)
+- [Validating multiple specs with one validator](#validating-multiple-specs-with-one-validator)
 
 ## What the validator expects
 
@@ -1266,6 +1267,50 @@ app.use(async (req, res, next) => {
   // ... 4xx response as usual
 });
 ```
+
+### Validating multiple specs with one validator
+
+When an app serves several OpenAPI documents (a versioned split, or
+separately-owned surfaces mounted under one server), build a validator
+per spec and stack them with `combineValidators`. The result is a
+single `Validator`, so the framework adapters consume it unchanged: one
+`validateRequests` mount instead of one per spec.
+
+```ts
+import { createValidator, combineValidators } from "@aahoughton/oav";
+
+const validator = combineValidators([createValidator(specV1), createValidator(specV2)], {
+  onOverlap: "error",
+});
+
+app.use(validateRequests(validator));
+```
+
+Each member keeps its own dialect, components, and compiled plans, so
+two specs that reuse a component name (`Error`, `Journey`) never clobber
+each other; a literal document merge would. The composite dispatches
+each request to the member that owns its route, then delegates to that
+member's `validateRequest` / `validateResponse` in full, so the owning
+member's own `ignorePaths` and content-type handling still apply.
+
+Two policies to know:
+
+- **`onOverlap`** (`"first-match"` default, or `"error"`). With
+  `"first-match"`, the earliest member in the array that owns a route
+  wins. With `"error"`, `combineValidators` asserts the members are
+  route-disjoint at construction and throws on any clash (structural, so
+  `/x/{id}` and `/x/{slug}` count as the same route). Use `"error"` when
+  the specs are supposed to be disjoint and a collision would be a bug.
+- **`ignoreUndocumented`** governs routes that _no_ member owns,
+  mirroring the single-validator option: `false` (default) yields a
+  `route` error, `true` passes. A member's own `ignoreUndocumented`
+  governs only the routes that member owns, reached through delegation.
+  So a path declared in no spec (an upload route bypassed entirely)
+  passes only when the composite is built with `ignoreUndocumented:
+true`.
+
+All members must share an `output` mode; mixing flat and tree throws at
+construction. See `CombineOptions` for the option contracts.
 
 ## Migration paths
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -7,7 +7,7 @@ further down). `oav-core` mirrors the same paths; substitute
 
 | Import                         | Surface                                                                         |
 | ------------------------------ | ------------------------------------------------------------------------------- |
-| `@aahoughton/oav`              | `createValidator`, error helpers, formatters, types                             |
+| `@aahoughton/oav`              | `createValidator`, `combineValidators`, error helpers, formatters, types        |
 | `@aahoughton/oav/schema`       | `compileSchema`, dialects, vocabularies, custom keywords                        |
 | `@aahoughton/oav/spec`         | `loadSpec`, `loadSpecSync`, `resolveSpec`, `applyOverlays`, readers             |
 | `@aahoughton/oav/overlay-spec` | `translateOverlay`, `applySpecOverlay`: OpenAPI Overlay 1.0 → typed SpecOverlay |

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -1,6 +1,7 @@
 export {
   createRouter,
   parseTemplate,
+  routeSignature,
   type MethodNotAllowed,
   type RouteInfo,
   type RouteMatch,

--- a/packages/router/src/matcher.ts
+++ b/packages/router/src/matcher.ts
@@ -255,6 +255,28 @@ function segmentSignature(s: Segment): string {
 }
 
 /**
+ * Structural signature of a path template: two templates share a
+ * signature iff they would match the same set of request paths for any
+ * choice of parameter names (`/items/{id}` and `/items/{slug}` both
+ * yield `items/\0{}`). Raw string comparison would call those two
+ * distinct; their signatures are equal.
+ *
+ * `createRouter` uses this internally to reject parameter-name-only
+ * collisions within one document. It is exported so cross-router checks
+ * (notably `@oav/validator`'s `combineValidators` route-disjointness
+ * guard) can detect the same overlap between separately-built routers,
+ * using the identical structural rule the matcher itself applies.
+ *
+ * @param pathPattern - A path template (e.g. `"/items/{id}"`).
+ * @returns A signature string; equal signatures denote overlapping routes.
+ *
+ * @public
+ */
+export function routeSignature(pathPattern: string): string {
+  return parseTemplate(pathPattern).map(segmentSignature).join("/");
+}
+
+/**
  * Build a router from a map of `pathTemplate → PathItem`. Paths with more
  * literal (non-template) segments win over more template-heavy siblings;
  * the route list is sorted once at construction, then each `match` call is

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -102,6 +102,29 @@ the upstream test suites live in
 | `ignorePaths`           | `(path: string) => boolean` predicate that short-circuits validation when it returns `true` (runs before routing).               |
 | `onUnknownVersion`      | `"fallback31"` \| `"warn"` \| `"throw"` when `openapi` is missing or unsupported. Default `"fallback31"`.                        |
 
+## Combining multiple specs
+
+`combineValidators([v1, v2, ...])` stacks several validators into one
+that dispatches each request to the member owning its route. The result
+is a `Validator`, so the framework adapters consume it unchanged.
+
+```ts
+import { createValidator, combineValidators } from "@aahoughton/oav";
+
+const validator = combineValidators(
+  [createValidator(specV1), createValidator(specV2)],
+  { onOverlap: "error" }, // assert the specs are route-disjoint at construction
+);
+```
+
+Each member keeps its own dialect and components, so specs that reuse a
+component name don't clobber each other (a literal document merge
+would). Dispatch keys on route ownership and delegates to the owner, so
+the owner's own `ignorePaths` still applies. `onOverlap` picks
+first-match (default) vs error-on-clash; `ignoreUndocumented` governs
+routes no member owns. All members must share an `output` mode. See
+`CombineOptions` and [docs/integration.md](../../docs/integration.md#validating-multiple-specs-with-one-validator).
+
 ## Custom keywords
 
 ```ts

--- a/packages/validator/src/combine.ts
+++ b/packages/validator/src/combine.ts
@@ -1,0 +1,284 @@
+import {
+  createLeafError,
+  type HttpRequest,
+  type HttpResponse,
+  type OpenAPIVersion,
+  type OperationObject,
+  type PathItem,
+} from "@oav/core";
+import { routeSignature, type RouteInfo } from "@oav/router";
+import type { SpecHygieneIssue } from "@oav/spec";
+import type { TreeValidationResult, ValidationResult } from "@oav/schema";
+import {
+  httpRequestFromFetch,
+  httpResponseFromFetch,
+  type FetchRequestOptions,
+} from "./from-fetch.js";
+import { reshapeResult, toFetchResult } from "./reshape.js";
+import type { PredicateValidator, TreeValidator, Validator, ValidatorStats } from "./validator.js";
+
+/**
+ * Options for {@link combineValidators}.
+ *
+ * The composite is itself a {@link Validator}, so its skip vocabulary
+ * mirrors {@link ValidatorOptions}: `ignoreUndocumented` and
+ * `ignorePaths` here govern routes that NO member owns (undocumented
+ * with respect to the whole composite). A route a member does own is
+ * delegated to that member, whose own `ignoreUndocumented` / `ignorePaths`
+ * still apply.
+ *
+ * @public
+ */
+export interface CombineOptions {
+  /**
+   * Policy when more than one member declares the same route (same
+   * method and structurally-equal path, so `/x/{id}` and `/x/{slug}`
+   * count as the same route).
+   *
+   * - `"first-match"` (default): the earliest member in array order
+   *   wins; later members never see the request. Mirrors the matcher's
+   *   specificity-ordered scan, lifted to the member level.
+   * - `"error"`: assert disjointness at construction. `combineValidators`
+   *   throws if any route is owned by two members, surfacing the clash
+   *   at assembly time instead of letting first-match silently shadow.
+   */
+  onOverlap?: "first-match" | "error";
+  /**
+   * No-owner skip policy. A request whose route no member owns is
+   * undocumented with respect to the composite. `false` (default,
+   * matching a single validator) produces a `route` error; `true`
+   * passes (`{ valid: true }`). Members' own
+   * {@link ValidatorOptions.ignoreUndocumented} governs only their owned
+   * routes, reached via delegation, not this no-owner case.
+   */
+  ignoreUndocumented?: boolean;
+  /**
+   * Validate-time predicate, mirroring {@link ValidatorOptions.ignorePaths}.
+   * Runs before dispatch; when it returns `true` the composite
+   * short-circuits to a valid result without consulting any member.
+   */
+  ignorePaths?: (path: string) => boolean;
+}
+
+/**
+ * The subset of the {@link Validator} surface `combineValidators` reads
+ * from its members. `Validator`, {@link TreeValidator}, and
+ * {@link PredicateValidator} are all structurally assignable to it (their
+ * narrower `validate*` returns widen into the union here), so the public
+ * overloads accept each concrete kind while the implementation works
+ * against this one shape. The Fetch wrappers are omitted deliberately:
+ * the composite rebuilds them from `validateRequest` / `validateResponse`
+ * rather than delegating, so it never calls a member's Fetch methods.
+ */
+interface CombinableValidator {
+  validateRequest(req: HttpRequest): ValidationResult | TreeValidationResult | boolean;
+  validateResponse(
+    req: HttpRequest,
+    res: HttpResponse,
+  ): ValidationResult | TreeValidationResult | boolean;
+  getOperation(req: { method: string; path: string }): {
+    pathPattern: string;
+    pathItem: PathItem;
+    operation: OperationObject;
+  } | null;
+  readonly routes: readonly RouteInfo[];
+  readonly output: "flat" | "tree" | "predicate";
+  readonly warnings: readonly string[];
+  readonly specHygieneIssues: readonly SpecHygieneIssue[];
+  readonly detectedVersion: OpenAPIVersion | undefined;
+  readonly stats: ValidatorStats;
+}
+
+/**
+ * Stack several validators into one that dispatches each request to the
+ * member that owns its route, so multiple OpenAPI documents validate
+ * through a single {@link Validator}.
+ *
+ * Built for multi-document deployments: load each spec into its own
+ * validator (each keeps its own dialect, components, and compiled
+ * plans, so cross-spec component-name clashes can't occur), then
+ * `combineValidators([a, b, c])` to get one validator the framework
+ * adapters consume unchanged. `validateRequests(combineValidators([...]))`
+ * replaces a stack of per-spec middlewares; a future `validateResponses`
+ * takes the same composite.
+ *
+ * Dispatch keys on route ownership ({@link Validator.getOperation}), not
+ * on a member's validation verdict, so a member configured with
+ * `ignoreUndocumented` can't pre-empt the member that actually owns the
+ * route. The owning member's `validateRequest` / `validateResponse` is
+ * then called in full, so its own `ignorePaths` / content-type / schema
+ * logic runs exactly as it would standalone. With no owner, the request
+ * is undocumented with respect to the composite and handled per
+ * {@link CombineOptions.ignoreUndocumented}.
+ *
+ * All members must share an `output` mode; mixing throws at construction
+ * (the composite presents one result shape). An empty array throws.
+ *
+ * @param members - Validators to combine, in first-match priority order.
+ * @param options - Overlap policy and no-owner skip policy.
+ * @returns A validator of the members' shared output kind.
+ *
+ * @example
+ * ```ts
+ * const v1 = createValidator(specV1);
+ * const v2 = createValidator(specV2);
+ * const validator = combineValidators([v1, v2], { onOverlap: "error" });
+ * app.use(validateRequests(validator));
+ * ```
+ *
+ * @public
+ */
+export function combineValidators(
+  members: TreeValidator[],
+  options?: CombineOptions,
+): TreeValidator;
+export function combineValidators(
+  members: PredicateValidator[],
+  options?: CombineOptions,
+): PredicateValidator;
+export function combineValidators(members: Validator[], options?: CombineOptions): Validator;
+export function combineValidators(
+  members: CombinableValidator[],
+  options: CombineOptions = {},
+): Validator | TreeValidator | PredicateValidator {
+  if (members.length === 0) {
+    throw new Error(
+      "combineValidators: at least one validator is required (received an empty array).",
+    );
+  }
+
+  // One output mode across all members: the composite presents a single
+  // result shape, and the typed overloads resolve to it. Mixing is a
+  // construction mistake, so fail at the seam rather than reshape per
+  // request.
+  const outputMode = members[0]!.output;
+  for (let i = 1; i < members.length; i += 1) {
+    if (members[i]!.output !== outputMode) {
+      throw new Error(
+        `combineValidators: all members must share an output mode; validators[0] is "${outputMode}" ` +
+          `but validators[${i}] is "${members[i]!.output}". Build each validator with the same \`output\` option.`,
+      );
+    }
+  }
+
+  // Optional startup assertion that the members are route-disjoint.
+  // Structural (parameter-name-insensitive), so /x/{id} and /x/{slug}
+  // count as the same routing cell, matching the matcher's own
+  // intra-document ambiguity rule.
+  if (options.onOverlap === "error") {
+    const seen = new Map<string, { index: number; pathPattern: string }>();
+    members.forEach((member, index) => {
+      for (const { method, pathPattern } of member.routes) {
+        const key = `${method}\t${routeSignature(pathPattern)}`;
+        const prior = seen.get(key);
+        if (prior !== undefined) {
+          throw new Error(
+            `combineValidators: route overlap with onOverlap: "error" — validators[${prior.index}] ` +
+              `(${method} ${prior.pathPattern}) and validators[${index}] (${method} ${pathPattern}) ` +
+              "own the same route. Make the specs path-disjoint, or drop onOverlap to let first-match win.",
+          );
+        }
+        seen.set(key, { index, pathPattern });
+      }
+    });
+  }
+
+  const ignoreUndocumented = options.ignoreUndocumented === true;
+
+  // First member that owns the route (first-match-wins by array order).
+  // Keys on getOperation (route ownership), never on a validate verdict,
+  // so a non-owning member's ignoreUndocumented / ignorePaths can't
+  // shadow the real owner.
+  const ownerFor = (req: { method: string; path: string }): CombinableValidator | undefined => {
+    for (const member of members) {
+      if (member.getOperation(req) !== null) return member;
+    }
+    return undefined;
+  };
+
+  // The composite's own no-owner result, mirroring a single validator's
+  // undocumented-route handling. A single `route` leaf, so the per-call
+  // error budget is irrelevant; Infinity keeps `truncated` false (there
+  // is nothing more to find).
+  const noOwnerResult = (req: HttpRequest): ValidationResult | TreeValidationResult | boolean => {
+    if (ignoreUndocumented) return reshapeResult(null, outputMode, Number.POSITIVE_INFINITY);
+    const error = createLeafError(
+      "route",
+      [],
+      `no route matches ${req.method.toUpperCase()} ${req.path}`,
+      { method: req.method, path: req.path },
+    );
+    return reshapeResult(error, outputMode, Number.POSITIVE_INFINITY);
+  };
+
+  const validateRequest = (req: HttpRequest): ValidationResult | TreeValidationResult | boolean => {
+    if (options.ignorePaths?.(req.path) === true) {
+      return reshapeResult(null, outputMode, Number.POSITIVE_INFINITY);
+    }
+    const owner = ownerFor(req);
+    return owner !== undefined ? owner.validateRequest(req) : noOwnerResult(req);
+  };
+
+  const validateResponse = (
+    req: HttpRequest,
+    res: HttpResponse,
+  ): ValidationResult | TreeValidationResult | boolean => {
+    if (options.ignorePaths?.(req.path) === true) {
+      return reshapeResult(null, outputMode, Number.POSITIVE_INFINITY);
+    }
+    const owner = ownerFor(req);
+    return owner !== undefined ? owner.validateResponse(req, res) : noOwnerResult(req);
+  };
+
+  const validateFetchRequest = async <T>(request: Request, fetchOptions?: FetchRequestOptions) => {
+    const { httpRequest, body } = await httpRequestFromFetch(request, fetchOptions);
+    return toFetchResult<T>(validateRequest(httpRequest), body);
+  };
+
+  const validateFetchResponse = async <T>(request: Request, response: Response) => {
+    const url = new URL(request.url);
+    const method = request.method.toUpperCase();
+    const httpRequest: HttpRequest = { method, path: url.pathname };
+    const { httpResponse, body } = await httpResponseFromFetch(response);
+    return toFetchResult<T>(validateResponse(httpRequest, httpResponse), body);
+  };
+
+  const getOperation = (req: { method: string; path: string }) => {
+    for (const member of members) {
+      const op = member.getOperation(req);
+      if (op !== null) return op;
+    }
+    return null;
+  };
+
+  // Static introspection is concatenated once (members freeze these at
+  // their own construction); `detectedVersion` collapses to the shared
+  // value or `undefined` when members disagree.
+  const firstVersion = members[0]!.detectedVersion;
+  const detectedVersion = members.every((m) => m.detectedVersion === firstVersion)
+    ? firstVersion
+    : undefined;
+
+  const combined = {
+    validateRequest,
+    validateResponse,
+    validateFetchRequest,
+    validateFetchResponse,
+    getOperation,
+    routes: Object.freeze(members.flatMap((m) => [...m.routes])),
+    detectedVersion,
+    output: outputMode,
+    warnings: Object.freeze(members.flatMap((m) => [...m.warnings])),
+    specHygieneIssues: Object.freeze(members.flatMap((m) => [...m.specHygieneIssues])),
+    // Live: response bodies compile lazily, so read members' counters on
+    // each access rather than snapshotting at construction.
+    get stats(): ValidatorStats {
+      return {
+        responseBodiesCompiled: members.reduce((n, m) => n + m.stats.responseBodiesCompiled, 0),
+        strictIssues: members.flatMap((m) => [...m.stats.strictIssues]),
+      };
+    },
+  };
+
+  return combined as unknown as Validator | TreeValidator | PredicateValidator;
+}

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -22,6 +22,7 @@ export {
   type ValidatorOptions,
   type ValidatorStats,
 } from "./validator.js";
+export { combineValidators, type CombineOptions } from "./combine.js";
 // Re-exported from `@oav/router` so consumers of the validator surface
 // get the `Validator.routes` element type without reaching across into
 // the router package.

--- a/packages/validator/test/combine.test.ts
+++ b/packages/validator/test/combine.test.ts
@@ -1,0 +1,287 @@
+import type { OpenAPIDocument } from "@oav/core";
+import { describe, expect, it } from "vitest";
+import { combineValidators } from "../src/combine.js";
+import { createValidator } from "../src/validator.js";
+
+/**
+ * `combineValidators` stacks several validators into one that dispatches
+ * each request to the member owning its route. Dispatch keys on route
+ * ownership (`getOperation`), then delegates to the owner's
+ * `validateRequest` / `validateResponse`, so a member's own
+ * `ignoreUndocumented` / `ignorePaths` still fire after dispatch. Routes
+ * no member owns are undocumented w.r.t. the composite, governed by
+ * `CombineOptions.ignoreUndocumented`.
+ */
+
+function specA(): OpenAPIDocument {
+  return {
+    openapi: "3.0.3",
+    info: { title: "A", version: "1" },
+    paths: {
+      "/a/items/{id}": {
+        get: {
+          operationId: "getItemA",
+          parameters: [
+            { name: "id", in: "path", required: true, schema: { type: "string" } },
+            { name: "q", in: "query", required: true, schema: { type: "string" } },
+          ],
+          responses: { "200": { description: "ok" } },
+        },
+      },
+    },
+  };
+}
+
+function specB(): OpenAPIDocument {
+  return {
+    openapi: "3.0.3",
+    info: { title: "B", version: "1" },
+    paths: {
+      "/b/widgets/{id}": {
+        get: {
+          operationId: "getWidgetB",
+          parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+          responses: {
+            "200": {
+              description: "ok",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    required: ["id"],
+                    properties: { id: { type: "string" } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+function flat(r: ReturnType<ReturnType<typeof createValidator>["validateRequest"]>) {
+  // Narrow the flat ValidationResult for assertions.
+  return r as { valid: boolean; errors?: { code: string; path: string[] }[]; truncated?: boolean };
+}
+
+describe("combineValidators dispatch", () => {
+  it("routes each request to the member that owns its path", () => {
+    const v = combineValidators([createValidator(specA()), createValidator(specB())]);
+
+    // Owned by A: real validation runs (q is required).
+    expect(
+      flat(v.validateRequest({ method: "GET", path: "/a/items/1", query: { q: "x" } })).valid,
+    ).toBe(true);
+    const missingQ = flat(v.validateRequest({ method: "GET", path: "/a/items/1", query: {} }));
+    expect(missingQ.valid).toBe(false);
+
+    // Owned by B.
+    expect(flat(v.validateRequest({ method: "GET", path: "/b/widgets/7" })).valid).toBe(true);
+  });
+
+  it("first-match-wins: the earliest member owning a route handles it", () => {
+    // Two specs declare the same path with different validation rules.
+    const strict: OpenAPIDocument = {
+      openapi: "3.0.3",
+      info: { title: "strict", version: "1" },
+      paths: {
+        "/shared": {
+          get: {
+            operationId: "strict",
+            parameters: [{ name: "q", in: "query", required: true, schema: { type: "string" } }],
+            responses: { "200": { description: "ok" } },
+          },
+        },
+      },
+    };
+    const lax: OpenAPIDocument = {
+      openapi: "3.0.3",
+      info: { title: "lax", version: "1" },
+      paths: {
+        "/shared": { get: { operationId: "lax", responses: { "200": { description: "ok" } } } },
+      },
+    };
+
+    const strictFirst = combineValidators([createValidator(strict), createValidator(lax)]);
+    // strict owns it first -> q required -> fails without q.
+    expect(
+      flat(strictFirst.validateRequest({ method: "GET", path: "/shared", query: {} })).valid,
+    ).toBe(false);
+
+    const laxFirst = combineValidators([createValidator(lax), createValidator(strict)]);
+    expect(
+      flat(laxFirst.validateRequest({ method: "GET", path: "/shared", query: {} })).valid,
+    ).toBe(true);
+  });
+
+  it("delegates to the owner so the owner's ignorePaths still fires after dispatch", () => {
+    // A owns /a/items/{id} but skips it via its own ignorePaths. The
+    // composite has no composite-level ignorePaths, so the only thing
+    // that can make this pass is delegation reaching A's predicate.
+    const a = createValidator(specA(), { ignorePaths: (p) => p === "/a/items/skipme" });
+    const v = combineValidators([a, createValidator(specB())]);
+    // Without the skip this would fail (q is required); the skip wins.
+    expect(
+      flat(v.validateRequest({ method: "GET", path: "/a/items/skipme", query: {} })).valid,
+    ).toBe(true);
+  });
+});
+
+describe("combineValidators no-owner policy", () => {
+  it("defaults to a route error for a path no member owns", () => {
+    const v = combineValidators([createValidator(specA()), createValidator(specB())]);
+    const r = flat(v.validateRequest({ method: "POST", path: "/uploads" }));
+    expect(r.valid).toBe(false);
+    expect(r.errors?.[0]?.code).toBe("route");
+  });
+
+  it("passes an undocumented path when ignoreUndocumented is true (upload-route bypass)", () => {
+    const v = combineValidators([createValidator(specA()), createValidator(specB())], {
+      ignoreUndocumented: true,
+    });
+    expect(flat(v.validateRequest({ method: "POST", path: "/uploads" })).valid).toBe(true);
+  });
+
+  it("composite ignorePaths short-circuits before dispatch, even for an owned route", () => {
+    const v = combineValidators([createValidator(specA()), createValidator(specB())], {
+      ignorePaths: (p) => p.startsWith("/b/"),
+    });
+    // B owns /b/widgets/{id} and would normally validate; the composite
+    // predicate skips it first.
+    expect(flat(v.validateRequest({ method: "GET", path: "/b/widgets/oops/extra" })).valid).toBe(
+      true,
+    );
+  });
+});
+
+describe("combineValidators overlap detection", () => {
+  it("onOverlap: error throws when two members declare the same route", () => {
+    expect(() =>
+      combineValidators([createValidator(specB()), createValidator(specB())], {
+        onOverlap: "error",
+      }),
+    ).toThrow(/route overlap/);
+  });
+
+  it("onOverlap: error catches structural (parameter-name-only) overlap", () => {
+    const byId: OpenAPIDocument = {
+      openapi: "3.0.3",
+      info: { title: "byId", version: "1" },
+      paths: { "/x/{id}": { get: { responses: { "200": { description: "ok" } } } } },
+    };
+    const bySlug: OpenAPIDocument = {
+      openapi: "3.0.3",
+      info: { title: "bySlug", version: "1" },
+      paths: { "/x/{slug}": { get: { responses: { "200": { description: "ok" } } } } },
+    };
+    expect(() =>
+      combineValidators([createValidator(byId), createValidator(bySlug)], { onOverlap: "error" }),
+    ).toThrow(/route overlap/);
+  });
+
+  it("onOverlap: error accepts disjoint members", () => {
+    expect(() =>
+      combineValidators([createValidator(specA()), createValidator(specB())], {
+        onOverlap: "error",
+      }),
+    ).not.toThrow();
+  });
+
+  it("disjoint methods on the same path structure do not overlap", () => {
+    const getter: OpenAPIDocument = {
+      openapi: "3.0.3",
+      info: { title: "g", version: "1" },
+      paths: { "/x/{id}": { get: { responses: { "200": { description: "ok" } } } } },
+    };
+    const poster: OpenAPIDocument = {
+      openapi: "3.0.3",
+      info: { title: "p", version: "1" },
+      paths: { "/x/{other}": { post: { responses: { "201": { description: "ok" } } } } },
+    };
+    expect(() =>
+      combineValidators([createValidator(getter), createValidator(poster)], { onOverlap: "error" }),
+    ).not.toThrow();
+  });
+});
+
+describe("combineValidators construction guards", () => {
+  it("throws on an empty array", () => {
+    expect(() => combineValidators([])).toThrow(/at least one validator/);
+  });
+
+  it("throws when members disagree on output mode", () => {
+    const flatV = createValidator(specA());
+    const treeV = createValidator(specB(), { output: "tree" });
+    expect(() => combineValidators([flatV, treeV as never])).toThrow(/share an output mode/);
+  });
+});
+
+describe("combineValidators introspection", () => {
+  it("concatenates member routes", () => {
+    const v = combineValidators([createValidator(specA()), createValidator(specB())]);
+    expect(v.routes).toEqual([
+      { method: "GET", pathPattern: "/a/items/{id}" },
+      { method: "GET", pathPattern: "/b/widgets/{id}" },
+    ]);
+    expect(Object.isFrozen(v.routes)).toBe(true);
+  });
+
+  it("getOperation resolves through the owning member", () => {
+    const v = combineValidators([createValidator(specA()), createValidator(specB())]);
+    expect(v.getOperation({ method: "GET", path: "/b/widgets/9" })?.operation.operationId).toBe(
+      "getWidgetB",
+    );
+    expect(v.getOperation({ method: "GET", path: "/nope" })).toBeNull();
+  });
+
+  it("reports the shared detectedVersion, or undefined when members disagree", () => {
+    const same = combineValidators([createValidator(specA()), createValidator(specB())]);
+    expect(same.detectedVersion).toBe("3.0");
+
+    const mixed = combineValidators([
+      createValidator(specA()),
+      createValidator({ ...specB(), openapi: "3.1.0" }),
+    ]);
+    expect(mixed.detectedVersion).toBeUndefined();
+  });
+
+  it("aggregates stats live as members lazily compile response bodies", () => {
+    const v = combineValidators([createValidator(specA()), createValidator(specB())]);
+    expect(v.stats.responseBodiesCompiled).toBe(0);
+    // Drive a response-body compile on member B.
+    v.validateResponse(
+      { method: "GET", path: "/b/widgets/1" },
+      { status: 200, contentType: "application/json", body: { id: "ok" } },
+    );
+    expect(v.stats.responseBodiesCompiled).toBe(1);
+  });
+});
+
+describe("combineValidators output modes", () => {
+  it("preserves tree output across the composite", () => {
+    const v = combineValidators([
+      createValidator(specA(), { output: "tree" }),
+      createValidator(specB(), { output: "tree" }),
+    ]);
+    const owned = v.validateRequest({ method: "GET", path: "/a/items/1", query: { q: "x" } });
+    expect(owned).toEqual({ valid: true });
+    const noOwner = v.validateRequest({ method: "GET", path: "/nope" }) as {
+      valid: boolean;
+      error?: { code: string };
+    };
+    expect(noOwner.valid).toBe(false);
+    expect(noOwner.error?.code).toBe("route");
+  });
+
+  it("preserves predicate output across the composite", () => {
+    const v = combineValidators([
+      createValidator(specA(), { output: "predicate" }),
+      createValidator(specB(), { output: "predicate" }),
+    ]);
+    expect(v.validateRequest({ method: "GET", path: "/a/items/1", query: { q: "x" } })).toBe(true);
+    expect(v.validateRequest({ method: "GET", path: "/a/items/1", query: {} })).toBe(false);
+    expect(v.validateRequest({ method: "GET", path: "/nope" })).toBe(false);
+  });
+});


### PR DESCRIPTION
> **Stacked on #368** (routes accessor). Review/merge that first; this PR's base is `feat/validator-routes-accessor`, so its diff is clean against it. Once #368 merges, GitHub retargets this to `main`.

## What

`combineValidators([v1, v2, ...], options?)` stacks several validators into one that dispatches each request to the member owning its route. The result is itself a `Validator`, so the framework adapters consume it unchanged.

```ts
const validator = combineValidators(
  [createValidator(specV1), createValidator(specV2)],
  { onOverlap: "error" },
);
app.use(validateRequests(validator)); // one mount, not one per spec
```

## Why not a document merge

Members keep their own dialect, components, and compiled plans. Specs that reuse a component name (`Error`, `Journey`, ...) — common across a v1/v2 split — would silently clobber each other under a literal merge; here they stay isolated. The composite only adds a dispatch layer on top.

## Design (locked in the design thread)

- **Dispatch on route ownership, not validation verdict.** `ownerFor` finds the first member whose `getOperation` is non-null, then delegates to that member's `validateRequest` / `validateResponse` in full. This is load-bearing: a non-owning member built with `ignoreUndocumented: true` would otherwise return `valid` and shadow the real owner. Delegating (rather than short-circuiting on `getOperation`) is also what lets the owner's own `ignorePaths` fire after dispatch — `getOperation` ignores `ignorePaths`, but the delegated `validateRequest` honors it.
- **`onOverlap`** `"first-match"` (default) | `"error"`. `"error"` asserts route-disjointness at construction via `Router.routes` (#368) + a new `routeSignature()` helper, so it's **structural**: `/x/{id}` and `/x/{slug}` count as the same route, matching the matcher's own intra-document ambiguity rule. Per-request would only catch exercised collisions; this is a true startup guard.
- **`ignoreUndocumented`** (default `false`) governs routes **no** member owns. `false` → `route` error, `true` → pass, mirroring the single-validator option exactly (reproduced via `reshapeResult`, so the no-owner result shape is byte-identical across flat/tree/predicate). A member's own `ignoreUndocumented` governs only its owned routes, via delegation. This is what keeps undeclared upload routes passing when the composite is built with `ignoreUndocumented: true`.
- **`ignorePaths`** validate-time short-circuit before dispatch.
- **Mixed `output` modes throw** at construction (the composite presents one result shape; the typed overloads resolve to it). Empty array throws.
- **Introspection** aggregates: `routes` / `warnings` / `specHygieneIssues` concatenated and frozen; `detectedVersion` collapses to the shared value or `undefined`; `stats` is a live getter (response bodies compile lazily, so it reads members' counters on each access).

## Tests

18 cases: disjoint dispatch, first-match-wins, delegated `ignorePaths`, no-owner default error, `ignoreUndocumented` upload bypass, composite `ignorePaths`, exact + structural overlap throw, disjoint-methods no-overlap, empty-array / mixed-mode guards, introspection aggregation, live stats, tree + predicate output preserved.

Full suite green (1318 tests), typecheck, lint, `check:deps` all pass.

Second of three PRs (#368 → this → `validateResponses` #357 independently).