### PR TITLE
fix(core): accept flat lists in formatSummary/countErrors/toJsonObject; fix stale docs

### DIFF
--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -66,23 +66,33 @@ export function formatText(
  * constructed (deep-cloned `children`, `path`, and `params`), so it
  * round-trips losslessly through `JSON.stringify` / `JSON.parse`.
  *
- * @param error - Root of the error tree.
- * @returns The same tree, safe to hand to `JSON.stringify`.
+ * Accepts either a single tree root or the flat leaf list the default
+ * (flat-output) validator returns; a list round-trips to a list.
+ *
+ * @param error - Root of the error tree, or a flat list of errors.
+ * @returns The same tree (or list), safe to hand to `JSON.stringify`.
  *
  * @example
  * ```ts
  * JSON.stringify(toJsonObject(rootError), null, 2);
+ * JSON.stringify(toJsonObject(result.errors), null, 2); // flat output
  * ```
  *
  * @public
  */
-export function toJsonObject(error: ValidationError): ValidationError {
+export function toJsonObject(error: ValidationError): ValidationError;
+export function toJsonObject(error: readonly ValidationError[]): ValidationError[];
+export function toJsonObject(
+  error: ValidationError | readonly ValidationError[],
+): ValidationError | ValidationError[] {
+  if (Array.isArray(error)) return error.map((e) => toJsonObject(e));
+  const e = error as ValidationError;
   return {
-    code: error.code,
-    path: [...error.path],
-    message: error.message,
-    params: { ...error.params },
-    children: error.children.map(toJsonObject),
+    code: e.code,
+    path: [...e.path],
+    message: e.message,
+    params: { ...e.params },
+    children: e.children.map((c) => toJsonObject(c)),
   };
 }
 
@@ -129,9 +139,11 @@ export interface FormatSummaryOptions {
 }
 
 /**
- * Render a {@link ValidationError} tree as a string. The workhorse for
+ * Render validation errors as a one-line string. The workhorse for
  * HTTP response-body `message` fields, log lines, error-monitoring
- * titles, and `Error.message`.
+ * titles, and `Error.message`. Accepts either a nested error tree
+ * (`output: "tree"`) or the flat leaf list the default validator
+ * returns.
  *
  * Two output shapes depending on {@link FormatSummaryOptions.select}:
  *
@@ -172,11 +184,18 @@ export interface FormatSummaryOptions {
  *
  * @public
  */
-export function formatSummary(error: ValidationError, options: FormatSummaryOptions = {}): string {
+export function formatSummary(
+  error: ValidationError | readonly ValidationError[],
+  options: FormatSummaryOptions = {},
+): string {
   const select = options.select ?? "first";
-  // collectLeaves defines a leaf as any node with no children, so even
-  // a single-leaf root yields one entry; leaves[0] is always present.
-  const leaves = collectLeaves(error);
+  // Accept either a single tree root or the flat leaf list the default
+  // (flat-output) validator returns. collectLeaves defines a leaf as any
+  // node with no children, so a single-leaf root yields one entry; an
+  // empty list yields none, hence the guard below before `leaves[0]`.
+  const leaves = Array.isArray(error) ? error : collectLeaves(error as ValidationError);
+
+  if (leaves.length === 0) return "";
 
   if (select === "all") {
     const separator = options.separator ?? "\n";
@@ -212,21 +231,27 @@ export function formatSummary(error: ValidationError, options: FormatSummaryOpti
 
 /**
  * Count the nodes in a {@link ValidationError} tree (branches + leaves).
+ * Accepts a flat list too, in which case it sums the node count of each
+ * root.
  *
- * @param error - Root of the error tree.
+ * @param error - Root of the error tree, or a flat list of errors.
  * @returns The total node count.
  *
  * @example
  * ```ts
  * countErrors(rootError); // 7
+ * countErrors(result.errors); // flat output: one node per leaf
  * ```
  *
  * @public
  */
-export function countErrors(error: ValidationError): number {
+export function countErrors(error: ValidationError | readonly ValidationError[]): number {
   let n = 0;
-  walkErrors(error, () => {
-    n += 1;
-  });
+  const roots = Array.isArray(error) ? error : [error as ValidationError];
+  for (const root of roots) {
+    walkErrors(root, () => {
+      n += 1;
+    });
+  }
   return n;
 }

--- a/packages/core/src/http-status.ts
+++ b/packages/core/src/http-status.ts
@@ -55,9 +55,9 @@ export const DEFAULT_HTTP_STATUS_MAP: HttpStatusMap = {
  * ```ts
  * import { httpStatusFor } from "@aahoughton/oav";
  *
- * const err = validator.validateRequest(httpRequest);
- * if (err !== null) {
- *   res.status(httpStatusFor(err)).json(toProblemDetails(err));
+ * const result = validator.validateRequest(httpRequest);
+ * if (!result.valid) {
+ *   res.status(httpStatusFor(result.errors)).json(toProblemDetails(result.errors));
  * }
  * ```
  *

--- a/packages/core/src/problem-details.ts
+++ b/packages/core/src/problem-details.ts
@@ -136,11 +136,11 @@ export function collectIssues(
  * @example
  * ```ts
  * // Express 5
- * const err = validator.validateRequest(httpRequest);
- * if (err !== null) {
+ * const result = validator.validateRequest(httpRequest);
+ * if (!result.valid) {
  *   res.status(400)
  *      .type("application/problem+json")
- *      .json(toProblemDetails(err, { instance: req.originalUrl }));
+ *      .json(toProblemDetails(result.errors, { instance: req.originalUrl }));
  * }
  * ```
  *

--- a/packages/core/test/format.test.ts
+++ b/packages/core/test/format.test.ts
@@ -71,6 +71,15 @@ describe("countErrors", () => {
   it("counts branches and leaves", () => {
     expect(countErrors(sampleTree())).toBe(6);
   });
+
+  it("sums node counts across a flat list (default output)", () => {
+    const flat = [
+      createLeafError("type", ["body", "age"], "must be number"),
+      createLeafError("required", ["body"], "missing name"),
+    ];
+    expect(countErrors(flat)).toBe(2);
+    expect(countErrors([])).toBe(0);
+  });
 });
 
 describe("toJsonObject", () => {
@@ -89,6 +98,17 @@ describe("toJsonObject", () => {
     if (firstChild === undefined) throw new Error("unreachable");
     firstChild.message = "mutated";
     expect(tree.children[0]?.message).not.toBe("mutated");
+  });
+
+  it("round-trips a flat list to a list (default output)", () => {
+    const flat = [
+      createLeafError("type", ["body", "age"], "must be number"),
+      createLeafError("required", ["body"], "missing name"),
+    ];
+    const cloned = toJsonObject(flat);
+    expect(Array.isArray(cloned)).toBe(true);
+    expect(JSON.parse(JSON.stringify(cloned))).toEqual(flat);
+    expect(cloned).not.toBe(flat);
   });
 });
 
@@ -171,6 +191,24 @@ describe("formatSummary", () => {
   it("renders a path-less leaf as just the message", () => {
     const tree = createLeafError("route", [], "no matching route");
     expect(formatSummary(tree)).toBe("no matching route");
+  });
+
+  it("accepts a flat list (default output) and treats elements as leaves", () => {
+    const flat = [
+      createLeafError("type", ["body", "age"], "must be number"),
+      createLeafError("required", ["body"], "missing name"),
+    ];
+    expect(formatSummary(flat)).toBe("body.age must be number");
+    expect(formatSummary(flat, { select: "deepest" })).toBe("body.age must be number");
+    expect(formatSummary(flat, { select: "all" })).toBe(
+      "body.age must be number [type]\nbody missing name [required]",
+    );
+    expect(formatSummary(flat, { select: { byCode: ["required"] } })).toBe("body missing name");
+  });
+
+  it("returns an empty string for an empty list", () => {
+    expect(formatSummary([])).toBe("");
+    expect(formatSummary([], { select: "all" })).toBe("");
   });
 });
 

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -114,7 +114,9 @@ export interface Validator {
    *
    * Each error's `path` is prefixed with its HTTP location: `["body",
    * …]`, `["query", name]`, `["header", name]`, `["cookie", name]`,
-   * `["path-param", name]`, or `["security"]`. Route and method
+   * `["path", name]`, or `["security"]`. (The matching error `code` is
+   * `query-param` / `header-param` / `cookie-param` / `path-param`; the
+   * path segment drops the `-param` suffix.) Route and method
    * mismatches surface as `route` / `method` leaves; see
    * {@link httpStatusFor} for the canonical status mapping.
    *


### PR DESCRIPTION
## What

Closes the two non-breaking findings from the API consistency audit (M1 + M2).

### M1: error-helper input contracts were split

The default validator (`output: "flat"`) returns a flat `ValidationError[]`, but the core error helpers were inconsistent about whether they accepted a list:

| Accepted `ValidationError \| readonly ValidationError[]` | Accepted only a single tree root |
|---|---|
| `formatText`, `collectIssues`, `toProblemDetails`, `httpStatusFor`, `allowHeaderFor` | `formatSummary`, `countErrors`, `toJsonObject`, `formatError` |

A caller holding `result.errors` could pass it to the left column but not the right, with no predictable line between the two. This widens `formatSummary`, `countErrors`, and `toJsonObject` to accept both, following the existing `Array.isArray(error) ? error : collectLeaves(error)` convention used by the left column.

- `formatSummary` returns `""` for an empty list.
- `toJsonObject` uses overloads: single → single, list → list.
- `countErrors` sums the node count of each root.

**`formatError` / `ErrorRenderer` are intentionally left tree-only.** Widening the `ErrorRenderer` parameter type (`(err: ValidationError) => string`) would break existing custom renderers by contravariance, so that one stays single-tree; callers with a flat list use `formatSummary` directly. Flagged here so the asymmetry is a documented decision rather than an oversight.

### M2: three stale TSDoc contracts

- `toProblemDetails` and `httpStatusFor` examples showed the removed v2 nullable-return shape (`if (err !== null)`), which no longer typechecks. Updated to the `{ valid, errors }` shape.
- `Validator.validateRequest` documented the path-param path prefix as `["path-param", name]`. The code emits `["path", name]` (validate-step.ts:63); the `-param` suffix is on the error **code**, not the path segment. The doc now matches emitted behavior and notes the code/path-segment distinction.

## Why non-breaking

Widening a parameter type is additive: every existing single-tree call still typechecks and behaves identically. No public signature is narrowed or removed; no major bump.

## Tests

Added list-input cases to `packages/core/test/format.test.ts` for `formatSummary` (first / deepest / all / byCode / empty), `countErrors` (sum + empty), and `toJsonObject` (list round-trips to list). Full suite: 1373 passing. `pnpm typecheck` and `pnpm lint` clean.

## Follow-ups (filed separately as `polish`)

The audit's remaining moderate findings (M4 `"flat"` overload, M5 `httpRequestFrom*`/`httpResponseFrom*` asymmetry, M6 param-name nits) are tracked as separate `polish` issues; none are addressed here.