### PR TITLE
docs(core): document formatError's tree-only contract and the flat-list recipe

### DIFF
--- a/docs/migration-v3.md
+++ b/docs/migration-v3.md
@@ -155,10 +155,29 @@ Use `output: "flat"` (default) or `"tree"`.
 
 ## 7. Problem-details and formatters accept a leaf list
 
-`httpStatusFor`, `allowHeaderFor`, `toProblemDetails`, `collectIssues`, and
-`formatText` now accept either a single `ValidationError` (tree) or a
-`ValidationError[]` (flat). Existing tree calls are unchanged; the new flat
-overload lets the same wiring serve either `output`.
+`httpStatusFor`, `allowHeaderFor`, `toProblemDetails`, `collectIssues`,
+`formatText`, `formatSummary`, `countErrors`, and `toJsonObject` accept
+either a single `ValidationError` (tree) or a `ValidationError[]` (flat).
+Existing tree calls are unchanged; the flat form lets the same wiring serve
+either `output`.
+
+`formatError` is the one exception: it renders a single tree. It backs the
+CLI `--format` flag and a custom `ErrorRenderer`, which is typed
+`(err: ValidationError) => string`; widening that parameter would break
+existing renderers, so the function stays tree-only. For the default flat
+output, call `formatText`, `formatSummary`, or `toJsonObject` on the list
+directly. If you specifically need `formatError` (a named built-in format or
+a custom renderer), wrap the list in a root first:
+
+```ts
+import { createBranchError, formatError } from "@aahoughton/oav";
+
+const result = validator.validateRequest(httpRequest);
+if (!result.valid) {
+  const root = createBranchError("request", [], "request validation failed", result.errors);
+  console.error(formatError(root, "text"));
+}
+```
 
 ## 8. `undefined`-valued properties count as absent
 

--- a/packages/core/src/format-output.ts
+++ b/packages/core/src/format-output.ts
@@ -44,6 +44,16 @@ export type ErrorRenderer = (err: ValidationError) => string;
  * library consumers plug in SARIF / RFC 7807 / JUnit renderers without
  * forking the dispatch switch.
  *
+ * @remarks
+ * Takes a single error tree, unlike {@link formatText},
+ * {@link formatSummary}, and {@link toJsonObject}, which also accept the
+ * flat `ValidationError[]` the default validator returns. `formatError`
+ * stays tree-only because a custom {@link ErrorRenderer} is typed
+ * `(err: ValidationError) => string`, and widening that would break
+ * existing renderers. For the default flat output, call those helpers
+ * directly, or wrap the list with {@link createBranchError} before passing
+ * it here.
+ *
  * @param err - The error tree.
  * @param renderer - A built-in format name or a custom render function.
  * @param depth - Optional max depth (applies to `"text"` format only).

--- a/packages/core/test/format-output.test.ts
+++ b/packages/core/test/format-output.test.ts
@@ -30,6 +30,19 @@ describe("formatError", () => {
     const out = formatError(sample, (err) => `custom:${err.code}:${err.children.length}`);
     expect(out).toBe("custom:request:1");
   });
+
+  // The documented recipe for rendering the default flat output through
+  // formatError (which is tree-only): wrap the leaf list in a root. See
+  // docs/migration-v3.md section 7.
+  it("renders a wrapped flat list via the createBranchError recipe", () => {
+    const flat = [
+      createLeafError("type", ["body", "age"], "must be number"),
+      createLeafError("required", ["body"], "missing name"),
+    ];
+    const root = createBranchError("request", [], "request validation failed", flat);
+    expect(formatError(root, "flat").split("\n")).toHaveLength(2);
+    expect(JSON.parse(formatError(root, "json")).children).toHaveLength(2);
+  });
 });
 
 describe("isOutputFormat", () => {


### PR DESCRIPTION
Follow-up to #373. That PR widened `formatSummary` / `countErrors` / `toJsonObject` to accept the default flat `ValidationError[]`, but deliberately left `formatError` / `ErrorRenderer` tree-only (widening the custom-renderer parameter `(err: ValidationError) => string` would break existing renderers by contravariance).

#373 left that exclusion as an undocumented gap, and it also made `docs/migration-v3.md` section 7 stale: that section enumerates which helpers accept a leaf list, and it still listed only the original five.

This closes both:

- **`docs/migration-v3.md` section 7:** lists every list-accepting helper (now including `formatSummary` / `countErrors` / `toJsonObject`), calls out `formatError` as the one exception with the reason, and shows the `createBranchError` wrap recipe for callers who specifically need `formatError` on flat output.
- **`formatError` TSDoc `@remarks`:** the same contract, on the canonical type (per the repo's "TSDoc is canonical contract, prose docs are recipes" rule).
- **Test:** locks the documented wrap recipe (`createBranchError(...)` → `formatError`).

Docs + TSDoc + one test only; no runtime behavior change. `pnpm test` / `typecheck` / `lint` clean.