### PR TITLE
feat(core): formatSummary path option for self-locating leaves

### DIFF
--- a/docs/migration-from-eov.md
+++ b/docs/migration-from-eov.md
@@ -222,6 +222,35 @@ the trailing ` [<code>]`. Both are ignored under single-leaf modes
 (`first` / `deepest` / `byCode`). See
 [`FormatSummaryOptions`](../packages/core/src/format.ts) for the type.
 
+### Avoiding the path/message stutter on missing-parameter errors
+
+The leaves `oav`'s validator emits for HTTP-level failures (missing
+required parameter or body, unknown query key, content-type mismatch,
+security) name their location in the message itself, so the default
+`<path> <message>` rendering repeats the field name:
+
+```
+query.persona missing required query parameter "persona"
+```
+
+`eov`/ajv never stutter here because they point the path at the
+parent. `oav` keeps the leaf path on the field (it's the
+machine-stable handle; `params.name` carries the name too) and fixes
+the rendering instead. `path: "auto"` drops the prefix for exactly
+those self-locating leaves and keeps it for value errors, where the
+path is load-bearing:
+
+```ts
+formatSummary(err, { path: "auto" });
+// missing required query parameter "persona"     (was: query.persona missing ...)
+// body.users[0].email must match format "email"  (unchanged)
+```
+
+The affected code set is published as `SELF_LOCATING_ERROR_CODES`;
+its TSDoc states the contract (a leaf with one of these codes always
+locates the error in its message; parameter value failures always
+carry schema-keyword codes instead).
+
 One delta from `eov` remains. `oav` uses dotted paths
 (`body.users[0].email`) where `eov` uses slash-separated
 (`request/body/users/0/email`). If your client pattern-matches on the

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -81,7 +81,7 @@ Detail:
 - **`formatText(err, { maxDepth?, indent? })`**: indented
   human-readable tree. One line per node.
 
-- **`formatSummary(err, { select? })`**: render the tree as a
+- **`formatSummary(err, { select?, path? })`**: render the tree as a
   string. Default picks one leaf and renders it as
   `<dotted-path> <message>` (e.g. `"body.users[0].email must match
 format \"email\""`). Selection options:
@@ -98,6 +98,14 @@ format \"email\""`). Selection options:
     highest-priority listed code; falls back to `"first"` if no
     match. Useful when the wire format wants to surface specific
     failure categories first.
+
+  `path: "auto"` drops the dotted-path prefix on leaves whose message
+  already names its location (the `SELF_LOCATING_ERROR_CODES` family:
+  missing parameter / body, unknown query key, content-type,
+  security), turning `query.persona missing required query parameter
+  "persona"` into `missing required query parameter "persona"` while
+  value errors keep their path. Default `"always"` keeps the prefix
+  everywhere.
 
 - **`toJsonObject(err)`**: deep copy that round-trips losslessly
   through `JSON.stringify` / `JSON.parse`.

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -243,6 +243,47 @@ export const BUILT_IN_ERROR_CODES = [
 ] as const satisfies ReadonlyArray<keyof BuiltInErrorParams>;
 
 /**
+ * The subset of {@link BUILT_IN_ERROR_CODES} whose leaves carry
+ * self-locating messages: the message alone names what failed and
+ * where (`missing required query parameter "persona"`, `missing
+ * required request body`), so prefixing the leaf's path restates it.
+ * {@link formatSummary} consults this set under `path: "auto"`.
+ *
+ * The contract renderers may rely on: a leaf with one of these codes
+ * always locates the error in its message. In particular, parameter
+ * VALUE failures (a query param failing `format` or `pattern`, a
+ * mis-serialized deepObject) are never reported under a `*-param`
+ * code; they surface as schema-keyword leaves (`type`, `format`, ...)
+ * whose generic message needs the path prefix. The `*-param` codes
+ * cover only the validator-emitted modes: missing-required, unknown
+ * key under `strictQueryParameters`, and `content` media-type parse
+ * failures, all of which quote the parameter name. `route`, `method`,
+ * and `status` belong here trivially (their paths are empty).
+ *
+ * The branch codes `request` and `response` are excluded: they never
+ * appear as leaves, so summary renderers never see them.
+ *
+ * Guarded by tests on both sides: this package asserts the subset
+ * relation, and `@oav/validator`'s error-codes suite asserts every
+ * emitted leaf with one of these codes names its location in the
+ * message.
+ *
+ * @public
+ */
+export const SELF_LOCATING_ERROR_CODES = [
+  "route",
+  "method",
+  "body",
+  "content-type",
+  "status",
+  "path-param",
+  "query-param",
+  "header-param",
+  "cookie-param",
+  "security",
+] as const satisfies ReadonlyArray<keyof BuiltInErrorParams>;
+
+/**
  * Type helper that narrows `ValidationError.params` for a specific
  * `code`. The generic parameter must be a key of
  * {@link BuiltInErrorParams}.

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -1,4 +1,12 @@
-import { collectLeaves, joinPath, walkErrors, type ValidationError } from "./errors.js";
+import {
+  SELF_LOCATING_ERROR_CODES,
+  collectLeaves,
+  joinPath,
+  walkErrors,
+  type ValidationError,
+} from "./errors.js";
+
+const SELF_LOCATING = new Set<string>(SELF_LOCATING_ERROR_CODES);
 
 /**
  * Options accepted by the text/flat formatters.
@@ -136,6 +144,18 @@ export interface FormatSummaryOptions {
    * on single-leaf modes (which never include the code).
    */
   includeCode?: boolean;
+  /**
+   * Path-prefix policy. `"always"` (the default) prefixes every leaf
+   * with its dotted path. `"auto"` drops the prefix for leaves whose
+   * code is in {@link SELF_LOCATING_ERROR_CODES}, the HTTP-level codes
+   * whose message already names the failing parameter / body / check,
+   * so `query.persona missing required query parameter "persona"`
+   * renders as `missing required query parameter "persona"`.
+   * Schema-keyword leaves (`type`, `enum`, ...) keep the prefix; their
+   * generic messages need it. Applies to single-leaf modes and to each
+   * line under `select: "all"`.
+   */
+  path?: "always" | "auto";
 }
 
 /**
@@ -155,6 +175,11 @@ export interface FormatSummaryOptions {
  *   each rendered as `<dotted-path> <message> [<code>]`. The trailing
  *   ` [<code>]` is suppressed when {@link FormatSummaryOptions.includeCode}
  *   is `false`. Tune both for `eov`-style flat output.
+ *
+ * In both shapes, {@link FormatSummaryOptions.path} `: "auto"` drops the
+ * dotted-path prefix on leaves whose message already names its location
+ * (the {@link SELF_LOCATING_ERROR_CODES} family), avoiding renderings
+ * like `query.persona missing required query parameter "persona"`.
  *
  * For the indented full-tree view, use {@link formatText}; for the raw
  * JSON-safe object, use {@link toJsonObject}.
@@ -180,6 +205,11 @@ export interface FormatSummaryOptions {
  * formatSummary(rootError, { select: { byCode: ["content-type", "required"] } });
  * // The first content-type leaf if any, else the first required leaf,
  * // else the first leaf overall.
+ *
+ * formatSummary(missingParamError, { path: "auto" });
+ * // "missing required query parameter \"persona\"" (no `query.persona`
+ * // prefix; the message locates itself). Value errors keep the prefix:
+ * // "body.users[0].email must match format \"email\"".
  * ```
  *
  * @public
@@ -189,6 +219,9 @@ export function formatSummary(
   options: FormatSummaryOptions = {},
 ): string {
   const select = options.select ?? "first";
+  const path = options.path ?? "always";
+  const locationOf = (leaf: ValidationError): string =>
+    path === "auto" && SELF_LOCATING.has(leaf.code) ? "" : joinPath(leaf.path);
   // Accept either a single tree root or the flat leaf list the default
   // (flat-output) validator returns. collectLeaves defines a leaf as any
   // node with no children, so a single-leaf root yields one entry; an
@@ -202,7 +235,7 @@ export function formatSummary(
     const includeCode = options.includeCode ?? true;
     const lines: string[] = [];
     for (const leaf of leaves) {
-      const location = joinPath(leaf.path);
+      const location = locationOf(leaf);
       const pathPart = location.length > 0 ? `${location} ` : "";
       const codePart = includeCode ? ` [${leaf.code}]` : "";
       lines.push(`${pathPart}${leaf.message}${codePart}`);
@@ -225,7 +258,7 @@ export function formatSummary(
     }
   }
 
-  const location = joinPath(chosen.path);
+  const location = locationOf(chosen);
   return location.length > 0 ? `${location} ${chosen.message}` : chosen.message;
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export {
   BUILT_IN_ERROR_CODES,
+  SELF_LOCATING_ERROR_CODES,
   collectLeaves,
   createBranchError,
   createError,

--- a/packages/core/test/errors.test.ts
+++ b/packages/core/test/errors.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, expectTypeOf } from "vitest";
 import {
+  BUILT_IN_ERROR_CODES,
+  SELF_LOCATING_ERROR_CODES,
   collectLeaves,
   createBranchError,
   createError,
@@ -169,6 +171,26 @@ describe("BuiltInErrorParams", () => {
     if (err.code === "required") {
       const p = err.params as ErrorParamsFor<"required">;
       expect(p.missing).toBe("name");
+    }
+  });
+});
+
+describe("SELF_LOCATING_ERROR_CODES", () => {
+  it("is a subset of BUILT_IN_ERROR_CODES", () => {
+    const documented = new Set<string>(BUILT_IN_ERROR_CODES);
+    for (const code of SELF_LOCATING_ERROR_CODES) {
+      expect(documented).toContain(code);
+    }
+  });
+
+  it("excludes the branch-only and schema-keyword codes", () => {
+    const set = new Set<string>(SELF_LOCATING_ERROR_CODES);
+    // Branches never reach a leaf renderer.
+    expect(set).not.toContain("request");
+    expect(set).not.toContain("response");
+    // Keyword leaves carry generic messages; the path is load-bearing.
+    for (const code of ["type", "enum", "format", "required", "pattern"]) {
+      expect(set).not.toContain(code);
     }
   });
 });

--- a/packages/core/test/format.test.ts
+++ b/packages/core/test/format.test.ts
@@ -167,6 +167,56 @@ describe("formatSummary", () => {
     );
   });
 
+  it('path: "auto" drops the prefix for self-locating HTTP-level leaves', () => {
+    const missingParam = createLeafError(
+      "query-param",
+      ["query", "persona"],
+      'missing required query parameter "persona"',
+      { name: "persona", in: "query" },
+    );
+    const missingBody = createLeafError("body", ["body"], "missing required request body");
+    expect(formatSummary([missingParam], { path: "auto" })).toBe(
+      'missing required query parameter "persona"',
+    );
+    expect(formatSummary([missingBody], { path: "auto" })).toBe("missing required request body");
+    // Default and explicit "always" keep the (stuttering) prefix.
+    expect(formatSummary([missingParam])).toBe(
+      'query.persona missing required query parameter "persona"',
+    );
+    expect(formatSummary([missingParam], { path: "always" })).toBe(
+      'query.persona missing required query parameter "persona"',
+    );
+  });
+
+  it('path: "auto" keeps the prefix on schema-keyword leaves', () => {
+    const typeLeaf = createLeafError("type", ["body", "outer", "inner"], "must be string");
+    expect(formatSummary([typeLeaf], { path: "auto" })).toBe("body.outer.inner must be string");
+    // The format/"email" trap: a field named like its format must keep
+    // its path; this is why "auto" keys on the code, not the message.
+    const emailLeaf = createLeafError("format", ["body", "email"], 'must match format "email"');
+    expect(formatSummary([emailLeaf], { path: "auto" })).toBe(
+      'body.email must match format "email"',
+    );
+  });
+
+  it('path: "auto" applies per leaf under select: "all"', () => {
+    const leaves = [
+      createLeafError(
+        "query-param",
+        ["query", "persona"],
+        'missing required query parameter "persona"',
+        {
+          name: "persona",
+          in: "query",
+        },
+      ),
+      createLeafError("type", ["body", "age"], "must be number"),
+    ];
+    expect(formatSummary(leaves, { select: "all", path: "auto" })).toBe(
+      'missing required query parameter "persona" [query-param]\nbody.age must be number [type]',
+    );
+  });
+
   it("byCode returns the first leaf matching the highest-priority listed code", () => {
     const tree = createBranchError("request", [], "request invalid", [
       createLeafError("type", ["body", "age"], "must be number"),

--- a/packages/validator/test/error-codes.test.ts
+++ b/packages/validator/test/error-codes.test.ts
@@ -1,11 +1,12 @@
 import {
   BUILT_IN_ERROR_CODES,
+  SELF_LOCATING_ERROR_CODES,
   walkErrors,
   type OpenAPIDocument,
   type ValidationError,
 } from "@oav/core";
 import { describe, expect, it } from "vitest";
-import { createValidator } from "./fixtures.js";
+import { createValidator, leafCodes } from "./fixtures.js";
 
 /**
  * Cross-check between actual emitted error codes and the documented
@@ -328,5 +329,201 @@ describe("BuiltInErrorParams registry cross-check", () => {
       ),
       "header-param",
     );
+  });
+});
+
+describe("self-locating message contract (SELF_LOCATING_ERROR_CODES)", () => {
+  // The contract documented on SELF_LOCATING_ERROR_CODES: every leaf
+  // emitted under one of these codes locates the error in its message
+  // alone, so formatSummary's `path: "auto"` drops no information. A
+  // message-wording change that stops naming the location must fail
+  // here, not regress downstream renderers silently. The corpus drives
+  // every code in the set, including the rarer *-param modes (cookie
+  // missing, path-param content-parse).
+
+  function contractSpec(): OpenAPIDocument {
+    return {
+      openapi: "3.1.0",
+      info: { title: "contract", version: "1" },
+      components: {
+        securitySchemes: {
+          ApiKey: { type: "apiKey", name: "X-Api-Key", in: "header" },
+        },
+      },
+      paths: {
+        "/items/{id}": {
+          parameters: [{ name: "id", in: "path", required: true, schema: { type: "integer" } }],
+          get: {
+            parameters: [
+              { name: "fields", in: "query", required: true, schema: { type: "string" } },
+              { name: "X-Tenant", in: "header", required: true, schema: { type: "string" } },
+              { name: "session", in: "cookie", required: true, schema: { type: "string" } },
+            ],
+            responses: {
+              "200": {
+                description: "ok",
+                headers: { "X-Rate": { required: true, schema: { type: "string" } } },
+                content: { "application/json": { schema: { type: "object" } } },
+              },
+            },
+          },
+          post: {
+            requestBody: {
+              required: true,
+              content: { "application/json": { schema: { type: "object" } } },
+            },
+            responses: { "200": { description: "ok" } },
+          },
+        },
+        "/blob/{data}": {
+          get: {
+            parameters: [
+              {
+                name: "data",
+                in: "path",
+                required: true,
+                content: { "application/json": { schema: { type: "object" } } },
+              },
+            ],
+            responses: { "200": { description: "ok" } },
+          },
+        },
+        "/secure": {
+          get: { security: [{ ApiKey: [] }], responses: { "200": { description: "ok" } } },
+        },
+      },
+    };
+  }
+
+  function namesItsLocation(leaf: ValidationError): boolean {
+    switch (leaf.code) {
+      // Empty-path codes: there is no prefix to drop.
+      case "route":
+      case "method":
+      case "status":
+        return leaf.path.length === 0;
+      case "body":
+        return leaf.message.includes("body");
+      case "content-type":
+        return leaf.message.includes("Content-Type");
+      case "security":
+        return leaf.message.includes("security");
+      // *-param: the message quotes the parameter name.
+      default:
+        return leaf.message.includes(`"${String((leaf.params as { name?: unknown }).name)}"`);
+    }
+  }
+
+  it("every emitted self-locating leaf names its location in its message", () => {
+    const selfLocating = new Set<string>(SELF_LOCATING_ERROR_CODES);
+    const v = createValidator(contractSpec(), {
+      strictQueryParameters: true,
+      validateSecurity: "shape",
+    });
+    const trees: (ValidationError | null)[] = [
+      v.validateRequest({ method: "GET", path: "/nope" }), // route
+      v.validateRequest({ method: "DELETE", path: "/items/1" }), // method
+      // query-param / header-param / cookie-param, all missing-required.
+      v.validateRequest({ method: "GET", path: "/items/1" }),
+      // query-param, unknown-key mode under strictQueryParameters.
+      v.validateRequest({
+        method: "GET",
+        path: "/items/1",
+        query: { fields: "id", bogus: "x" },
+        headers: { "x-tenant": "t" },
+        cookies: { session: "s" },
+      }),
+      v.validateRequest({ method: "POST", path: "/items/1", contentType: "application/json" }), // body
+      v.validateRequest({
+        method: "POST",
+        path: "/items/1",
+        contentType: "text/plain",
+        body: "x",
+      }), // content-type (request)
+      v.validateRequest({ method: "GET", path: "/blob/not-json" }), // path-param (content-parse)
+      v.validateRequest({ method: "GET", path: "/secure" }), // security
+      v.validateResponse({ method: "GET", path: "/items/1" }, { status: 500 }), // status
+      v.validateResponse(
+        { method: "GET", path: "/items/1" },
+        { status: 200, contentType: "text/plain", body: "x", headers: { "x-rate": "1" } },
+      ), // content-type (response)
+      v.validateResponse(
+        { method: "GET", path: "/items/1" },
+        { status: 200, contentType: "application/json", body: {}, headers: {} },
+      ), // header-param (response, missing required header)
+    ];
+
+    const observed = new Set<string>();
+    for (const tree of trees) {
+      if (tree === null) continue;
+      walkErrors(tree, (node) => {
+        if (!selfLocating.has(node.code)) return;
+        observed.add(node.code);
+        expect(node.children, `code=${node.code} must only appear as a leaf`).toEqual([]);
+        expect(
+          namesItsLocation(node),
+          `code=${node.code} message '${node.message}' does not name its location`,
+        ).toBe(true);
+      });
+    }
+
+    // Bidirectional: the corpus must actually surface every code in the
+    // set, so a new entry added without a reachable emission (or a
+    // fixture gone stale) fails loudly.
+    for (const code of SELF_LOCATING_ERROR_CODES) {
+      expect([...observed], `fixture corpus did not surface code=${code}`).toContain(code);
+    }
+  });
+
+  it("parameter value failures surface as schema-keyword codes, never *-param", () => {
+    // The other half of the contract: a *-param code never carries a
+    // generic value-error message. format / pattern / type failures on
+    // a parameter, including deserialized deepObject members, keep
+    // their keyword codes (where the path prefix is load-bearing).
+    const spec: OpenAPIDocument = {
+      openapi: "3.1.0",
+      info: { title: "v", version: "1" },
+      paths: {
+        "/search": {
+          get: {
+            parameters: [
+              { name: "limit", in: "query", required: true, schema: { type: "integer" } },
+              {
+                name: "tag",
+                in: "query",
+                required: true,
+                schema: { type: "string", pattern: "^[a-z]+$" },
+              },
+              {
+                name: "filter",
+                in: "query",
+                required: true,
+                style: "deepObject",
+                explode: true,
+                schema: {
+                  type: "object",
+                  required: ["depth"],
+                  properties: { depth: { type: "integer" } },
+                },
+              },
+            ],
+            responses: { "200": { description: "ok" } },
+          },
+        },
+      },
+    };
+    const v = createValidator(spec);
+    const err = v.validateRequest({
+      method: "GET",
+      path: "/search",
+      query: { limit: "abc", tag: "UPPER", "filter[depth]": "xyz" },
+    });
+    expect(err).not.toBeNull();
+    const codes = leafCodes(err);
+    expect(codes).toContain("type"); // limit=abc, filter[depth]=xyz
+    expect(codes).toContain("pattern"); // tag=UPPER
+    for (const code of codes) {
+      expect(SELF_LOCATING_ERROR_CODES).not.toContain(code);
+    }
   });
 });


### PR DESCRIPTION
Closes #380. Requested by a downstream user migrating off express-openapi-validator: `formatSummary(firstLeaf)` renders missing-parameter leaves as `query.persona missing required query parameter "persona"`, repeating the field name, because the validator's HTTP-level leaves carry self-locating messages while the formatter unconditionally prefixes the path.

## The change

`FormatSummaryOptions.path`: `"always"` (default; output unchanged) or `"auto"`, which drops the dotted-path prefix for leaves whose code is in the new `SELF_LOCATING_ERROR_CODES` set (route, method, body, content-type, status, the four `*-param`s, security) and keeps it for schema-keyword leaves, where the generic message needs the path. Applies to single-leaf modes and per-line under `select: "all"`. Leaf data is byte-identical; rendering only.

Keyed on the code set rather than a message-content heuristic: a field named `email` with `format: "email"` produces path `body.email` and message `must match format "email"`, so a quoted-segment heuristic would wrongly strip the path there.

## The contract, now in writing

`SELF_LOCATING_ERROR_CODES` is exported next to `BUILT_IN_ERROR_CODES`; its TSDoc states the guarantee renderers may rely on: a leaf under one of these codes always locates the error in its message, and parameter VALUE failures (format/pattern/type, including deserialized deepObject members) always surface under schema-keyword codes, never `*-param`. The `*-param` codes cover exactly missing-required, unknown key under `strictQueryParameters`, and `content` media-type parse failures, all of which quote the parameter name. Verified against every `createLeafError` site in the validator; `deserialize` emits no errors of its own.

## Guard tests

- core: `path: "auto"` rendering for single-leaf and `"all"` modes, the format/"email" trap, subset relation to `BUILT_IN_ERROR_CODES`.
- validator: a fixture corpus drives all ten codes (including the rare modes: cookie-param missing-required, path-param content-parse, security under `validateSecurity: "shape"`) and asserts each emitted leaf names its location in its message, with bidirectional coverage so a new set entry without a reachable emission fails. A second test asserts value failures never carry a `*-param` code.

## Verification

1399 unit tests, `tsc -b`, oxlint, oxfmt, dep-graph check all pass.

Docs: recipe in `docs/migration-from-eov.md` (the requesting use case), option summary in the core README, TSDoc on the option and on `formatSummary`.