### PR TITLE
fix(core, cli): rename the flat output format to summary, keep flat as a deprecated alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ oav compile-schema schema.json -o validator.mjs             # JSON Schema -> sta
 oav compile-spec openapi.yaml  -o validator.mjs             # OpenAPI   -> standalone HTTP validator (edge / Lambda)
 ```
 
-Flags: `--format text|json|flat`, `--depth n`, `--overlay file`
+Flags: `--format text|json|summary`, `--depth n`, `--overlay file`
 (repeatable), `-o file`, `--quiet`, `--dialect` (compile-schema /
 compile-spec), `--requests-only` (compile-spec), `--only METHOD PATH`
 (compile-spec, repeatable). See

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -56,7 +56,7 @@ below for the expected shape.
 
 | Flag                                          | Command                           | Meaning                                                                                              |
 | --------------------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `--format text\|json\|flat`                   | validate                          | Error rendering. Default `text`.                                                                     |
+| `--format text\|json\|summary`                | validate                          | Error rendering. Default `text`. `summary` is one line per leaf; `flat` is its deprecated alias.     |
 | `--depth <n>`                                 | validate                          | Truncate error tree depth (text format).                                                             |
 | `--overlay <file>`                            | resolve / validate / compile-spec | Repeatable; applies overlays in order.                                                               |
 | `--lint`                                      | resolve                           | Run spec-hygiene checks; findings to stderr (or JSON envelope with `--envelope json`).               |

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -269,17 +269,36 @@ describe("buildProgram: argv-level", () => {
     expect(parsed.code).toBeDefined();
   });
 
-  it("validate --format flat on the error path emits one error per line", async () => {
+  it("validate --format summary on the error path emits one error per line", async () => {
+    const mem = memoryIo([["spec.json", spec]], [["body.json", JSON.stringify({})]]);
+    const out = await runCli(
+      [
+        "validate",
+        "spec.json",
+        "--path",
+        "POST /pets",
+        "--body",
+        "body.json",
+        "--format",
+        "summary",
+      ],
+      mem,
+    );
+    expect(out.exitCode).toBe(1);
+    const lines = out.stdout.split("\n").filter((l) => l.length > 0);
+    expect(lines.length).toBeGreaterThan(0);
+    // Summary format puts each leaf on its own line; no nested indentation.
+    for (const line of lines) expect(line.startsWith(" ")).toBe(false);
+  });
+
+  it("validate --format flat still parses as a deprecated alias of summary", async () => {
     const mem = memoryIo([["spec.json", spec]], [["body.json", JSON.stringify({})]]);
     const out = await runCli(
       ["validate", "spec.json", "--path", "POST /pets", "--body", "body.json", "--format", "flat"],
       mem,
     );
     expect(out.exitCode).toBe(1);
-    const lines = out.stdout.split("\n").filter((l) => l.length > 0);
-    expect(lines.length).toBeGreaterThan(0);
-    // Flat format puts each leaf on its own line; no nested indentation.
-    for (const line of lines) expect(line.startsWith(" ")).toBe(false);
+    expect(out.stdout.length).toBeGreaterThan(0);
   });
 });
 

--- a/packages/core/src/format-output.ts
+++ b/packages/core/src/format-output.ts
@@ -5,27 +5,44 @@ import type { ValidationError } from "./errors.js";
  * Single source of truth for the CLI's `--format` flag. The
  * {@link OutputFormat} union and the Commander parser validator both
  * derive from this tuple; add a new name here and extend
- * {@link formatError} to wire it up end-to-end.
+ * {@link formatError} to wire it up end-to-end. Deprecated aliases
+ * (accepted but not advertised in help text) live in
+ * `DEPRECATED_OUTPUT_FORMATS` instead.
  *
  * @public
  */
-export const KNOWN_OUTPUT_FORMATS = ["text", "json", "flat"] as const;
+export const KNOWN_OUTPUT_FORMATS = ["text", "json", "summary"] as const;
+
+// Accepted by isOutputFormat / formatError but kept out of
+// KNOWN_OUTPUT_FORMATS so CLI help text stops advertising them.
+const DEPRECATED_OUTPUT_FORMATS = ["flat"] as const;
 
 /**
  * Supported built-in output formats.
  *
+ * `"flat"` is a deprecated alias of `"summary"`, kept for one major.
+ * It named a rendering style (one line per leaf) with the same word
+ * that `ValidatorOptions.output: "flat"` uses for an unrelated result
+ * shape (the errors-list shape vs a tree); `"summary"` pairs the
+ * format name with {@link formatSummary}, the renderer behind it.
+ *
  * @public
  */
-export type OutputFormat = (typeof KNOWN_OUTPUT_FORMATS)[number];
+export type OutputFormat =
+  | (typeof KNOWN_OUTPUT_FORMATS)[number]
+  | (typeof DEPRECATED_OUTPUT_FORMATS)[number];
 
 /**
  * Type guard: narrows an arbitrary string to {@link OutputFormat} iff
- * it appears in {@link KNOWN_OUTPUT_FORMATS}.
+ * it appears in {@link KNOWN_OUTPUT_FORMATS} or is a deprecated alias.
  *
  * @public
  */
 export function isOutputFormat(value: string): value is OutputFormat {
-  return (KNOWN_OUTPUT_FORMATS as readonly string[]).includes(value);
+  return (
+    (KNOWN_OUTPUT_FORMATS as readonly string[]).includes(value) ||
+    (DEPRECATED_OUTPUT_FORMATS as readonly string[]).includes(value)
+  );
 }
 
 /**
@@ -70,7 +87,8 @@ export function formatError(
   switch (renderer) {
     case "json":
       return JSON.stringify(toJsonObject(err), null, 2);
-    case "flat":
+    case "summary":
+    case "flat": // deprecated alias of "summary"
       return formatSummary(err, { select: "all" });
     case "text":
     default:

--- a/packages/core/test/format-output.test.ts
+++ b/packages/core/test/format-output.test.ts
@@ -17,8 +17,12 @@ describe("formatError", () => {
     expect(JSON.parse(out).code).toBe("request");
   });
 
-  it("renders as flat one-line-per-leaf", () => {
-    expect(formatError(sample, "flat").split("\n")).toHaveLength(1);
+  it("renders as summary one-line-per-leaf", () => {
+    expect(formatError(sample, "summary").split("\n")).toHaveLength(1);
+  });
+
+  it('accepts "flat" as a deprecated alias of "summary"', () => {
+    expect(formatError(sample, "flat")).toBe(formatError(sample, "summary"));
   });
 
   it("respects depth truncation in text mode", () => {
@@ -40,7 +44,7 @@ describe("formatError", () => {
       createLeafError("required", ["body"], "missing name"),
     ];
     const root = createBranchError("request", [], "request validation failed", flat);
-    expect(formatError(root, "flat").split("\n")).toHaveLength(2);
+    expect(formatError(root, "summary").split("\n")).toHaveLength(2);
     expect(JSON.parse(formatError(root, "json")).children).toHaveLength(2);
   });
 });
@@ -49,6 +53,10 @@ describe("isOutputFormat", () => {
   it("narrows valid names", () => {
     expect(isOutputFormat("text")).toBe(true);
     expect(isOutputFormat("json")).toBe(true);
+    expect(isOutputFormat("summary")).toBe(true);
+  });
+
+  it("accepts the deprecated flat alias", () => {
     expect(isOutputFormat("flat")).toBe(true);
   });
 


### PR DESCRIPTION
Closes #374 (API consistency M4).

`"flat"` named two unrelated things: the `output: "flat"` result shape on `ValidatorOptions` / `CompileOptions`, and the CLI `--format` rendering style (one line per leaf). This renames the rendering to `"summary"`, pairing the format name with `formatSummary`, the renderer behind it. The issue left the name open between `"lines"` and `"summary"`; `"summary"` wins on the pairs-with-sibling principle, but it's a one-word change if you prefer `"lines"`.

- `KNOWN_OUTPUT_FORMATS` advertises `text | json | summary`, so CLI help stops offering the deprecated name.
- `isOutputFormat` and the `formatError` switch still accept `"flat"` via a separate alias list; the `OutputFormat` union keeps the member, so existing typed callers and `--format flat` invocations keep working for one major.
- README / cli README updated; the `--output-mode flat` result-shape mentions are unrelated and untouched.
- Tests: `summary` wired end-to-end (core + CLI argv level), alias coverage for `flat`.