### PR TITLE
chore(dependabot): ignore express major bumps in performance/mem-bench

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -86,6 +86,13 @@ updates:
       # auto-PRs; bump it deliberately when the time is right.
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      # mem-bench deliberately benchmarks the eov server on Express 4
+      # (server-eov.mjs), pinned to express ^4 with express-openapi-validator.
+      # A 4 -> 5 major is a breaking change that would silently alter what
+      # the benchmark measures, and nothing under performance/ runs in CI to
+      # catch it. Keep 4.x patches flowing; bump the major by hand if ever.
+      - dependency-name: "express"
+        update-types: ["version-update:semver-major"]
     groups:
       dev-minor-and-patch:
         dependency-type: development


### PR DESCRIPTION
mem-bench benchmarks the express-openapi-validator server on Express 4 (`server-eov.mjs`, `express: ^4.21.2`). Dependabot opened #394 bumping express 4 -> 5, a breaking change that would silently alter what the benchmark measures: nothing under `performance/` runs in CI to catch it.

Add an explicit `express` major-version ignore to the `/performance/mem-bench` block, mirroring the existing typescript-major and express-4/5 ignores. 4.x patches keep flowing; bump the major by hand if ever.

Closes #394 (closed manually; the ignore lives in `dependabot.yml` rather than dependabot-managed state, per the repo convention).