### PR TITLE
fix(performance): make the benchmarks type-clean and restore collect-all

### DIFF
--- a/performance/error-tree-anatomy.ts
+++ b/performance/error-tree-anatomy.ts
@@ -23,7 +23,7 @@
  */
 
 import { compileSchema, jsonSchemaDialect } from "../packages/schema/src/index.ts";
-import type { ValidationError } from "../packages/core/src/index.ts";
+import type { SchemaOrBoolean, ValidationError } from "../packages/core/src/index.ts";
 
 const SCHEMA = {
   $schema: "https://json-schema.org/draft/2020-12/schema",
@@ -65,7 +65,11 @@ function main(): void {
   }
 
   const data = buildInvalid(N);
-  const v = compileSchema(SCHEMA as Record<string, unknown>, { dialect: jsonSchemaDialect });
+  const v = compileSchema(SCHEMA as SchemaOrBoolean, {
+    dialect: jsonSchemaDialect,
+    output: "tree",
+    maxErrors: Number.POSITIVE_INFINITY,
+  });
   const res = v.validate(data) as { valid: boolean; error?: ValidationError };
   const root = res.error;
   if (root === undefined) throw new Error("expected the payload to be invalid");

--- a/performance/flat-vs-tree-mem.ts
+++ b/performance/flat-vs-tree-mem.ts
@@ -4,6 +4,7 @@
  *   node --expose-gc --import tsx flat-vs-tree-mem.ts
  */
 import { compileSchema, jsonSchemaDialect } from "../packages/schema/src/index.ts";
+import type { SchemaOrBoolean } from "../packages/core/src/index.ts";
 
 const SCHEMA = {
   type: "array",
@@ -55,10 +56,19 @@ function main(): void {
   }
   const mode = process.env.MODE ?? "tree";
   const data = buildInvalid(N);
-  const v = compileSchema(SCHEMA as Record<string, unknown>, {
-    dialect: jsonSchemaDialect,
-    ...(mode === "flat" ? { flat: true } : {}),
-  });
+  const schema = SCHEMA as SchemaOrBoolean;
+  const v =
+    mode === "flat"
+      ? compileSchema(schema, {
+          dialect: jsonSchemaDialect,
+          output: "flat",
+          maxErrors: Number.POSITIVE_INFINITY,
+        })
+      : compileSchema(schema, {
+          dialect: jsonSchemaDialect,
+          output: "tree",
+          maxErrors: Number.POSITIVE_INFINITY,
+        });
   const baseline = heapMB(); // data held, no result
   const res = v.validate(data) as {
     valid: boolean;

--- a/performance/large-payload.ts
+++ b/performance/large-payload.ts
@@ -37,10 +37,11 @@ import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import Ajv from "ajv/dist/2020.js";
 import { compileSchema, jsonSchemaDialect } from "../packages/schema/src/index.ts";
+import type { SchemaOrBoolean } from "../packages/core/src/index.ts";
 
 // ----- shared shape -----
 
-const SCHEMA = {
+const SCHEMA: SchemaOrBoolean = {
   $schema: "https://json-schema.org/draft/2020-12/schema",
   type: "array",
   items: {
@@ -53,7 +54,7 @@ const SCHEMA = {
     },
     additionalProperties: false,
   },
-} as const;
+};
 
 type Engine = "oav-default" | "oav-maxErrors1" | "oav-predicate" | "ajv-default" | "ajv-allErrors";
 type Validity = "valid" | "invalid";
@@ -144,7 +145,7 @@ function runCell(engine: Engine, validity: Validity): CellResult {
         : engine === "oav-maxErrors1"
           ? ({ dialect: jsonSchemaDialect, maxErrors: 1 } as const)
           : ({ dialect: jsonSchemaDialect } as const);
-    const compiled = compileSchema(SCHEMA as Record<string, unknown>, opts);
+    const compiled = compileSchema(SCHEMA, opts);
     const res = compiled.validate(parsed) as boolean | { valid: boolean; truncated?: boolean };
     if (typeof res === "boolean") {
       valid = res;

--- a/performance/mem.ts
+++ b/performance/mem.ts
@@ -30,7 +30,8 @@
  *   WARMUP (default 500)
  */
 
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { spawn, type ChildProcessByStdio } from "node:child_process";
+import type { Readable } from "node:stream";
 import { writeFileSync, mkdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -254,7 +255,7 @@ async function batchRun(
 // ----- server lifecycle -----
 
 interface ServerHandle {
-  proc: ChildProcessWithoutNullStreams;
+  proc: ChildProcessByStdio<null, Readable, Readable>;
   base: string;
 }
 

--- a/performance/package.json
+++ b/performance/package.json
@@ -10,7 +10,8 @@
     "bench:render": "tsx render.ts",
     "bench:mem": "tsx mem.ts",
     "bench:large": "tsx large-payload.ts",
-    "bench:anatomy": "node --expose-gc --import tsx error-tree-anatomy.ts"
+    "bench:anatomy": "node --expose-gc --import tsx error-tree-anatomy.ts",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "^15.3.6",

--- a/performance/schemas.ts
+++ b/performance/schemas.ts
@@ -9,10 +9,12 @@
  * don't just measure a hot no-op loop.
  */
 
+import type { SchemaOrBoolean } from "../packages/core/src/index.ts";
+
 export interface PerfSchema {
   name: string;
   description: string;
-  schema: Record<string, unknown>;
+  schema: SchemaOrBoolean;
   validInputs: unknown[];
   invalidInputs: unknown[];
 }

--- a/performance/tsconfig.json
+++ b/performance/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": false,
+    "incremental": false,
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
Fixes the obvious typing errors and low-hanging fruit in `performance/`, surfaced while scoping a possible CI typecheck (#401 context).

Adds a `tsconfig.json` + `typecheck` script (mirroring `framework-tests`) so the root is locally type-checkable, and fixes the 10 errors it reports. No CI job yet.

What the type errors exposed (each fix is the real fix, not a cast-over):

- **`Record<string, unknown>` schema casts** broke `compileSchema` overload resolution, collapsing the result type to a union that included the predicate `boolean`, which is where the downstream invalid casts came from. Typed the schema literals/fields as `SchemaOrBoolean`.
- **`error-tree-anatomy` and `flat-vs-tree-mem` were broken at runtime**: both read `.error` (the tree root) but compiled with the flat default, so `.error` was always `undefined`. `error-tree-anatomy` threw; `flat-vs-tree-mem` tree mode reported 0 items. Now compile with `output: "tree"` (and `flat-vs-tree-mem` selects the mode explicitly).
- **Both benches measure large error structures, but the v3 `maxErrors: 1` default neutered them** (1 error retains ~nothing). Restored `maxErrors: Infinity`, matching their own docs (collect-all, N=200000).
- **`mem.ts`**: typed the spawn handle as `ChildProcessByStdio<null, Readable, Readable>` to match `stdio: ["ignore","pipe","pipe"]`.

Scope: only the 8 `performance/*.ts` files. The `.mjs` files (`bench-real-world.mjs`, `mem-bench/server-*.mjs`) and the separate `mem-bench` pnpm root are out of scope for this tsconfig.

Verified: `pnpm typecheck` clean; root `pnpm lint` clean; smoke-ran error-tree-anatomy (12000 leaves), flat-vs-tree-mem (tree 5.1MB vs flat 4.0MB retained), and large-payload.