### PR TITLE
docs(performance): record the flat-vs-tree-mem baseline

### DIFF
--- a/performance/flat-vs-tree-mem.ts
+++ b/performance/flat-vs-tree-mem.ts
@@ -2,6 +2,13 @@
  * Quick retained-memory comparison of tree mode vs flat mode (#314) on
  * a broadly-invalid large array. Run:
  *   node --expose-gc --import tsx flat-vs-tree-mem.ts
+ *
+ * Both modes collect every error (maxErrors: Infinity); the cap is the
+ * real memory lever, this isolates the per-error cost of the two shapes.
+ *
+ * Headline finding (N=200000, 1.2M errors): tree retains ~505MB vs flat
+ * ~396MB, so the tree shape is ~28% heavier per error. Both retain
+ * hundreds of MB at this scale; neither is free.
  */
 import { compileSchema, jsonSchemaDialect } from "../packages/schema/src/index.ts";
 import type { SchemaOrBoolean } from "../packages/core/src/index.ts";


### PR DESCRIPTION
Follow-up to #402. Captures the restored N=200000 finding in the `flat-vs-tree-mem` header (tree ~505MB vs flat ~396MB, ~28% heavier per error), so the next reader has a baseline to notice regressions against, matching `error-tree-anatomy.ts`. Also notes both modes collect all errors (`maxErrors: Infinity`).

This commit was originally pushed to the #402 branch after that PR had already merged, so it never reached main; re-opening it here.