### PR TITLE
feat(schema): public keyword-introspection surface (registry + public schemaUsesUnevaluated)

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -8,7 +8,7 @@ further down). `oav-core` mirrors the same paths; substitute
 | Import                         | Surface                                                                         |
 | ------------------------------ | ------------------------------------------------------------------------------- |
 | `@aahoughton/oav`              | `createValidator`, `combineValidators`, error helpers, formatters, types        |
-| `@aahoughton/oav/schema`       | `compileSchema`, dialects, vocabularies, custom keywords                        |
+| `@aahoughton/oav/schema`       | `compileSchema`, dialects, vocabularies, custom keywords, keyword introspection |
 | `@aahoughton/oav/spec`         | `loadSpec`, `loadSpecSync`, `resolveSpec`, `applyOverlays`, readers             |
 | `@aahoughton/oav/overlay-spec` | `translateOverlay`, `applySpecOverlay`: OpenAPI Overlay 1.0 → typed SpecOverlay |
 | `@aahoughton/oav/formats`      | Built-in string format validators                                               |

--- a/packages/schema/src/compiler/compiler.ts
+++ b/packages/schema/src/compiler/compiler.ts
@@ -1,5 +1,6 @@
 import type { PathSegment, SchemaObject, SchemaOrBoolean, ValidationError } from "@oav/core";
 import { CodeGen, NAMES } from "../codegen/index.js";
+import { buildKeywordMap } from "../introspection.js";
 import type { CompileMode, Dialect, KeywordDefinition } from "../keywords/types.js";
 import { createKeywordContext, emitPushStatement } from "../keywords/context.js";
 import { createCustomKeywordDefinition, type CustomKeywordValidator } from "../keywords/custom.js";
@@ -716,8 +717,16 @@ export interface CompileState {
  * `unevaluatedItems` keyword. The detector is the gate for the
  * evaluated-keys-Set machinery: when it's `false`, the compiler emits
  * a form that skips the per-function Set allocation entirely.
+ *
+ * The walk descends the local subschema positions (the same set
+ * {@link walkSubschemas} uses) and is cycle-safe: a `$ref` value is a
+ * string, so the walk never recurses through one. A schema whose only
+ * `unevaluated*` keyword sits behind a `$ref` is therefore not detected
+ * by this predicate; resolve such refs first if that matters.
+ *
+ * @public
  */
-function schemaUsesUnevaluated(schema: SchemaOrBoolean): boolean {
+export function schemaUsesUnevaluated(schema: SchemaOrBoolean): boolean {
   const seen = new WeakSet<object>();
   const walk = (s: unknown): boolean => {
     if (typeof s !== "object" || s === null || Array.isArray(s)) return false;
@@ -813,15 +822,8 @@ export function compileSchema(
   schema: SchemaOrBoolean,
   options: CompileOptions,
 ): CompiledSchema | CompiledTreeSchema | CompiledPredicate {
-  const byKeyword = new Map<string, KeywordDefinition>();
-  const ordered: KeywordDefinition[] = [];
-  for (const vocab of options.dialect.vocabularies) {
-    for (const kw of vocab.keywords) {
-      if (byKeyword.has(kw.keyword)) continue;
-      byKeyword.set(kw.keyword, kw);
-      ordered.push(kw);
-    }
-  }
+  const byKeyword = buildKeywordMap(options.dialect.vocabularies);
+  const ordered: KeywordDefinition[] = [...byKeyword.values()];
   if (options.keywords) {
     for (const name of Object.keys(options.keywords)) {
       if (byKeyword.has(name)) {

--- a/packages/schema/src/compiler/index.ts
+++ b/packages/schema/src/compiler/index.ts
@@ -1,5 +1,6 @@
 export {
   compileSchema,
+  schemaUsesUnevaluated,
   type CompileOptions,
   type CompileStats,
   type CompiledFlatSchema,

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -21,6 +21,7 @@
 // Compiler: turning schemas into validators.
 export {
   compileSchema,
+  schemaUsesUnevaluated,
   type CompiledFlatSchema,
   type CompiledPredicate,
   type CompiledRegex,
@@ -178,3 +179,8 @@ export {
 // tooling. For rewriting use cases, the raw `SUBSCHEMA_*_POSITIONS`
 // constants are in `./internals`.
 export { walkSubschemas, type SubschemaVisitor } from "./subschema-positions.js";
+
+// Keyword introspection: enumerate the built-in keyword set (with its
+// classification flags) for a dialect. Reads keyword metadata; pairs
+// with `schemaUsesUnevaluated` (above) and `walkSubschemas`.
+export { keywordDefinitions } from "./introspection.js";

--- a/packages/schema/src/introspection.ts
+++ b/packages/schema/src/introspection.ts
@@ -1,0 +1,83 @@
+/**
+ * Read-only introspection over the built-in keyword set: enumerate the
+ * keywords a dialect dispatches, and read their classification flags
+ * (`applicator` / `annotation` / `evaluates` / `implements`) off the
+ * `@public` {@link KeywordDefinition}. For walking a schema's subschema
+ * positions see {@link walkSubschemas}; for the `unevaluated*` gate see
+ * `schemaUsesUnevaluated` (both also `@public`).
+ *
+ * This is the consumer-facing half of the keyword surface (reading
+ * keyword metadata), distinct from the keyword-authoring surface
+ * (defining keywords). Tooling that reasons about keywords (a linter, a
+ * coverage check, the streaming validator's classifier) reads here; it
+ * never needs the codegen internals.
+ *
+ * @packageDocumentation
+ */
+
+import type { Dialect, KeywordDefinition, Vocabulary } from "./keywords/types.js";
+import { jsonSchemaDialect } from "./keywords/vocabulary.js";
+
+/**
+ * Flatten a vocabulary stack into a `name -> definition` map, first-wins
+ * on a repeated keyword name.
+ *
+ * First-wins is not arbitrary: it is exactly the precedence the compiler
+ * uses to build its dispatch table (see `compileSchema`), so a 3.0
+ * compile's `oas30Vocabulary` (placed ahead of the 2020-12 validation
+ * vocabulary) wins `type` / `maximum` / ... here too. Sharing this
+ * builder between the compiler and {@link keywordDefinitions} keeps the
+ * introspection registry from drifting out of step with what actually
+ * dispatches.
+ *
+ * @internal
+ */
+export function buildKeywordMap(
+  vocabularies: readonly Vocabulary[],
+): Map<string, KeywordDefinition> {
+  const byKeyword = new Map<string, KeywordDefinition>();
+  for (const vocab of vocabularies) {
+    for (const kw of vocab.keywords) {
+      if (byKeyword.has(kw.keyword)) continue;
+      byKeyword.set(kw.keyword, kw);
+    }
+  }
+  return byKeyword;
+}
+
+const cache = new WeakMap<Dialect, ReadonlyMap<string, KeywordDefinition>>();
+
+/**
+ * The built-in keyword set a dialect dispatches, as a flat
+ * `keyword name -> {@link KeywordDefinition}` map. Each definition
+ * carries its classification flags (`applicator`, `annotation`,
+ * `evaluates`, `implements`, `partial`), so a consumer can bucket every
+ * keyword without re-deriving the vocabulary stack.
+ *
+ * The map mirrors the compiler's dispatch precedence: keywords are
+ * flattened across the dialect's vocabularies in order, first-wins on a
+ * repeated name. For {@link oas30Dialect} that means `get("type")`
+ * returns the 3.0 `type` flavour (string-only, sibling `nullable`), not
+ * the 2020-12 one, because `oas30Vocabulary` sits ahead of the standard
+ * validation vocabulary in that dialect's stack.
+ *
+ * @param dialect - The dialect to enumerate. Defaults to
+ *   {@link jsonSchemaDialect} (JSON Schema 2020-12). Pass
+ *   {@link openapi31Dialect} or {@link oas30Dialect} for the OpenAPI
+ *   keyword sets.
+ * @returns A read-only map; the returned identity is memoized per
+ *   dialect, so repeated calls with the same dialect return the same
+ *   object.
+ *
+ * @public
+ */
+export function keywordDefinitions(
+  dialect: Dialect = jsonSchemaDialect,
+): ReadonlyMap<string, KeywordDefinition> {
+  let map = cache.get(dialect);
+  if (map === undefined) {
+    map = buildKeywordMap(dialect.vocabularies);
+    cache.set(dialect, map);
+  }
+  return map;
+}

--- a/packages/schema/test/keyword-introspection.test.ts
+++ b/packages/schema/test/keyword-introspection.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import type { SchemaOrBoolean } from "@oav/core";
+import {
+  jsonSchemaDialect,
+  keywordDefinitions,
+  oas30Dialect,
+  oas30MaximumKeyword,
+  oas30TypeKeyword,
+  openapi31Dialect,
+  schemaUsesUnevaluated,
+  typeKeyword,
+  unevaluatedPropertiesKeyword,
+} from "../src/index.js";
+
+describe("keywordDefinitions", () => {
+  it("defaults to the JSON Schema 2020-12 dialect", () => {
+    expect(keywordDefinitions()).toBe(keywordDefinitions(jsonSchemaDialect));
+  });
+
+  it("memoizes a stable map per dialect", () => {
+    expect(keywordDefinitions(oas30Dialect)).toBe(keywordDefinitions(oas30Dialect));
+    expect(keywordDefinitions(jsonSchemaDialect)).not.toBe(keywordDefinitions(oas30Dialect));
+  });
+
+  it("exposes the built-in keywords keyed by name, with their definitions", () => {
+    const kw = keywordDefinitions();
+    expect(kw.get("type")).toBe(typeKeyword);
+    // A representative sample across vocabularies.
+    for (const name of ["properties", "allOf", "format", "items", "$ref", "required"]) {
+      expect(kw.has(name)).toBe(true);
+      expect(kw.get(name)?.keyword).toBe(name);
+    }
+  });
+
+  it("surfaces the classification flags off the definition", () => {
+    const kw = keywordDefinitions();
+    expect(kw.get("properties")?.applicator).toBe(true);
+    expect(kw.get("properties")?.evaluates).toEqual({ properties: true });
+    expect(kw.get("title")?.annotation).toBe(true);
+  });
+
+  it("includes the unevaluated vocabulary in 2020-12 but not in 3.0", () => {
+    expect(keywordDefinitions(jsonSchemaDialect).has("unevaluatedProperties")).toBe(true);
+    expect(keywordDefinitions(openapi31Dialect).has("unevaluatedProperties")).toBe(true);
+    expect(keywordDefinitions(oas30Dialect).has("unevaluatedProperties")).toBe(false);
+  });
+
+  it("mirrors the compiler's first-wins precedence: 3.0 overrides win", () => {
+    // oas30Vocabulary sits ahead of the standard validation vocabulary
+    // in the 3.0 stack, so its `type` / `maximum` flavours win dispatch.
+    const kw = keywordDefinitions(oas30Dialect);
+    expect(kw.get("type")).toBe(oas30TypeKeyword);
+    expect(kw.get("maximum")).toBe(oas30MaximumKeyword);
+    // The default dialect keeps the 2020-12 `type`.
+    expect(keywordDefinitions(jsonSchemaDialect).get("type")).toBe(typeKeyword);
+  });
+
+  it("agrees with the dialect's own vocabulary stack (no keyword dropped)", () => {
+    const kw = keywordDefinitions(jsonSchemaDialect);
+    const names = new Set<string>();
+    for (const vocab of jsonSchemaDialect.vocabularies) {
+      for (const def of vocab.keywords) names.add(def.keyword);
+    }
+    expect(new Set(kw.keys())).toEqual(names);
+  });
+});
+
+describe("schemaUsesUnevaluated", () => {
+  const uses = (schema: SchemaOrBoolean) => schemaUsesUnevaluated(schema);
+
+  it("is the definition keyword's name", () => {
+    // Sanity: the keyword the predicate gates on is the one we export.
+    expect(unevaluatedPropertiesKeyword.keyword).toBe("unevaluatedProperties");
+  });
+
+  it("detects unevaluatedProperties / unevaluatedItems at the root", () => {
+    expect(uses({ unevaluatedProperties: false })).toBe(true);
+    expect(uses({ unevaluatedItems: false })).toBe(true);
+  });
+
+  it("detects a use nested behind subschema positions", () => {
+    expect(uses({ properties: { a: { unevaluatedProperties: false } } })).toBe(true);
+    expect(uses({ allOf: [{ minProperties: 1 }, { unevaluatedItems: true }] })).toBe(true);
+    expect(uses({ items: { unevaluatedProperties: false } })).toBe(true);
+  });
+
+  it("returns false when nothing uses unevaluated*", () => {
+    expect(uses({ type: "object", properties: { a: { type: "string" } } })).toBe(false);
+    expect(uses(true)).toBe(false);
+    expect(uses(false)).toBe(false);
+  });
+
+  it("is cycle-safe over an object graph", () => {
+    const cyclic: SchemaOrBoolean = { type: "object" };
+    (cyclic as Record<string, unknown>).properties = { self: cyclic };
+    expect(uses(cyclic)).toBe(false);
+  });
+
+  it("descends $defs structurally but does not resolve $ref strings", () => {
+    // $defs is a walked subschema position, so a use there is found by
+    // structural descent (not by following the $ref).
+    expect(uses({ $ref: "#/$defs/X", $defs: { X: { unevaluatedProperties: false } } })).toBe(true);
+    // With the use reachable only by resolving the ref target (no
+    // structural descent reaches it), the predicate does not detect it.
+    expect(uses({ $ref: "#/$defs/X" })).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds the read-only, additive `@oav/schema` introspection surface tracked by #405: a public way to enumerate the built-in keyword set and read each keyword's classification flags, plus a public `unevaluated*` gate.

- **`keywordDefinitions(dialect?)`** -> `ReadonlyMap<string, KeywordDefinition>`. The built-in keyword set a dialect dispatches, flattened to a `name -> definition` map (default `jsonSchemaDialect`). Each value carries the existing `@public` classification flags (`applicator` / `annotation` / `evaluates` / `implements` / `partial`). Memoized per dialect.
- **`schemaUsesUnevaluated`** promoted from a private `compiler.ts` helper to `@public`.

## Why first-wins, and why a shared helper

The map mirrors the compiler's dispatch precedence exactly: keywords flatten across the dialect's vocabulary stack first-wins on a repeated name, so an `oas30Dialect` lookup of `type` / `maximum` returns the OAS 3.0 flavour (its vocabulary sits ahead of the 2020-12 validation vocabulary). To guarantee the introspection registry never drifts from what actually dispatches, the flatten logic is extracted into a shared `buildKeywordMap` used by both `compileSchema` and `keywordDefinitions`.

## Scope

Purely additive, read-only, behavior-preserving. This is the introspection slice carved out of #349; it does not touch the contentious codegen-authoring surface. It is the only `@oav/schema` change the streaming validator (#404) requires (build step 1): its classifier reads the keyword set + flags and uses `schemaUsesUnevaluated` as the REJECT gate.

## Tests

`packages/schema/test/keyword-introspection.test.ts` (13 cases): default dialect, per-dialect memoized identity, flag surfacing, 3.0 first-wins precedence, unevaluated-vocabulary presence per dialect, agreement with the dialect's own vocabulary stack, and `schemaUsesUnevaluated` detection / cycle-safety / `$ref`-not-followed behavior. Full schema suite (606) green; typecheck, lint, format, dep-check clean.

Closes #405