### PR TITLE
fix(stream-validator): memoize $ref resolution on the spine hot path

### DIFF
--- a/packages/stream-validator/README.md
+++ b/packages/stream-validator/README.md
@@ -99,6 +99,14 @@ bytes before a scope's closing delimiter (append-only; appended bytes are
 not validated). A `ScopeContext` carries the scope path, verdict, member
 count, and a `field(name, value)` helper.
 
+`onScopeClose` / `editClose` fire for STREAM scopes only. A scope the
+classifier routes to a BUFFER island (`uniqueItems`, `contains`, an
+object-valued `const`) or a TEE composition branch
+(`oneOf`/`anyOf`/`allOf`) does not emit a scope-close hook, so which
+scopes a hook sees depends on the schema's classification. Use the hooks
+for observing/editing forward-decidable structure, not as a general JSON
+visitor over an arbitrary schema.
+
 ## Status
 
 Incubating and **unpublished** (`private`). The package lives in the

--- a/packages/stream-validator/src/engine/hooks.ts
+++ b/packages/stream-validator/src/engine/hooks.ts
@@ -4,6 +4,14 @@
  * or append sibling bytes (append-only, never validated). See the design
  * doc's "Edit hooks".
  *
+ * Scope coverage is STREAM-only: hooks fire for forward-decidable
+ * (STREAM) scopes, not for scopes the classifier routes to a BUFFER
+ * island (e.g. `uniqueItems`, `contains`, an object-valued `const`) or a
+ * TEE composition branch (`oneOf`/`anyOf`/`allOf`). The set of scopes a
+ * hook observes is a function of the schema's classification, so a hook
+ * meant for generic JSON transformation will appear to fire
+ * intermittently if the schema mixes streamable and buffered subtrees.
+ *
  * @packageDocumentation
  */
 

--- a/packages/stream-validator/src/spine/spine.ts
+++ b/packages/stream-validator/src/spine/spine.ts
@@ -246,6 +246,13 @@ export class SpineValidator implements JsonEventHandler {
   private readonly path: PathSegment[] = [];
   private readonly frames: Frame[] = [];
   private readonly regexCache = new Map<string, { test(s: string): boolean }>();
+  // Memoized `$ref` / `$dynamicRef` resolution against the fixed `refRoot`.
+  // `expand` runs per value, so without this an anchor ref (`#name`) would
+  // re-scan the whole document via `walkSubschemas` on every occurrence
+  // (O(N*M) across a large array or broad object). Keyed by ref string,
+  // which is stable because `refRoot` is immutable for the spine's life;
+  // `undefined` (a dangling/external ref) is cached too via `has`.
+  private readonly refCache = new Map<string, SchemaOrBoolean | undefined>();
   // Memoized per-node stream/tee/buffer decision (see nodeKind).
   private readonly kindCache = new Map<SchemaObject, "stream" | "tee" | "buffer">();
   private readonly onViolation: ((violation: SchemaViolation) => void) | undefined;
@@ -375,7 +382,13 @@ export class SpineValidator implements JsonEventHandler {
     // document root (may differ from the validation root in a sub-spine).
     const ref = (s as Record<string, unknown>).$ref ?? (s as Record<string, unknown>).$dynamicRef;
     if (typeof ref !== "string") return;
-    const target = resolveRef(this.refRoot, ref);
+    let target: SchemaOrBoolean | undefined;
+    if (this.refCache.has(ref)) {
+      target = this.refCache.get(ref);
+    } else {
+      target = resolveRef(this.refRoot, ref);
+      this.refCache.set(ref, target);
+    }
     if (target === undefined) return;
     if (!isObjectSchema(target)) {
       this.expand(target, out, seen); // boolean target

--- a/packages/stream-validator/test/ref-resolution.test.ts
+++ b/packages/stream-validator/test/ref-resolution.test.ts
@@ -65,6 +65,25 @@ describe("components is a ref container, not an unknown keyword", () => {
   });
 });
 
+describe("anchor refs resolve (and stay correct) across many array elements", () => {
+  // Regression for the per-value anchor-resolution scan: an anchor ref
+  // (`#name`) used as the items schema is followed once per element via
+  // `expand`. The spine memoizes the resolution, so a large array must
+  // not change the verdict (and must not re-walk the schema per element).
+  it("validates each element of a long array against an anchor ref", async () => {
+    const schema: SchemaObject = {
+      type: "array",
+      items: { $ref: "#item" },
+      $defs: {
+        Item: { $anchor: "item", type: "object", required: ["id"] },
+      },
+    };
+    const good = Array.from({ length: 200 }, (_, i) => ({ id: i }));
+    const oneBad = [...good.slice(0, 100), { nope: true }, ...good.slice(100)];
+    await expectParity(schema, [good, oneBad, []]);
+  });
+});
+
 describe("island ref-container graft: root #/$defs wins over a node-local $defs", () => {
   it("a buffer island's root-targeting ref resolves against the document root", async () => {
     // `#/$defs/Strict` inside the island means the DOCUMENT root's $defs


### PR DESCRIPTION
From Gemini's review of the streaming validator (#408), the one finding that was an actual defect rather than a documented tradeoff.

## The bug

`SpineValidator.expand` runs per value during streaming and resolves `$ref` / `$dynamicRef` each time. For an anchor ref (`#name`), `resolveRef` walks the whole document via `walkSubschemas`. An anchor-keyed `items` / property schema therefore re-scanned the entire schema (including large OpenAPI `components`) on every element: O(N*M) in document size times schema size. A multi-GB body against such a schema degrades catastrophically.

## The fix

Memoize resolution on the spine, keyed by ref string. The key is stable because `refRoot` is immutable for the spine's life. A dangling / external ref (`undefined`) is cached via `has`, so it is not re-walked either. JSON-pointer refs collapse to a single lookup as a side benefit (cheap before, free now).

Regression test: an anchor ref used as the `items` schema across a 200-element array must keep its verdict (valid, one-bad, empty), proving the cache never returns a stale target.

## Docs polish (separate commit)

While here, made the scope-hook coverage limitation explicit: `onScopeClose` / `editClose` fire for STREAM scopes only, not BUFFER islands or TEE composition branches. Spelled out in the hooks TSDoc (canonical contract) and the README recipe. Gemini flagged this as a DX surprise; it is intended behavior, so the response is documentation, not a code change.

## Verification

- `pnpm vitest run packages/stream-validator` (1276 tests) pass
- `pnpm typecheck` clean
- `oxfmt --check` clean on touched files; `check:deps` clean

The pre-existing `oxfmt` failure on the untracked `stream-validator-evaluation.md` (the review doc) is unrelated and not part of this branch.