### PR TITLE
feat(stream-validator): surface scalar value spans on a value channel

### DIFF
--- a/packages/stream-validator/README.md
+++ b/packages/stream-validator/README.md
@@ -99,6 +99,40 @@ bytes before a scope's closing delimiter (append-only; appended bytes are
 not validated). A `ScopeContext` carries the scope path, verdict, member
 count, and a `field(name, value)` helper.
 
+Recovering scalar fields: `valueEvents` emits a `value` event when a
+scalar object-member value completes, carrying the member's absolute
+input-byte span (`valueStart` / `valueEnd`). Code that needs a few small
+top-level scalars (an id, a version, a timestamp) recovers them without
+materializing the body or running a second parser: slice
+`[valueStart, valueEnd)` from its own copy of the input (a string span
+includes its quotes, so the slice is valid JSON) and `JSON.parse` it. The
+span is in the same pre-injection input space as `editClose` and
+violations, so slice the **input**, not the echoed output (under
+`editClose` the output is respliced and its offsets shift).
+
+```ts
+const captured = new Map<string, unknown>();
+const validator = createStreamValidator(bodySchema, {
+  // Decode the matched scalars under a byte cap.
+  valueEvents: { at: (path) => path.length === 1, capture: true },
+});
+validator.on("value", (e) => captured.set(e.key, e.value));
+// `e.value` is the decoded scalar (present when within `maxCaptureBytes`);
+// `e.truncated` flags an over-cap value (span still reported). Omit
+// `capture` for span-only events and slice the bytes yourself.
+```
+
+`valueEvents` fires for scalar object members on both the STREAM path and
+scalar BUFFER islands, so a `format`-bearing string (`date-time`, `uri`,
+`uuid`) reports its value even under an asserting OpenAPI dialect that
+delegates it to the in-memory engine. Array elements, the root value,
+container-valued members, and members under a TEE composition branch do
+not fire. `capture` retains a matched member's decoded bytes bounded by
+`maxCaptureBytes` (default 64 KiB); an over-cap value reports
+`truncated: true` rather than buffering unbounded. A delegated scalar is
+already buffered for its own check, so there `maxCaptureBytes` only gates
+delivery (the memory bound is `maxBufferedBytes`).
+
 `onScopeClose` / `editClose` fire for STREAM scopes only. A scope the
 classifier routes to a BUFFER island (`uniqueItems`, `contains`, an
 object-valued `const`) or a TEE composition branch

--- a/packages/stream-validator/src/engine/hooks.ts
+++ b/packages/stream-validator/src/engine/hooks.ts
@@ -17,6 +17,52 @@
 
 import type { JsonValue, PathSegment } from "@oav/core";
 
+/**
+ * Default cap on a captured scalar's source-byte span, applied when
+ * `valueEvents.capture` is on and `maxCaptureBytes` is unset. Capture is
+ * meant for small scalars (an id, a version, a timestamp); a member whose
+ * value exceeds this is reported with `value` omitted and `truncated`
+ * set, never buffered past the cap.
+ */
+export const DEFAULT_MAX_CAPTURE_BYTES = 65536;
+
+/**
+ * A `value` event: a scalar object-member value completed (validated on
+ * the STREAM path or routed to a scalar BUFFER island, e.g. a
+ * `format`-bearing string). Reports the member location and the value's
+ * absolute input-byte span; carries the decoded value only when capture
+ * is on.
+ *
+ * `valueStart` / `valueEnd` are absolute offsets into the **input** byte
+ * stream, in the pre-injection space `editClose` and violations share. A
+ * consumer slices `[valueStart, valueEnd)` from its own copy of the input
+ * (the bytes include a string's surrounding quotes, so the slice is
+ * itself valid JSON to `JSON.parse`). Slice the input, not the echoed
+ * output: under `editClose` the output is respliced and its offsets no
+ * longer line up.
+ *
+ * @public
+ */
+export interface ValueEvent {
+  /** Path to the enclosing object scope (the root scope is `[]`). */
+  path: PathSegment[];
+  /** The member key. */
+  key: string;
+  /** Byte offset of the value's first byte (a string's opening quote). */
+  valueStart: number;
+  /** Byte offset just past the value's last byte. */
+  valueEnd: number;
+  /** JSON type of the value. */
+  type: "string" | "number" | "boolean" | "null";
+  /**
+   * The decoded value, present only when `valueEvents.capture` is on and
+   * the value fit within `maxCaptureBytes`; otherwise `undefined`.
+   */
+  value?: string | number | boolean | null;
+  /** True when capture was requested but the value exceeded `maxCaptureBytes` (the span is still reported). */
+  truncated: boolean;
+}
+
 /** Bytes an `editClose` hook may append. A string is encoded as UTF-8. */
 export type Bytes = Buffer | Uint8Array | string;
 

--- a/packages/stream-validator/src/engine/index.ts
+++ b/packages/stream-validator/src/engine/index.ts
@@ -3,4 +3,5 @@ export {
   StreamValidator,
   ValidationFailedError,
 } from "./stream-validator.js";
-export type { Bytes, ScopeContext, ScopeEditor, ScopeObserver } from "./hooks.js";
+export { DEFAULT_MAX_CAPTURE_BYTES } from "./hooks.js";
+export type { Bytes, ScopeContext, ScopeEditor, ScopeObserver, ValueEvent } from "./hooks.js";

--- a/packages/stream-validator/src/engine/stream-validator.ts
+++ b/packages/stream-validator/src/engine/stream-validator.ts
@@ -51,7 +51,14 @@ import {
 } from "../spine/index.js";
 import { JsonTokenizer } from "../tokenizer/index.js";
 import type { JsonPath, PathFilter, StreamValidatorOptions } from "../options.js";
-import { makeScopeContext, type ScopeEditor, type ScopeObserver, toBuffer } from "./hooks.js";
+import {
+  DEFAULT_MAX_CAPTURE_BYTES,
+  makeScopeContext,
+  type ScopeEditor,
+  type ScopeObserver,
+  toBuffer,
+  type ValueEvent,
+} from "./hooks.js";
 
 /** Does a path filter match this scope path + kind? */
 function matchPathFilter(
@@ -61,6 +68,23 @@ function matchPathFilter(
 ): boolean {
   if (typeof filter === "function") return filter(path as JsonPath, kind);
   return filter.length === path.length && filter.every((seg, i) => seg === path[i]);
+}
+
+// Does a value-event filter match this member? The filter is matched
+// against the member's full path (the enclosing scope path plus the key),
+// so a filter targets a specific field rather than every member of a
+// scope. The predicate form receives that full path with kind "object"
+// (a value member is always an object member).
+function matchValueFilter(
+  filter: PathFilter,
+  scopePath: readonly PathSegment[],
+  key: string,
+): boolean {
+  if (typeof filter === "function") return filter([...scopePath, key] as JsonPath, "object");
+  return (
+    filter.length === scopePath.length + 1 &&
+    filter.every((seg, i) => (i < scopePath.length ? seg === scopePath[i] : seg === key))
+  );
 }
 
 /**
@@ -192,6 +216,12 @@ export class StreamValidator extends Transform {
   private readonly tokenizer: JsonTokenizer;
   private readonly maxErrors: number;
   private readonly policy: "terminate" | "detach";
+  private readonly valueEvents: StreamValidatorOptions["valueEvents"];
+  // Capture mode: the spine applies the value-event filter (to gate text
+  // retention) and gates emission on it, so the driver trusts the spine
+  // and does not re-run the filter. Span-only: the spine emits every
+  // scalar and the driver filters here.
+  private readonly valueCaptureConfigured: boolean;
 
   private readonly maxTotalBytes: number | undefined;
   private totalBytes = 0;
@@ -233,10 +263,30 @@ export class StreamValidator extends Transform {
       options.maxTotalBytes,
       "Omit the option for no total-size cap.",
     );
+    if (typeof options.valueEvents === "object") {
+      assertPositiveIntOption(
+        "valueEvents.maxCaptureBytes",
+        options.valueEvents.maxCaptureBytes,
+        "Omit it to use the default capture cap.",
+      );
+    }
     this.maxErrors = options.maxErrors ?? 1;
     this.policy = options.policy ?? "terminate";
     this.maxTotalBytes = options.maxTotalBytes;
     const keyEvents = options.keyEvents;
+    const valueEvents = options.valueEvents;
+    this.valueEvents = valueEvents;
+    // When capture is on, the matched members retain their decoded scalar
+    // (bounded by the cap); an offsets-only subscription leaves this unset
+    // and the spine buffers nothing. Hoisted so the closures below keep a
+    // narrowed type.
+    const captureFilter =
+      typeof valueEvents === "object" && valueEvents.capture ? valueEvents.at : undefined;
+    this.valueCaptureConfigured = captureFilter !== undefined;
+    const captureCap =
+      typeof valueEvents === "object" && valueEvents.maxCaptureBytes !== undefined
+        ? valueEvents.maxCaptureBytes
+        : DEFAULT_MAX_CAPTURE_BYTES;
 
     // OpenAPI 3.0 -> 2020-12 normalization (nullable / boolean exclusive*
     // / $ref sibling suppression) before any classification. 3.1 / 3.2
@@ -285,6 +335,30 @@ export class StreamValidator extends Transform {
             },
           }
         : {}),
+      ...(valueEvents
+        ? {
+            valueEvent: (
+              scopePath: readonly PathSegment[],
+              key: string,
+              valueStart: number,
+              valueEnd: number,
+              type: "string" | "number" | "boolean" | "null",
+              value: string | number | boolean | null | undefined,
+              truncated: boolean,
+            ) => {
+              this.handleValueEvent(scopePath, key, valueStart, valueEnd, type, value, truncated);
+            },
+            // Capture (retaining the decoded scalar) is gated to the
+            // matched members so a huge unmatched value never buffers.
+            ...(captureFilter !== undefined
+              ? {
+                  shouldCapture: (scopePath: readonly PathSegment[], key: string) =>
+                    matchValueFilter(captureFilter, scopePath, key),
+                  maxCaptureBytes: captureCap,
+                }
+              : {}),
+          }
+        : {}),
       onScopeClose: (close: ScopeClose) => this.handleScopeClose(close),
     });
     this.tokenizer = new JsonTokenizer(this.spine);
@@ -301,6 +375,32 @@ export class StreamValidator extends Transform {
   private handleViolation(violation: SchemaViolation): void {
     this.errorCount += 1;
     this.emit("violation", violation);
+  }
+
+  // Emit a `value` event for a scalar member the spine reported. Where the
+  // path filter runs depends on the mode (see below): span-only mode
+  // filters here, mirroring how `keyEvent` filters in the driver; capture
+  // mode filters in the spine.
+  private handleValueEvent(
+    scopePath: readonly PathSegment[],
+    key: string,
+    valueStart: number,
+    valueEnd: number,
+    type: "string" | "number" | "boolean" | "null",
+    value: string | number | boolean | null | undefined,
+    truncated: boolean,
+  ): void {
+    const ve = this.valueEvents;
+    if (ve === undefined || ve === false) return;
+    // Capture mode: the spine already applied the (identical) filter and
+    // only emits matched members, so re-filtering here would run the
+    // predicate twice per value. Span-only mode filters here.
+    if (!this.valueCaptureConfigured && ve !== true && !matchValueFilter(ve.at, scopePath, key)) {
+      return;
+    }
+    const event: ValueEvent = { path: [...scopePath], key, valueStart, valueEnd, type, truncated };
+    if (value !== undefined) event.value = value;
+    this.emit("value", event);
   }
 
   /**

--- a/packages/stream-validator/src/index.ts
+++ b/packages/stream-validator/src/index.ts
@@ -20,12 +20,14 @@
 export type { JsonPath, PathFilter, StreamValidatorOptions } from "./options.js";
 export {
   createStreamValidator,
+  DEFAULT_MAX_CAPTURE_BYTES,
   StreamValidator,
   ValidationFailedError,
   type Bytes,
   type ScopeContext,
   type ScopeEditor,
   type ScopeObserver,
+  type ValueEvent,
 } from "./engine/index.js";
 export type { StreamVerdict, SchemaViolation } from "./spine/index.js";
 export { normalizeOas30 } from "./openapi/index.js";

--- a/packages/stream-validator/src/options.ts
+++ b/packages/stream-validator/src/options.ts
@@ -130,6 +130,39 @@ export interface StreamValidatorOptions {
   keyEvents?: boolean | { at: PathFilter };
 
   /**
+   * Emit a `value` event when a scalar object-member value completes,
+   * carrying the member's absolute input-byte span (`valueStart` /
+   * `valueEnd`, the same pre-injection space `editClose` and violations
+   * use) so a consumer can slice and parse it off its own copy of the
+   * input without a second parser. Absent = off: the spine does no
+   * value-event work and emits nothing (one unsubscribed early-return per
+   * scalar, no allocation).
+   *
+   *   - `true`: emit for every scalar member, span only (no decode).
+   *   - `{ at }`: restrict to members whose **full path** (the enclosing
+   *     scope path plus the key) matches the filter. This differs from
+   *     `keyEvents.at`, which matches the enclosing scope path: a value
+   *     filter targets one field (`["meta", "id"]`), not a whole scope.
+   *   - `{ at, capture: true }`: also decode the matched scalar and deliver
+   *     it as `value` on the event, bounded by `maxCaptureBytes` (a value
+   *     larger than the cap is reported with `value` omitted and
+   *     `truncated: true`; its span is still reported). Capture defaults to
+   *     a {@link DEFAULT_MAX_CAPTURE_BYTES}-byte cap when `maxCaptureBytes`
+   *     is unset; pass `Infinity` to disable the cap (retain the whole
+   *     value, the way the other `max*` options read `Infinity`).
+   *
+   * Scope is scalar object members. Every scalar member fires, whether
+   * validated on the STREAM path or routed to a scalar BUFFER island, so a
+   * `format`-bearing string (`date-time`, `uri`, `uuid`) reports its value
+   * even under an asserting OpenAPI dialect, where it would otherwise be
+   * delegated silently. Array elements, the root value, and members routed
+   * to a TEE composition branch (`oneOf`/`anyOf`/...) are not reported; an
+   * object- or array-valued member is a container, not a scalar, and never
+   * fires. See {@link ValueEvent}.
+   */
+  valueEvents?: boolean | { at: PathFilter; capture?: boolean; maxCaptureBytes?: number };
+
+  /**
    * Cap on any single internal buffer (a forced-buffer scalar or a
    * BUFFER island), in **UTF-8 source bytes** spanned by the buffered
    * region. A proportional proxy for heap, not an exact heap bound; size

--- a/packages/stream-validator/src/spine/spine.ts
+++ b/packages/stream-validator/src/spine/spine.ts
@@ -153,6 +153,38 @@ export interface SpineOptions {
    */
   keyEvent?: (scopePath: readonly PathSegment[], key: string, byteOffset: number) => void;
   /**
+   * Fired when a scalar object-member value completes, with the enclosing
+   * scope path, the member key, the value's absolute input-byte span, its
+   * JSON type, and (when this member is being captured) the decoded value.
+   * Fires for every scalar member, whether validated on the STREAM path or
+   * routed to a scalar BUFFER island (a `format`-bearing string, a
+   * buffered scalar): the value is materialized for the delegate either
+   * way. Array elements, the root value, and TEE composition members are
+   * not reported. Set only when value events are requested (so the spine
+   * pays nothing when they are off); the driver applies any path filter
+   * and routes the event.
+   */
+  valueEvent?: (
+    scopePath: readonly PathSegment[],
+    key: string,
+    valueStart: number,
+    valueEnd: number,
+    type: "string" | "number" | "boolean" | "null",
+    value: string | number | boolean | null | undefined,
+    truncated: boolean,
+  ) => void;
+  /**
+   * Whether a matched member's decoded scalar should be captured (retained
+   * and delivered on {@link SpineOptions.valueEvent}). Consulted at a
+   * STREAM string's first byte to gate text retention, and at completion
+   * for values already in hand. Set only when capture is requested; an
+   * offsets-only value subscription leaves it unset and the spine buffers
+   * nothing.
+   */
+  shouldCapture?: (scopePath: readonly PathSegment[], key: string) => boolean;
+  /** Cap on a captured scalar's source-byte span; past it the value is dropped and `truncated` is set. Unset: no cap. */
+  maxCaptureBytes?: number;
+  /**
    * Fired when a forward-decidable (STREAM) object/array scope closes,
    * after its verdict is known and before its delimiter, for edit hooks.
    * Islands (composition / buffered scopes) are not reported: their
@@ -266,6 +298,21 @@ export class SpineValidator implements JsonEventHandler {
   private readonly keyEvent:
     | ((scopePath: readonly PathSegment[], key: string, byteOffset: number) => void)
     | undefined;
+  private readonly valueEvent:
+    | ((
+        scopePath: readonly PathSegment[],
+        key: string,
+        valueStart: number,
+        valueEnd: number,
+        type: "string" | "number" | "boolean" | "null",
+        value: string | number | boolean | null | undefined,
+        truncated: boolean,
+      ) => void)
+    | undefined;
+  private readonly shouldCapture:
+    | ((scopePath: readonly PathSegment[], key: string) => boolean)
+    | undefined;
+  private readonly maxCaptureBytes: number | undefined;
   private readonly onScopeClose: ((close: ScopeClose) => void) | undefined;
   // Verdict-only mode (TEE branch sub-spines): track a single invalid flag
   // instead of retaining a violation per failure, so a branch over a huge
@@ -287,6 +334,13 @@ export class SpineValidator implements JsonEventHandler {
     text: string;
     offset: number;
     island: boolean;
+    // `capture`: retain the decoded text for a `value` event (decided at
+    // string start from `shouldCapture`). `captureTruncated`: the captured
+    // span passed `maxCaptureBytes`, so the value is dropped (span still
+    // reported). Independent of `needText` / `maxBufferedBytes`, which
+    // govern validation buffering.
+    capture: boolean;
+    captureTruncated: boolean;
   } | null = null;
 
   // An open BUFFER island being materialized for delegation.
@@ -321,7 +375,60 @@ export class SpineValidator implements JsonEventHandler {
     this.regexCompiler = options.regexCompiler;
     this.assertsFormat = options.assertsFormat ?? false;
     this.keyEvent = options.keyEvent;
+    this.valueEvent = options.valueEvent;
+    this.shouldCapture = options.shouldCapture;
+    this.maxCaptureBytes = options.maxCaptureBytes;
     this.onScopeClose = options.onScopeClose;
+  }
+
+  // The enclosing object member's key, when the value about to / just
+  // completed is an object member (not an array element or the root
+  // value). Gates value events to scalar object members.
+  private memberKey(): string | null {
+    const top = this.frames[this.frames.length - 1];
+    if (top === undefined || top.kind !== "object") return null;
+    return top.pendingKey;
+  }
+
+  // Report a completed scalar object-member value through the one emit
+  // path every scalar uses (no per-type drift). Call only when
+  // `valueEvent` is set (the callers guard, matching `keyEvent?.()`).
+  //
+  // Capture mode (`shouldCapture` set): the spine applies the filter here
+  // and the driver trusts it, so the filter runs once per member, not
+  // again in the driver. A non-matching member emits nothing; a matching
+  // one carries `decoded` (or nothing when `truncated`). A STREAM string
+  // decided its match at string start (to gate text retention) and passes
+  // it as `precomputedMatch` so the filter is not re-run; other scalars
+  // have it in hand at completion and let this method evaluate it.
+  //
+  // Span-only mode (`shouldCapture` unset): every scalar member is emitted
+  // with no value, and the driver applies any path filter.
+  private emitScalarMember(
+    valueStart: number,
+    valueEnd: number,
+    type: "string" | "number" | "boolean" | "null",
+    decoded: string | number | boolean | null,
+    truncated: boolean,
+    precomputedMatch?: boolean,
+  ): void {
+    const key = this.memberKey();
+    if (key === null) return;
+    if (this.shouldCapture === undefined) {
+      this.valueEvent!(this.path, key, valueStart, valueEnd, type, undefined, false);
+      return;
+    }
+    const matched = precomputedMatch ?? this.shouldCapture(this.path, key);
+    if (!matched) return;
+    this.valueEvent!(
+      this.path,
+      key,
+      valueStart,
+      valueEnd,
+      type,
+      truncated ? undefined : decoded,
+      truncated,
+    );
   }
 
   /** The verdict so far (final once `end` has been called on the tokenizer). */
@@ -962,7 +1069,14 @@ export class SpineValidator implements JsonEventHandler {
     // const) or when the value is a BUFFER island (delegated whole).
     const needText =
       island || app.schemas.some((s) => s.pattern !== undefined || "enum" in s || "const" in s);
-    this.str = { app, needText, text: "", offset, island };
+    // Capture is STREAM-member-only: an island string is delegated whole
+    // and does not emit a value event, so never retain it for capture.
+    let capture = false;
+    if (!island && this.shouldCapture !== undefined) {
+      const key = this.memberKey();
+      capture = key !== null && this.shouldCapture(this.path, key);
+    }
+    this.str = { app, needText, text: "", offset, island, capture, captureTruncated: false };
   }
 
   onStringChunk(chunk: string, offset: number): void {
@@ -975,12 +1089,39 @@ export class SpineValidator implements JsonEventHandler {
       this.forwardIsland((b) => b.onStringChunk(chunk));
       return;
     }
-    if (this.str !== null && this.str.needText) {
-      this.str.text += chunk;
-      // A forced-buffer scalar (pattern / enum / const) accumulates; cap
-      // its source-byte span so it can't grow unbounded on hostile input.
-      if (this.maxBufferedBytes !== undefined && offset - this.str.offset > this.maxBufferedBytes) {
-        throw new BufferLimitError(this.maxBufferedBytes, offset);
+    if (this.str !== null && (this.str.needText || this.str.capture)) {
+      const span = offset - this.str.offset;
+      if (this.str.needText) {
+        this.str.text += chunk;
+        // A forced-buffer scalar (pattern / enum / const) accumulates; cap
+        // its source-byte span so it can't grow unbounded on hostile input.
+        if (this.maxBufferedBytes !== undefined && span > this.maxBufferedBytes) {
+          throw new BufferLimitError(this.maxBufferedBytes, offset);
+        }
+        // The same text serves capture; drop delivery (not the run) past
+        // the capture cap.
+        if (this.str.capture && this.maxCaptureBytes !== undefined && span > this.maxCaptureBytes) {
+          this.str.captureTruncated = true;
+        }
+      } else if (!this.str.captureTruncated) {
+        // Capture-only accumulation: bound retention by the decoded length
+        // *before* appending, so a single large chunk (a long string in
+        // one input buffer) cannot be retained past the cap. `span` is
+        // measured to this chunk's start, so it would pass for a one-shot
+        // chunk; the held length is the real memory bound. Decoded UTF-16
+        // length <= the source-byte span, so a length over the cap implies
+        // the span is too, and onStringEnd's source-span check sets the
+        // verdict. Soft limit: drop the held text, never fatal, keep
+        // parsing.
+        if (
+          this.maxCaptureBytes !== undefined &&
+          this.str.text.length + chunk.length > this.maxCaptureBytes
+        ) {
+          this.str.captureTruncated = true;
+          this.str.text = "";
+        } else {
+          this.str.text += chunk;
+        }
       }
     }
   }
@@ -999,13 +1140,7 @@ export class SpineValidator implements JsonEventHandler {
       this.forwardIsland((b) => b.onStringEnd());
       return;
     }
-    const s = this.str as {
-      app: Applicable;
-      needText: boolean;
-      text: string;
-      offset: number;
-      island: boolean;
-    };
+    const s = this.str as NonNullable<typeof this.str>;
     this.str = null;
     // Close the single-chunk bypass: cap the forced-buffer scalar on its
     // full source-byte span, known only now.
@@ -1016,18 +1151,46 @@ export class SpineValidator implements JsonEventHandler {
     ) {
       throw new BufferLimitError(this.maxBufferedBytes, endOffset);
     }
+    // Capture cap on the full span (a single-chunk string skipped the
+    // per-chunk check above).
+    let captureTruncated = s.captureTruncated;
+    if (
+      s.capture &&
+      this.maxCaptureBytes !== undefined &&
+      endOffset - s.offset > this.maxCaptureBytes
+    ) {
+      captureTruncated = true;
+    }
     this.curOffset = s.offset;
     if (s.island) {
+      // A scalar string routed to a BUFFER island (e.g. `format` under an
+      // asserting dialect) is still a scalar member with a known span, and
+      // its text is already materialized for the delegate. Report it like
+      // any other scalar member, so the channel is uniform across STREAM
+      // and buffer-delegated scalars. The match is decided at completion
+      // (the text is in hand, not gated at string start); the cap is a
+      // delivery gate, the bytes already bounded by `maxBufferedBytes`.
+      if (this.valueEvent !== undefined) {
+        const truncated =
+          this.maxCaptureBytes !== undefined && endOffset - s.offset > this.maxCaptureBytes;
+        this.emitScalarMember(s.offset, endOffset, "string", s.text, truncated);
+      }
       this.delegateScalar(s.app, s.text);
       return;
     }
+    // STREAM string member: report the span (opening quote .. past closing
+    // quote, so a slice is valid JSON); deliver the decoded text only when
+    // captured and within the cap. The match was decided at string start
+    // (to gate text retention), so reuse it rather than re-run the filter.
+    if (this.valueEvent !== undefined)
+      this.emitScalarMember(s.offset, endOffset, "string", s.text, captureTruncated, s.capture);
     this.scalar("string", s.needText ? s.text : "", codePoints, s.app);
   }
 
-  onNumber(value: number, raw: string, startOffset: number): void {
+  onNumber(value: number, raw: string, startOffset: number, endOffset: number): void {
     this.curOffset = startOffset;
     if (this.tee !== null) {
-      this.teeFeed((s) => s.onNumber(value, raw, startOffset));
+      this.teeFeed((s) => s.onNumber(value, raw, startOffset, endOffset));
       this.tee.started = true;
       if (this.teeComplete()) this.finalizeTee();
       return;
@@ -1039,16 +1202,18 @@ export class SpineValidator implements JsonEventHandler {
     const app = this.schemasForValue();
     const type = Number.isInteger(value) ? "integer" : "number";
     if (this.needsTee(app)) {
-      this.teeScalar(app, (s) => s.onNumber(value, raw, startOffset));
+      this.teeScalar(app, (s) => s.onNumber(value, raw, startOffset, endOffset));
       return;
     }
+    if (this.valueEvent !== undefined)
+      this.emitScalarMember(startOffset, endOffset, "number", value, false);
     this.scalar(type, value, 0, app);
   }
 
-  onBoolean(value: boolean, startOffset: number): void {
+  onBoolean(value: boolean, startOffset: number, endOffset: number): void {
     this.curOffset = startOffset;
     if (this.tee !== null) {
-      this.teeFeed((s) => s.onBoolean(value, startOffset));
+      this.teeFeed((s) => s.onBoolean(value, startOffset, endOffset));
       this.tee.started = true;
       if (this.teeComplete()) this.finalizeTee();
       return;
@@ -1059,16 +1224,18 @@ export class SpineValidator implements JsonEventHandler {
     }
     const app = this.schemasForValue();
     if (this.needsTee(app)) {
-      this.teeScalar(app, (s) => s.onBoolean(value, startOffset));
+      this.teeScalar(app, (s) => s.onBoolean(value, startOffset, endOffset));
       return;
     }
+    if (this.valueEvent !== undefined)
+      this.emitScalarMember(startOffset, endOffset, "boolean", value, false);
     this.scalar("boolean", value, 0, app);
   }
 
-  onNull(startOffset: number): void {
+  onNull(startOffset: number, endOffset: number): void {
     this.curOffset = startOffset;
     if (this.tee !== null) {
-      this.teeFeed((s) => s.onNull(startOffset));
+      this.teeFeed((s) => s.onNull(startOffset, endOffset));
       this.tee.started = true;
       if (this.teeComplete()) this.finalizeTee();
       return;
@@ -1079,9 +1246,11 @@ export class SpineValidator implements JsonEventHandler {
     }
     const app = this.schemasForValue();
     if (this.needsTee(app)) {
-      this.teeScalar(app, (s) => s.onNull(startOffset));
+      this.teeScalar(app, (s) => s.onNull(startOffset, endOffset));
       return;
     }
+    if (this.valueEvent !== undefined)
+      this.emitScalarMember(startOffset, endOffset, "null", null, false);
     this.scalar("null", null, 0, app);
   }
 }

--- a/packages/stream-validator/test/value-events.test.ts
+++ b/packages/stream-validator/test/value-events.test.ts
@@ -1,0 +1,407 @@
+import { Readable, Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { describe, expect, it } from "vitest";
+import type { PathSegment, SchemaOrBoolean } from "@oav/core";
+import {
+  createStreamValidator,
+  type StreamValidatorOptions,
+  type ValueEvent,
+} from "../src/index.js";
+
+const enc = new TextEncoder();
+
+// Feed `json` (optionally pre-split into chunks) through a validator with
+// the given value-event options and collect the `value` events. Returns
+// the events plus the raw input bytes, so a test can slice spans.
+async function collectValues(
+  schema: SchemaOrBoolean,
+  json: string | string[],
+  valueEvents: StreamValidatorOptions["valueEvents"],
+  extra: StreamValidatorOptions = {},
+): Promise<{ events: ValueEvent[]; input: Buffer }> {
+  const chunks = (Array.isArray(json) ? json : [json]).map((c) => Buffer.from(enc.encode(c)));
+  const input = Buffer.concat(chunks);
+  const validator = createStreamValidator(schema, {
+    policy: "detach",
+    maxErrors: Number.POSITIVE_INFINITY,
+    valueEvents,
+    ...extra,
+  });
+  const events: ValueEvent[] = [];
+  validator.on("value", (e: ValueEvent) => events.push(e));
+  validator.on("error", () => {});
+  await pipeline(Readable.from(chunks), validator, new Writable({ write: (_c, _e, cb) => cb() }));
+  return { events, input };
+}
+
+// The bytes a `value` event points at, as JSON.parse sees them.
+function sliceParse(input: Buffer, e: ValueEvent): unknown {
+  return JSON.parse(input.subarray(e.valueStart, e.valueEnd).toString("utf8"));
+}
+
+const objectSchema: SchemaOrBoolean = { type: "object" };
+
+describe("value events", () => {
+  it("reports a span for each scalar member, across every JSON scalar type", async () => {
+    const json = '{"s":"abc","n":42,"f":1.5,"b":true,"z":null}';
+    const { events, input } = await collectValues(objectSchema, json, true);
+    expect(events.map((e) => [e.key, e.type])).toEqual([
+      ["s", "string"],
+      ["n", "number"],
+      ["f", "number"],
+      ["b", "boolean"],
+      ["z", "null"],
+    ]);
+    // Each span slices to valid JSON whose value matches the source.
+    expect(events.map((e) => sliceParse(input, e))).toEqual(["abc", 42, 1.5, true, null]);
+  });
+
+  it("spans a string from its opening quote to just past its closing quote", async () => {
+    const { events, input } = await collectValues(objectSchema, '{"id":"abc"}', true);
+    const [e] = events;
+    expect(input.subarray(e.valueStart, e.valueEnd).toString()).toBe('"abc"');
+    expect(sliceParse(input, e)).toBe("abc");
+  });
+
+  it("carries the enclosing scope path and the member key", async () => {
+    const { events } = await collectValues(objectSchema, '{"meta":{"id":"x"}}', true);
+    expect(events.map((e) => [e.path, e.key])).toEqual([[["meta"], "id"]]);
+  });
+
+  it("filters by the member's full path, not just the scope", async () => {
+    const json = '{"a":1,"meta":{"id":"x","ver":2}}';
+    const { events } = await collectValues(objectSchema, json, { at: ["meta", "id"] });
+    expect(events.map((e) => [e.path, e.key])).toEqual([[["meta"], "id"]]);
+  });
+
+  it("filters by a predicate over the full path", async () => {
+    const json = '{"id":1,"meta":{"id":2}}';
+    const { events } = await collectValues(objectSchema, json, {
+      at: (path: PathSegment[]) => path[path.length - 1] === "id",
+    });
+    expect(events.map((e) => e.path)).toEqual([[], ["meta"]]);
+  });
+
+  it("emits nothing when off (the default)", async () => {
+    const { events } = await collectValues(objectSchema, '{"a":1}', undefined);
+    expect(events).toEqual([]);
+    const off = await collectValues(objectSchema, '{"a":1}', false);
+    expect(off.events).toEqual([]);
+  });
+
+  describe("scope: scalar object members (STREAM and buffer-delegated)", () => {
+    it("skips array elements (and the array-valued member, a container)", async () => {
+      const { events } = await collectValues({ type: "object" }, '{"xs":[1,2,3]}', true);
+      // `xs` is a container, not a scalar; its elements are array elements.
+      expect(events).toEqual([]);
+    });
+
+    it("reports scalar siblings of an array member, but not the array's elements", async () => {
+      const { events } = await collectValues({ type: "object" }, '{"xs":[1,2],"k":9}', true);
+      expect(events.map((e) => [e.key, e.type])).toEqual([["k", "number"]]);
+    });
+
+    it("skips the root scalar", async () => {
+      const { events } = await collectValues(true, '"just a string"', true);
+      expect(events).toEqual([]);
+    });
+
+    it("skips a member routed to a TEE composition branch", async () => {
+      const schema: SchemaOrBoolean = {
+        type: "object",
+        properties: { x: { oneOf: [{ type: "string" }, { type: "number" }] } },
+      };
+      const { events } = await collectValues(schema, '{"x":"hi"}', true);
+      expect(events).toEqual([]);
+    });
+
+    it("still reports a STREAM scalar that buffers for a forward keyword (pattern)", async () => {
+      const schema: SchemaOrBoolean = {
+        type: "object",
+        properties: { code: { type: "string", pattern: "^[a-z]+$" } },
+      };
+      const { events, input } = await collectValues(schema, '{"code":"abc"}', true);
+      expect(events.map((e) => e.key)).toEqual(["code"]);
+      expect(sliceParse(input, events[0])).toBe("abc");
+    });
+
+    it("reports a format-bearing string island under an asserting dialect", async () => {
+      // The headline case: `date-time` routes to a BUFFER island under an
+      // OpenAPI dialect, but its value is materialized for the format
+      // check, so the channel still fires (no schema fork needed).
+      const schema: SchemaOrBoolean = {
+        type: "object",
+        properties: { ts: { type: "string", format: "date-time" } },
+      };
+      const { events, input } = await collectValues(
+        schema,
+        '{"ts":"2026-06-19T00:00:00Z"}',
+        { at: ["ts"], capture: true },
+        { openApiVersion: "3.1" },
+      );
+      expect(events.map((e) => [e.key, e.type, e.value])).toEqual([
+        ["ts", "string", "2026-06-19T00:00:00Z"],
+      ]);
+      expect(sliceParse(input, events[0])).toBe("2026-06-19T00:00:00Z");
+    });
+
+    it("reports a format-string island in span-only mode (no capture)", async () => {
+      const schema: SchemaOrBoolean = {
+        type: "object",
+        properties: { ts: { type: "string", format: "date-time" } },
+      };
+      const { events, input } = await collectValues(schema, '{"ts":"2026-06-19T00:00:00Z"}', true, {
+        openApiVersion: "3.1",
+      });
+      expect(events.map((e) => [e.key, e.type, e.value])).toEqual([["ts", "string", undefined]]);
+      expect(sliceParse(input, events[0])).toBe("2026-06-19T00:00:00Z");
+    });
+
+    it("does not fire for a scalar string nested inside a container island", async () => {
+      // `o` is an object-valued island (enum of objects); the string `s`
+      // inside it is part of the buffered subtree, not a top-level member.
+      const schema: SchemaOrBoolean = {
+        type: "object",
+        properties: { o: { enum: [{ s: "x" }] } },
+      };
+      const { events } = await collectValues(schema, '{"o":{"s":"x"}}', true);
+      expect(events).toEqual([]);
+    });
+
+    it("reports a format-bearing number island under an asserting dialect", async () => {
+      // Numbers already fired for islands (their decode is in hand before
+      // delegation); lock it so strings and numbers stay consistent.
+      const schema: SchemaOrBoolean = {
+        type: "object",
+        properties: { n: { type: "number", format: "int64" } },
+      };
+      const { events } = await collectValues(
+        schema,
+        '{"n":42}',
+        { at: ["n"], capture: true },
+        {
+          openApiVersion: "3.1",
+        },
+      );
+      expect(events.map((e) => [e.key, e.type, e.value])).toEqual([["n", "number", 42]]);
+    });
+
+    it("still skips an object-valued island member (a container, not a scalar)", async () => {
+      // `enum` of objects forces a BUFFER island, but the value is a
+      // container, so no value event.
+      const schema: SchemaOrBoolean = {
+        type: "object",
+        properties: { o: { enum: [{ a: 1 }] } },
+      };
+      const { events } = await collectValues(schema, '{"o":{"a":1}}', true);
+      expect(events).toEqual([]);
+    });
+
+    it("truncates an over-cap format-string island, still reporting the span", async () => {
+      const schema: SchemaOrBoolean = {
+        type: "object",
+        properties: { u: { type: "string", format: "uri" } },
+      };
+      const { events, input } = await collectValues(
+        schema,
+        '{"u":"https://example.com/a/very/long/path"}',
+        { at: ["u"], capture: true, maxCaptureBytes: 8 },
+        { openApiVersion: "3.1" },
+      );
+      const [e] = events;
+      expect(e.truncated).toBe(true);
+      expect(e.value).toBeUndefined();
+      expect(sliceParse(input, e)).toBe("https://example.com/a/very/long/path");
+    });
+  });
+
+  describe("capture", () => {
+    it("delivers the decoded value when capture is on", async () => {
+      const json = '{"s":"a\\nb","n":42,"z":null}';
+      const { events } = await collectValues(objectSchema, json, {
+        at: () => true,
+        capture: true,
+      });
+      expect(events.map((e) => e.value)).toEqual(["a\nb", 42, null]);
+      // A captured null is present (not merely absent).
+      const nullEvent = events.find((e) => e.key === "z")!;
+      expect("value" in nullEvent).toBe(true);
+      expect(nullEvent.value).toBeNull();
+      expect(events.every((e) => e.truncated === false)).toBe(true);
+    });
+
+    it("delivers falsy captured values (0, false, empty string)", async () => {
+      // The driver guards on `value !== undefined`, not falsiness, so a
+      // captured 0 / false / "" must ride along, not be dropped.
+      const { events } = await collectValues(objectSchema, '{"n":0,"b":false,"s":""}', {
+        at: () => true,
+        capture: true,
+      });
+      expect(events.map((e) => [e.key, e.value])).toEqual([
+        ["n", 0],
+        ["b", false],
+        ["s", ""],
+      ]);
+      expect(events.every((e) => "value" in e)).toBe(true);
+    });
+
+    it("omits the value (offsets only) when capture is off", async () => {
+      const { events } = await collectValues(objectSchema, '{"s":"abc"}', { at: ["s"] });
+      expect(events[0].value).toBeUndefined();
+      expect(events[0].truncated).toBe(false);
+    });
+
+    it("drops the value and sets truncated past maxCaptureBytes, keeping the span", async () => {
+      const { events, input } = await collectValues(objectSchema, '{"s":"abcdefghij"}', {
+        at: ["s"],
+        capture: true,
+        maxCaptureBytes: 4,
+      });
+      const [e] = events;
+      expect(e.truncated).toBe(true);
+      expect(e.value).toBeUndefined();
+      // The span is still usable: the consumer can slice the raw bytes.
+      expect(sliceParse(input, e)).toBe("abcdefghij");
+    });
+
+    it("bounds capture for a large value delivered in a single chunk", async () => {
+      // A long string arriving in one input buffer reaches the spine as a
+      // single onStringChunk. The per-chunk cap must bound retention before
+      // the append, not only at string end, so a value far over the cap is
+      // truncated (value dropped) without being retained whole.
+      const big = "x".repeat(100_000);
+      const { events, input } = await collectValues(objectSchema, `{"s":"${big}"}`, {
+        at: ["s"],
+        capture: true,
+        maxCaptureBytes: 16,
+      });
+      const [e] = events;
+      expect(e.truncated).toBe(true);
+      expect(e.value).toBeUndefined();
+      expect(e.valueEnd - e.valueStart).toBe(big.length + 2); // span covers the quotes
+      expect(sliceParse(input, e)).toBe(big);
+    });
+
+    it("truncates capture without starving validation when the schema also buffers the text", async () => {
+      // `pattern` forces full-text buffering (needText), governed by
+      // maxBufferedBytes (here unset); capture truncation is a separate,
+      // softer limit. A pattern-violating char beyond the capture cap must
+      // still be validated: the value is dropped, but the verdict reflects
+      // the whole string.
+      const schema: SchemaOrBoolean = {
+        type: "object",
+        properties: { code: { type: "string", pattern: "^[a-z]+$" } },
+      };
+      const validator = createStreamValidator(schema, {
+        policy: "detach",
+        maxErrors: Number.POSITIVE_INFINITY,
+        valueEvents: { at: ["code"], capture: true, maxCaptureBytes: 4 },
+      });
+      const events: ValueEvent[] = [];
+      validator.on("value", (e: ValueEvent) => events.push(e));
+      validator.on("error", () => {});
+      await pipeline(
+        Readable.from([Buffer.from(enc.encode('{"code":"abcdefgZ"}'))]),
+        validator,
+        new Writable({ write: (_c, _e, cb) => cb() }),
+      );
+      const verdict = await validator.result;
+      // The capital Z (past the 4-byte capture cap) still fails the pattern.
+      expect(verdict.valid).toBe(false);
+      expect(verdict.violations.some((v) => v.code === "pattern")).toBe(true);
+      // Capture itself was dropped over the cap; span still reported.
+      expect(events[0].truncated).toBe(true);
+      expect(events[0].value).toBeUndefined();
+    });
+
+    it("accumulates a captured value across chunk boundaries", async () => {
+      const { events, input } = await collectValues(objectSchema, ['{"id":"hel', 'lo world"}'], {
+        at: ["id"],
+        capture: true,
+      });
+      expect(events[0].value).toBe("hello world");
+      expect(sliceParse(input, events[0])).toBe("hello world");
+    });
+
+    it("does not fail the stream when a captured value exceeds the cap (soft limit)", async () => {
+      // A schema that would reject nothing; the run must still settle valid.
+      const validator = createStreamValidator(objectSchema, {
+        valueEvents: { at: ["s"], capture: true, maxCaptureBytes: 2 },
+      });
+      validator.on("value", () => {});
+      validator.on("error", () => {});
+      await pipeline(
+        Readable.from([Buffer.from(enc.encode('{"s":"a very long value"}'))]),
+        validator,
+        new Writable({ write: (_c, _e, cb) => cb() }),
+      );
+      const verdict = await validator.result;
+      expect(verdict.valid).toBe(true);
+    });
+
+    it("rejects a non-positive maxCaptureBytes at construction", () => {
+      expect(() =>
+        createStreamValidator(objectSchema, { valueEvents: { at: ["s"], maxCaptureBytes: 0 } }),
+      ).toThrow(/positive integer/);
+    });
+  });
+
+  it("uses absolute input offsets that ignore editClose injections", async () => {
+    // editClose splices bytes into the OUTPUT; value spans stay in the
+    // pre-injection INPUT space, so slicing the input still lines up.
+    const json = '{"id":"x","n":7}';
+    const validator = createStreamValidator(objectSchema, {
+      valueEvents: { at: () => true, capture: true },
+    });
+    const events: ValueEvent[] = [];
+    validator.on("value", (e: ValueEvent) => events.push(e));
+    validator.on("error", () => {});
+    validator.editClose([], (ctx) => ctx.field("added", true));
+    const out: Buffer[] = [];
+    await pipeline(
+      Readable.from([Buffer.from(enc.encode(json))]),
+      validator,
+      new Writable({
+        write: (c: Buffer, _e, cb) => {
+          out.push(c);
+          cb();
+        },
+      }),
+    );
+    // Output grew (the injection landed), but input-space spans are intact.
+    const output = Buffer.concat(out).toString();
+    expect(output).toContain('"added":true');
+    const input = Buffer.from(enc.encode(json));
+    expect(events.map((e) => sliceParse(input, e))).toEqual(["x", 7]);
+    expect(events.map((e) => e.value)).toEqual(["x", 7]);
+  });
+
+  it("captures a member before the enclosing scope's editClose, so a rename can use it", async () => {
+    // The consumer's pattern: capture scalars during member traversal,
+    // then emit renamed copies at the enclosing scope's close. The value
+    // event must fire before that scope's editClose for the value to be in
+    // hand.
+    const json = '{"message_id":"m-1","ts":"2026-06-19"}';
+    const captured = new Map<string, unknown>();
+    const validator = createStreamValidator(objectSchema, {
+      valueEvents: { at: (path) => path.length === 1, capture: true },
+    });
+    validator.on("value", (e: ValueEvent) => captured.set(e.key, e.value));
+    validator.on("error", () => {});
+    validator.editClose([], (ctx) => ctx.field("id", captured.get("message_id") as string));
+    const out: Buffer[] = [];
+    await pipeline(
+      Readable.from([Buffer.from(enc.encode(json))]),
+      validator,
+      new Writable({
+        write: (c: Buffer, _e, cb) => {
+          out.push(c);
+          cb();
+        },
+      }),
+    );
+    expect(captured.get("message_id")).toBe("m-1");
+    // The renamed copy carries the captured value, spliced before `}`.
+    expect(Buffer.concat(out).toString()).toBe('{"message_id":"m-1","ts":"2026-06-19","id":"m-1"}');
+  });
+});


### PR DESCRIPTION
## Why

A consumer streaming a large JSON body through the validator (e.g. an HTTP proxy validating multi-GB request bodies at flat heap) often needs a handful of small top-level scalars back: an id, a version, a timestamp. Today the key channel (`keyEvents`) reports the key with a byte offset at the key's opening quote, but never hands back the value. The only options were to materialize the body (defeats the engine) or run a second streaming parser over the same bytes (re-imposes the burden the library removes).

The value's byte span is forward-decidable and already computed by the tokenizer (every value event carries an exclusive end offset); it was dropped before reaching the public surface.

## What

Adds `valueEvents`: an opt-in, path-filtered `value` event fired when a scalar object-member value completes.

```ts
valueEvents?: boolean | { at: PathFilter; capture?: boolean; maxCaptureBytes?: number }
```

- `true` / `{ at }` -> a `value` event per matched scalar member, carrying the member's absolute pre-injection input-byte span (`valueStart` / `valueEnd`) and JSON type. The consumer slices `[valueStart, valueEnd)` from its own copy of the input (a string span includes its quotes, so it is valid JSON) and `JSON.parse`s it.
- `{ at, capture: true }` -> the engine also decodes the matched scalar under `maxCaptureBytes` (default 64 KiB) and delivers it as `event.value`. An over-cap value reports `truncated: true` with the span still reported, never buffering unbounded.

Offsets live in the same pre-injection input space as `editClose` and violations, so a member captured during traversal is in hand when the enclosing scope's `editClose` runs (the rename path). Slice the **input**, not the echoed output, since `editClose` resplices the output.

## Scope

Scalar object members. Every scalar member fires, whether validated on the STREAM path or routed to a **scalar BUFFER island** -- so a `format`-bearing string (`date-time`, `uri`, `uuid`) reports its value even under an asserting OpenAPI dialect, where it is delegated to the in-memory engine. The value is materialized for that delegate anyway, so the channel reads the existing buffer rather than adding one (there `maxCaptureBytes` only gates delivery; the memory bound is `maxBufferedBytes`). This also keeps strings consistent with numbers/bool/null, which already fired for islands. Recovering the format-bearing fields is the headline case, and it no longer requires forking the schema (assert `format` here, annotate-only there).

Not reported: array elements, the root value, container-valued members (an object/array is not a scalar), and members routed to a TEE composition branch. The TEE-scalar case is the one place the value is not materialized (sub-spines stream it); offsets-only there is a possible later increment.

## Implementation

- Value completion in `spine.ts` (`onStringEnd` / `onNumber` / `onBoolean` / `onNull`), gated to object-member scalars. STREAM-string capture is decided at value start (`shouldCapture`) so buffering begins in time; numbers/bool/null and buffer-delegated strings decode in hand (the island branch reads the already-materialized text, no new state). The spine's `onNumber`/`onBoolean`/`onNull` now thread the `endOffset` the tokenizer already passed.
- Capture truncation is a soft limit (drop the value, keep parsing), independent of the fatal `maxBufferedBytes` cap that governs validation buffering.
- Engine filters and routes (mirroring `keyEvent`); `maxCaptureBytes` is validated at construction.

## Tests

`value-events.test.ts`: every scalar type, span/quote correctness, full-path filtering (exact + predicate), off-by-default, the scope rules (array elements, root, container islands, TEE excluded; STREAM scalars and `format` string/number islands included), capture on/off/truncated (STREAM and island), cross-chunk capture accumulation, capture-truncation-without-starving-validation, soft-limit-does-not-fail-the-stream, construction validation of `maxCaptureBytes`, and an end-to-end `editClose` rename smoke proving a captured member is in hand at the enclosing scope's close.

Full repo: typecheck clean, all tests pass, lint + format + check:deps clean.

Closes #411