### PR TITLE
docs: scrub internal references and clean up docs/comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,17 +205,15 @@ OpenAPI validator output. See [docs/comparison.md](https://github.com/aahoughton
 for the feature map, and [docs/migration-from-eov.md](https://github.com/aahoughton/oav/blob/main/docs/migration-from-eov.md)
 if you are migrating from `express-openapi-validator`.
 
-On raw speed, oav wins some and loses some against Ajv, and for most
-services the difference is immaterial. oav compiles schemas far faster
-(tens of microseconds against milliseconds), validates competitively on
-typical request bodies, and carries a slightly smaller steady-state
-memory footprint than `express-openapi-validator`. Ajv is faster on
-fast-fail validation of some ordinary object shapes. At normal request
-volumes (a validation or two per request, thousands of requests per
-second) these gaps are nanoseconds per call and vanish into everything
-else a handler does. They only start to matter if you validate at
-extreme volume or against pathological shapes (very large `uniqueItems`
-arrays, very long length-bounded strings).
+On raw speed, oav wins some and loses some against Ajv. oav compiles
+schemas far faster (tens of microseconds against milliseconds),
+validates competitively on typical request bodies, and carries a
+slightly smaller steady-state memory footprint than
+`express-openapi-validator`. Ajv is faster on fast-fail validation of
+some ordinary object shapes. At normal request volumes these gaps are
+nanoseconds per call; they only start to matter at extreme volume or
+against pathological shapes (very large `uniqueItems` arrays, very long
+length-bounded strings).
 
 For the host-stamped per-shape numbers, the memory comparison, and the
 methodology, see [docs/comparison.md](https://github.com/aahoughton/oav/blob/main/docs/comparison.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,9 +48,7 @@ benchmark dependencies, isolated from the main workspace:
 Dependabot scans each of those lockfiles. CVEs reported against a
 package that only appears under one of those directories affect that
 sub-root's test or benchmark harness; they do not reach the runtime
-tree that consumers of the npm packages receive. If you are a
-downstream consumer who has seen a CVE under one of these directories
-on the security tab and is unsure whether your install is affected,
-the answer is no: the affected package is not present in any
-published tarball, and your transitive resolution does not pick it
-up via these packages.
+tree that consumers of the npm packages receive. A downstream consumer
+who sees such a CVE on the security tab is not affected: the package is
+not present in any published tarball, so transitive resolution does not
+pick it up.

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -53,10 +53,11 @@ this suite adds the breadth of a real-world corpus.
 
 Output: per-file table on stdout, raw JSON written to
 `json-schema-results.json` / `json-parse-results.json` /
-`overlay-results.json` / `openapi-results.json` (`json-parse-results.json`,
-`overlay-results.json`, and `openapi-results.json` are committed baselines
-that CI compares against with `--check-baseline`; `json-schema-results.json`
-is committed but the `+optional` variant is gitignored as a moving target).
+`overlay-results.json` / `openapi-results.json`. `json-parse-results.json`,
+`json-schema-results.json`, and `overlay-results.json` are committed
+baselines that CI compares against with `--check-baseline`;
+`openapi-results.json` and the `+optional` JSON Schema variant are
+gitignored as moving targets.
 
 ## Where to add new cases
 

--- a/conformance/REPORT.md
+++ b/conformance/REPORT.md
@@ -1,14 +1,16 @@
 # Conformance report
 
-Generated against three upstream / hand-curated test corpora:
+Generated 2026-06-19 against commit `b8d5dd7`.
 
-- **JSON Schema Test Suite** — the canonical draft-2020-12 cases at
+Run against three upstream / hand-curated test corpora:
+
+- **JSON Schema Test Suite**: the canonical draft-2020-12 cases at
   <https://github.com/json-schema-org/JSON-Schema-Test-Suite>,
   cloned into `conformance/JSON-Schema-Test-Suite/` by `pnpm setup`.
-- **OpenAPI Overlay 1.0 Test Suite** — the envelope-schema fixtures
+- **OpenAPI Overlay 1.0 Test Suite**: the envelope-schema fixtures
   at <https://github.com/OAI/Overlay-Specification>, cloned into
   `conformance/Overlay-Specification/` by `pnpm setup:overlay`.
-- **OpenAPI cases** — hand-curated request/response scenarios under
+- **OpenAPI cases**: hand-curated request/response scenarios under
   `conformance/openapi-cases/<group>/`, covering the petstore shape
   across 3.0, 3.1, and 3.2.
 
@@ -16,10 +18,10 @@ Generated against three upstream / hand-curated test corpora:
 
 | Source                              | Cases | Pass | Mismatch | Error | % pass |
 | ----------------------------------- | ----- | ---- | -------- | ----- | ------ |
-| JSON Schema Test Suite (required)   | 1290  | 1271 | 15       | 4     | 98.5%  |
+| JSON Schema Test Suite (required)   | 1290  | 1270 | 16       | 4     | 98.4%  |
 | JSON Schema Test Suite (+ optional) | 1452  | 1429 | 19       | 4     | 98.4%  |
 | OpenAPI Overlay 1.0 (envelope)      | 32    | 32   | 0        | 0     | 100%   |
-| OpenAPI `petstore` via `oav` CLI    | 14    | 14   | 0        | 0     | 100%   |
+| OpenAPI `petstore` via `oav` CLI    | 32    | 32   | 0        | 0     | 100%   |
 
 "Mismatch" = our verdict differs from upstream; "error" = our compiler
 crashed (we couldn't produce a verdict at all).
@@ -33,63 +35,44 @@ checkable.
 
 ## Where we diverge from the JSON Schema suite
 
-Every remaining divergence falls into a small number of categories,
-documented below.
+The 20 non-passing required-suite cases (16 mismatch + 4 error) fall
+into three groups.
 
-### 1. `$dynamicRef` with runtime dynamic scope (~25 cases)
+### `$dynamicRef` with runtime dynamic scope (12 cases)
 
 Partial implementation. Our `$dynamicRef` resolves statically against
-the anchor map. Tests that rely on a `$dynamicRef` rebinding at the
-outermost `$dynamicAnchor` encountered during validation fail.
-Documented in `CLAUDE.md`.
+the anchor map, so tests that rely on a `$dynamicRef` rebinding at the
+outermost `$dynamicAnchor` encountered during validation fail
+(`dynamicRef.json`). Documented in `CLAUDE.md`.
 
-**Fix path**: maintain a runtime stack of `$dynamicAnchor` scopes during
+Fix path: maintain a runtime stack of `$dynamicAnchor` scopes during
 validation, resolve `$dynamicRef` at call time.
 
-### 2. Fixed so far
+### External / cross-document `$ref` loading (4 errors)
 
-- `format.json` (17 → 0). Flipped `format` to the spec's non-assertive
-  default and put the assertion keyword behind an opt-in vocabulary that
-  `@oav/validator` enables.
-- JSON Pointer percent-decoding (6 → 0 on `ref.json`).
-- `dependencies` (draft-07 compat): 14 → 0 on
-  `optional/dependencies-compatibility.json`. The keyword was split in
-  2020-12 into `dependentRequired` / `dependentSchemas`; older schemas
-  continue to use the combined form, so we added a keyword that
-  dispatches per-entry on value shape.
-- External / cross-document `$ref`: `refRemote.json` 0/31 → 31/31.
-  `compileSchema` now accepts a pre-registered external schema map
-  via the `external` option, and `resolve()` walks every registered
-  schema to collect its `$id` / `$anchor` entries scoped by base URI.
-- `unevaluatedProperties` / `unevaluatedItems` across composition.
-  Generated subvalidators now take out-parameter `Set<string>`s and
-  composition / `$ref` / `if-then-else` / `dependentSchemas` keywords
-  thread them through, merging keys from passing branches only.
-- `if`-branch annotations & nested `unevaluated*: true`: fixed 14
-  cases across `unevaluatedProperties.json` / `unevaluatedItems.json`.
-  `if`'s evaluated-key set is now merged into the outer scope when
-  `if` passes (2020-12 semantics, not 2019-09's drop-on-if), which
-  also threads `contains`-via-`if` annotations into
-  `unevaluatedItems`. A nested `unevaluatedProperties: true` /
-  `unevaluatedItems: true` now marks every iterated key/index as
-  evaluated so outer scopes see them.
+`defs.json` and `ref.json` surface 2 errors each where a referenced
+document is not loaded into the schema map.
+
+### Residual singletons (4 mismatches)
+
+One mismatch each in `multipleOf.json`, `unevaluatedItems.json`,
+`unevaluatedProperties.json`, and `vocabulary.json`.
 
 ## Optional-suite breakdown
 
 Running with `--optional` widens to 1452 cases. The extra 162 cases
-live under `tests/draft2020-12/optional/`. Current state:
+live under `tests/draft2020-12/optional/`. The 23 non-passing optional
+cases (19 mismatch + 4 error):
 
-| File                                                                                                 | Status                                                                                                                |
-| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `anchor.json`, `cross-draft.json`                                                                    | 3 errors, external-ref loading (same as category #1).                                                                 |
-| `dependencies-compatibility.json`                                                                    | **14 → 0** (fixed in commit `79af5a7`).                                                                               |
-| `dynamicRef.json`                                                                                    | 2 failures, subset of category #1.                                                                                    |
-| `float-overflow.json`                                                                                | 1 failure: "optional overflow handling", explicitly flagged as implementation-optional in the test group description. |
-| `format-assertion.json`                                                                              | 2 failures: requires meta-schema loading via `$schema`, tied to category #1.                                          |
-| `bignum.json`, `ecmascript-regex.json`                                                               | pass.                                                                                                                 |
-| `non-bmp-regex.json`, `id.json`, `no-schema.json`, `unknownKeyword.json`, `refOfUnknownKeyword.json` | pass.                                                                                                                 |
+| File                                                                                        | Status                                                    |
+| ------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `dynamicRef.json`                                                                           | 12 mismatches, the `$dynamicRef` runtime-scope group.     |
+| `defs.json`, `ref.json`                                                                     | 4 errors, external / cross-document ref loading.          |
+| `cross-draft.json`                                                                          | 1 mismatch, same ref-loading root.                        |
+| `format-assertion.json`                                                                     | 2 mismatches, requires meta-schema loading via `$schema`. |
+| `multipleOf.json`, `unevaluatedItems.json`, `unevaluatedProperties.json`, `vocabulary.json` | 1 mismatch each.                                          |
 
-The per-format subtree (`optional/format/*.json`) isn't traversed by
+All other optional files pass. The per-format subtree (`optional/format/*.json`) isn't traversed by
 our runner. Those tests target strict-format-assertion behavior; by
 spec default and our default, format is annotation-only, so most tests
 there would vacuously pass. Enabling format-assertion and running them
@@ -108,7 +91,7 @@ must match the canonical overlay JSON Schema, every fixture under
 The runner also feeds every pass fixture through
 `@oav/overlay-spec`'s `translateOverlay()` and classifies the result
 as `ok` / `unrecognised-target` / `translator-error`. This is
-informational — upstream does not assert semantic translation — but
+informational (upstream does not assert semantic translation), but
 it surfaces translator-coverage gaps next to the envelope numbers.
 
 Current translator classification on pass fixtures (12 total):
@@ -167,6 +150,7 @@ pnpm openapi                    # CLI-driven OpenAPI scenarios
 
 Detailed per-case output lands in `conformance/json-schema-results.json`,
 `conformance/overlay-results.json`, and `conformance/openapi-results.json`.
-`overlay-results.json` and `openapi-results.json` are committed
-baselines that CI compares against with `--check-baseline`; the
-`+optional` JSON Schema variant remains gitignored.
+`json-schema-results.json` and `overlay-results.json` are committed
+baselines that CI compares against with `--check-baseline`;
+`openapi-results.json` and the `+optional` JSON Schema variant are
+gitignored.

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1344,7 +1344,3 @@ stay framework-shaped rather than competitor-shaped:
   from `express-openapi-validator`. Behavior-difference reference,
   option map (eov → oav), features not carried over, features
   added.
-
-When other migration paths surface (from-fastify-inline,
-from-zod-first), they get their own focused docs in the same
-shape, linked from here.

--- a/docs/migration-from-eov.md
+++ b/docs/migration-from-eov.md
@@ -201,7 +201,7 @@ Keep them in the map if it's simpler; they cost nothing.
 string, use `formatSummary` with `{ select: "all" }`:
 
 ```ts
-import { formatSummary } from "@aahoughton/oav-core";
+import { formatSummary } from "@aahoughton/oav";
 
 // Default: first failing leaf, equivalent to eov's default `message`.
 formatSummary(err);

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,8 +2,8 @@
 
 Self-contained TypeScript examples that exercise the most common
 `oav` entry points. Each file loads a spec from [`specs/`](./specs)
-and prints what it did to stdout — the same pattern a real application
-uses, so the example code translates 1:1 into production use.
+and prints what it did to stdout, the same pattern a real application
+uses.
 
 ## Running
 

--- a/framework-tests/README.md
+++ b/framework-tests/README.md
@@ -59,7 +59,7 @@ present at the package being type-checked. So `fastify` stays in
 `oav-fastify/devDependencies` for type-check purposes, even though the
 integration test runs here. Dependabot noise from fastify transitives
 is therefore not eliminated by this split, only the much larger express
-noise is. (See issue #295 for context.)
+noise is.
 
 ## How tests reach into the main packages
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -181,14 +181,12 @@ resolve` or `resolveSpec` before running `compile-spec`.
 
 ### Relationship to ajv's `standaloneCode`
 
-Ajv's `standaloneCode` covers the schema layer: it emits a compiled
-JSON Schema validator as module source. `compile-schema` does the
-same thing. `compile-spec` covers the HTTP layer on top: router
-matching, content-type dispatch, parameter deserialisation
-(style / explode), response status matching, and shape-only
-security checks. Rebuilding that layer on top of ajv's standalone
-output is re-implementing `express-openapi-validator`
-from scratch; `compile-spec` emits it directly.
+Ajv's `standaloneCode` emits a compiled JSON Schema validator as
+module source; `compile-schema` does the same. `compile-spec` adds
+the HTTP layer on top: router matching, content-type dispatch,
+parameter deserialisation (style / explode), response status
+matching, and shape-only security checks, emitted directly rather
+than hand-built over a standalone schema validator.
 
 ## Exit codes
 

--- a/packages/cli/src/emit-spec.ts
+++ b/packages/cli/src/emit-spec.ts
@@ -434,7 +434,7 @@ function buildEmittedOp(args: BuildEmittedOpArgs): EmittedOp {
   // runtime.
   const introspectionLiteral = JSON.stringify({ pathItem, operation }, null, 2);
 
-  void document; // currently unused; keep in signature for future overlay resolution
+  void document; // reserved for overlay resolution
   return { pathPattern, method, stateLiteral, introspectionLiteral };
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,6 @@
 /**
  * Shared structural types for OpenAPI 3.1 documents, JSON Schema objects, and
- * HTTP request/response envelopes. These types are intentionally permissive —
+ * HTTP request/response envelopes. These types are intentionally permissive:
  * they describe the shape {@link @oav/spec} and {@link @oav/validator}
  * produce/consume, not a fully-checked schema.
  */

--- a/packages/formats/src/date.ts
+++ b/packages/formats/src/date.ts
@@ -44,7 +44,7 @@ export function validateTime(value: string): boolean {
   const second = Number.parseInt(match[3] ?? "0", 10);
   if (hour > 23) return false;
   if (minute > 59) return false;
-  // allow leap second 60 at any minute for v1 simplicity
+  // accept second 60 as a leap second at any minute
   if (second > 60) return false;
   return true;
 }

--- a/packages/formats/src/hostname.ts
+++ b/packages/formats/src/hostname.ts
@@ -21,8 +21,8 @@ export function validateHostname(value: string): boolean {
 
 /**
  * RFC 5890 internationalized `hostname`. Same rules as {@link validateHostname}
- * after punycoding each label; for v1 we accept any non-empty labels made
- * of unicode letters, digits, and hyphens, 1-63 code points each.
+ * after punycoding each label: accepts any non-empty label of unicode
+ * letters, digits, and hyphens, 1-63 code points each.
  *
  * @public
  */

--- a/packages/formats/src/misc.ts
+++ b/packages/formats/src/misc.ts
@@ -19,12 +19,11 @@ export function validateUuid(value: string): boolean {
  * ECMA 262 `regex`: the value must compile as a JavaScript regular
  * expression with the `u` flag (per JSON Schema 2020-12 recommendation).
  *
- * Standalone utility. `compileSchema` no longer wires this into
- * `builtInFormats`: the schema compiler registers its own `regex`
+ * Standalone utility. The schema compiler registers its own `regex`
  * format inside `createDeps` so it shares the `regexCompiler` hook
- * with the `pattern` keyword. Reach for this function directly when
- * you want u-mode strictness independent of whatever compiler is
- * configured.
+ * with the `pattern` keyword; this function is not wired into
+ * `builtInFormats`. Reach for it directly when you want u-mode
+ * strictness independent of whatever compiler is configured.
  *
  * @public
  */

--- a/packages/overlay-spec/README.md
+++ b/packages/overlay-spec/README.md
@@ -6,21 +6,7 @@ Translator from [OpenAPI Overlay 1.0](https://spec.openapis.org/overlay/1.0.0) s
 
 oav's first-party overlay surface is `SpecOverlay` from `@aahoughton/oav/spec`: typed verbs scoped to known OpenAPI shapes, hand-authored against the type. The OpenAPI Overlay 1.0 spec describes overlays as a list of JSONPath-targeted actions instead. This package consumes spec-format input and re-expresses it as typed `SpecOverlay` so callers can apply third-party overlay documents through the same code path.
 
-The translator is not a JSONPath engine. It recognises a closed set of `target` expression shapes and throws on anything outside that set. The shapes cover the conventional patterns the OpenAPI Overlay spec uses to describe typical OAS axes; pathological JSONPath (recursive descent, slices, arbitrary filter expressions) is out of scope by design. See [`docs/configuration.md`](../../docs/configuration.md) and [`docs/overlays.md`](../../docs/overlays.md) for the typed-authoring path.
-
-`@oav/overlay-spec` does not ship a JSONPath engine. It maps a closed
-set of `target` expression shapes (the ones that describe typical
-OAS axes: paths, methods, parameters by name and `in`, component
-buckets by name) onto the typed `SpecOverlay` verbs in `@oav/spec`.
-Targets outside that recognised set throw a translation error naming
-the offending expression; no silent partial application. Against the
-OpenAPI Overlay 1.0 canonical test suite, this covers the cases
-whose targets use the conventional shapes; cases that lean on
-recursive descent (`..`), array slices, filter functions, or
-wildcards across non-OAS axes throw rather than translating. The fix
-when one comes up is either an additive new shape pattern in this
-package, or expressing the same intent through `@oav/spec`'s typed
-surface directly.
+The translator is not a JSONPath engine. It maps a closed set of `target` expression shapes (the ones that describe typical OAS axes: paths, methods, parameters by name and `in`, component buckets by name) onto the typed `SpecOverlay` verbs in `@oav/spec`, and throws a translation error naming the offending expression for anything outside that set (recursive descent `..`, array slices, filter functions, wildcards across non-OAS axes); no silent partial application. Against the OpenAPI Overlay 1.0 canonical test suite this covers the conventional-shape targets; the rest throw. See [`docs/configuration.md`](../../docs/configuration.md) and [`docs/overlays.md`](../../docs/overlays.md) for the typed-authoring path.
 
 ## API
 

--- a/packages/schema/src/compiler/compiler.ts
+++ b/packages/schema/src/compiler/compiler.ts
@@ -256,11 +256,6 @@ export type ValidationResult =
  * fields; a failing result always carries both `error` (the tree root)
  * and `truncated`.
  *
- * Migrating from v2: this nested shape was the v2 default and was named
- * `ValidationResult`. v3 makes flat the default, so the name
- * `ValidationResult` now refers to the flat shape and the tree moved
- * here. (`FlatValidationResult` aliases the new flat default, not this.)
- *
  * @public
  */
 export type TreeValidationResult =
@@ -277,9 +272,8 @@ export type TreeValidationResult =
     };
 
 /**
- * @deprecated Renamed to {@link ValidationResult} now that flat is the
- * default error shape (v3). This alias is kept for one major and will be
- * removed in v4. Update imports to `ValidationResult`.
+ * @deprecated Use {@link ValidationResult}. Kept as an alias for one
+ * major; will be removed in v4.
  *
  * @public
  */
@@ -420,10 +414,9 @@ export type CompiledPredicate = Omit<CompiledSchema, "validate"> & {
 };
 
 /**
- * @deprecated Flat is the default error shape now (v3), so the default
- * {@link CompiledSchema} already returns a flat {@link ValidationResult}.
- * This alias is kept for one major and will be removed in v4. Drop the
- * `flat: true` option and use `CompiledSchema`.
+ * @deprecated Use {@link CompiledSchema}, which returns a flat
+ * {@link ValidationResult} by default. Kept as an alias for one major;
+ * will be removed in v4.
  *
  * @public
  */
@@ -587,11 +580,10 @@ export interface CompileOptions {
    */
   predicate?: boolean;
   /**
-   * @deprecated Flat is the default error shape now (v3), so the bare
-   * `compileSchema(schema)` already returns a flat
-   * {@link ValidationResult}. `flat: true` remains a working alias for
-   * `output: "flat"` for one major and will be removed in v4. Supplying
-   * it together with a conflicting `output` throws.
+   * @deprecated Use `output: "flat"`. The bare `compileSchema(schema)`
+   * already returns a flat {@link ValidationResult}. `flat: true` remains
+   * a working alias for one major and will be removed in v4. Supplying it
+   * together with a conflicting `output` throws.
    */
   flat?: boolean;
   /**
@@ -1086,7 +1078,7 @@ function compileValidator(schema: SchemaOrBoolean, state: CompileState, mode: Co
  * validator directly.
  *
  * Boolean schemas are excluded (not object-valued); schemas with any
- * other validation keyword (even a second applicator) are excluded —
+ * other validation keyword (even a second applicator) are excluded:
  * those need a full compile because the sibling keywords contribute
  * to the result.
  */

--- a/packages/schema/src/keywords/context.ts
+++ b/packages/schema/src/keywords/context.ts
@@ -291,7 +291,7 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
   // Assemble a `deps.createLeafError(...)` / `createBranchError(...)`
   // call. Up to two trailing segments embed as explicit parameters,
   // matching the runtime signature; three-plus fall back to eagerly
-  // materializing `[...path, ...segs]` at the call site (rare —
+  // materializing `[...path, ...segs]` at the call site (rare:
   // pathologically nested inlined subschemas, capped by
   // MAX_INLINE_DEPTH).
   const assembleErrorExpr = (

--- a/packages/stream-validator/README.md
+++ b/packages/stream-validator/README.md
@@ -16,9 +16,8 @@ reuses `@oav/core`'s flat error model.
 
 > **Incubating, unpublished.** This package is `private` and ships
 > TypeScript source, not a build. It is consumed inside the OAV monorepo
-> via `workspace:*`; there is no `@oav/stream-validator` on npm yet. The
-> import below is the eventual published name and resolves to the
-> workspace source today.
+> via `workspace:*`; there is no `@oav/stream-validator` on npm. The
+> import path below resolves to the workspace source.
 
 ## Usage
 
@@ -74,9 +73,9 @@ body that is (or contains) an internal ref like
 `#/components/schemas/Pet` must carry the document's ref containers
 (`components` / `$defs` / `definitions`) alongside it, or construction
 throws `unresolvable $ref`. Routing, content negotiation, OpenAPI version
-detection, and body-schema lookup stay the caller's job in v1 (the HTTP
-adapter that bundles them is post-v1); the bridge from a resolved
-document is short:
+detection, and body-schema lookup stay the caller's job; this package
+validates one resolved schema, so those concerns sit above it. The
+bridge from a resolved document is short:
 
 ```ts
 import { resolveSpec } from "@oav/spec";
@@ -146,5 +145,4 @@ visitor over an arbitrary schema.
 Incubating and **unpublished** (`private`). The package lives in the
 monorepo via `workspace:*` so its classifier can co-evolve with
 `@oav/schema`'s keyword set (a CI drift test makes that a build failure
-rather than silent breakage). Maturity gate: `private` -> `experimental`
-dist-tag -> public `latest`.
+rather than silent breakage).

--- a/packages/stream-validator/src/spine/spine.ts
+++ b/packages/stream-validator/src/spine/spine.ts
@@ -86,9 +86,9 @@ export type IslandDelegate = (
  * `message` / `params` / `children` are populated on the BUFFER (island)
  * path, where the in-memory engine produces them; on the forward STREAM
  * path they are absent (a leaf violation carries `code` + `path` +
- * `byteOffset`). They are optional so a future stream-path enrichment
- * lands additively. Codes are coarse for now; the channel layer refines
- * them.
+ * `byteOffset`). They are optional so stream-path enrichment can land
+ * additively; stream-path codes are coarse and the channel layer
+ * refines them.
  */
 export interface SchemaViolation {
   code: string;

--- a/packages/stream-validator/src/tokenizer/tokenizer.ts
+++ b/packages/stream-validator/src/tokenizer/tokenizer.ts
@@ -447,7 +447,7 @@ export class JsonTokenizer {
     }
     if (j > i) {
       // Build the run's ASCII string in one append (no per-char re-entry
-      // into step, and no Buffer view — a typed-array allocation per
+      // into step, and no Buffer view; a typed-array allocation per
       // number showed up hot in profiling).
       let run = "";
       for (let k = i; k < j; k++) run += String.fromCharCode(chunk[k] as number);

--- a/packages/validator/src/deserialize.ts
+++ b/packages/validator/src/deserialize.ts
@@ -5,7 +5,7 @@ import type { ParameterObject, ParameterStyle, SchemaObject } from "@oav/core";
  * typed value implied by the parameter's schema + style/explode options.
  *
  * @remarks
- * Supported styles (as of v1):
+ * Supported styles:
  * - path: `simple` (default), `label`, `matrix`
  * - query: `form` (default), `deepObject` (limited), `spaceDelimited`, `pipeDelimited`
  * - header: `simple` (default)

--- a/packages/validator/src/security.ts
+++ b/packages/validator/src/security.ts
@@ -14,7 +14,7 @@ import {
  * scheme definition. Returns `null` when the request carries the
  * declared credential (presence + structural shape only); returns a
  * short human-readable reason when it doesn't. Credential verification
- * (token validity, API key lookup, password match) is outside scope —
+ * (token validity, API key lookup, password match) is outside scope;
  * that's the app's auth middleware.
  *
  * @internal

--- a/packages/validator/test/fetch-validators.test.ts
+++ b/packages/validator/test/fetch-validators.test.ts
@@ -312,7 +312,7 @@ describe("validator.validateFetchRequest", () => {
     });
 
     it("works with a multer-equivalent multipart streaming pattern", async () => {
-      // The sureify / puddle-rest-proxy shape: a multipart endpoint
+      // A streaming multipart-proxy shape: a multipart endpoint
       // declared in the spec as `{ documents: string, format: binary }`
       // (or an array of same). A user's streaming parser pulls bytes off
       // the request and assembles whatever body the spec expects;

--- a/performance/README.md
+++ b/performance/README.md
@@ -15,7 +15,7 @@ pnpm install
 
 ## Entry points
 
-### `run.ts` — cross-library schema benchmark
+### `run.ts`: cross-library schema benchmark
 
 ```bash
 pnpm bench                                      # default 500ms per task
@@ -46,7 +46,7 @@ between tasks.
 
 Two modes, one script:
 
-- **Default (synthetic).** Iterates the schemas in `./schemas.ts` — a
+- **Default (synthetic).** Iterates the schemas in `./schemas.ts`, a
   curated shape distribution (trivial scalar, flat object, recursive
   `$ref`, `oneOf`+`allOf` composition, large array of small objects,
   `uniqueItems` array, and an object with large length-bounded
@@ -61,14 +61,15 @@ Two modes, one script:
   every unique request- and response-body schema, and times each
   library's compile across the whole set with plain
   `performance.now()`. Validate is skipped in this mode: real-world
-  schemas don't come with paired valid/invalid fixtures, so there's
-  no apples-to-apples way to measure it here. Use the
-  synthetic mode if you need validate throughput numbers.
+  schemas don't come with paired valid/invalid fixtures, and any
+  synthetic input would favor one library's fast path. For validate
+  throughput on real shapes, copy the body schema into `schemas.ts`
+  with hand-authored inputs and run the synthetic mode.
 
 Output lands on stdout and as JSON under `./results/<iso-timestamp>.json`
 (see [Results file](#results-file)).
 
-### `bench-real-world.mjs` — oav end-to-end on one spec
+### `bench-real-world.mjs`: oav end-to-end on one spec
 
 ```bash
 pnpm build                                      # dist/ needs to exist
@@ -88,7 +89,7 @@ more specs and reports:
 Use it to sanity-check a new spec loads end-to-end through oav, or to
 regression-check when you touch `@oav/spec` / `@oav/validator`.
 
-### `mem.ts` — steady-state memory under HTTP load
+### `mem.ts`: steady-state memory under HTTP load
 
 ```bash
 # One-time bootstrap (builds oav, installs both server fixtures):
@@ -100,7 +101,7 @@ pnpm bench:mem                                      # default 100 × 500 = 50,00
 BATCHES=20 PER_BATCH=500 WARMUP=250 pnpm bench:mem  # quick smoke
 ```
 
-Spawns two Express 4 servers — one wraps `oav`, the other
+Spawns two Express 4 servers: one wraps `oav`, the other
 wraps `express-openapi-validator` (which pulls in ajv). Both validate
 a ~40-schema OpenAPI spec with discriminated payment-method unions,
 nested address + amount objects, and array-of-items transfers. The
@@ -184,16 +185,16 @@ batch throughput (avg ms per 500-req batch): oav 75ms, eov 80ms
 
 What to look at:
 
-- **`baseline RSS`** — the library + validator-set footprint at rest,
+- **`baseline RSS`**: the library + validator-set footprint at rest,
   right after `app.listen`. Stable across runs; typically eov+ajv is
   ~30 MB higher than oav on the bench spec.
-- **`steady heapUsed`** — V8 heap after 50k requests with GC forced
+- **`steady heapUsed`**: V8 heap after 50k requests with GC forced
   before each sample. Stable; typically eov+ajv is ~2.5–3 MB higher
   (~15–20%).
-- **`growth` rows** — delta from post-warmup to end-of-run. Both
+- **`growth` rows**: delta from post-warmup to end-of-run. Both
   libraries plateau; if either grows without bound the value here
   diverges and the steady rows keep rising across runs.
-- **`steady RSS`** is noisier than heapUsed — V8 expands the heap in
+- **`steady RSS`** is noisier than heapUsed: V8 expands the heap in
   chunks, and when a chunk boundary falls mid-run the final RSS
   differs by 10–15 MB between runs even though the actual working
   set is stable. The heapUsed number is the cleaner signal for
@@ -206,23 +207,13 @@ What to look at:
 
 Raw per-batch data lands in `results/mem-<timestamp>.json`.
 
-### Note on `validate` under `--spec`
-
-Deliberately omitted. Without paired valid/invalid fixtures per
-schema, any choice of synthetic input (`{}`, an example mined from
-the spec, a type-driven synthesized value) would favor one library's
-fast-path over another in ways that don't reflect real workloads. If
-you need validate throughput numbers on real shapes, copy the
-relevant body schema into `schemas.ts` with hand-authored inputs and
-run the synthetic mode.
-
 ## Methodology
 
 **Compile (synthetic).** Each hot-loop iteration is only the
 library's work:
 
 - **ajv**: `new Ajv({allErrors, strict:false}).compile(schema)`. The
-  instance construction stays in — it's part of the cold-start cost
+  instance construction stays in; it's part of the cold-start cost
   for a consumer that doesn't already have an Ajv around.
 - **oav**: `compileSchema(schema, opts)` with pre-built `opts`.
 
@@ -232,7 +223,7 @@ warnings don't flood stdout.
 
 **Validate (synthetic).** Every library pre-compiles its validator
 once, outside the timed loop. The hot path is literally
-`validator(sample)` — no closures, no cursor math, no per-iteration
+`validator(sample)`: no closures, no cursor math, no per-iteration
 setup; each task validates one fixed payload.
 
 The **valid** path uses one representative sample per shape. The
@@ -247,7 +238,7 @@ fixtures in `schemas.ts` are deliberately authored to cover that spread
 (early / mid / deep / late / many-errors).
 
 Before any timing, a pre-flight pass validates every authored input
-under all five configs and asserts the verdict matches its label —
+under all five configs and asserts the verdict matches its label,
 catching a mislabeled fixture or an ajv/oav disagreement that would
 otherwise silently time the wrong path.
 
@@ -277,7 +268,7 @@ fast path.
     large valid body costs O(1).
 
 - **Predicate mode (`output: "predicate"`).** When consumers only need a
-  yes/no answer — routing, gating, hot-path filtering — `oav-predicate`
+  yes/no answer (routing, gating, hot-path filtering), `oav-predicate`
   brings oav to parity with ajv's fail-fast mode on invalid paths and
   typically edges it out on valid paths. The compiler drops error-tree
   construction entirely: no leaf-allocation, no path snapshot, no params
@@ -300,8 +291,8 @@ fast path.
 ## Results file
 
 Each run writes `./results/<iso-timestamp>.json`. The `results/` directory is
-gitignored — benchmark numbers depend on the host machine, so committing them
-across contributors would be misleading. Compare runs locally instead, or roll
+gitignored (benchmark numbers depend on the host machine, so committing them
+across contributors would be misleading). Compare runs locally instead, or roll
 back to a commit and re-run.
 
 Format:


### PR DESCRIPTION
Holistic docs/comments pass: drop stale planning and completed-work narration, cut redundancy, remove own-version comparisons, and fix correctness drift. No behavior changes (docs and comments only, plus one test comment).

## Changes
- **Scrub internal references**: removed an internal project name from a validator test comment, and explicitly named the proprietary local conformance corpus so it stays out of the repo.
- **Conformance report**: corrected stale summary counts against the committed baselines (petstore 14 -> 32, required 1271/15 -> 1270/16), added a date + commit-SHA timestamp, dropped the "Fixed so far" history log, and rewrote the divergence tables to the real per-file breakdown. Re-verified end-to-end with a fresh suite run (required 1270/16/4, optional 1429/19/4, overlay 32/32, petstore 32/32).
- **Code comments**: removed v2->v3 rename narration from compiler TSDoc (deprecation notes kept and made consistent), reworded "for v1"/"no longer wires" WIP framing, turned a future-work TODO into a "reserved" note, and dropped em-dashes.
- **Markdown**: removed future-docs promises and a maturity-gate roadmap, trimmed redundant passages (README Ajv-speed, SECURITY dependabot note, overlay-spec's repeated "not a JSONPath engine", performance duplicate note), and removed prose em-dashes.

## Deferred
Internal-URL/link normalization (relative-vs-absolute README links, the broken `schema/README.md` anchor, two plain-text doc refs in `oav-fastify/README.md`) is left for a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)