### PR TITLE
fix(stream-validator): eager over-limits + value-event full path (first-consumer fixes)

### DIFF
--- a/packages/stream-validator/README.md
+++ b/packages/stream-validator/README.md
@@ -131,6 +131,13 @@ validator.on("value", (e) => captured.set(e.key, e.value));
 // `capture` for span-only events and slice the bytes yourself.
 ```
 
+A `value` event's `path` is the **full path to the value** (the enclosing
+scope plus the member key), the same coordinate `valueEvents.at` matches,
+so the filter and the event speak one path: a top-level member `{version}`
+is `["version"]` (length 1), not `[]`. (`event.key` is that path's last
+segment.) This differs from `keyEvents`, whose `at` and `path` are both
+the enclosing scope.
+
 `valueEvents` fires for scalar object members on both the STREAM path and
 scalar BUFFER islands, so a `format`-bearing string (`date-time`, `uri`,
 `uuid`) reports its value even under an asserting OpenAPI dialect that

--- a/packages/stream-validator/README.md
+++ b/packages/stream-validator/README.md
@@ -45,6 +45,16 @@ The default policy is `terminate` with `maxErrors: 1` (the first violation
 destroys the stream and rejects the `pipeline`); `detach` instead seals
 the verdict and raw-copies the tail.
 
+Count and length limits resolve as early as the input allows: an
+**over-limit** (`maxItems`, `maxProperties`, `maxLength`) fails at the
+offending element / key / code point, before the rest of the value
+streams, so under `terminate` an over-count body is rejected without
+echoing its tail downstream. An **under-limit** (`minItems`,
+`minProperties`, `minLength`) can only be known once the scope closes, so
+it reports at the closing delimiter. The verdict is identical either way;
+eager enforcement only moves _when_ the violation surfaces (and its byte
+offset points at the cause rather than the delimiter).
+
 ### Supported schemas (incubation)
 
 The STREAM keyword set (`type`, scalar/string/number constraints,

--- a/packages/stream-validator/src/engine/hooks.ts
+++ b/packages/stream-validator/src/engine/hooks.ts
@@ -44,9 +44,14 @@ export const DEFAULT_MAX_CAPTURE_BYTES = 65536;
  * @public
  */
 export interface ValueEvent {
-  /** Path to the enclosing object scope (the root scope is `[]`). */
+  /**
+   * Full path to the value: the enclosing scope path plus the member key.
+   * This is the same coordinate `valueEvents.at` matches, so the filter and
+   * the event speak the same path (a top-level member `{version}` is
+   * `["version"]`, not `[]`). The last segment equals {@link key}.
+   */
   path: PathSegment[];
-  /** The member key. */
+  /** The member key (the last segment of {@link path}). */
   key: string;
   /** Byte offset of the value's first byte (a string's opening quote). */
   valueStart: number;

--- a/packages/stream-validator/src/engine/stream-validator.ts
+++ b/packages/stream-validator/src/engine/stream-validator.ts
@@ -398,7 +398,18 @@ export class StreamValidator extends Transform {
     if (!this.valueCaptureConfigured && ve !== true && !matchValueFilter(ve.at, scopePath, key)) {
       return;
     }
-    const event: ValueEvent = { path: [...scopePath], key, valueStart, valueEnd, type, truncated };
+    // `path` is the value's full path (enclosing scope plus key), the same
+    // coordinate `valueEvents.at` matches, so a caller can filter and read
+    // the event in one coordinate system. `key` is the trailing segment,
+    // kept as a convenience.
+    const event: ValueEvent = {
+      path: [...scopePath, key],
+      key,
+      valueStart,
+      valueEnd,
+      type,
+      truncated,
+    };
     if (value !== undefined) event.value = value;
     this.emit("value", event);
   }

--- a/packages/stream-validator/src/options.ts
+++ b/packages/stream-validator/src/options.ts
@@ -140,9 +140,12 @@ export interface StreamValidatorOptions {
    *
    *   - `true`: emit for every scalar member, span only (no decode).
    *   - `{ at }`: restrict to members whose **full path** (the enclosing
-   *     scope path plus the key) matches the filter. This differs from
-   *     `keyEvents.at`, which matches the enclosing scope path: a value
-   *     filter targets one field (`["meta", "id"]`), not a whole scope.
+   *     scope path plus the key) matches the filter, so a value filter
+   *     targets one field (`["meta", "id"]`), not a whole scope. That full
+   *     path is also the event's {@link ValueEvent.path}, so the filter and
+   *     the event use one coordinate: a top-level member `{version}` is
+   *     `["version"]` (length 1), not `[]`. This differs from `keyEvents.at`,
+   *     which matches (and reports) the enclosing scope path.
    *   - `{ at, capture: true }`: also decode the matched scalar and deliver
    *     it as `value` on the event, bounded by `maxCaptureBytes` (a value
    *     larger than the cap is reported with `value` omitted and

--- a/packages/stream-validator/src/spine/spine.ts
+++ b/packages/stream-validator/src/spine/spine.ts
@@ -341,6 +341,13 @@ export class SpineValidator implements JsonEventHandler {
     // govern validation buffering.
     capture: boolean;
     captureTruncated: boolean;
+    // Eager `maxLength`: the tightest applicable cap (min across schemas, a
+    // STREAM string only; an island string's length is the delegate's job),
+    // a running code-point count, and a once-fired flag. `undefined` cap =
+    // no `maxLength` applies, so the per-chunk counter is skipped entirely.
+    maxLen: number | undefined;
+    cp: number;
+    lenFailed: boolean;
   } | null = null;
 
   // An open BUFFER island being materialized for delegation.
@@ -388,6 +395,15 @@ export class SpineValidator implements JsonEventHandler {
     const top = this.frames[this.frames.length - 1];
     if (top === undefined || top.kind !== "object") return null;
     return top.pendingKey;
+  }
+
+  // The path to the value currently being read, including its own segment
+  // (mirrors what `pushSegment` would push at value start). Used to report
+  // an eager scalar failure at the same path the close-time check would.
+  private pendingPath(): PathSegment[] {
+    const top = this.frames[this.frames.length - 1];
+    if (top === undefined) return [...this.path]; // root value
+    return [...this.path, top.kind === "object" ? (top.pendingKey as string) : top.count];
   }
 
   // Report a completed scalar object-member value through the one emit
@@ -516,6 +532,13 @@ export class SpineValidator implements JsonEventHandler {
     } else if (top.kind === "object") {
       for (const s of top.schemas) this.collectObjectValue(s, top.pendingKey as string, out);
     } else {
+      // Over-limit is verdict-decided the moment the (max+1)th element
+      // starts, before it streams: fail eagerly (`=== count`, so once) so
+      // `terminate` aborts the tail instead of echoing the whole over-count
+      // body. `minItems` stays at close (you cannot know you are under until
+      // the array ends). See {@link onEndArray}.
+      for (const s of top.schemas)
+        if (s.maxItems !== undefined && top.count === s.maxItems) this.fail("maxItems");
       for (const s of top.schemas) this.collectArrayElement(s, top.count, out);
     }
     return out;
@@ -801,8 +824,9 @@ export class SpineValidator implements JsonEventHandler {
       if ("const" in s && (s as { const?: unknown }).const !== value) this.fail("const");
       if (actual === "string") {
         const str = value as string;
+        // `maxLength` is enforced eagerly during streaming (see
+        // {@link onStringChunk}); only the under-limit closes here.
         if (s.minLength !== undefined && codePoints < s.minLength) this.fail("minLength");
-        if (s.maxLength !== undefined && codePoints > s.maxLength) this.fail("maxLength");
         if (s.pattern !== undefined && !this.regex(s.pattern).test(str)) this.fail("pattern");
       } else if (actual === "number" || actual === "integer") {
         const num = value as number;
@@ -893,10 +917,10 @@ export class SpineValidator implements JsonEventHandler {
       if (Array.isArray(s.required)) {
         for (const r of s.required) if (!frame.seen.has(r)) this.fail("required");
       }
+      // `maxProperties` is enforced eagerly at the offending key (see
+      // {@link onKey}); only the under-limit closes here.
       if (s.minProperties !== undefined && frame.count < s.minProperties)
         this.fail("minProperties");
-      if (s.maxProperties !== undefined && frame.count > s.maxProperties)
-        this.fail("maxProperties");
       const dep = s.dependentRequired;
       if (dep !== undefined) {
         for (const k of Object.keys(dep)) {
@@ -983,8 +1007,9 @@ export class SpineValidator implements JsonEventHandler {
     }
     const frame = this.frames.pop() as ArrayFrame;
     for (const s of frame.schemas) {
+      // `maxItems` is enforced eagerly at the offending element's start
+      // (see {@link schemasForValue}); only the under-limit closes here.
       if (s.minItems !== undefined && frame.count < s.minItems) this.fail("minItems");
-      if (s.maxItems !== undefined && frame.count > s.maxItems) this.fail("maxItems");
     }
     this.onScopeClose?.({
       path: [...this.path],
@@ -1011,6 +1036,11 @@ export class SpineValidator implements JsonEventHandler {
     const top = this.frames[this.frames.length - 1] as ObjectFrame;
     for (const s of top.schemas) {
       if (s.propertyNames !== undefined) this.checkPropertyName(s.propertyNames, value, codePoints);
+      // Over-limit is decided at the (max+1)th key, before its value
+      // streams: fail eagerly (`=== count`, so once). `minProperties` stays
+      // at close. See {@link onEndObject}.
+      if (s.maxProperties !== undefined && top.count === s.maxProperties)
+        this.fail("maxProperties");
     }
     top.seen.add(value);
     top.count += 1;
@@ -1076,7 +1106,27 @@ export class SpineValidator implements JsonEventHandler {
       const key = this.memberKey();
       capture = key !== null && this.shouldCapture(this.path, key);
     }
-    this.str = { app, needText, text: "", offset, island, capture, captureTruncated: false };
+    // The tightest applicable `maxLength` for eager enforcement. An island
+    // string is delegated whole, so its length is the delegate's job; only
+    // a STREAM string is bounded here.
+    let maxLen: number | undefined;
+    if (!island) {
+      for (const s of app.schemas)
+        if (s.maxLength !== undefined)
+          maxLen = maxLen === undefined ? s.maxLength : Math.min(maxLen, s.maxLength);
+    }
+    this.str = {
+      app,
+      needText,
+      text: "",
+      offset,
+      island,
+      capture,
+      captureTruncated: false,
+      maxLen,
+      cp: 0,
+      lenFailed: false,
+    };
   }
 
   onStringChunk(chunk: string, offset: number): void {
@@ -1088,6 +1138,18 @@ export class SpineValidator implements JsonEventHandler {
     if (this.island !== null) {
       this.forwardIsland((b) => b.onStringChunk(chunk));
       return;
+    }
+    // Eager `maxLength`: count code points as they arrive (for..of yields one
+    // per code point, matching the tokenizer's lead-byte count) and fail the
+    // moment the cap is first exceeded, before the rest of the string
+    // streams. Skipped entirely when no `maxLength` applies. `minLength`
+    // necessarily waits for string close (see {@link checkScalar}).
+    if (this.str !== null && this.str.maxLen !== undefined && !this.str.lenFailed) {
+      for (const _ of chunk) this.str.cp += 1;
+      if (this.str.cp > this.str.maxLen) {
+        this.fail("maxLength", this.pendingPath());
+        this.str.lenFailed = true;
+      }
     }
     if (this.str !== null && (this.str.needText || this.str.capture)) {
       const span = offset - this.str.offset;

--- a/packages/stream-validator/test/engine.test.ts
+++ b/packages/stream-validator/test/engine.test.ts
@@ -85,6 +85,67 @@ describe("createStreamValidator: terminate policy (default)", () => {
   });
 });
 
+describe("createStreamValidator: eager over-limit aborts before echoing the tail", () => {
+  it("terminates a maxItems-violating array without echoing the whole over-count body", async () => {
+    // 200 elements against maxItems 3. Under `terminate`, the eager
+    // violation at the 4th element destroys the stream, so the long tail is
+    // never forwarded downstream (to e.g. S3). A close-time check would
+    // echo the entire body first.
+    const validator = createStreamValidator({ type: "array", maxItems: 3 });
+    const violations: { code: string; byteOffset: number }[] = [];
+    validator.on("violation", (v) => violations.push(v as { code: string; byteOffset: number }));
+    const text = `[${Array.from({ length: 200 }, (_, i) => i).join(",")}]`;
+    const { sink, bytes } = collector();
+    await expect(pipeline(chunkedSource(text, 8), validator, sink)).rejects.toBeInstanceOf(
+      ValidationFailedError,
+    );
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.code).toBe("maxItems");
+    // The echo stopped well before the closing bracket: the tail is unsent.
+    expect(bytes().length).toBeLessThan(text.length);
+    expect(bytes().toString("utf8")).not.toContain("]");
+  });
+
+  it("counts maxLength code points across chunk boundaries", async () => {
+    // A long string fed two bytes at a time: the eager counter accumulates
+    // across onStringChunk calls and fires once the cap is exceeded, before
+    // the closing quote.
+    const validator = createStreamValidator({
+      type: "object",
+      properties: { s: { type: "string", maxLength: 10 } },
+    });
+    const violations: { code: string; path: unknown[] }[] = [];
+    validator.on("violation", (v) => violations.push(v as { code: string; path: unknown[] }));
+    const text = `{"s":"${"x".repeat(500)}"}`;
+    const { sink, bytes } = collector();
+    await expect(pipeline(chunkedSource(text, 2), validator, sink)).rejects.toBeInstanceOf(
+      ValidationFailedError,
+    );
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.code).toBe("maxLength");
+    expect(violations[0]?.path).toEqual(["s"]);
+    // Aborted mid-string: the 500-char body was not echoed in full.
+    expect(bytes().length).toBeLessThan(text.length);
+  });
+
+  it("counts astral code points, not UTF-16 units, across chunks", async () => {
+    // 8 astral chars (each a surrogate pair in UTF-16, 4 UTF-8 bytes) under
+    // maxLength 10: 8 code points <= 10, so valid. A UTF-16-unit count would
+    // see 16 and wrongly reject. Chunked at 3 bytes to split multibyte runs.
+    const validator = createStreamValidator({
+      type: "object",
+      properties: { s: { type: "string", maxLength: 10 } },
+    });
+    const violations: unknown[] = [];
+    validator.on("violation", (v) => violations.push(v));
+    const text = `{"s":"${"\u{1F600}".repeat(8)}"}`;
+    const { sink } = collector();
+    await pipeline(chunkedSource(text, 3), validator, sink);
+    expect(violations).toHaveLength(0);
+    expect((await validator.result).valid).toBe(true);
+  });
+});
+
 describe("createStreamValidator: detach policy", () => {
   it("finishes cleanly, echoes all bytes, and reports an invalid verdict", async () => {
     const validator = createStreamValidator(

--- a/packages/stream-validator/test/spine.test.ts
+++ b/packages/stream-validator/test/spine.test.ts
@@ -91,3 +91,81 @@ describe("SpineValidator recursion is bounded by the heap, not the native stack"
     expect(validate(schema, json).valid).toBe(false);
   });
 });
+
+describe("SpineValidator enforces over-limits eagerly, under-limits at close", () => {
+  // The byte offset of the first violation; proves a count/length limit is
+  // reported at the offending token, not at the scope's closing delimiter.
+  function firstViolation(
+    schema: SchemaOrBoolean,
+    json: string,
+  ): { code: string; path: (string | number)[]; byteOffset: number } {
+    const spine = new SpineValidator(schema);
+    const tok = new JsonTokenizer(spine);
+    tok.write(enc.encode(json));
+    tok.end();
+    const v = spine.verdict();
+    const first = v.violations[0];
+    if (first === undefined) throw new Error("expected a violation");
+    return {
+      code: first.code,
+      path: first.path as (string | number)[],
+      byteOffset: first.byteOffset,
+    };
+  }
+
+  it("fails maxItems at the (max+1)th element's start, not the closing bracket", () => {
+    //            0123456789
+    const json = "[1,2,3,4]"; // maxItems 2: the 3rd element ('3') is at offset 5
+    const codes = validate({ type: "array", maxItems: 2 }, json);
+    expect(codes.codes.filter((c) => c === "maxItems")).toHaveLength(1);
+    const v = firstViolation({ type: "array", maxItems: 2 }, json);
+    expect(v.code).toBe("maxItems");
+    expect(v.byteOffset).toBe(5); // '3', not the ']' at offset 8
+  });
+
+  it("fails maxProperties at the (max+1)th key, not the closing brace", () => {
+    //            0         1
+    //            0123456789012345678
+    const json = '{"a":1,"b":2,"c":3}'; // maxProperties 2: key "c" opens at offset 13
+    const v = firstViolation({ type: "object", maxProperties: 2 }, json);
+    expect(v.code).toBe("maxProperties");
+    expect(v.byteOffset).toBe(13); // the '"c"' key, not the '}' at offset 18
+  });
+
+  it("fails maxLength while the string streams, not at its closing quote", () => {
+    //            0    5
+    const json = '{"s":"abcdef"}'; // maxLength 3: content 'abcdef' starts at offset 6
+    const schema: SchemaOrBoolean = {
+      type: "object",
+      properties: { s: { type: "string", maxLength: 3 } },
+    };
+    const v = firstViolation(schema, json);
+    expect(v.code).toBe("maxLength");
+    expect(v.path).toEqual(["s"]);
+    expect(v.byteOffset).toBeLessThan(12); // before the closing quote at offset 12
+  });
+
+  it("reports minItems / minProperties / minLength at close (the under-limit cannot be eager)", () => {
+    expect(validate({ type: "array", minItems: 3 }, "[1,2]").codes).toContain("minItems");
+    expect(validate({ type: "object", minProperties: 2 }, '{"a":1}').codes).toContain(
+      "minProperties",
+    );
+    expect(
+      validate(
+        { type: "object", properties: { s: { type: "string", minLength: 5 } } },
+        '{"s":"ab"}',
+      ).codes,
+    ).toContain("minLength");
+  });
+
+  it("keeps the verdict identical to the close-time check (valid stays valid)", () => {
+    expect(validate({ type: "array", maxItems: 3 }, "[1,2,3]").valid).toBe(true);
+    expect(validate({ type: "object", maxProperties: 2 }, '{"a":1,"b":2}').valid).toBe(true);
+    expect(
+      validate(
+        { type: "object", properties: { s: { type: "string", maxLength: 3 } } },
+        '{"s":"abc"}',
+      ).valid,
+    ).toBe(true);
+  });
+});

--- a/packages/stream-validator/test/value-events.test.ts
+++ b/packages/stream-validator/test/value-events.test.ts
@@ -63,15 +63,17 @@ describe("value events", () => {
     expect(sliceParse(input, e)).toBe("abc");
   });
 
-  it("carries the enclosing scope path and the member key", async () => {
+  it("carries the value's full path and the member key", async () => {
     const { events } = await collectValues(objectSchema, '{"meta":{"id":"x"}}', true);
-    expect(events.map((e) => [e.path, e.key])).toEqual([[["meta"], "id"]]);
+    // `path` is the full path to the value (scope plus key); `key` is its
+    // last segment, the same coordinate the filter matches.
+    expect(events.map((e) => [e.path, e.key])).toEqual([[["meta", "id"], "id"]]);
   });
 
-  it("filters by the member's full path, not just the scope", async () => {
+  it("filters by the member's full path, which the event also reports", async () => {
     const json = '{"a":1,"meta":{"id":"x","ver":2}}';
     const { events } = await collectValues(objectSchema, json, { at: ["meta", "id"] });
-    expect(events.map((e) => [e.path, e.key])).toEqual([[["meta"], "id"]]);
+    expect(events.map((e) => [e.path, e.key])).toEqual([[["meta", "id"], "id"]]);
   });
 
   it("filters by a predicate over the full path", async () => {
@@ -79,7 +81,15 @@ describe("value events", () => {
     const { events } = await collectValues(objectSchema, json, {
       at: (path: PathSegment[]) => path[path.length - 1] === "id",
     });
-    expect(events.map((e) => e.path)).toEqual([[], ["meta"]]);
+    expect(events.map((e) => e.path)).toEqual([["id"], ["meta", "id"]]);
+  });
+
+  it("a top-level scalar member has a length-1 path (filter and event agree)", async () => {
+    const json = '{"version":"1.0","other":2}';
+    const { events } = await collectValues(objectSchema, json, { at: ["version"] });
+    // The trap: filtering on `[]` (the enclosing scope) captures nothing;
+    // the value's path is `["version"]`, which is also what the filter matches.
+    expect(events.map((e) => [e.path, e.key])).toEqual([[["version"], "version"]]);
   });
 
   it("emits nothing when off (the default)", async () => {


### PR DESCRIPTION
Two fixes surfaced by the first end-to-end consumer (puddle) of `@oav/stream-validator`. Each commit is independently revertable.

## 1. Over-limits enforced eagerly, under-limits at close

Count and length limits previously all resolved at the close of the scope they constrain. Under the default `terminate` policy this meant an over-count body streamed through in full before the close-time rejection: a gatekeeper forwarded the whole oversize payload downstream (e.g. to S3) before aborting.

Now the over-limit side fails at the offending token:
- `maxItems` at the `(max+1)`th element's start
- `maxProperties` at the `(max+1)`th key
- `maxLength` mid-string, when the running code-point count first exceeds the cap

The under-limit side (`minItems` / `minProperties` / `minLength`) stays at close, since being under a minimum is only knowable once the scope ends. Coherent rule: **over-limits eager, under-limits at close.**

The verdict is unchanged (an over-limit decides invalid the moment it is crossed); eager enforcement only moves *when* the violation surfaces and points its byte offset at the cause rather than the closing delimiter. Code points are counted with `for..of`, matching the tokenizer's lead-byte count and handling astral characters across chunk boundaries. Under `terminate`, an over-count body is now destroyed mid-stream with the tail unsent.

## 2. A value event's `path` is the value's full path

`valueEvents.at` matched against the member's full path (`[...scope, key]`), but the emitted `ValueEvent.path` was the enclosing scope with `key` separate. The filter and the event spoke different coordinates: filtering a top-level member on the event's `path` (`[]`) captured nothing, since the filter wanted `["version"]`.

`ValueEvent.path` is now the full path to the value (`[...scope, key]`), the same coordinate the filter matches; `key` remains the trailing segment. Each event type's path now equals its own filter coordinate (`keyEvents` stays scope-path on both sides, correct for keys).

## Known tradeoff

For `maxLength` with multiple applicable caps (e.g. `allOf` of two `maxLength`s), the eager path reports a single `maxLength` at the tightest cap, where the old close-time path reported one per violated schema. Verdict is identical and it is moot under the default `maxErrors: 1`; multiplicity only differs under `detach` + high `maxErrors`. `maxItems` / `maxProperties` preserve exact multiplicity. Easy to make `maxLength` per-schema if we want multiplicity identical there too.

## Tests

`pnpm test` green (2734). New: eager-offset cases in `spine.test.ts`; `terminate` early-out, cross-chunk and astral `maxLength` in `engine.test.ts`; updated value-event path cases plus a top-level-scalar case in `value-events.test.ts`.