### PR TITLE
feat(stream-validator): make maxUniqueItems actually bound the buffered uniqueItems island

### DIFF
--- a/packages/stream-validator/src/engine/stream-validator.ts
+++ b/packages/stream-validator/src/engine/stream-validator.ts
@@ -324,6 +324,7 @@ export class StreamValidator extends Transform {
       ...(options.maxBufferedBytes === undefined
         ? {}
         : { maxBufferedBytes: options.maxBufferedBytes }),
+      ...(options.maxUniqueItems === undefined ? {} : { maxUniqueItems: options.maxUniqueItems }),
       ...(options.maxDepth === undefined ? {} : { maxDepth: options.maxDepth }),
       ...(options.regexCompiler === undefined ? {} : { regexCompiler: options.regexCompiler }),
       ...(keyEvents

--- a/packages/stream-validator/src/options.ts
+++ b/packages/stream-validator/src/options.ts
@@ -189,11 +189,13 @@ export interface StreamValidatorOptions {
   maxTotalBytes?: number;
 
   /**
-   * Cap on `uniqueItems`' seen-hash set (O(array length) memory, not
-   * covered by `maxBufferedBytes`). Reserved: the current build delegates
-   * `uniqueItems` arrays to the in-memory engine as a BUFFER island
-   * (bounded by `maxBufferedBytes`), so this knob is inert until the
-   * streaming canonical-hash mode lands. Default off.
+   * Cap on the element count of a `uniqueItems` array (its seen-set is
+   * O(array length) memory, not covered by `maxBufferedBytes`, which bounds
+   * UTF-8 bytes). A `uniqueItems` array buffers as a BUFFER island
+   * delegated to the in-memory engine; this refuses one whose element count
+   * exceeds the cap, before the rest of the array buffers, failing the
+   * stream fatally. The bound survives the streaming canonical-hash mode
+   * (which will cap the streamed seen-set by the same count). Default off.
    */
   maxUniqueItems?: number;
 

--- a/packages/stream-validator/src/spine/index.ts
+++ b/packages/stream-validator/src/spine/index.ts
@@ -3,6 +3,7 @@ export {
   BufferLimitError,
   SpineUnsupportedError,
   SpineValidator,
+  UniqueItemsLimitError,
   type IslandDelegate,
   type ScopeClose,
   type SpineOptions,

--- a/packages/stream-validator/src/spine/spine.ts
+++ b/packages/stream-validator/src/spine/spine.ts
@@ -69,6 +69,20 @@ export class BufferLimitError extends Error {
   }
 }
 
+/**
+ * A `uniqueItems` array buffered for delegation exceeded the configured
+ * `maxUniqueItems` element count. Fatal: the array cannot be validated
+ * within the seen-set budget, so it is refused rather than held unbounded.
+ */
+export class UniqueItemsLimitError extends Error {
+  readonly byteOffset: number;
+  constructor(limit: number, byteOffset: number) {
+    super(`uniqueItems array exceeded maxUniqueItems=${limit} (at byte ${byteOffset})`);
+    this.name = "UniqueItemsLimitError";
+    this.byteOffset = byteOffset;
+  }
+}
+
 /** Validates a materialized island value against schemas; returns flat violations. */
 export type IslandDelegate = (
   schemas: SchemaObject[],
@@ -136,6 +150,8 @@ export interface SpineOptions {
   verdictOnly?: boolean;
   /** Cap on a single buffered island's UTF-8 source-byte span (and forced-buffer scalar). Unset: no cap. */
   maxBufferedBytes?: number;
+  /** Cap on the element count of a buffered `uniqueItems` array (its seen-set is O(that)). Unset: no cap. */
+  maxUniqueItems?: number;
   /** Maximum nesting depth. Exceeding it is a `depth` violation. Unset: no cap. */
   maxDepth?: number;
   /** Regex engine for `pattern` (e.g. RE2). Hardens the spine's own regex use. */
@@ -292,6 +308,7 @@ export class SpineValidator implements JsonEventHandler {
   private readonly delegate: IslandDelegate | undefined;
   private readonly maxErrors: number;
   private readonly maxBufferedBytes: number | undefined;
+  private readonly maxUniqueItems: number | undefined;
   private readonly maxDepth: number | undefined;
   private readonly regexCompiler: RegexCompiler | undefined;
   private readonly assertsFormat: boolean;
@@ -356,6 +373,9 @@ export class SpineValidator implements JsonEventHandler {
     path: PathSegment[];
     builder: ValueBuilder;
     byteStart: number;
+    // Element-count cap when this island is a `uniqueItems` array and
+    // `maxUniqueItems` is set; `undefined` otherwise (no count enforced).
+    uniqueCap: number | undefined;
   } | null = null;
 
   // An open TEE: the value's events are forwarded to one forward sub-spine
@@ -378,6 +398,7 @@ export class SpineValidator implements JsonEventHandler {
     this.maxErrors = options.maxErrors ?? Number.POSITIVE_INFINITY;
     this.verdictOnly = options.verdictOnly ?? false;
     this.maxBufferedBytes = options.maxBufferedBytes;
+    this.maxUniqueItems = options.maxUniqueItems;
     this.maxDepth = options.maxDepth;
     this.regexCompiler = options.regexCompiler;
     this.assertsFormat = options.assertsFormat ?? false;
@@ -649,15 +670,24 @@ export class SpineValidator implements JsonEventHandler {
     this.requireDelegate();
     this.pushSegment();
     if (app.hasFalse) this.fail("false");
+    // A `uniqueItems` array island's seen-set is O(element count); cap it
+    // when `maxUniqueItems` is set so the buffered array cannot grow
+    // unbounded on hostile input. Other islands (object `const`, `contains`,
+    // ...) are bounded by `maxBufferedBytes` only.
+    const uniqueCap =
+      this.maxUniqueItems !== undefined && app.schemas.some((s) => s.uniqueItems === true)
+        ? this.maxUniqueItems
+        : undefined;
     this.island = {
       schemas: app.schemas,
       path: [...this.path],
       builder: new ValueBuilder(),
       byteStart: this.curOffset,
+      uniqueCap,
     };
   }
 
-  // Forward an event into the open island, enforcing the buffer cap, and
+  // Forward an event into the open island, enforcing the buffer caps, and
   // finalize when the island's value is complete.
   private forwardIsland(feed: (b: ValueBuilder) => void): void {
     const island = this.island as NonNullable<typeof this.island>;
@@ -667,6 +697,14 @@ export class SpineValidator implements JsonEventHandler {
       this.curOffset - island.byteStart > this.maxBufferedBytes
     ) {
       throw new BufferLimitError(this.maxBufferedBytes, this.curOffset);
+    }
+    // The island's root array grows one entry per top-level element; refuse
+    // a `uniqueItems` array past its element cap before the rest buffers.
+    if (island.uniqueCap !== undefined) {
+      const v = island.builder.value;
+      if (Array.isArray(v) && v.length > island.uniqueCap) {
+        throw new UniqueItemsLimitError(island.uniqueCap, this.curOffset);
+      }
     }
     if (island.builder.complete) this.finalizeIsland();
   }
@@ -695,6 +733,7 @@ export class SpineValidator implements JsonEventHandler {
     };
     if (this.delegate !== undefined) opts.delegate = this.delegate;
     if (this.maxBufferedBytes !== undefined) opts.maxBufferedBytes = this.maxBufferedBytes;
+    if (this.maxUniqueItems !== undefined) opts.maxUniqueItems = this.maxUniqueItems;
     if (this.maxDepth !== undefined) opts.maxDepth = this.maxDepth;
     if (this.regexCompiler !== undefined) opts.regexCompiler = this.regexCompiler;
     return new SpineValidator(branch, opts);

--- a/packages/stream-validator/test/resource-limits.test.ts
+++ b/packages/stream-validator/test/resource-limits.test.ts
@@ -105,6 +105,80 @@ describe("regexCompiler hardens the spine's own pattern check", () => {
   });
 });
 
+describe("uniqueItems buffers as an island, bounded by maxUniqueItems / maxBufferedBytes", () => {
+  const bigUnique = (n: number): string => `[${Array.from({ length: n }, (_, i) => i).join(",")}]`;
+
+  it("validates the uniqueItems verdict via the in-memory delegate", async () => {
+    const schema: SchemaOrBoolean = { type: "array", uniqueItems: true };
+    expect((await verdictOf(schema, [1, 2, 3])).valid).toBe(true);
+    expect((await verdictOf(schema, [1, 2, 2])).valid).toBe(false);
+  });
+
+  it("maxUniqueItems refuses an over-count array before it fully buffers", async () => {
+    const validator = createStreamValidator(
+      { type: "array", uniqueItems: true },
+      { maxUniqueItems: 4 },
+    );
+    validator.on("error", () => {});
+    validator.resume();
+    const guard = validator.result.catch((e) => e as Error);
+    await expect(
+      pipeline(source(bigUnique(300), 8), validator, new Writable({ write: (_c, _e, cb) => cb() })),
+    ).rejects.toThrow(/maxUniqueItems/);
+    expect((await guard).message).toMatch(/maxUniqueItems/);
+  });
+
+  it("maxUniqueItems within the cap validates normally", async () => {
+    const verdict = await verdictOf({ type: "array", uniqueItems: true }, [1, 2, 3], {
+      maxUniqueItems: 4,
+    });
+    expect(verdict.valid).toBe(true);
+  });
+
+  it("maxUniqueItems applies to a uniqueItems array under a composition branch", async () => {
+    // The array sits under `allOf`, validated by a TEE sub-spine; the cap is
+    // plumbed into the sub-spine, so the buffered island is still bounded.
+    const validator = createStreamValidator(
+      { allOf: [{ type: "array", uniqueItems: true }] },
+      { maxUniqueItems: 4 },
+    );
+    validator.on("error", () => {});
+    validator.resume();
+    const guard = validator.result.catch((e) => e as Error);
+    await expect(
+      pipeline(source(bigUnique(300), 8), validator, new Writable({ write: (_c, _e, cb) => cb() })),
+    ).rejects.toThrow(/maxUniqueItems/);
+    expect((await guard).message).toMatch(/maxUniqueItems/);
+  });
+
+  it("maxBufferedBytes also caps the uniqueItems island (byte budget)", async () => {
+    const validator = createStreamValidator(
+      { type: "array", uniqueItems: true },
+      { maxBufferedBytes: 32 },
+    );
+    validator.on("error", () => {});
+    validator.resume();
+    const guard = validator.result.catch((e) => e as Error);
+    await expect(
+      pipeline(source(bigUnique(300), 8), validator, new Writable({ write: (_c, _e, cb) => cb() })),
+    ).rejects.toThrow(/maxBufferedBytes/);
+    expect((await guard).message).toMatch(/maxBufferedBytes/);
+  });
+
+  it("enforceBounds rejects uniqueItems without maxItems at construction", () => {
+    expect(() =>
+      createStreamValidator({ type: "array", uniqueItems: true }, { enforceBounds: true }),
+    ).toThrow(/maxItems/);
+    // A structural bound (maxItems) clears the warning.
+    expect(() =>
+      createStreamValidator(
+        { type: "array", uniqueItems: true, maxItems: 10 },
+        { enforceBounds: true },
+      ),
+    ).not.toThrow();
+  });
+});
+
 describe("maxTotalBytes / maxDepth", () => {
   it("rejects input larger than maxTotalBytes", async () => {
     const validator = createStreamValidator(true, { maxTotalBytes: 4 });


### PR DESCRIPTION
Follow-up from verifying the `uniqueItems` / `maxUniqueItems` finding flagged in review. The claim was confirmed empirically, and this wires the inert option.

## What was wrong

`maxUniqueItems` was a public option documented as *reserved / inert*. Verified against the code and at runtime:

- A `uniqueItems` array always routes to a **BUFFER island** (`spine.ts`: `uniqueItems === true => "buffer"`), materialized and delegated to `@oav/schema`. It never streams.
- `maxUniqueItems` was read **nowhere** outside its own declaration — a no-op.
- So a large `uniqueItems` array without `maxItems` buffered the **whole array**, bounded only by `maxBufferedBytes` (a byte budget, off by default). Proven: a 300-element unique array with `maxUniqueItems: 2` validated clean (no bound), while the same array with `maxBufferedBytes: 32` failed with `buffered island exceeded maxBufferedBytes=32`.

A public knob that silently does nothing is the kind of debugging dead-end the project's "no magic" principle warns against.

## The fix (option: wire it, keep the name)

When a `uniqueItems` array islands and `maxUniqueItems` is set, count the island's top-level elements as they accumulate and refuse the array once the count exceeds the cap — **before the rest buffers** — with a fatal `UniqueItemsLimitError` (parallel to `BufferLimitError` / `maxTotalBytes`). The cap is plumbed into TEE sub-spines too, so a `uniqueItems` array under a composition branch is bounded as well.

Element count is the right proxy for the seen-set's O(array length) memory, and the bound **survives the eventual streaming canonical-hash mode** (which will cap the streamed seen-set by the same count), so the option's observable contract doesn't change when that lands. TSDoc updated from "reserved/inert" to the working semantics.

This is deliberately the bridge, not the full streaming `uniqueItems`. The full version forces a probabilistic-soundness decision (hash collisions vs the engine's absolute verdict-equivalence guarantee) that's a philosophy call, not just code; `maxUniqueItems` remains the necessary safety valve either way, since even streamed, `uniqueItems` is O(unique-count) memory, never O(1).

## Tests

`pnpm test` green. New regression coverage in `resource-limits.test.ts`:
- `maxUniqueItems` refuses an over-count array before it fully buffers (direct, and under an `allOf` composition branch)
- within-cap arrays validate normally
- `maxBufferedBytes` still caps the island (byte budget)
- `enforceBounds` rejects `uniqueItems` without `maxItems` at construction
- verdict correctness (dup detection) via the in-memory delegate