### PR TITLE
docs(oav): correct the root package's batteries-included loader note

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -14,10 +14,11 @@ further down). `oav-core` mirrors the same paths; substitute
 | `@aahoughton/oav/formats`      | Built-in string format validators                                               |
 | `@aahoughton/oav/core`         | Error tree model, shared OpenAPI / HTTP types                                   |
 
-`oav` also exports `createYamlFileReader`, `createSmartHttpReader`
-(HTTP reader that handles both JSON and YAML by inspecting
-`Content-Type`), and `parseYamlString` at the root entry, and ships
-the `oav` CLI as a `bin`.
+`oav` also exports `loadSpecSync` (YAML-defaulting, so a `.yaml`
+spec loads with no reader composition), `createYamlFileReader`,
+`createSmartHttpReader` (HTTP reader that handles both JSON and YAML
+by inspecting `Content-Type`), and `parseYamlString` at the root
+entry, and ships the `oav` CLI as a `bin`.
 
 ## Internal subpaths (not covered by semver)
 

--- a/packages/oav/src/index.ts
+++ b/packages/oav/src/index.ts
@@ -1,8 +1,10 @@
 /**
  * `oav`: batteries-included distribution. Re-exports the
- * full surface of `oav-core` and adds YAML readers so
- * `loadSpec` works against hand-authored `.yaml` specs out of the
- * box. Also ships the `oav` CLI binary.
+ * full surface of `oav-core` and adds YAML readers plus a
+ * YAML-defaulting `loadSpecSync`, so loading a hand-authored
+ * `.yaml` spec works out of the box. (Async `loadSpec` stays in
+ * `oav/spec`; compose it with the exported YAML readers for the
+ * same.) Also ships the `oav` CLI binary.
  *
  * Consumers who want the zero-runtime-dep version (edge runtimes,
  * JSON-only workloads, minimal bundles) install `oav-core`


### PR DESCRIPTION
From the public-surface consistency audit (finding S4/N1). Doc-only, no API change.

The root `oav` package doc-comment claimed "adds YAML readers so `loadSpec` works against hand-authored `.yaml` specs out of the box." Only the **sync** `loadSpecSync` is actually batteries-included at the root: it defaults to a YAML-aware reader (whose sync implementation is deliberately module-private, so the wrapper is the only sync-YAML path). Async `loadSpec` is not wrapped at the root and composes the **exported** YAML readers (`createYamlFileReader` + `composeReaders`), which is the intended path since that reader is public.

The audit's first instinct was "complete the pair by adding an async root `loadSpec`," but that would be a redundant second way to do the async load. The real issue was just the loosely-worded comment. This:

- Names `loadSpecSync` as the out-of-the-box loader and points async `loadSpec` at the exported readers (`packages/oav/src/index.ts`).
- Adds the omitted `loadSpecSync` to the `docs/modules.md` root-entry note.

The rest of the audit's findings were judged not worth their churn (notably: renaming the stream validator's `verdict.violations` to `errors` would collide with the engine's separate fatal `error` channel and erase a real distinction, so it was deliberately left alone).