### PR TITLE
refactor(stream-validator): tighten public surface before publish

### DIFF
--- a/packages/stream-validator/src/engine/stream-validator.ts
+++ b/packages/stream-validator/src/engine/stream-validator.ts
@@ -592,6 +592,13 @@ export class StreamValidator extends Transform {
  * Create a {@link StreamValidator} for `schema`. Throws at construction
  * (before any byte) if the schema cannot be soundly streamed.
  *
+ * Validates one complete JSON document as it streams. Per-record
+ * validation of a sequence (NDJSON / json-seq under an OpenAPI 3.2
+ * `itemSchema`) is a distinct lifecycle (N item verdicts plus an
+ * aggregate, gate vs pass-through emission, a per-record byte ceiling)
+ * and will arrive as a sibling factory, not a mode of this one. This
+ * factory's contract stays single-document.
+ *
  * @public
  */
 export function createStreamValidator(

--- a/packages/stream-validator/src/index.ts
+++ b/packages/stream-validator/src/index.ts
@@ -21,13 +21,17 @@ export type { JsonPath, PathFilter, StreamValidatorOptions } from "./options.js"
 export {
   createStreamValidator,
   DEFAULT_MAX_CAPTURE_BYTES,
-  StreamValidator,
   ValidationFailedError,
   type Bytes,
   type ScopeContext,
   type ScopeEditor,
   type ScopeObserver,
+  // Exported as a type only: construct through `createStreamValidator`.
+  // The factory is the construction contract; a type-only export keeps
+  // `instanceof` and the `new` constructor out of the public surface, so
+  // a later engine refactor (a shared base transform, a different
+  // lifecycle class) does not break consumers.
+  type StreamValidator,
   type ValueEvent,
 } from "./engine/index.js";
 export type { StreamVerdict, SchemaViolation } from "./spine/index.js";
-export { normalizeOas30 } from "./openapi/index.js";

--- a/packages/stream-validator/src/spine/spine.ts
+++ b/packages/stream-validator/src/spine/spine.ts
@@ -109,6 +109,11 @@ export interface SchemaViolation {
   path: PathSegment[];
   /**
    * Byte offset in the input stream nearest the violation (for re-sync).
+   * Stream-absolute: counted from the first byte fed to the validator,
+   * never reset or rebased. A future per-record (sequence) lifecycle
+   * reports record position additively on its own item channel and does
+   * not redefine this field, so a consumer can treat this offset as a
+   * stable, monotonic coordinate.
    * On the BUFFER path every node of one island (a violation and its
    * `children`) shares the island's start offset; per-child precision is
    * not tracked.

--- a/packages/stream-validator/test/openapi.test.ts
+++ b/packages/stream-validator/test/openapi.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { SchemaObject, SchemaOrBoolean } from "@oav/core";
 import { compileSchema, jsonSchemaDialect, oas30Dialect } from "@oav/schema";
-import { createStreamValidator, normalizeOas30, type StreamVerdict } from "../src/index.js";
+import { createStreamValidator, type StreamVerdict } from "../src/index.js";
+// `normalizeOas30` is engine-internal (not on the package's public index);
+// the OAS-3.0 normalization it drives is exercised through the public
+// `openApiVersion: "3.0"` path below, and unit-tested here directly.
+import { normalizeOas30 } from "../src/openapi/index.js";
 
 const enc = new TextEncoder();
 


### PR DESCRIPTION
Pre-publish surface hardening for `@oav/stream-validator`, the first of two PRs (this one is the discussed surface work; a follow-up wires up the actual publish). Goal: lock a forward-compatible public API so the sequence/per-record work (#417) lands as additions, not breaks.

## Changes

- **`StreamValidator` is now a type-only export.** `createStreamValidator` is the construction contract; a type-only export keeps `new` / `instanceof` out of the public surface, so a later engine refactor (a shared base `Transform`, a distinct sequence-lifecycle class) stays non-breaking. Verified no consumer constructs the class directly (the only `new StreamValidator` is inside the factory; tests use it as a type).
- **`SchemaViolation.byteOffset` pinned as stream-absolute** in its TSDoc. A future sequence lifecycle reports record position additively on its own item channel rather than reinterpreting this published field.
- **`normalizeOas30` dropped from the public index** (engine-internal; driven by the `openApiVersion: "3.0"` path). Its unit test imports it from the internal module instead.
- **`createStreamValidator` documented as single-document**, with per-record sequence validation noted as a future sibling factory, not a mode.

## Why now

The package is still `private` / unpublished, so this is the free window to tighten the surface. These four are the API-shape items from the architecture read; the structural decisions (sibling `createSequenceValidator`, document-specific `StreamValidatorOptions`) need no code change today, only that the surface above stays additive.

## Verification

- `pnpm vitest run packages/stream-validator` — 1319 passed
- `pnpm typecheck` — clean
- `pnpm lint` (oxlint + oxfmt + check:deps) — clean

## Not in this PR

The publish enablement (un-private, tsup build + dist exports, release-please wiring, dist-tag, `pack-smoke`). Lands as a follow-up so the surface change is reviewable on its own and revertible independently.