### PR TITLE
feat(stream-validator): publish as @aahoughton/oav-stream-validator (experimental)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,7 @@ jobs:
           (cd packages/oav-express4 && pnpm pack --pack-destination "$GITHUB_WORKSPACE/packed")
           (cd packages/oav-express5 && pnpm pack --pack-destination "$GITHUB_WORKSPACE/packed")
           (cd packages/oav-fastify && pnpm pack --pack-destination "$GITHUB_WORKSPACE/packed")
+          (cd packages/stream-validator && pnpm pack --pack-destination "$GITHUB_WORKSPACE/packed")
           ls -1 "$GITHUB_WORKSPACE/packed"
       - name: smoke-import @aahoughton/oav-core
         run: |
@@ -403,5 +404,43 @@ jobs:
           );
           if (typeof hook !== "function") throw new Error("validateRequests did not return a hook");
           console.log("oav-fastify smoke ok");
+          EOF
+          node smoke.mjs
+      - name: smoke-import @aahoughton/oav-stream-validator
+        run: |
+          set -euo pipefail
+          CORE_TGZ="$(ls "$GITHUB_WORKSPACE/packed"/aahoughton-oav-core-*.tgz | head -n1)"
+          SV_TGZ="$(ls "$GITHUB_WORKSPACE/packed"/aahoughton-oav-stream-validator-*.tgz | head -n1)"
+          rm -rf /tmp/smoke-sv && mkdir -p /tmp/smoke-sv && cd /tmp/smoke-sv
+          npm init -y > /dev/null
+          # Install both tarballs together so the stream validator's
+          # dependency on @aahoughton/oav-core resolves against the locally
+          # packed core, not the registry.
+          npm install "$CORE_TGZ" "$SV_TGZ"
+          cat > smoke.mjs <<'EOF'
+          import { pipeline } from "node:stream/promises";
+          import { Readable } from "node:stream";
+          import { createStreamValidator } from "@aahoughton/oav-stream-validator";
+          // Exercise the cross-package boundary: the engine delegates BUFFER
+          // islands and dialect handling to the published core, so this proves
+          // the rewritten `@aahoughton/oav-core/{core,schema,schema/internals}`
+          // imports load. A leaked `@oav/*` import would fail resolution here.
+          const validator = createStreamValidator({
+            type: "object",
+            required: ["a"],
+            properties: { a: { type: "integer" } },
+          });
+          await pipeline(
+            Readable.from([Buffer.from('{"a":1}')]),
+            validator,
+            async function (source) {
+              for await (const _chunk of source) {
+                // drain the echoed bytes so the transform can finish
+              }
+            },
+          );
+          const verdict = await validator.result;
+          if (!verdict.valid) throw new Error("expected a valid verdict");
+          console.log("oav-stream-validator smoke ok");
           EOF
           node smoke.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,13 @@ on:
     inputs:
       tag:
         # release-please creates one tag per package per release
-        # (component prefix from release-please-config.json, linked
-        # versions, so all 5 point at the same commit). Any of them
-        # is fine to pass here; oav-core is the conventional choice.
-        description: "Release tag to (re)publish, e.g. oav-core-v2.1.1"
+        # (component prefix from release-please-config.json). The five
+        # linked packages share a version, so their tags point at the same
+        # commit; oav-stream-validator is unlinked (incubating, 0.x) and
+        # carries its own tag at its own commit. Pass whichever package's
+        # tag you are republishing; oav-core is the conventional choice for
+        # the linked group.
+        description: "Release tag to (re)publish, e.g. oav-core-v2.1.1 or oav-stream-validator-v0.1.0"
         required: true
         type: string
 
@@ -80,7 +83,7 @@ jobs:
         env:
           TAG: ${{ inputs.tag }}
         run: |
-          if [[ ! "$TAG" =~ ^(oav-core|oav|oav-express4|oav-express5|oav-fastify)-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ ! "$TAG" =~ ^(oav-core|oav|oav-express4|oav-express5|oav-fastify|oav-stream-validator)-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Invalid tag '$TAG'. Expected <component>-v<MAJOR>.<MINOR>.<PATCH>, e.g. oav-core-v2.1.1"
             exit 1
           fi
@@ -124,7 +127,7 @@ jobs:
       - name: Pack
         run: |
           mkdir -p pkgs
-          for pkg in . packages/oav packages/oav-express4 packages/oav-express5 packages/oav-fastify; do
+          for pkg in . packages/oav packages/oav-express4 packages/oav-express5 packages/oav-fastify packages/stream-validator; do
             (cd "$pkg" && pnpm pack --pack-destination "$GITHUB_WORKSPACE/pkgs")
           done
       # Publish via npm CLI, which performs the OIDC token exchange

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,5 +3,6 @@
   "packages/oav": "3.3.0",
   "packages/oav-express4": "3.3.0",
   "packages/oav-express5": "3.3.0",
-  "packages/oav-fastify": "3.3.0"
+  "packages/oav-fastify": "3.3.0",
+  "packages/stream-validator": "0.0.0"
 }

--- a/packages/stream-validator/LICENSE
+++ b/packages/stream-validator/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Andrew Houghton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/stream-validator/README.md
+++ b/packages/stream-validator/README.md
@@ -1,29 +1,42 @@
-# @oav/stream-validator (incubating)
+# oav-stream-validator (incubating)
 
-A streaming JSON Schema 2020-12 validator. It validates a JSON document
-against a resolved schema **as it streams**, echoing the input bytes
-through unchanged while reporting violations on a side channel. Memory is
-bounded for forward-decidable schemas with structural bounds (or
-configured caps), so multi-GB request bodies validate without
-materializing in heap.
+A streaming JSON Schema 2020-12 validator for
+[`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core). It
+validates a JSON document against a resolved schema **as it streams**,
+echoing the input bytes through unchanged while reporting violations on a
+side channel. Memory is bounded for forward-decidable schemas with
+structural bounds (or configured caps), so multi-GB request bodies
+validate without materializing in heap.
 
-This is a second engine, not a mode of `@oav/schema`. `@oav/schema`'s
-compiler is pull-based over a fully-parsed value; this engine is
-push-based over a token stream. It reuses `@oav/schema`'s in-memory
+This is a second engine, not a mode of the in-memory validator.
+`oav-core`'s compiler is pull-based over a fully-parsed value; this engine
+is push-based over a token stream. It reuses `oav-core`'s in-memory
 validator for the subtrees a compile-time classifier marks BUFFER (so
-format assertion and built-in formats come from that delegate), and
-reuses `@oav/core`'s flat error model.
+format assertion and built-in formats come from that delegate), and reuses
+its flat error model.
 
-> **Incubating, unpublished.** This package is `private` and ships
-> TypeScript source, not a build. It is consumed inside the OAV monorepo
-> via `workspace:*`; there is no `@oav/stream-validator` on npm. The
-> import path below resolves to the workspace source.
+Thin: this package bundles nothing from `oav-core`. It declares
+`@aahoughton/oav-core` as a regular dependency, so installing the stream
+validator pulls the engine it delegates to along with it.
+
+> **Incubating, on the `experimental` dist-tag.** Published to
+> `experimental` (not `latest`) and versioned independently of the
+> `oav-core` family while the API settles (`0.x`). Install it by tag:
+>
+> ```bash
+> npm install @aahoughton/oav-stream-validator@experimental
+> ```
+>
+> A plain `npm install @aahoughton/oav-stream-validator` (no tag) will not
+> resolve until it graduates to `latest`. The public surface is small and
+> additive-by-design, but treat `0.x` minor bumps as potentially breaking
+> until then.
 
 ## Usage
 
 ```ts
 import { pipeline } from "node:stream/promises";
-import { createStreamValidator } from "@oav/stream-validator";
+import { createStreamValidator } from "@aahoughton/oav-stream-validator";
 
 const validator = createStreamValidator(schema); // throws here if the schema can't be streamed
 
@@ -88,8 +101,8 @@ validates one resolved schema, so those concerns sit above it. The
 bridge from a resolved document is short:
 
 ```ts
-import { resolveSpec } from "@oav/spec";
-import { createStreamValidator } from "@oav/stream-validator";
+import { resolveSpec } from "@aahoughton/oav-core/spec";
+import { createStreamValidator } from "@aahoughton/oav-stream-validator";
 
 const doc = await resolveSpec(source); // inlines external refs; internal refs stay
 const op = doc.paths["/pets"].post; // your router selects the operation
@@ -159,7 +172,8 @@ visitor over an arbitrary schema.
 
 ## Status
 
-Incubating and **unpublished** (`private`). The package lives in the
-monorepo via `workspace:*` so its classifier can co-evolve with
-`@oav/schema`'s keyword set (a CI drift test makes that a build failure
-rather than silent breakage).
+Incubating: published to the `experimental` dist-tag (not `latest`) and
+versioned independently of the `oav-core` family. The classifier
+co-evolves with `oav-core`'s keyword set inside the monorepo (a CI drift
+test makes a divergence a build failure rather than silent breakage); the
+published bundle pins `@aahoughton/oav-core` so the two move together.

--- a/packages/stream-validator/package.json
+++ b/packages/stream-validator/package.json
@@ -1,22 +1,78 @@
 {
-  "name": "@oav/stream-validator",
+  "name": "@aahoughton/oav-stream-validator",
   "version": "0.0.0",
-  "private": true,
-  "description": "Internal (incubating): streaming JSON Schema validator for @aahoughton/oav. Validates a JSON document against a resolved 2020-12 schema as it streams, echoing bytes through unchanged.",
+  "description": "Streaming JSON Schema 2020-12 validator for @aahoughton/oav-core. Validates a JSON document against a resolved schema as it streams, echoing bytes through unchanged while reporting violations on a side channel; memory stays bounded for forward-decidable schemas, so multi-GB bodies validate without materializing in heap.",
+  "keywords": [
+    "json-schema",
+    "json-schema-2020-12",
+    "openapi",
+    "openapi-3.0",
+    "openapi-3.1",
+    "openapi-3.2",
+    "sax",
+    "stream",
+    "streaming",
+    "validation",
+    "validator"
+  ],
+  "homepage": "https://github.com/aahoughton/oav#readme",
+  "bugs": {
+    "url": "https://github.com/aahoughton/oav/issues"
+  },
+  "license": "MIT",
+  "author": "Andrew Houghton <aah@roarmouse.org>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aahoughton/oav.git",
+    "directory": "packages/stream-validator"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "type": "module",
   "sideEffects": false,
-  "main": "./src/index.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "import": "./src/index.ts"
-    }
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "tag": "experimental"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "typecheck": "tsc -b",
+    "prepack": "node -e \"if((process.env.npm_config_user_agent||'').startsWith('npm/'))throw Error('Use pnpm pack: npm pack does not rewrite workspace:* deps.')\" && tsup && node ../../scripts/pack-devdeps.mjs strip",
+    "postpack": "node ../../scripts/pack-devdeps.mjs restore"
   },
   "dependencies": {
+    "@aahoughton/oav-core": "workspace:*"
+  },
+  "devDependencies": {
     "@oav/core": "workspace:*",
-    "@oav/schema": "workspace:*"
+    "@oav/schema": "workspace:*",
+    "tsup": "8.5.1",
+    "typescript": "5.9.3",
+    "vitest": "4.1.9"
   },
   "engines": {
-    "node": ">=20"
-  }
+    "node": ">=22"
+  },
+  "//": "Incubating: published to the `experimental` dist-tag (publishConfig.tag), not `latest`, and versioned independently of the lockstep oav-core family. No prepublishOnly: release.yml runs `pnpm test` from root before publish."
 }

--- a/packages/stream-validator/tsup.config.ts
+++ b/packages/stream-validator/tsup.config.ts
@@ -1,0 +1,52 @@
+import { resolve } from "node:path";
+import type { Plugin } from "esbuild";
+import { defineConfig } from "tsup";
+
+/**
+ * Build config for `oav-stream-validator`, the streaming JSON Schema
+ * validator.
+ *
+ * Thin tarball: nothing from `oav-core` is bundled. The engine imports
+ * `@oav/core` / `@oav/schema` (workspace aliases) in source; the plugin
+ * below rewrites those to `@aahoughton/oav-core/*` AND marks them
+ * external, so the published bundle resolves them from the consumer's
+ * install of `@aahoughton/oav-core` (a regular dependency). This is the
+ * same pattern the framework adapters use; it keeps the in-memory
+ * compiler from being duplicated into this tarball.
+ *
+ * The map covers every `@oav/*` subpath the source imports: the base
+ * `@oav/schema` and `@oav/schema/internals` are distinct npm subpaths and
+ * map separately. Keep this in sync with the imports if a new one is
+ * added (an unmapped `@oav/*` import would be bundled from source instead
+ * of externalized, silently fattening the tarball).
+ */
+const oavCoreRewrite: Record<string, string> = {
+  "@oav/core": "@aahoughton/oav-core/core",
+  "@oav/schema": "@aahoughton/oav-core/schema",
+  "@oav/schema/internals": "@aahoughton/oav-core/schema/internals",
+};
+
+function rewriteOavCore(): Plugin {
+  return {
+    name: "oav-core-rewrite",
+    setup(build) {
+      build.onResolve({ filter: /^@oav\// }, (args) => {
+        const rewrite = oavCoreRewrite[args.path];
+        if (rewrite) return { path: rewrite, external: true };
+        return null;
+      });
+    },
+  };
+}
+
+export default defineConfig({
+  entry: { index: "src/index.ts" },
+  format: ["esm", "cjs"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  target: "es2022",
+  tsconfig: resolve(__dirname, "../../tsconfig.build.json"),
+  external: ["@aahoughton/oav-core"],
+  esbuildPlugins: [rewriteOavCore()],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,12 +211,25 @@ importers:
 
   packages/stream-validator:
     dependencies:
+      '@aahoughton/oav-core':
+        specifier: workspace:*
+        version: link:../..
+    devDependencies:
       '@oav/core':
         specifier: workspace:*
         version: link:../core
       '@oav/schema':
         specifier: workspace:*
         version: link:../schema
+      tsup:
+        specifier: 8.5.1
+        version: 8.5.1(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 4.1.9
+        version: 4.1.9(@types/node@25.9.3)(esbuild@0.28.1)(yaml@2.9.0)
 
   packages/validator:
     dependencies:
@@ -1472,10 +1485,6 @@ packages:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -2577,7 +2586,7 @@ snapshots:
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       ts-interface-checker: 0.1.13
 
   thenify-all@1.6.0:
@@ -2597,11 +2606,6 @@ snapshots:
   tinyexec@0.3.2: {}
 
   tinyexec@1.2.4: {}
-
-  tinyglobby@0.2.16:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
 
   tinyglobby@0.2.17:
     dependencies:
@@ -2638,7 +2642,7 @@ snapshots:
       source-map: 0.7.6
       sucrase: 3.35.1
       tinyexec: 0.3.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.15

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -53,6 +53,13 @@
       "package-name": "@aahoughton/oav-fastify",
       "component": "oav-fastify",
       "changelog-path": "CHANGELOG.md"
+    },
+    "packages/stream-validator": {
+      "release-type": "node",
+      "package-name": "@aahoughton/oav-stream-validator",
+      "component": "oav-stream-validator",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
Second of two PRs (follows #418). Turns `@oav/stream-validator` into a published package, `@aahoughton/oav-stream-validator`, on the **`experimental`** dist-tag and versioned **independently** of the lockstep `oav-core` family (decision: incubating `0.x`).

Cloned from the framework-adapter pattern: a thin tarball that bundles nothing from oav-core and declares `@aahoughton/oav-core` as a runtime dependency.

## What's wired

**Packaging**
- `package.json`: un-private; published metadata (keywords, repository.directory, `files`, `publishConfig`, dual ESM/CJS `exports`, `engines >=22`). `@aahoughton/oav-core` is a runtime dep; the `@oav/*` workspace packages move to `devDependencies` (build-time aliases).
- `tsup.config.ts`: rewrite plugin maps the three source imports (`@oav/core`, `@oav/schema`, `@oav/schema/internals`) to `@aahoughton/oav-core/*` and marks them external. Verified oav-core already exposes every used symbol on a public subpath, so **oav-core needs no change**.
- `LICENSE`; README de-incubated (install via `@experimental`).

**Release (incubating, non-lockstep)**
- `release-please-config.json`: a **non-linked** `oav-stream-validator` component (not in the `linked-versions` group) with `bump-minor-pre-major`, bootstrapped at `0.0.0` in the manifest so the first `feat` (this PR's title) cuts **`0.1.0`**, and breaking changes stay in `0.x`.
- Dist-tag `experimental` via `publishConfig.tag` (honored from the tarball the same way `access`/`provenance` already are, so the generic publish loop needs no tag-branching). `release.yml` packs the package and accepts its dispatch tag.
- `ci.yml` `pack-smoke`: packs the tarball and imports it against a packed oav-core.

## Verification

- `pnpm typecheck`, `pnpm lint` (oxlint + oxfmt + check:deps), `pnpm vitest run packages/stream-validator` (1319) — all green.
- Build externalizes `@aahoughton/oav-core/*` (71 KB bundle, compiler not inlined); `.d.ts` self-contained.
- **`pnpm pack` + `npm install` in a clean `/tmp` sandbox**: validates a document (valid and invalid verdicts) over both ESM and CJS entries. The `workspace:*` core dep rewrites to `@aahoughton/oav-core@3.3.0`; `StreamValidator` is correctly absent from the runtime entry (type-only since #418).

## Maintainer action items (outside this PR)

1. **Register `@aahoughton/oav-stream-validator` as a trusted publisher** on npmjs.com (this repo + the `release` workflow), same as the other five. The publish job can't push to npm until this exists. The PR is safe to merge before it; the publish step just no-ops/fails until registered.
2. After merge, **sanity-check the release-please PR**: it should propose `oav-stream-validator: 0.1.0` (independent of the family's version). Publishing only happens when you merge that release PR.
3. First publish lands on `@experimental`; promote to `latest` (and, if desired, fold into the linked group) when it graduates.

## Note on the experimental tag

Because nothing is published to `latest`, a plain `npm install @aahoughton/oav-stream-validator` will not resolve until graduation. Install is `@aahoughton/oav-stream-validator@experimental` (documented in the README).