### PR TITLE
docs(examples): add streaming examples and refresh existing ones

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -19,7 +19,17 @@ The examples import from `packages/*/src` directly so they work without
 instead; the logic translates 1:1. Consumers on the lean
 `@aahoughton/oav-core` package can substitute `@aahoughton/oav-core`
 for `@aahoughton/oav` in import specifiers that don't touch
-`createYamlFileReader` (oav-core is JSON-only).
+`createYamlFileReader` (oav-core is JSON-only); `resolveSpec` lives at
+`@aahoughton/oav-core/spec`.
+
+The streaming examples import from `packages/stream-validator/src`, which
+translates to `@aahoughton/oav-stream-validator`. That is a separate
+package (not part of the `oav` / `oav-core` re-export), incubating on the
+`experimental` dist-tag, so install it by tag:
+
+```bash
+npm install @aahoughton/oav-stream-validator@experimental
+```
 
 ## What's in here
 
@@ -39,6 +49,23 @@ for `@aahoughton/oav` in import specifiers that don't touch
 See [`docs/overlays.md`](../docs/overlays.md) for a walk-through of the overlay
 shape and when to use each section (`extendSchemas`, `replaceSchemas`,
 `overrides`, `addPaths`).
+
+### Streaming
+
+The streaming validator (`@aahoughton/oav-stream-validator`, incubating)
+is a second engine: it validates a JSON body as the bytes flow through,
+echoing them out unchanged, without buffering the whole document. These
+examples break the load-a-spec / print-a-verdict mold: they pipe a
+lazily generated body through `createStreamValidator` and read the
+side channel, so each fabricates its body inline rather than loading a
+fixture.
+
+| File                       | Shows                                                                     |
+| -------------------------- | ------------------------------------------------------------------------- |
+| `stream-basic.ts`          | `pipeline` echo-through; the `violation` channel and `result` verdict     |
+| `stream-from-spec.ts`      | Bridge a resolved spec to a body validator; carry `components` for `$ref` |
+| `stream-limits.ts`         | Bound untrusted input: `enforceBounds`, `maxTotalBytes`, eager `maxItems` |
+| `stream-recover-fields.ts` | Recover top-level scalars with `valueEvents` while a large body streams   |
 
 ## Conventions
 

--- a/examples/basic-validation.ts
+++ b/examples/basic-validation.ts
@@ -1,9 +1,9 @@
 /**
- * Basic HTTP validation: load a petstore spec from disk, build a
- * validator, and check one valid + one invalid request, then a response.
+ * Basic HTTP validation: load a petstore spec, build a validator, then
+ * check a valid request, an invalid one, and a response.
  *
  * Run from the repo root:
- *   pnpm tsx examples/basic-validation.ts
+ *   pnpm dlx tsx examples/basic-validation.ts
  */
 
 import { fileURLToPath } from "node:url";

--- a/examples/cross-field-validation.ts
+++ b/examples/cross-field-validation.ts
@@ -14,7 +14,7 @@
  * subschema.
  *
  * Run from the repo root:
- *   pnpm tsx examples/cross-field-validation.ts
+ *   pnpm dlx tsx examples/cross-field-validation.ts
  */
 
 import { fileURLToPath } from "node:url";
@@ -25,7 +25,7 @@ import { createValidator } from "../packages/validator/src/index.ts";
 import type { CustomKeywordValidator } from "../packages/validator/src/index.ts";
 
 /**
- * `x-cross-field: { <field>: { atLeast: <other-field> } }` — the
+ * `x-cross-field: { <field>: { atLeast: <other-field> } }`: the
  * named field must be `>=` the named other field. Walks the rules
  * map, reaches each named sibling directly on the object data.
  */

--- a/examples/custom-formats.ts
+++ b/examples/custom-formats.ts
@@ -1,11 +1,11 @@
 /**
  * Custom formats: register a string format (here, E.164 phone numbers)
- * and have it enforced alongside the built-ins. A format is any
- * `(value: string) => boolean`; merged on top of
- * `oav/formats`' defaults at validator-construction time.
+ * and enforce it alongside the built-ins. A format is any
+ * `(value: string) => boolean`, merged onto the `oav/formats` defaults
+ * when you build the validator.
  *
  * Run from the repo root:
- *   pnpm tsx examples/custom-formats.ts
+ *   pnpm dlx tsx examples/custom-formats.ts
  */
 
 import { fileURLToPath } from "node:url";

--- a/examples/custom-keywords.ts
+++ b/examples/custom-keywords.ts
@@ -1,11 +1,11 @@
 /**
  * Custom keywords: register a schema keyword whose behavior depends on
- * runtime state the spec itself can't capture — here, an "active tenant"
- * check backed by an in-memory cache. Good for Luhn checks, tick-size
+ * runtime state the spec can't capture. Here, an "active tenant" check
+ * backed by an in-memory cache. Good for Luhn checks, tick-size
  * multiples, currency-whitelists, etc.
  *
  * Run from the repo root:
- *   pnpm tsx examples/custom-keywords.ts
+ *   pnpm dlx tsx examples/custom-keywords.ts
  */
 
 import { fileURLToPath } from "node:url";

--- a/examples/max-errors.ts
+++ b/examples/max-errors.ts
@@ -1,11 +1,11 @@
 /**
- * Bounded error collection: compare the default exhaustive mode with
- * `maxErrors: 1` (classic fast-fail) and `maxErrors: 3` (bounded) on
- * the same invalid payload. Hot loops short-circuit once the budget
- * is exhausted, so a huge invalid array doesn't cost proportional CPU.
+ * Bounded error collection: run the same invalid payload at the default
+ * fast-fail (`maxErrors: 1`), bounded budgets (`maxErrors: 3` and `10`),
+ * and uncapped (`Infinity`). Hot loops short-circuit once the budget is
+ * spent, so a huge invalid array doesn't cost proportional CPU.
  *
  * Run from the repo root:
- *   pnpm tsx examples/max-errors.ts
+ *   pnpm dlx tsx examples/max-errors.ts
  */
 
 import { fileURLToPath } from "node:url";

--- a/examples/overlay-petstore-endpoint.ts
+++ b/examples/overlay-petstore-endpoint.ts
@@ -13,7 +13,7 @@
  * body schema is untouched; only the parameter list changes.
  *
  * Run from the repo root:
- *   pnpm tsx examples/overlay-petstore-endpoint.ts
+ *   pnpm dlx tsx examples/overlay-petstore-endpoint.ts
  */
 
 import { fileURLToPath } from "node:url";

--- a/examples/overlay-petstore-schema.ts
+++ b/examples/overlay-petstore-schema.ts
@@ -7,12 +7,12 @@
  * fork in sync, you overlay an extension onto the `Pet` component.
  *
  * The overlay merges the extension into the original schema via
- * `allOf` — the original shape still applies; the extension adds to it.
+ * `allOf`: the original shape still applies, and the extension adds to it.
  * Consumers that only know about the upstream `Pet` continue to see a
  * compatible shape; the extra constraint is enforced on top.
  *
  * Run from the repo root:
- *   pnpm tsx examples/overlay-petstore-schema.ts
+ *   pnpm dlx tsx examples/overlay-petstore-schema.ts
  */
 
 import { fileURLToPath } from "node:url";

--- a/examples/overlay.ts
+++ b/examples/overlay.ts
@@ -5,7 +5,7 @@
  * extra properties, or replacing a response shape in test environments.
  *
  * Run from the repo root:
- *   pnpm tsx examples/overlay.ts
+ *   pnpm dlx tsx examples/overlay.ts
  */
 
 import { fileURLToPath } from "node:url";
@@ -39,12 +39,12 @@ const overlay: SpecOverlay = {
 const merged = applyOverlays(base, [overlay]);
 const v = createValidator(merged);
 
-// Without the header — should fail.
+// Without the header: should fail.
 const missing = v.validateRequest({ method: "GET", path: "/pets" });
 console.log("without X-Request-Id:");
 if (!missing.valid) console.log(formatText(missing.errors));
 
-// With the header — clean.
+// With the header: clean.
 const ok = v.validateRequest({
   method: "GET",
   path: "/pets",

--- a/examples/spec-digest.ts
+++ b/examples/spec-digest.ts
@@ -7,15 +7,15 @@
  * types, auth-middleware expectations). One source of truth: the
  * spec; the middleware reads it instead of hardcoding duplicates.
  *
- * This file is **documentation, not library API.** Copy it into your
- * project and adapt the interpretation choices — what `maxLength`
- * means on a binary field, which `x-*` extensions to recognize, how
- * nested `properties` roll up — to match your domain. Keeping those
- * decisions in application code (rather than in oav) avoids baking
- * one team's conventions into every team's startup.
+ * This file is documentation, not library API. Copy it into your
+ * project and adapt the interpretation choices (what `maxLength` means
+ * on a binary field, which `x-*` extensions to recognize, how nested
+ * `properties` roll up) to match your domain. Keeping those decisions
+ * in application code, not in oav, avoids baking one team's conventions
+ * into every team's startup.
  *
  * Run from the repo root:
- *   pnpm tsx examples/spec-digest.ts
+ *   pnpm dlx tsx examples/spec-digest.ts
  */
 
 import { fileURLToPath } from "node:url";
@@ -89,9 +89,9 @@ function bodyLimitsByMediaType(op: OperationObject): Record<string, { maxBytes?:
  * Recursive scan of a schema for a `maxLength` on a binary/byte
  * field. `maxLength` on a `format: binary` field is the OpenAPI
  * convention for byte-count; on a plain string it means code
- * points. This recipe treats only the binary case as a byte ceiling
- * — your domain may want to recognize an `x-max-bytes` extension, a
- * custom annotation keyword, or something else entirely.
+ * points. This recipe treats only the binary case as a byte ceiling.
+ * Your domain may want an `x-max-bytes` extension, a custom annotation
+ * keyword, or something else entirely.
  */
 function declaredMaxBytes(schema: SchemaObject | boolean | undefined): number | undefined {
   if (!schema || typeof schema !== "object") return undefined;

--- a/examples/stream-basic.ts
+++ b/examples/stream-basic.ts
@@ -9,11 +9,11 @@
  * with `maxErrors: 1`: the first violation destroys the stream and
  * rejects the `pipeline`.
  *
- * This is a second engine, not a mode of `createValidator`: push-based
- * over a token stream rather than pull-based over a parsed value. It
- * suits large bodies (multi-GB uploads, bulk arrays) you do not want to
- * buffer. For the in-memory validator that takes an already-parsed body,
- * see basic-validation.ts.
+ * A second engine alongside `createValidator`: push-based over a token
+ * stream rather than pull-based over a parsed value. It suits large
+ * bodies (multi-GB uploads, bulk arrays) you don't want to buffer. For
+ * the in-memory validator that takes an already-parsed body, see
+ * basic-validation.ts.
  *
  * Translation to the published packages: import `createStreamValidator`
  * from `@aahoughton/oav-stream-validator` (incubating, install with

--- a/examples/stream-basic.ts
+++ b/examples/stream-basic.ts
@@ -1,0 +1,102 @@
+/**
+ * Streaming validation: validate a JSON body against a schema as the
+ * bytes flow through, without ever holding the whole document in memory.
+ *
+ * `createStreamValidator` returns a Node `Transform`. Drop it into a
+ * `pipeline` between a byte source and a sink: the input bytes echo
+ * through unchanged, violations report on a side channel, and a clean
+ * finish means the body validated. The default policy is `terminate`
+ * with `maxErrors: 1`: the first violation destroys the stream and
+ * rejects the `pipeline`.
+ *
+ * This is a second engine, not a mode of `createValidator`: push-based
+ * over a token stream rather than pull-based over a parsed value. It
+ * suits large bodies (multi-GB uploads, bulk arrays) you do not want to
+ * buffer. For the in-memory validator that takes an already-parsed body,
+ * see basic-validation.ts.
+ *
+ * Translation to the published packages: import `createStreamValidator`
+ * from `@aahoughton/oav-stream-validator` (incubating, install with
+ * `@experimental`). See ./README.md.
+ *
+ * Run from the repo root:
+ *   pnpm dlx tsx examples/stream-basic.ts
+ */
+
+import { Readable, Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import type { SchemaOrBoolean } from "../packages/core/src/index.ts";
+import {
+  createStreamValidator,
+  type SchemaViolation,
+  ValidationFailedError,
+} from "../packages/stream-validator/src/index.ts";
+
+// A bulk-create array: each element must be `{ id: integer }`. Plain
+// STREAM keywords (`type`, `properties`, `required`, `items`), so the
+// whole body validates on the forward spine in one pass.
+const schema: SchemaOrBoolean = {
+  type: "array",
+  items: {
+    type: "object",
+    required: ["id"],
+    properties: { id: { type: "integer" } },
+  },
+};
+
+// Generate the body lazily: each yield is one chunk, so the full array
+// is never materialized in this process either. `badAt >= 0` makes one
+// element invalid (missing `id`).
+function* itemsBody(count: number, badAt = -1): Generator<string> {
+  yield "[";
+  for (let i = 0; i < count; i++) {
+    const item = i === badAt ? '{"oops":true}' : `{"id":${i}}`;
+    yield (i === 0 ? "" : ",") + item;
+  }
+  yield "]";
+}
+
+// A sink that discards the echoed bytes but tallies them, so we can show
+// the input streamed through unchanged. A real caller would write to a
+// file, an upstream service, or `/dev/null`.
+function countingSink(): { sink: Writable; bytes: () => number } {
+  let total = 0;
+  const sink = new Writable({
+    write(chunk: Buffer, _enc, cb) {
+      total += chunk.length;
+      cb();
+    },
+  });
+  return { sink, bytes: () => total };
+}
+
+const fmt = (v: SchemaViolation): string =>
+  `${v.path.length ? "/" + v.path.join("/") : "(root)"}  ${v.code}  @byte ${v.byteOffset}`;
+
+// --- A valid 100k-element body streams clean ------------------------------
+{
+  const validator = createStreamValidator(schema);
+  const { sink, bytes } = countingSink();
+  await pipeline(Readable.from(itemsBody(100_000)), validator, sink);
+  const verdict = await validator.result;
+  console.log(`valid 100k items  → ${verdict.valid ? "ok" : "FAIL"}, echoed ${bytes()} bytes`);
+}
+
+// --- One bad element fails fast, before the tail streams ------------------
+{
+  const validator = createStreamValidator(schema);
+  const seen: SchemaViolation[] = [];
+  validator.on("violation", (v: SchemaViolation) => seen.push(v));
+
+  try {
+    await pipeline(Readable.from(itemsBody(100_000, 7)), validator, countingSink().sink);
+    console.log("\nbad element       → ok (should have failed!)");
+  } catch (err) {
+    if (err instanceof ValidationFailedError) {
+      console.log("\nbad element       → rejected (as expected)");
+      for (const v of seen) console.log("  " + fmt(v));
+    } else {
+      throw err;
+    }
+  }
+}

--- a/examples/stream-from-spec.ts
+++ b/examples/stream-from-spec.ts
@@ -11,8 +11,8 @@
  * (`#/components/schemas/Pet`). The engine resolves refs against the
  * schema you pass it, not against the original document, so you must
  * carry the document's ref container (`components`) alongside the body
- * schema. Omit it and construction throws `unresolvable $ref`, eagerly,
- * before any byte streams.
+ * schema. Omit it and construction throws `unresolvable $ref` before any
+ * byte streams.
  *
  * Translation to the published packages: `resolveSpec` from
  * `@aahoughton/oav-core/spec`, `createStreamValidator` from

--- a/examples/stream-from-spec.ts
+++ b/examples/stream-from-spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Bridge an OpenAPI document to a streaming body validator.
+ *
+ * The stream validator validates one *resolved* schema; routing, content
+ * negotiation, and body-schema lookup stay the caller's job (the same
+ * split the framework adapters keep). The steps: resolve the spec, pick
+ * the operation your router matched, pull its request-body schema, and
+ * hand that schema to `createStreamValidator`.
+ *
+ * The one gotcha: a body schema is usually an internal `$ref`
+ * (`#/components/schemas/Pet`). The engine resolves refs against the
+ * schema you pass it, not against the original document, so you must
+ * carry the document's ref container (`components`) alongside the body
+ * schema. Omit it and construction throws `unresolvable $ref`, eagerly,
+ * before any byte streams.
+ *
+ * Translation to the published packages: `resolveSpec` from
+ * `@aahoughton/oav-core/spec`, `createStreamValidator` from
+ * `@aahoughton/oav-stream-validator`. See ./README.md.
+ *
+ * Run from the repo root:
+ *   pnpm dlx tsx examples/stream-from-spec.ts
+ */
+
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { fileURLToPath } from "node:url";
+import type { SchemaObject } from "../packages/core/src/index.ts";
+import { createYamlFileReader } from "../packages/oav/src/yaml.ts";
+import { resolveSpec } from "../packages/spec/src/index.ts";
+import {
+  createStreamValidator,
+  ValidationFailedError,
+} from "../packages/stream-validator/src/index.ts";
+
+const specPath = fileURLToPath(new URL("./specs/petstore.yaml", import.meta.url));
+const { document } = await resolveSpec({ reader: createYamlFileReader(), entry: specPath });
+
+// Your router selects the operation; here we hardcode POST /pets. Its
+// request body schema is `{ $ref: "#/components/schemas/Pet" }`.
+const op = document.paths?.["/pets"]?.post;
+const body = op?.requestBody;
+if (body === undefined || "$ref" in body) throw new Error("expected an inline requestBody");
+const bodySchema = body.content["application/json"]?.schema;
+if (bodySchema === undefined || typeof bodySchema === "boolean") {
+  throw new Error("expected a JSON body schema");
+}
+
+// --- The footgun: a `$ref` with no ref container ----------------------------
+try {
+  createStreamValidator(bodySchema, { openApiVersion: "3.1" });
+  console.log("without components → constructed (unexpected!)");
+} catch (err) {
+  console.log("without components → throws at construction:");
+  console.log("  " + (err as Error).message);
+}
+
+// --- The fix: carry `components` so `#/components/schemas/Pet` resolves -----
+const schema: SchemaObject = { ...bodySchema, components: document.components } as SchemaObject;
+
+// Drain the echoed bytes; a real caller would forward them to storage.
+const drain = async (src: AsyncIterable<Buffer>): Promise<void> => {
+  for await (const _ of src) {
+    /* discard */
+  }
+};
+
+async function streamPet(label: string, pet: unknown): Promise<void> {
+  const validator = createStreamValidator(schema, { openApiVersion: "3.1" });
+  try {
+    await pipeline(Readable.from(JSON.stringify(pet)), validator, drain);
+    console.log(`${label} → ok`);
+  } catch (err) {
+    if (err instanceof ValidationFailedError) {
+      const v = err.verdict.violations[0];
+      const where = v?.path.length ? "/" + v.path.join("/") : "(root)";
+      console.log(`${label} → rejected: ${v?.code} at ${where}`);
+    } else {
+      throw err;
+    }
+  }
+}
+
+console.log();
+await streamPet("valid Pet        ", { name: "Fido", tag: "dog" });
+await streamPet("Pet missing name ", { tag: "dog" });

--- a/examples/stream-limits.ts
+++ b/examples/stream-limits.ts
@@ -1,0 +1,90 @@
+/**
+ * Bounding untrusted streamed input. A streaming validator keeps memory
+ * bounded for forward-decidable schemas, but a schema can still leave
+ * dimensions open (an array with no `maxItems`, a `uniqueItems` whose
+ * seen-set grows with the input). For untrusted callers, close them:
+ *
+ *   - `enforceBounds: true` turns the classifier's unbounded-* warnings
+ *     into a construction-time throw, so an open-ended schema is rejected
+ *     before any byte streams.
+ *   - `maxTotalBytes` refuses input past a byte ceiling regardless of
+ *     validity (a policy lever, enforced mid-stream).
+ *   - An over-limit count/length (`maxItems`, `maxProperties`,
+ *     `maxLength`) fails fast at the offending element, before the rest
+ *     of the body streams.
+ *
+ * These examples use inline schemas rather than a spec file: the subject
+ * is the raw schema/option surface, the same shape `createStreamValidator`
+ * takes. See docs/configuration.md for the in-memory analogs (`maxDepth`,
+ * regex hardening) and stream-validator's README for the full limit set.
+ *
+ * Translation to the published package: import from
+ * `@aahoughton/oav-stream-validator`. See ./README.md.
+ *
+ * Run from the repo root:
+ *   pnpm dlx tsx examples/stream-limits.ts
+ */
+
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import type { SchemaOrBoolean } from "../packages/core/src/index.ts";
+import {
+  createStreamValidator,
+  ValidationFailedError,
+} from "../packages/stream-validator/src/index.ts";
+
+const drain = async (src: AsyncIterable<Buffer>): Promise<void> => {
+  for await (const _ of src) {
+    /* discard */
+  }
+};
+
+// --- enforceBounds rejects an open-ended schema at construction -------------
+// `uniqueItems` keeps an O(elements) seen-set; with no `maxItems` it is
+// unbounded. enforceBounds refuses it before streaming a byte.
+{
+  const open: SchemaOrBoolean = { type: "array", uniqueItems: true };
+  try {
+    createStreamValidator(open, { enforceBounds: true });
+    console.log("enforceBounds (no maxItems) → constructed (unexpected!)");
+  } catch (err) {
+    console.log("enforceBounds (no maxItems) → rejected: " + (err as Error).message);
+  }
+
+  // A structural bound clears the warning: now it constructs.
+  const bounded: SchemaOrBoolean = { type: "array", uniqueItems: true, maxItems: 1000 };
+  createStreamValidator(bounded, { enforceBounds: true });
+  console.log("enforceBounds (maxItems: 1000) → constructed");
+}
+
+// --- maxTotalBytes refuses oversize input mid-stream -----------------------
+{
+  const validator = createStreamValidator(true, { maxTotalBytes: 16 });
+  try {
+    await pipeline(Readable.from('{"data":"' + "x".repeat(64) + '"}'), validator, drain);
+    console.log("\nmaxTotalBytes: 16 → accepted (unexpected!)");
+  } catch (err) {
+    // A size-limit overflow is a fatal error (not a schema violation),
+    // so `pipeline` rejects with a plain Error, not ValidationFailedError.
+    console.log("\nmaxTotalBytes: 16 → rejected: " + (err as Error).message);
+  }
+}
+
+// --- An over-count body fails fast at the offending element ----------------
+// maxItems: 3, but the body has 5 elements. Under the default `terminate`
+// policy the stream fails at element 3, before elements 4 and 5 stream.
+{
+  const schema: SchemaOrBoolean = { type: "array", items: { type: "integer" }, maxItems: 3 };
+  const validator = createStreamValidator(schema);
+  try {
+    await pipeline(Readable.from("[1,2,3,4,5]"), validator, drain);
+    console.log("\nmaxItems: 3 on [1..5] → accepted (unexpected!)");
+  } catch (err) {
+    if (err instanceof ValidationFailedError) {
+      const v = err.verdict.violations[0];
+      console.log(`\nmaxItems: 3 on [1..5] → rejected: ${v?.code} @byte ${v?.byteOffset}`);
+    } else {
+      throw err;
+    }
+  }
+}

--- a/examples/stream-limits.ts
+++ b/examples/stream-limits.ts
@@ -13,10 +13,10 @@
  *     `maxLength`) fails fast at the offending element, before the rest
  *     of the body streams.
  *
- * These examples use inline schemas rather than a spec file: the subject
- * is the raw schema/option surface, the same shape `createStreamValidator`
- * takes. See docs/configuration.md for the in-memory analogs (`maxDepth`,
- * regex hardening) and stream-validator's README for the full limit set.
+ * These examples use inline schemas instead of a spec file, since the
+ * subject is the raw schema and option surface. See docs/configuration.md
+ * for the in-memory analogs (`maxDepth`, regex hardening) and
+ * stream-validator's README for the full limit set.
  *
  * Translation to the published package: import from
  * `@aahoughton/oav-stream-validator`. See ./README.md.

--- a/examples/stream-recover-fields.ts
+++ b/examples/stream-recover-fields.ts
@@ -1,8 +1,8 @@
 /**
- * Recover a few small scalar fields while validating a large body, with
- * no second parser and no materializing the whole document.
+ * Recover a few small scalar fields while validating a large body,
+ * without a second parser or materializing the whole document.
  *
- * A streaming body still often carries a handful of small top-level
+ * A streaming body often carries a handful of small top-level
  * scalars you need eagerly: an id to route on, a schema version, a
  * timestamp to log. `valueEvents` emits a `value` event when a scalar
  * object member completes; with `capture: true` the decoded value rides

--- a/examples/stream-recover-fields.ts
+++ b/examples/stream-recover-fields.ts
@@ -1,0 +1,72 @@
+/**
+ * Recover a few small scalar fields while validating a large body, with
+ * no second parser and no materializing the whole document.
+ *
+ * A streaming body still often carries a handful of small top-level
+ * scalars you need eagerly: an id to route on, a schema version, a
+ * timestamp to log. `valueEvents` emits a `value` event when a scalar
+ * object member completes; with `capture: true` the decoded value rides
+ * along (bounded by `maxCaptureBytes`). The `at` filter matches a
+ * member's *full path*, so `path.length === 1` selects top-level
+ * members. Container members (objects, arrays) never fire, so the large
+ * `items` array below streams past without buffering.
+ *
+ * Because object members complete in document order, `id` and `version`
+ * are captured before the big `items` array streams: a caller can route
+ * or log on them while the rest of the body is still in flight.
+ *
+ * Translation to the published package: import from
+ * `@aahoughton/oav-stream-validator`. See ./README.md.
+ *
+ * Run from the repo root:
+ *   pnpm dlx tsx examples/stream-recover-fields.ts
+ */
+
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import type { SchemaOrBoolean } from "../packages/core/src/index.ts";
+import { createStreamValidator, type ValueEvent } from "../packages/stream-validator/src/index.ts";
+
+const schema: SchemaOrBoolean = {
+  type: "object",
+  required: ["id"],
+  properties: {
+    id: { type: "string" },
+    version: { type: "integer" },
+    items: {
+      type: "array",
+      items: { type: "object", required: ["sku"], properties: { sku: { type: "string" } } },
+    },
+  },
+};
+
+// Lazily emit a body with two small top-level scalars followed by a large
+// `items` array. The array is generated chunk-by-chunk, never assembled.
+function* docBody(itemCount: number): Generator<string> {
+  yield '{"id":"doc-42","version":3,"items":[';
+  for (let i = 0; i < itemCount; i++) {
+    yield (i === 0 ? "" : ",") + `{"sku":"sku-${i}"}`;
+  }
+  yield "]}";
+}
+
+const captured = new Map<string, unknown>();
+
+const validator = createStreamValidator(schema, {
+  // Capture only top-level scalar members (id, version). `items` is a
+  // container and does not fire.
+  valueEvents: { at: (path) => path.length === 1, capture: true },
+});
+validator.on("value", (e: ValueEvent) => captured.set(e.key, e.value));
+
+const drain = async (src: AsyncIterable<Buffer>): Promise<void> => {
+  for await (const _ of src) {
+    /* discard the echoed bytes */
+  }
+};
+
+await pipeline(Readable.from(docBody(50_000)), validator, drain);
+const verdict = await validator.result;
+
+console.log(`validated 50k items → ${verdict.valid ? "ok" : "FAIL"}`);
+console.log("recovered scalars   →", Object.fromEntries(captured));

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -17,6 +17,7 @@
       "@oav/router": ["./packages/router/src/index.ts"],
       "@oav/validator": ["./packages/validator/src/index.ts"],
       "@oav/validator/internals": ["./packages/validator/src/internals.ts"],
+      "@oav/stream-validator": ["./packages/stream-validator/src/index.ts"],
       "@oav/cli": ["./packages/cli/src/index.ts"],
       "@oav/oav": ["./packages/oav/src/index.ts"]
     }

--- a/examples/versions.ts
+++ b/examples/versions.ts
@@ -1,15 +1,15 @@
 /**
  * Multi-version support: the same conceptual "create a pet" operation,
  * declared three different ways, one per OpenAPI version. The validator
- * reads `openapi` once at construction and picks the right dialect —
- * no per-request branching.
+ * reads `openapi` once at construction and picks the right dialect, so
+ * there's no per-request branching.
  *
  * - 3.0.x: `nullable: true`, boolean `exclusiveMaximum`
  * - 3.1.x: `type: ["string", "null"]`, numeric `exclusiveMaximum`
  * - 3.2.x: like 3.1 but can use the new `QUERY` HTTP method
  *
  * Run from the repo root:
- *   pnpm tsx examples/versions.ts
+ *   pnpm dlx tsx examples/versions.ts
  */
 
 import { fileURLToPath } from "node:url";

--- a/packages/stream-validator/src/index.ts
+++ b/packages/stream-validator/src/index.ts
@@ -12,7 +12,9 @@
  * BUFFER (so format assertion and built-in formats come from that
  * delegate), and reuses `@oav/core`'s flat error model.
  *
- * The package is unpublished during incubation (`private`).
+ * Published as `@aahoughton/oav-stream-validator` on the `experimental`
+ * dist-tag during incubation, versioned independently of the `oav-core`
+ * family.
  *
  * @packageDocumentation
  */


### PR DESCRIPTION
Adds streaming-validator examples (the package had none) and gives the existing examples an upkeep pass.

## New examples
- `stream-basic` — pipeline echo-through, the violation channel, the result verdict
- `stream-from-spec` — bridge a resolved spec to a body validator (carry `components` for `$ref`)
- `stream-limits` — bound untrusted input: `enforceBounds`, `maxTotalBytes`, eager `maxItems`
- `stream-recover-fields` — recover top-level scalars with `valueEvents` while a large body streams

## Existing examples
- README import-translation note + Streaming table; `@oav/stream-validator` tsconfig path
- Concise/casual writing pass, dropping em-dashes and contrastive negation per the house style
- Fixed the broken run command (`pnpm tsx` → `pnpm dlx tsx`) and a stale `max-errors` default-mode description

Every example was run end to end; typecheck, lint, and format all pass.