### PR TITLE
feat(stream-validator): public-surface ergonomics (#423)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -60,12 +60,12 @@ lazily generated body through `createStreamValidator` and read the
 side channel, so each fabricates its body inline rather than loading a
 fixture.
 
-| File                       | Shows                                                                     |
-| -------------------------- | ------------------------------------------------------------------------- |
-| `stream-basic.ts`          | `pipeline` echo-through; the `violation` channel and `result` verdict     |
-| `stream-from-spec.ts`      | Bridge a resolved spec to a body validator; carry `components` for `$ref` |
-| `stream-limits.ts`         | Bound untrusted input: `enforceBounds`, `maxTotalBytes`, eager `maxItems` |
-| `stream-recover-fields.ts` | Recover top-level scalars with `valueEvents` while a large body streams   |
+| File                       | Shows                                                                         |
+| -------------------------- | ----------------------------------------------------------------------------- |
+| `stream-basic.ts`          | `pipeline` echo-through; the `violation` channel and `result` verdict         |
+| `stream-from-spec.ts`      | Bridge a resolved spec to a body validator with `streamValidatorForOperation` |
+| `stream-limits.ts`         | Bound untrusted input: `enforceBounds`, `maxTotalBytes`, eager `maxItems`     |
+| `stream-recover-fields.ts` | Recover top-level scalars with `valueEvents` while a large body streams       |
 
 ## Conventions
 

--- a/examples/stream-basic.ts
+++ b/examples/stream-basic.ts
@@ -25,10 +25,11 @@
 
 import { Readable, Writable } from "node:stream";
 import { pipeline } from "node:stream/promises";
-import type { SchemaOrBoolean } from "../packages/core/src/index.ts";
+import { formatText, type SchemaOrBoolean } from "../packages/core/src/index.ts";
 import {
   createStreamValidator,
   type SchemaViolation,
+  toValidationError,
   ValidationFailedError,
 } from "../packages/stream-validator/src/index.ts";
 
@@ -70,9 +71,6 @@ function countingSink(): { sink: Writable; bytes: () => number } {
   return { sink, bytes: () => total };
 }
 
-const fmt = (v: SchemaViolation): string =>
-  `${v.path.length ? "/" + v.path.join("/") : "(root)"}  ${v.code}  @byte ${v.byteOffset}`;
-
 // --- A valid 100k-element body streams clean ------------------------------
 {
   const validator = createStreamValidator(schema);
@@ -94,7 +92,12 @@ const fmt = (v: SchemaViolation): string =>
   } catch (err) {
     if (err instanceof ValidationFailedError) {
       console.log("\nbad element       → rejected (as expected)");
-      for (const v of seen) console.log("  " + fmt(v));
+      // Bridge the stream violations to @oav/core's error model, then reuse
+      // its formatter instead of hand-rolling one. The stream-specific
+      // byteOffset rides in params; append it for the "failed early" point.
+      for (const v of seen) {
+        console.log("  " + formatText(toValidationError(v)) + `  @byte ${v.byteOffset}`);
+      }
     } else {
       throw err;
     }

--- a/examples/stream-from-spec.ts
+++ b/examples/stream-from-spec.ts
@@ -1,21 +1,26 @@
 /**
  * Bridge an OpenAPI document to a streaming body validator.
  *
- * The stream validator validates one *resolved* schema; routing, content
- * negotiation, and body-schema lookup stay the caller's job (the same
- * split the framework adapters keep). The steps: resolve the spec, pick
- * the operation your router matched, pull its request-body schema, and
- * hand that schema to `createStreamValidator`.
+ * The stream validator validates one *resolved* schema; routing and
+ * body-schema lookup stay the caller's job (the same split the framework
+ * adapters keep). `streamValidatorForOperation` does the mechanical part:
+ * given a resolved document and an operation locator, it pulls the
+ * request-body schema, carries the document's ref container so an internal
+ * `$ref` (`#/components/schemas/Pet`) resolves, and reads the OpenAPI
+ * version off `doc.openapi`. It mirrors `@aahoughton/oav-core`'s
+ * `getOperation` locator (`{ method, path }`).
  *
- * The one gotcha: a body schema is usually an internal `$ref`
- * (`#/components/schemas/Pet`). The engine resolves refs against the
- * schema you pass it, not against the original document, so you must
- * carry the document's ref container (`components`) alongside the body
- * schema. Omit it and construction throws `unresolvable $ref` before any
- * byte streams.
+ * `path` is the literal path-template key, looked up exactly (no
+ * template matching). Resolve a real request path to its template
+ * upstream, then pass the template here.
+ *
+ * The footgun this removes: by hand you must spread the document's
+ * `components` onto the body schema, or construction throws
+ * `unresolvable $ref` before any byte streams. The helper carries it for
+ * you.
  *
  * Translation to the published packages: `resolveSpec` from
- * `@aahoughton/oav-core/spec`, `createStreamValidator` from
+ * `@aahoughton/oav-core/spec`, `streamValidatorForOperation` from
  * `@aahoughton/oav-stream-validator`. See ./README.md.
  *
  * Run from the repo root:
@@ -25,38 +30,17 @@
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
-import type { SchemaObject } from "../packages/core/src/index.ts";
+import { formatSummary } from "../packages/core/src/index.ts";
 import { createYamlFileReader } from "../packages/oav/src/yaml.ts";
 import { resolveSpec } from "../packages/spec/src/index.ts";
 import {
-  createStreamValidator,
+  streamValidatorForOperation,
+  toValidationError,
   ValidationFailedError,
 } from "../packages/stream-validator/src/index.ts";
 
 const specPath = fileURLToPath(new URL("./specs/petstore.yaml", import.meta.url));
 const { document } = await resolveSpec({ reader: createYamlFileReader(), entry: specPath });
-
-// Your router selects the operation; here we hardcode POST /pets. Its
-// request body schema is `{ $ref: "#/components/schemas/Pet" }`.
-const op = document.paths?.["/pets"]?.post;
-const body = op?.requestBody;
-if (body === undefined || "$ref" in body) throw new Error("expected an inline requestBody");
-const bodySchema = body.content["application/json"]?.schema;
-if (bodySchema === undefined || typeof bodySchema === "boolean") {
-  throw new Error("expected a JSON body schema");
-}
-
-// --- The footgun: a `$ref` with no ref container ----------------------------
-try {
-  createStreamValidator(bodySchema, { openApiVersion: "3.1" });
-  console.log("without components → constructed (unexpected!)");
-} catch (err) {
-  console.log("without components → throws at construction:");
-  console.log("  " + (err as Error).message);
-}
-
-// --- The fix: carry `components` so `#/components/schemas/Pet` resolves -----
-const schema: SchemaObject = { ...bodySchema, components: document.components } as SchemaObject;
 
 // Drain the echoed bytes; a real caller would forward them to storage.
 const drain = async (src: AsyncIterable<Buffer>): Promise<void> => {
@@ -66,21 +50,23 @@ const drain = async (src: AsyncIterable<Buffer>): Promise<void> => {
 };
 
 async function streamPet(label: string, pet: unknown): Promise<void> {
-  const validator = createStreamValidator(schema, { openApiVersion: "3.1" });
+  // Your router selects the operation; here we name POST /pets directly.
+  // The helper pulls its body schema (`$ref: #/components/schemas/Pet`),
+  // carries `components`, and detects the 3.1 version off the document.
+  const validator = streamValidatorForOperation(document, { method: "post", path: "/pets" });
   try {
     await pipeline(Readable.from(JSON.stringify(pet)), validator, drain);
     console.log(`${label} → ok`);
   } catch (err) {
     if (err instanceof ValidationFailedError) {
-      const v = err.verdict.violations[0];
-      const where = v?.path.length ? "/" + v.path.join("/") : "(root)";
-      console.log(`${label} → rejected: ${v?.code} at ${where}`);
+      // Bridge to @oav/core's error model and reuse its one-line summary.
+      const summary = formatSummary(toValidationError(err.verdict.violations));
+      console.log(`${label} → rejected: ${summary}`);
     } else {
       throw err;
     }
   }
 }
 
-console.log();
 await streamPet("valid Pet        ", { name: "Fido", tag: "dog" });
 await streamPet("Pet missing name ", { tag: "dog" });

--- a/examples/stream-limits.ts
+++ b/examples/stream-limits.ts
@@ -30,6 +30,7 @@ import { pipeline } from "node:stream/promises";
 import type { SchemaOrBoolean } from "../packages/core/src/index.ts";
 import {
   createStreamValidator,
+  MaxTotalBytesError,
   ValidationFailedError,
 } from "../packages/stream-validator/src/index.ts";
 
@@ -64,9 +65,14 @@ const drain = async (src: AsyncIterable<Buffer>): Promise<void> => {
     await pipeline(Readable.from('{"data":"' + "x".repeat(64) + '"}'), validator, drain);
     console.log("\nmaxTotalBytes: 16 → accepted (unexpected!)");
   } catch (err) {
-    // A size-limit overflow is a fatal error (not a schema violation),
-    // so `pipeline` rejects with a plain Error, not ValidationFailedError.
-    console.log("\nmaxTotalBytes: 16 → rejected: " + (err as Error).message);
+    // A size-limit overflow is a fatal error (not a schema violation), so
+    // `pipeline` rejects with a MaxTotalBytesError, not ValidationFailedError.
+    // `instanceof` tells "too big" from "invalid" without matching the message.
+    if (err instanceof MaxTotalBytesError) {
+      console.log(`\nmaxTotalBytes: 16 → rejected: over the ${err.limit}-byte cap`);
+    } else {
+      throw err;
+    }
   }
 }
 

--- a/packages/stream-validator/src/engine/index.ts
+++ b/packages/stream-validator/src/engine/index.ts
@@ -1,5 +1,6 @@
 export {
   createStreamValidator,
+  MaxTotalBytesError,
   StreamValidator,
   ValidationFailedError,
 } from "./stream-validator.js";

--- a/packages/stream-validator/src/engine/stream-validator.ts
+++ b/packages/stream-validator/src/engine/stream-validator.ts
@@ -103,6 +103,32 @@ export class ValidationFailedError extends Error {
   }
 }
 
+/**
+ * Input exceeded the configured `maxTotalBytes`. Fatal, raised on the
+ * `error` channel regardless of validity (a policy lever, not a schema
+ * verdict).
+ *
+ * The total-size member of the package's resource-limit family
+ * ({@link BufferLimitError}, {@link UniqueItemsLimitError}), so a caller
+ * can `instanceof` any of them to tell "too big" from a
+ * {@link ValidationFailedError} ("well-formed but invalid"), then read
+ * `limit` for which cap tripped.
+ *
+ * @public
+ */
+export class MaxTotalBytesError extends Error {
+  /** The `maxTotalBytes` value that was exceeded. */
+  readonly limit: number;
+  /** Stream-absolute byte count reached when the cap was crossed. */
+  readonly byteOffset: number;
+  constructor(limit: number, byteOffset: number) {
+    super(`stream-validator: input exceeded maxTotalBytes=${limit} (at byte ${byteOffset})`);
+    this.name = "MaxTotalBytesError";
+    this.limit = limit;
+    this.byteOffset = byteOffset;
+  }
+}
+
 // Containers a local `$ref` may target. Carried onto a delegated island
 // subschema so internal refs (`#/$defs/...`, `#/components/schemas/...`,
 // draft-07 `#/definitions/...`) resolve against the in-memory compile.
@@ -477,7 +503,7 @@ export class StreamValidator extends Transform {
     // Refuse oversize input regardless of validity (policy lever).
     if (this.maxTotalBytes !== undefined && this.totalBytes > this.maxTotalBytes) {
       this.push(chunk);
-      const err = new Error(`stream-validator: input exceeded maxTotalBytes=${this.maxTotalBytes}`);
+      const err = new MaxTotalBytesError(this.maxTotalBytes, this.totalBytes);
       this.finished = true;
       this.rejectResult(err);
       cb(err);

--- a/packages/stream-validator/src/index.ts
+++ b/packages/stream-validator/src/index.ts
@@ -39,3 +39,4 @@ export {
 } from "./engine/index.js";
 export { BufferLimitError, UniqueItemsLimitError } from "./spine/index.js";
 export type { StreamVerdict, SchemaViolation } from "./spine/index.js";
+export { toValidationError } from "./violation.js";

--- a/packages/stream-validator/src/index.ts
+++ b/packages/stream-validator/src/index.ts
@@ -23,6 +23,7 @@ export type { JsonPath, PathFilter, StreamValidatorOptions } from "./options.js"
 export {
   createStreamValidator,
   DEFAULT_MAX_CAPTURE_BYTES,
+  MaxTotalBytesError,
   ValidationFailedError,
   type Bytes,
   type ScopeContext,
@@ -36,4 +37,5 @@ export {
   type StreamValidator,
   type ValueEvent,
 } from "./engine/index.js";
+export { BufferLimitError, UniqueItemsLimitError } from "./spine/index.js";
 export type { StreamVerdict, SchemaViolation } from "./spine/index.js";

--- a/packages/stream-validator/src/index.ts
+++ b/packages/stream-validator/src/index.ts
@@ -37,6 +37,7 @@ export {
   type StreamValidator,
   type ValueEvent,
 } from "./engine/index.js";
+export { type OperationLocator, streamValidatorForOperation } from "./operation.js";
 export { BufferLimitError, UniqueItemsLimitError } from "./spine/index.js";
 export type { StreamVerdict, SchemaViolation } from "./spine/index.js";
 export { toValidationError } from "./violation.js";

--- a/packages/stream-validator/src/operation.ts
+++ b/packages/stream-validator/src/operation.ts
@@ -1,0 +1,179 @@
+/**
+ * Bridge a resolved OpenAPI document to a streaming body validator,
+ * mirroring `@oav/validator`'s `Validator.getOperation` locator shape
+ * (`{ method, path }`).
+ *
+ * The stream validator validates one resolved schema; routing and
+ * body-schema lookup stay the caller's job (the split the framework
+ * adapters keep). This helper does the mechanical part the
+ * `stream-from-spec` recipe spelled out by hand: pull the operation's
+ * request-body schema and carry the document's ref container so an
+ * internal `$ref` (`#/components/schemas/Pet`) resolves. Omitting that
+ * container is the footgun that throws `unresolvable $ref` at
+ * construction.
+ *
+ * `path` is the literal path-template key (`"/pets/{id}"`), looked up
+ * exactly: no template matching (that needs the router). Resolve a real
+ * request path to its template upstream (e.g. `Validator.matchRoute`),
+ * then pass the template here. The document must be resolved (via
+ * `resolveSpec`) so internal refs live under `components`.
+ *
+ * @packageDocumentation
+ */
+
+import type {
+  HttpMethod,
+  OpenAPIDocument,
+  RequestBodyObject,
+  SchemaObject,
+  SchemaOrBoolean,
+} from "@oav/core";
+import { createStreamValidator, type StreamValidator } from "./engine/index.js";
+import type { StreamValidatorOptions } from "./options.js";
+import { resolveRef } from "./ref-resolve.js";
+
+const HTTP_METHODS = new Set<string>([
+  "get",
+  "put",
+  "post",
+  "delete",
+  "options",
+  "head",
+  "patch",
+  "trace",
+  "query",
+]);
+
+// Map an OpenAPI version string ("3.0.3") to the engine's normalization
+// selector. Unknown prefixes return undefined (treated as raw JSON Schema,
+// or overridden via options.openApiVersion).
+function versionFromDoc(openapi: string): StreamValidatorOptions["openApiVersion"] {
+  if (openapi.startsWith("3.0")) return "3.0";
+  if (openapi.startsWith("3.1")) return "3.1";
+  if (openapi.startsWith("3.2")) return "3.2";
+  return undefined;
+}
+
+function isObjectSchema(s: SchemaOrBoolean): s is SchemaObject {
+  return typeof s === "object" && s !== null && !Array.isArray(s);
+}
+
+// Follow a (possibly $ref'd) requestBody to its object form. A local
+// `#/components/requestBodies/...` ref is a normal shape resolveSpec leaves
+// in place, so resolve it here (mirroring @oav/validator's
+// resolveOperationRef) rather than rejecting it. External refs should have
+// been inlined upstream; surface a clear error if one survived.
+function resolveRequestBody(
+  doc: OpenAPIDocument,
+  requestBody: RequestBodyObject | { $ref: string },
+  where: string,
+): RequestBodyObject {
+  let current: unknown = requestBody;
+  for (let hops = 0; hops < 32; hops++) {
+    if (current === null || typeof current !== "object") break;
+    const ref = (current as { $ref?: unknown }).$ref;
+    if (typeof ref !== "string") return current as RequestBodyObject;
+    if (!ref.startsWith("#")) {
+      throw new Error(
+        `streamValidatorForOperation: external requestBody ref "${ref}" for ${where} not resolved; run resolveSpec() over the document first`,
+      );
+    }
+    const target = resolveRef(doc as unknown as SchemaObject, ref);
+    if (target === undefined) {
+      throw new Error(
+        `streamValidatorForOperation: requestBody ref "${ref}" for ${where} does not resolve`,
+      );
+    }
+    current = target;
+  }
+  throw new Error(
+    `streamValidatorForOperation: requestBody $ref chain for ${where} exceeded 32 hops (possible cycle)`,
+  );
+}
+
+/**
+ * Locates a request body within an {@link OpenAPIDocument}.
+ *
+ * @public
+ */
+export interface OperationLocator {
+  /** HTTP method (case-insensitive), e.g. `"post"`. */
+  method: string;
+  /** Literal path-template key as declared, e.g. `"/pets/{id}"`. Matched exactly. */
+  path: string;
+  /** Request body media type. Defaults to `"application/json"`. */
+  mediaType?: string;
+}
+
+/**
+ * Build a {@link StreamValidator} for an operation's request body. Reads
+ * the OpenAPI version off `doc.openapi` (override with
+ * `options.openApiVersion`) and carries `doc.components` so internal
+ * `$ref`s resolve.
+ *
+ * ```ts
+ * import { resolveSpec } from "@aahoughton/oav-core/spec";
+ * import { streamValidatorForOperation } from "@aahoughton/oav-stream-validator";
+ *
+ * const { document } = await resolveSpec({ reader, entry });
+ * const validator = streamValidatorForOperation(document, {
+ *   method: "post",
+ *   path: "/pets",
+ * });
+ * await pipeline(request, validator, sink);
+ * ```
+ *
+ * A local `requestBody` `$ref` (`#/components/requestBodies/...`, a normal
+ * shape `resolveSpec` leaves in place) is followed; an external one that
+ * survived resolution throws. Throws (before any byte) when the path,
+ * method, request body, media type, or body schema is absent. Pairs with
+ * `@oav/validator`'s `getOperation`: same `{ method, path }` locator,
+ * exact-key lookup, no routing.
+ *
+ * @public
+ */
+export function streamValidatorForOperation(
+  doc: OpenAPIDocument,
+  locator: OperationLocator,
+  options: StreamValidatorOptions = {},
+): StreamValidator {
+  const method = locator.method.toLowerCase();
+  if (!HTTP_METHODS.has(method)) {
+    throw new Error(`streamValidatorForOperation: unknown HTTP method "${locator.method}"`);
+  }
+  const pathItem = doc.paths?.[locator.path];
+  if (pathItem === undefined) {
+    throw new Error(`streamValidatorForOperation: no path "${locator.path}" in the document`);
+  }
+  const where = `${method.toUpperCase()} "${locator.path}"`;
+  const operation = pathItem[method as HttpMethod];
+  if (operation === undefined) {
+    throw new Error(`streamValidatorForOperation: no ${where} operation in the document`);
+  }
+  if (operation.requestBody === undefined) {
+    throw new Error(`streamValidatorForOperation: ${where} has no requestBody`);
+  }
+  const requestBody = resolveRequestBody(doc, operation.requestBody, where);
+  const mediaType = locator.mediaType ?? "application/json";
+  const mediaTypeObject = requestBody.content[mediaType];
+  if (mediaTypeObject === undefined) {
+    throw new Error(`streamValidatorForOperation: no "${mediaType}" content for ${where}`);
+  }
+  const bodySchema = mediaTypeObject.schema;
+  if (bodySchema === undefined) {
+    throw new Error(`streamValidatorForOperation: no schema for "${mediaType}" on ${where}`);
+  }
+
+  // Carry the document's ref container so an internal `$ref` in the body
+  // schema resolves. A boolean schema needs nothing and is passed as-is.
+  const schema: SchemaOrBoolean =
+    isObjectSchema(bodySchema) && doc.components !== undefined
+      ? ({ ...bodySchema, components: doc.components } as SchemaObject)
+      : bodySchema;
+
+  const openApiVersion = options.openApiVersion ?? versionFromDoc(doc.openapi);
+  return createStreamValidator(schema, {
+    ...options,
+    ...(openApiVersion === undefined ? {} : { openApiVersion }),
+  });
+}

--- a/packages/stream-validator/src/spine/spine.ts
+++ b/packages/stream-validator/src/spine/spine.ts
@@ -59,12 +59,24 @@ export class BudgetReached extends Error {
   }
 }
 
-/** A buffered island exceeded the configured `maxBufferedBytes`. Fatal. */
+/**
+ * A buffered island exceeded the configured `maxBufferedBytes`. Fatal.
+ *
+ * One of the package's resource-limit errors (alongside
+ * {@link UniqueItemsLimitError} and `MaxTotalBytesError`): a fatal `error`
+ * channel throw distinct from a {@link SchemaViolation} (a well-formed but
+ * invalid value). Caught with `instanceof` to tell "too big" from
+ * "invalid".
+ */
 export class BufferLimitError extends Error {
+  /** The `maxBufferedBytes` value that was exceeded. */
+  readonly limit: number;
+  /** Stream-absolute byte offset at which the cap was crossed. */
   readonly byteOffset: number;
   constructor(limit: number, byteOffset: number) {
     super(`buffered island exceeded maxBufferedBytes=${limit} (at byte ${byteOffset})`);
     this.name = "BufferLimitError";
+    this.limit = limit;
     this.byteOffset = byteOffset;
   }
 }
@@ -73,12 +85,18 @@ export class BufferLimitError extends Error {
  * A `uniqueItems` array buffered for delegation exceeded the configured
  * `maxUniqueItems` element count. Fatal: the array cannot be validated
  * within the seen-set budget, so it is refused rather than held unbounded.
+ *
+ * A resource-limit error (see {@link BufferLimitError}).
  */
 export class UniqueItemsLimitError extends Error {
+  /** The `maxUniqueItems` value that was exceeded. */
+  readonly limit: number;
+  /** Stream-absolute byte offset at which the cap was crossed. */
   readonly byteOffset: number;
   constructor(limit: number, byteOffset: number) {
     super(`uniqueItems array exceeded maxUniqueItems=${limit} (at byte ${byteOffset})`);
     this.name = "UniqueItemsLimitError";
+    this.limit = limit;
     this.byteOffset = byteOffset;
   }
 }

--- a/packages/stream-validator/src/violation.ts
+++ b/packages/stream-validator/src/violation.ts
@@ -1,0 +1,102 @@
+/**
+ * Bridge a {@link SchemaViolation} to `@oav/core`'s {@link ValidationError}
+ * so streaming output flows into the existing rendering surface
+ * (`formatText`, `formatSummary`, `toProblemDetails`, and the framework
+ * adapters' `renderProblemDetails`) instead of needing a stream-specific
+ * formatter.
+ *
+ * The two types are deliberate parallels: a violation shares `code` and
+ * `path` with an error and adds a stream `byteOffset`. On the BUFFER
+ * (delegated) path a violation already carries the in-memory engine's
+ * `message` / `params` / `children`, which pass through unchanged. On the
+ * forward STREAM path it carries only `code` + `path` + `byteOffset`, so
+ * this fills a coarse human-readable `message` from the code (the spine
+ * does not synthesize one in the hot path, and there are no params to
+ * interpolate a bound from). Either way the stream `byteOffset` rides in
+ * `params.byteOffset`, the documented home for machine-readable detail.
+ *
+ * @packageDocumentation
+ */
+
+import type { PathSegment, ValidationError } from "@oav/core";
+import type { SchemaViolation } from "./spine/index.js";
+
+// Coarse, parameterless gloss per STREAM-path code. The forward spine
+// emits a bare code with no params, so these cannot name the failing bound
+// (the in-memory delegate's messages, which can, pass through on the
+// BUFFER path via `violation.message`). ASCII, lower-case, no trailing
+// punctuation, to read uniformly under `formatText` / `formatSummary`.
+const STREAM_CODE_MESSAGE: Record<string, string> = {
+  type: "value has the wrong type",
+  false: "no value is allowed here",
+  const: "value is not the allowed constant",
+  enum: "value is not one of the allowed values",
+  minLength: "string is too short",
+  maxLength: "string is too long",
+  pattern: "string does not match the required pattern",
+  minimum: "number is too small",
+  maximum: "number is too large",
+  exclusiveMinimum: "number is too small",
+  exclusiveMaximum: "number is too large",
+  multipleOf: "number is not a multiple of the required divisor",
+  required: "a required property is missing",
+  minProperties: "object has too few properties",
+  maxProperties: "object has too many properties",
+  dependentRequired: "a dependent required property is missing",
+  dependencies: "a dependency property is missing",
+  minItems: "array has too few items",
+  maxItems: "array has too many items",
+  uniqueItems: "array items are not unique",
+  propertyNames: "a property name is not allowed",
+  depth: "value is nested too deeply",
+  composition: "value does not satisfy the schema composition",
+};
+
+/** A coarse human-readable message for a STREAM-path code. */
+function messageForCode(code: string): string {
+  return STREAM_CODE_MESSAGE[code] ?? `value does not satisfy "${code}"`;
+}
+
+function convertOne(violation: SchemaViolation): ValidationError {
+  const params: Record<string, unknown> = { ...violation.params, byteOffset: violation.byteOffset };
+  return {
+    code: violation.code,
+    path: [...(violation.path as PathSegment[])],
+    message: violation.message ?? messageForCode(violation.code),
+    params,
+    children: violation.children?.map(convertOne) ?? [],
+  };
+}
+
+/**
+ * Convert a streaming {@link SchemaViolation} (or a list of them, e.g. a
+ * verdict's `violations`) to `@oav/core`'s {@link ValidationError},
+ * carrying the stream `byteOffset` in `params.byteOffset`. Hand the result
+ * to any `@oav/core` renderer:
+ *
+ * ```ts
+ * import { formatText, toProblemDetails } from "@aahoughton/oav-core";
+ * import { toValidationError } from "@aahoughton/oav-stream-validator";
+ *
+ * const verdict = await validator.result;
+ * if (!verdict.valid) {
+ *   const errors = toValidationError(verdict.violations);
+ *   console.error(formatText(errors));
+ *   res.status(400).json(toProblemDetails(errors));
+ * }
+ * ```
+ *
+ * Mirrors `@oav/core`'s `toJsonObject`: a single violation in yields a
+ * single error; a list yields a list.
+ *
+ * @public
+ */
+export function toValidationError(violation: SchemaViolation): ValidationError;
+export function toValidationError(violations: readonly SchemaViolation[]): ValidationError[];
+export function toValidationError(
+  violation: SchemaViolation | readonly SchemaViolation[],
+): ValidationError | ValidationError[] {
+  return Array.isArray(violation)
+    ? violation.map(convertOne)
+    : convertOne(violation as SchemaViolation);
+}

--- a/packages/stream-validator/test/operation.test.ts
+++ b/packages/stream-validator/test/operation.test.ts
@@ -1,0 +1,183 @@
+import { Readable, Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { describe, expect, it } from "vitest";
+import type { OpenAPIDocument } from "@oav/core";
+import {
+  streamValidatorForOperation,
+  ValidationFailedError,
+  type StreamVerdict,
+} from "../src/index.js";
+
+const enc = new TextEncoder();
+
+function petstore(openapi = "3.1.0"): OpenAPIDocument {
+  return {
+    openapi,
+    info: { title: "petstore", version: "1.0.0" },
+    paths: {
+      "/pets": {
+        post: {
+          requestBody: {
+            content: { "application/json": { schema: { $ref: "#/components/schemas/Pet" } } },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        Pet: {
+          type: "object",
+          required: ["name"],
+          properties: { name: { type: "string" }, tag: { type: "string" } },
+        },
+      },
+    },
+  } as OpenAPIDocument;
+}
+
+/** Validate a value through the built validator; return the verdict. */
+async function run(
+  validator: ReturnType<typeof streamValidatorForOperation>,
+  value: unknown,
+): Promise<StreamVerdict> {
+  validator.on("error", () => {});
+  try {
+    await pipeline(
+      Readable.from(Buffer.from(enc.encode(JSON.stringify(value)))),
+      validator,
+      new Writable({ write: (_c, _e, cb) => cb() }),
+    );
+  } catch (err) {
+    if (!(err instanceof ValidationFailedError)) throw err;
+  }
+  return validator.result;
+}
+
+describe("streamValidatorForOperation", () => {
+  it("carries components so an internal $ref body schema resolves", async () => {
+    const ok = await run(
+      streamValidatorForOperation(petstore(), { method: "post", path: "/pets" }),
+      {
+        name: "Fido",
+        tag: "dog",
+      },
+    );
+    expect(ok.valid).toBe(true);
+
+    const bad = await run(
+      streamValidatorForOperation(petstore(), { method: "post", path: "/pets" }),
+      { tag: "dog" },
+    );
+    expect(bad.valid).toBe(false);
+    expect(bad.violations[0]!.code).toBe("required");
+  });
+
+  it("is case-insensitive on the method", () => {
+    expect(() =>
+      streamValidatorForOperation(petstore(), { method: "POST", path: "/pets" }),
+    ).not.toThrow();
+  });
+
+  it("forwards options (maxErrors) to the validator", async () => {
+    const v = streamValidatorForOperation(
+      petstore(),
+      { method: "post", path: "/pets" },
+      { maxErrors: Number.POSITIVE_INFINITY, policy: "detach" },
+    );
+    const verdict = await run(v, { name: 42 });
+    expect(verdict.valid).toBe(false);
+  });
+
+  it("reads the version off doc.openapi (3.0 normalizes nullable)", async () => {
+    // A 3.0 doc with `nullable: true`: only the 3.0 normalization path
+    // accepts an explicit null. Detecting the version off the doc proves
+    // the right path ran.
+    const doc = {
+      openapi: "3.0.3",
+      info: { title: "t", version: "1" },
+      paths: {
+        "/x": {
+          post: {
+            requestBody: {
+              content: {
+                "application/json": {
+                  schema: { type: "string", nullable: true },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as unknown as OpenAPIDocument;
+    const verdict = await run(
+      streamValidatorForOperation(doc, { method: "post", path: "/x" }),
+      null,
+    );
+    expect(verdict.valid).toBe(true);
+  });
+
+  it("throws a clear error for a missing path / method / body / media type", () => {
+    expect(() =>
+      streamValidatorForOperation(petstore(), { method: "post", path: "/nope" }),
+    ).toThrow(/no path "\/nope"/);
+    expect(() => streamValidatorForOperation(petstore(), { method: "get", path: "/pets" })).toThrow(
+      /no GET .* operation/,
+    );
+    expect(() =>
+      streamValidatorForOperation(petstore(), {
+        method: "post",
+        path: "/pets",
+        mediaType: "application/xml",
+      }),
+    ).toThrow(/no "application\/xml" content/);
+    expect(() =>
+      streamValidatorForOperation(petstore(), { method: "fetch", path: "/pets" }),
+    ).toThrow(/unknown HTTP method/);
+  });
+
+  it("resolves a local requestBody $ref (#/components/requestBodies/...)", async () => {
+    const doc = {
+      openapi: "3.1.0",
+      info: { title: "t", version: "1" },
+      paths: { "/pets": { post: { requestBody: { $ref: "#/components/requestBodies/PetBody" } } } },
+      components: {
+        requestBodies: {
+          PetBody: {
+            content: { "application/json": { schema: { $ref: "#/components/schemas/Pet" } } },
+          },
+        },
+        schemas: {
+          Pet: { type: "object", required: ["name"], properties: { name: { type: "string" } } },
+        },
+      },
+    } as unknown as OpenAPIDocument;
+    const ok = await run(streamValidatorForOperation(doc, { method: "post", path: "/pets" }), {
+      name: "Fido",
+    });
+    expect(ok.valid).toBe(true);
+    const bad = await run(streamValidatorForOperation(doc, { method: "post", path: "/pets" }), {});
+    expect(bad.valid).toBe(false);
+  });
+
+  it("throws on an unresolvable requestBody $ref", () => {
+    const doc = {
+      openapi: "3.1.0",
+      info: { title: "t", version: "1" },
+      paths: { "/pets": { post: { requestBody: { $ref: "#/components/requestBodies/Missing" } } } },
+    } as unknown as OpenAPIDocument;
+    expect(() => streamValidatorForOperation(doc, { method: "post", path: "/pets" })).toThrow(
+      /does not resolve/,
+    );
+  });
+
+  it("throws on an external requestBody $ref that survived resolution", () => {
+    const doc = {
+      openapi: "3.1.0",
+      info: { title: "t", version: "1" },
+      paths: { "/pets": { post: { requestBody: { $ref: "common.yaml#/PetBody" } } } },
+    } as unknown as OpenAPIDocument;
+    expect(() => streamValidatorForOperation(doc, { method: "post", path: "/pets" })).toThrow(
+      /external requestBody ref/,
+    );
+  });
+});

--- a/packages/stream-validator/test/resource-limits.test.ts
+++ b/packages/stream-validator/test/resource-limits.test.ts
@@ -4,9 +4,12 @@ import { describe, expect, it } from "vitest";
 import type { RegexCompiler, SchemaOrBoolean } from "@oav/core";
 import { compileSchema, jsonSchemaDialect, openapi31Dialect } from "@oav/schema";
 import {
+  BufferLimitError,
   createStreamValidator,
+  MaxTotalBytesError,
   type StreamValidatorOptions,
   type StreamVerdict,
+  UniqueItemsLimitError,
 } from "../src/index.js";
 
 const enc = new TextEncoder();
@@ -84,7 +87,10 @@ describe("forced-buffer scalar is capped by maxBufferedBytes", () => {
     await expect(
       pipeline(source(big, 16), validator, new Writable({ write: (_c, _e, cb) => cb() })),
     ).rejects.toThrow(/maxBufferedBytes/);
-    expect((await guard).message).toMatch(/maxBufferedBytes/);
+    const err = await guard;
+    expect(err).toBeInstanceOf(BufferLimitError);
+    expect((err as BufferLimitError).limit).toBe(8);
+    expect((err as BufferLimitError).byteOffset).toBeGreaterThan(0);
   });
 });
 
@@ -125,7 +131,9 @@ describe("uniqueItems buffers as an island, bounded by maxUniqueItems / maxBuffe
     await expect(
       pipeline(source(bigUnique(300), 8), validator, new Writable({ write: (_c, _e, cb) => cb() })),
     ).rejects.toThrow(/maxUniqueItems/);
-    expect((await guard).message).toMatch(/maxUniqueItems/);
+    const err = await guard;
+    expect(err).toBeInstanceOf(UniqueItemsLimitError);
+    expect((err as UniqueItemsLimitError).limit).toBe(4);
   });
 
   it("maxUniqueItems within the cap validates normally", async () => {
@@ -188,7 +196,9 @@ describe("maxTotalBytes / maxDepth", () => {
     await expect(
       pipeline(source('"abcdefghij"', 3), validator, new Writable({ write: (_c, _e, cb) => cb() })),
     ).rejects.toThrow(/maxTotalBytes/);
-    expect((await guard).message).toMatch(/maxTotalBytes/);
+    const err = await guard;
+    expect(err).toBeInstanceOf(MaxTotalBytesError);
+    expect((err as MaxTotalBytesError).limit).toBe(4);
   });
 
   it("reports a depth violation past maxDepth instead of growing unbounded", async () => {

--- a/packages/stream-validator/test/violation.test.ts
+++ b/packages/stream-validator/test/violation.test.ts
@@ -1,0 +1,88 @@
+import { Readable, Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { describe, expect, it } from "vitest";
+import { formatSummary, formatText, toProblemDetails } from "@oav/core";
+import type { SchemaOrBoolean } from "@oav/core";
+import { createStreamValidator, type SchemaViolation, toValidationError } from "../src/index.js";
+
+const enc = new TextEncoder();
+
+/** Collect every violation from a detached, unbounded run. */
+async function violationsOf(schema: SchemaOrBoolean, value: unknown): Promise<SchemaViolation[]> {
+  const validator = createStreamValidator(schema, {
+    policy: "detach",
+    maxErrors: Number.POSITIVE_INFINITY,
+  });
+  const seen: SchemaViolation[] = [];
+  validator.on("violation", (v: SchemaViolation) => seen.push(v));
+  validator.on("error", () => {});
+  await pipeline(
+    Readable.from(Buffer.from(enc.encode(JSON.stringify(value)))),
+    validator,
+    new Writable({ write: (_c, _e, cb) => cb() }),
+  );
+  return seen;
+}
+
+describe("toValidationError", () => {
+  it("fills a coarse message and carries byteOffset on a STREAM-path violation", () => {
+    const v: SchemaViolation = { code: "type", path: ["age"], byteOffset: 42 };
+    const e = toValidationError(v);
+    expect(e.code).toBe("type");
+    expect(e.path).toEqual(["age"]);
+    expect(e.message).toBe("value has the wrong type");
+    expect(e.params).toEqual({ byteOffset: 42 });
+    expect(e.children).toEqual([]);
+  });
+
+  it("falls back to a generic message for an unknown code", () => {
+    expect(toValidationError({ code: "mystery", path: [], byteOffset: 0 }).message).toBe(
+      'value does not satisfy "mystery"',
+    );
+  });
+
+  it("preserves the BUFFER-path message/params/children and merges byteOffset", () => {
+    const v: SchemaViolation = {
+      code: "enum",
+      path: ["kind"],
+      byteOffset: 7,
+      message: "value must be one of x, y",
+      params: { allowed: ["x", "y"] },
+      children: [{ code: "const", path: ["kind"], byteOffset: 7 }],
+    };
+    const e = toValidationError(v);
+    expect(e.message).toBe("value must be one of x, y");
+    expect(e.params).toEqual({ allowed: ["x", "y"], byteOffset: 7 });
+    expect(e.children).toHaveLength(1);
+    expect(e.children[0]!.message).toBe("value is not the allowed constant");
+    expect(e.children[0]!.params).toEqual({ byteOffset: 7 });
+  });
+
+  it("maps a list to a list (mirrors toJsonObject)", () => {
+    const errors = toValidationError([
+      { code: "required", path: [], byteOffset: 0 },
+      { code: "type", path: ["id"], byteOffset: 5 },
+    ]);
+    expect(errors).toHaveLength(2);
+    expect(errors.map((e) => e.code)).toEqual(["required", "type"]);
+  });
+
+  it("renders through core's formatters (STREAM path)", async () => {
+    const schema: SchemaOrBoolean = {
+      type: "object",
+      required: ["id"],
+      properties: { id: { type: "integer" } },
+    };
+    const violations = await violationsOf(schema, { id: "nope" });
+    const errors = toValidationError(violations);
+
+    expect(violations.length).toBeGreaterThan(0);
+    expect(formatText(errors)).toContain("[type]");
+    expect(formatSummary(errors)).toContain("wrong type");
+
+    const pd = toProblemDetails(errors);
+    expect(pd.status).toBe(400);
+    expect(pd.issues[0]!.code).toBe("type");
+    expect(pd.issues[0]!.params).toMatchObject({ byteOffset: expect.any(Number) });
+  });
+});


### PR DESCRIPTION
Closes #423.

Three small public-surface gaps in `@aahoughton/oav-stream-validator`, each surfaced while writing the streaming examples (#421) and each forcing example boilerplate a normal consumer would also hit. One commit per concern, independently revertable.

Framing: every addition is shaped to fit the existing library, not bolted on. The error-rendering surface, the `getOperation` locator, and the distinct-named-`Error`-class idiom all already exist; these changes plug into them.

## 1. Bridge `SchemaViolation` to core's error model (`38a2c7d`)
STREAM-path violations carried only `code` + `path` + `byteOffset` (no `message`), so `@oav/core`'s `formatText` / `formatSummary` / `toProblemDetails` did not apply and each example hand-rolled a `path/code @byte` formatter.

Rather than add a stream-specific formatter (a fourth parallel rendering path), add `toValidationError`: it converts a `SchemaViolation` (or a list, mirroring core's `toJsonObject` overload) to a `ValidationError`. BUFFER-path `message`/`params`/`children` pass through; STREAM-path codes get a coarse message; the stream `byteOffset` rides in `params.byteOffset`. Stream output now flows into the whole existing rendering surface, including the framework adapters' `renderProblemDetails`.

## 2. `streamValidatorForOperation` spec bridge (`8d3662d`)
Going from a resolved document to a validator meant pulling the body schema, spreading `components` onto it (or construction throws `unresolvable $ref`), and hardcoding the version.

Add `streamValidatorForOperation(doc, { method, path, mediaType? }, options?)`, mirroring `@oav/validator`'s `getOperation` locator: exact-key lookup (no routing; resolve the template upstream), carries `doc.components`, reads the version off `doc.openapi` (overridable), and throws clear errors when a piece is absent. Local `requestBody` `$ref`s (`#/components/requestBodies/...`, a normal shape `resolveSpec` leaves in place) are followed, mirroring the validator's `resolveOperationRef`; external/unresolvable refs throw with a hint. Lives in `@oav/core`'s type space, so no dependency-graph change.

## 3. Export resource-limit errors for `instanceof` (`55f3825`)
A `maxBufferedBytes` / `maxUniqueItems` / `maxTotalBytes` overflow rejected the pipeline, but `BufferLimitError` / `UniqueItemsLimitError` were not exported and `maxTotalBytes` threw a plain `Error`. Telling "too big" from "invalid" (`ValidationFailedError`) meant string-matching the message.

Export `BufferLimitError` and `UniqueItemsLimitError`, add a named `MaxTotalBytesError` (was a plain `Error`), and give all three a `limit` field beside the existing `byteOffset`. Following the repo's distinct-named-class idiom (no shared base), callers `instanceof` the specific class and read `limit`.

## Verification
- `pnpm test` (full suite, 111 files), `pnpm typecheck`, `pnpm lint` (oxlint + oxfmt + check:deps) all green.
- New tests: `violation.test.ts`, `operation.test.ts`; expanded `resource-limits.test.ts` with `instanceof` assertions.
- All four streaming examples run; `stream-basic`, `stream-from-spec`, and `stream-limits` updated to use the new surface instead of boilerplate.