### PR TITLE
fix(stream-validator): resolve and normalize 3.0 $ref request bodies

### DIFF
--- a/packages/stream-validator/src/openapi/normalize.ts
+++ b/packages/stream-validator/src/openapi/normalize.ts
@@ -35,6 +35,23 @@ function isObjectSchema(s: unknown): s is SchemaObject {
   return typeof s === "object" && s !== null && !Array.isArray(s);
 }
 
+// Normalize the schema-bearing positions of a carried OpenAPI `components`
+// container. A body schema's internal `$ref` resolves against this container
+// (`#/components/schemas/Name`), so its targets need the same 3.0 -> 2020-12
+// rewrite as the inline body; without this, `nullable` / boolean `exclusive*`
+// inside a referenced component survive un-normalized. Only `schemas` holds
+// JSON Schemas a schema `$ref` can name; the other component sub-objects
+// (responses, parameters, ...) are never schema-ref targets and pass through.
+function normalizeComponents(components: Record<string, unknown>): Record<string, unknown> {
+  const schemas = components.schemas;
+  if (!isObjectSchema(schemas)) return components;
+  const out: Record<string, unknown> = {};
+  for (const [name, sub] of Object.entries(schemas)) {
+    out[name] = normalizeOas30(sub as SchemaOrBoolean);
+  }
+  return { ...components, schemas: out };
+}
+
 // Fold a boolean exclusive bound into its 2020-12 numeric form.
 function foldExclusive(out: Record<string, unknown>, bound: "maximum" | "minimum"): void {
   const exKey = bound === "maximum" ? "exclusiveMaximum" : "exclusiveMinimum";
@@ -64,7 +81,9 @@ export function normalizeOas30(schema: SchemaOrBoolean): SchemaOrBoolean {
   const out: Record<string, unknown> = {};
   for (const [key, val] of Object.entries(schema)) {
     if (key === "nullable") continue; // folded into `type` below
-    if (SINGLE.has(key)) out[key] = normalizeOas30(val as SchemaOrBoolean);
+    if (key === "components" && isObjectSchema(val))
+      out[key] = normalizeComponents(val as Record<string, unknown>);
+    else if (SINGLE.has(key)) out[key] = normalizeOas30(val as SchemaOrBoolean);
     else if (ARRAY.has(key))
       out[key] = Array.isArray(val) ? val.map((v) => normalizeOas30(v as SchemaOrBoolean)) : val;
     else if (MAP.has(key) && isObjectSchema(val)) {

--- a/packages/stream-validator/src/operation.ts
+++ b/packages/stream-validator/src/operation.ts
@@ -91,6 +91,25 @@ function resolveRequestBody(
   );
 }
 
+// Follow a top-level body `$ref` to its non-`$ref` node form. A bare-`$ref`
+// body schema (`{ $ref }`) cannot carry a `components` sibling: 3.0
+// `$ref`-sibling suppression (normalizeOas30) drops the sibling, leaving the
+// internal ref with nothing to resolve against. Dereferencing first leaves a
+// non-`$ref` root the container can sit beside, and internal refs inside the
+// target still resolve through the carried `components`. Returns the schema
+// unchanged when the top-level node is not a `$ref`, or when the ref does not
+// resolve locally (the classifier then throws a clear `unresolvable $ref`).
+function derefTopLevelSchemaRef(doc: OpenAPIDocument, schema: SchemaOrBoolean): SchemaOrBoolean {
+  let current = schema;
+  for (let hops = 0; hops < 32; hops++) {
+    if (!isObjectSchema(current) || typeof current.$ref !== "string") return current;
+    const target = resolveRef(doc as unknown as SchemaObject, current.$ref);
+    if (target === undefined) return schema;
+    current = target;
+  }
+  return schema;
+}
+
 /**
  * Locates a request body within an {@link OpenAPIDocument}.
  *
@@ -165,11 +184,14 @@ export function streamValidatorForOperation(
   }
 
   // Carry the document's ref container so an internal `$ref` in the body
-  // schema resolves. A boolean schema needs nothing and is passed as-is.
+  // schema resolves. Dereference a top-level body `$ref` first so the
+  // container sits beside a non-`$ref` root (see derefTopLevelSchemaRef). A
+  // boolean schema needs nothing and is passed as-is.
+  const resolvedBody = derefTopLevelSchemaRef(doc, bodySchema);
   const schema: SchemaOrBoolean =
-    isObjectSchema(bodySchema) && doc.components !== undefined
-      ? ({ ...bodySchema, components: doc.components } as SchemaObject)
-      : bodySchema;
+    isObjectSchema(resolvedBody) && doc.components !== undefined
+      ? ({ ...resolvedBody, components: doc.components } as SchemaObject)
+      : resolvedBody;
 
   const openApiVersion = options.openApiVersion ?? versionFromDoc(doc.openapi);
   return createStreamValidator(schema, {

--- a/packages/stream-validator/test/openapi.test.ts
+++ b/packages/stream-validator/test/openapi.test.ts
@@ -61,6 +61,25 @@ describe("normalizeOas30", () => {
     }) as SchemaObject;
     expect(out.properties?.a).toEqual({ type: ["integer", "null"] });
   });
+
+  it("normalizes components.schemas reached by an inline body's $ref", () => {
+    const out = normalizeOas30({
+      type: "object",
+      properties: { n: { $ref: "#/components/schemas/Nb" } },
+      components: {
+        schemas: {
+          Nb: { type: "integer", nullable: true },
+          Ex: { minimum: 5, exclusiveMinimum: true },
+        },
+        responses: { NotFound: { description: "absent" } },
+      },
+    } as unknown as SchemaOrBoolean) as SchemaObject;
+    const components = out.components as Record<string, Record<string, unknown>>;
+    expect(components.schemas.Nb).toEqual({ type: ["integer", "null"] });
+    expect(components.schemas.Ex).toEqual({ exclusiveMinimum: 5 });
+    // Non-schema component sub-objects pass through untouched.
+    expect(components.responses.NotFound).toEqual({ description: "absent" });
+  });
 });
 
 describe("OpenAPI 3.0 verdict parity with @oav/schema oas30Dialect", () => {

--- a/packages/stream-validator/test/operation.test.ts
+++ b/packages/stream-validator/test/operation.test.ts
@@ -91,6 +91,53 @@ describe("streamValidatorForOperation", () => {
     expect(bad.violations[0]!.code).toBe("required");
   });
 
+  it("normalizes a 3.0 component reached by an internal $ref (nullable / exclusive*)", async () => {
+    // A nested $ref into components must hit the 3.0-normalized target, not
+    // the raw 3.0 shape: `nullable` folds to a null union, boolean
+    // `exclusiveMinimum` folds to the numeric form.
+    const doc = {
+      openapi: "3.0.3",
+      info: { title: "t", version: "1" },
+      paths: {
+        "/x": {
+          post: {
+            requestBody: {
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      n: { $ref: "#/components/schemas/Nullable" },
+                      m: { $ref: "#/components/schemas/Excl" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Nullable: { type: "integer", nullable: true },
+          Excl: { type: "integer", minimum: 5, exclusiveMinimum: true },
+        },
+      },
+    } as unknown as OpenAPIDocument;
+
+    const ok = await run(streamValidatorForOperation(doc, { method: "post", path: "/x" }), {
+      n: null,
+      m: 6,
+    });
+    expect(ok.valid).toBe(true);
+
+    const bad = await run(streamValidatorForOperation(doc, { method: "post", path: "/x" }), {
+      n: 1,
+      m: 5, // excluded by exclusiveMinimum: 5
+    });
+    expect(bad.valid).toBe(false);
+  });
+
   it("is case-insensitive on the method", () => {
     expect(() =>
       streamValidatorForOperation(petstore(), { method: "POST", path: "/pets" }),

--- a/packages/stream-validator/test/operation.test.ts
+++ b/packages/stream-validator/test/operation.test.ts
@@ -72,6 +72,25 @@ describe("streamValidatorForOperation", () => {
     expect(bad.violations[0]!.code).toBe("required");
   });
 
+  it("resolves a bare top-level $ref body on a 3.0 doc (components survive normalization)", async () => {
+    // Regression: a 3.0 bare-$ref body becomes `{ $ref, components }`, and
+    // 3.0 $ref-sibling suppression then drops `components`, leaving the
+    // internal $ref unresolvable. Dereferencing the top-level $ref before
+    // attaching `components` keeps a non-$ref root the container sits beside.
+    const ok = await run(
+      streamValidatorForOperation(petstore("3.0.3"), { method: "post", path: "/pets" }),
+      { name: "Fido", tag: "dog" },
+    );
+    expect(ok.valid).toBe(true);
+
+    const bad = await run(
+      streamValidatorForOperation(petstore("3.0.3"), { method: "post", path: "/pets" }),
+      { tag: "dog" },
+    );
+    expect(bad.valid).toBe(false);
+    expect(bad.violations[0]!.code).toBe("required");
+  });
+
   it("is case-insensitive on the method", () => {
     expect(() =>
       streamValidatorForOperation(petstore(), { method: "POST", path: "/pets" }),


### PR DESCRIPTION
Two related fixes to OpenAPI 3.0 `$ref` handling in `streamValidatorForOperation` / the 3.0 normalization pass. Both are about a body schema's internal `$ref` resolving against the carried `components` container.

## 1. Bare top-level `$ref` body throws (closes #432)

`streamValidatorForOperation` carries the document's `components` as a sibling of the body schema so internal `$ref`s resolve. For a bare-`$ref` body on an OAS 3.0 spec:

```yaml
requestBody:
  content:
    application/json:
      schema:
        $ref: '#/components/schemas/Envelope'
```

the resulting `{ $ref, components }` hits 3.0 `$ref`-sibling suppression (`normalizeOas30`), which drops the carried `components` and leaves the internal `$ref` with nothing to resolve against. It threw `unresolvable $ref` at construction.

Fix: dereference a top-level body `$ref` to its node form before attaching `components`, so the container sits beside a non-`$ref` root and no sibling is left to suppress. 3.1 / 3.2 are unaffected (they skip normalization); an inline or deeper-nested `$ref` body was already fine.

## 2. Components reached by an internal `$ref` were never normalized (pre-existing)

While fixing #1, found that `normalizeOas30` recurses JSON Schema subschema positions but treated `components` as an opaque pass-through. So a body schema's internal `$ref` (`#/components/schemas/Name`) resolved against the *raw 3.0* component:

- `nullable: true` was not widened to a null union (a `null` was wrongly rejected).
- boolean `exclusiveMinimum` / `exclusiveMaximum` were ignored by the 2020-12 engine (a boundary value was wrongly accepted).

Confirmed with a probe on the **inline-body** path (a property `$ref`-ing a component), which fix #1 does not touch, so this is pre-existing; #1 only exposed it more broadly.

Fix: normalize the schema-bearing `components.schemas` map (the only shape a schema `$ref` can name; responses / parameters / etc. are never schema-ref targets and pass through untouched).

## Tests

- `operation.test.ts`: bare-`$ref` body on a 3.0 doc resolves; a 3.0 component reached by an internal `$ref` normalizes `nullable` / `exclusive*`.
- `openapi.test.ts`: `normalizeOas30` folds `nullable` / boolean `exclusive*` inside `components.schemas` and leaves non-schema sub-objects untouched.

Full suite (1335 tests), typecheck, lint, and dep-graph check all pass.