### PR TITLE
feat(stream-validator): streamability analyzer + oav stream-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,13 +253,15 @@ jobs:
         run: |
           set -euo pipefail
           CORE_TGZ="$(ls "$GITHUB_WORKSPACE/packed"/aahoughton-oav-core-*.tgz | head -n1)"
+          SV_TGZ="$(ls "$GITHUB_WORKSPACE/packed"/aahoughton-oav-stream-validator-*.tgz | head -n1)"
           OAV_TGZ="$(ls "$GITHUB_WORKSPACE/packed"/aahoughton-oav-[0-9]*.tgz | head -n1)"
           rm -rf /tmp/smoke-oav && mkdir -p /tmp/smoke-oav && cd /tmp/smoke-oav
           npm init -y > /dev/null
-          # Install both tarballs in one shot so `@aahoughton/oav`'s
-          # dependency on `@aahoughton/oav-core` resolves against the
-          # locally-packed artifact, not the registry.
-          npm install commander "$CORE_TGZ" "$OAV_TGZ"
+          # Install all tarballs in one shot so `@aahoughton/oav`'s
+          # dependencies on `@aahoughton/oav-core` and
+          # `@aahoughton/oav-stream-validator` (the CLI's stream-check command)
+          # resolve against the locally-packed artifacts, not the registry.
+          npm install commander "$CORE_TGZ" "$SV_TGZ" "$OAV_TGZ"
           cat > smoke.mjs <<'EOF'
           import { createValidator, createYamlFileReader, parseYamlString } from "@aahoughton/oav";
           import { compileSchema, jsonSchemaDialect } from "@aahoughton/oav/schema";
@@ -304,6 +306,13 @@ jobs:
           node smoke.mjs
           # CLI should be present in bin; verify --help exits 0
           npx oav --help > /dev/null
+          # Exercise stream-check: it imports analyzeSpec from
+          # @aahoughton/oav-stream-validator, so this fails if that dependency
+          # is missing or stale in the installed tree.
+          cat > spec.json <<'JSON'
+          {"openapi":"3.1.0","info":{"title":"t","version":"1"},"paths":{"/x":{"post":{"requestBody":{"content":{"application/json":{"schema":{"type":"object"}}}}}}}}
+          JSON
+          npx oav stream-check spec.json > /dev/null
       - name: smoke-import @aahoughton/oav-express4
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ on:
         # release-please creates one tag per package per release
         # (component prefix from release-please-config.json). The five
         # linked packages share a version, so their tags point at the same
-        # commit; oav-stream-validator is unlinked (incubating, 0.x) and
+        # commit; oav-stream-validator is unlinked (its own 0.x line) and
         # carries its own tag at its own commit. Pass whichever package's
         # tag you are republishing; oav-core is the conventional choice for
         # the linked group.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,9 +226,9 @@ string) => boolean>` shaped for `compileSchema`'s `formats` option. A
   sub-validator's subtree with its HTTP location (`body`, `query`, …)
   so error paths are unambiguous. Also exports the Fetch-API adapter
   (`httpRequestFromFetch`, …) for Next.js / Hono / Bun / Deno.
-- **`@aahoughton/oav-stream-validator`** (incubating, published
-  standalone on the `experimental` dist-tag, not folded into the
-  `oav-core` bundle): a second, push-based streaming engine. Beyond
+- **`@aahoughton/oav-stream-validator`** (published standalone on its own
+  `0.x` line, not folded into the `oav-core` bundle): a second, push-based
+  streaming engine. Beyond
   `createStreamValidator`, it exports the **streamability analyzer**:
   `analyzeStreamability(schema)` returns a peak-buffer budget (where a
   schema buffers and how much, in wire bytes, `"unbounded"` where a
@@ -292,9 +292,12 @@ The `cli → stream-validator` edge is the one exception not asserted by
 CLI imports it by that published name, which `check-deps` (scoped to
 `@oav/*`) does not police. Its source alias lives in `workspace-aliases.ts`
 (consumed by vitest + tsup) and the published `@aahoughton/oav` carries it
-as a real runtime dependency. This crosses the incubation boundary on
-purpose (a CLI-only convenience), so a `stream-validator` bump can ripple
-into a CLI release.
+as a real runtime dependency (the same shape the framework adapters use for
+`@aahoughton/oav-core`). The `pack-smoke` job installs the locally-packed
+stream-validator tarball alongside oav so this dep resolves to the workspace
+build, not the registry. `stream-validator` is unlinked from the `oav-core`
+release group (its own `0.x` line), so a `stream-validator` bump can ripple
+into a CLI release that picks it up.
 
 ## Extending the compiler
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,7 +215,25 @@ string) => boolean>` shaped for `compileSchema`'s `formats` option. A
   sub-validator's subtree with its HTTP location (`body`, `query`, …)
   so error paths are unambiguous. Also exports the Fetch-API adapter
   (`httpRequestFromFetch`, …) for Next.js / Hono / Bun / Deno.
-- **`@oav/cli`**: thin commander wrapper; no business logic.
+- **`@aahoughton/oav-stream-validator`** (incubating, published
+  standalone on the `experimental` dist-tag, not folded into the
+  `oav-core` bundle): a second, push-based streaming engine. Beyond
+  `createStreamValidator`, it exports the **streamability analyzer**:
+  `analyzeStreamability(schema)` returns a peak-buffer budget (where a
+  schema buffers and how much, in wire bytes, `"unbounded"` where a
+  structural bound is missing), and `analyzeSpec(doc)` rolls that up per
+  operation (request + each response body). The analyzer mirrors the
+  spine's `computeKind` (not just the classifier's `strategyOf`), so
+  `contains` / asserting `format` / `uniqueItems` are caught as buffering;
+  it is engine-free (calls neither the spine nor `createStreamValidator`),
+  so a consumer importing only the analyzer does not pull the engine. Body
+  extraction (`carryComponents`, `resolveLocalRef`) lives in the shared
+  engine-free `openapi/body-schema.ts` so both `operation.ts` and the
+  analyzer use it.
+- **`@oav/cli`**: thin commander wrapper. The one place it reaches past
+  pure wiring is `stream-check`, which calls `analyzeSpec` and renders the
+  per-operation table; the business logic stays in the analyzer, the CLI
+  owns only the rendering (`stream-check.ts`).
 - **`@oav/oav-express4` / `oav-express5` / `oav-fastify`**: thin
   framework adapters with identical export names and option shapes
   (`validateRequests`, `httpRequestFrom<Framework>`,
@@ -237,6 +255,7 @@ cli           → validator → router
                          → core
               → spec → core
               → core
+              → stream-validator (the published @aahoughton/oav-stream-validator)
 overlay-spec  → spec → core
               → core
 oav-express4  → validator → ... (same as cli's chain)
@@ -255,6 +274,16 @@ carry their deps at runtime while the published `@aahoughton/*` bundles
 carry the same `@oav/*` as build-only devDeps. Adding a real edge means
 updating both the graph above and the relevant `package.json`; a phantom
 or undeclared edge fails the build.
+
+The `cli → stream-validator` edge is the one exception not asserted by
+`check-deps`: the stream validator is published standalone as
+`@aahoughton/oav-stream-validator` (not an `@oav/*` bundle-member), so the
+CLI imports it by that published name, which `check-deps` (scoped to
+`@oav/*`) does not police. Its source alias lives in `workspace-aliases.ts`
+(consumed by vitest + tsup) and the published `@aahoughton/oav` carries it
+as a real runtime dependency. This crosses the incubation boundary on
+purpose (a CLI-only convenience), so a `stream-validator` bump can ripple
+into a CLI release.
 
 ## Extending the compiler
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,18 +124,29 @@ locally too (`pnpm pack` + `npm install` in `/tmp`).
 
 ```bash
 pnpm install
-pnpm build                        # tsup: single multi-entry bundle (ESM + CJS + .d.ts)
+pnpm build                        # tsup: oav-core + stream-validator + the oav CLI
 pnpm test                         # vitest for everything
 pnpm vitest run packages/schema   # run a single package's tests (path filter)
 pnpm lint                         # oxlint + oxfmt --check + check:deps
 pnpm check:deps                   # assert the @oav/* dependency graph (see below)
 pnpm fmt                          # oxfmt --write .
 pnpm typecheck                    # tsc -b (composite project references)
+pnpm oav <args>                   # run the built CLI (e.g. pnpm oav stream-check spec.yaml)
 ```
 
 `pnpm test` uses vitest with workspace aliases from `vitest.config.ts` so
 tests run against `packages/*/src` directly; no need to build before
 testing.
+
+`pnpm oav` runs `packages/oav/dist/cli.js`, so it needs a prior `pnpm build`
+(which builds oav-core, the standalone stream-validator, and the CLI). The
+standalone-tsup packages (`oav`, `stream-validator`, the three adapters)
+set `emitDeclarationOnly: true` in their `tsconfig.json`: their `dist/` is
+the tsup-built runtime artifact, and without this `tsc -b` (typecheck)
+would emit per-file `.js` over the tsup bundle, breaking the built CLI
+until the next `pnpm build`. Leave it in place. (The `@oav/*` packages
+bundled into `oav-core` don't need it: their `dist/` is unused, since the
+root tsup bundles them from source.)
 
 Use `pnpm pack` (not `npm pack`) for any workspace package. `npm pack`
 ships unrewritten `workspace:*` deps; the prepack guard rejects it

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,11 +24,11 @@ for `@aahoughton/oav` in import specifiers that don't touch
 
 The streaming examples import from `packages/stream-validator/src`, which
 translates to `@aahoughton/oav-stream-validator`. That is a separate
-package (not part of the `oav` / `oav-core` re-export), incubating on the
-`experimental` dist-tag, so install it by tag:
+package (not part of the `oav` / `oav-core` re-export), versioned
+independently on its own `0.x` line:
 
 ```bash
-npm install @aahoughton/oav-stream-validator@experimental
+npm install @aahoughton/oav-stream-validator
 ```
 
 ## What's in here
@@ -52,8 +52,8 @@ shape and when to use each section (`extendSchemas`, `replaceSchemas`,
 
 ### Streaming
 
-The streaming validator (`@aahoughton/oav-stream-validator`, incubating)
-is a second engine: it validates a JSON body as the bytes flow through,
+The streaming validator (`@aahoughton/oav-stream-validator`) is a second
+engine: it validates a JSON body as the bytes flow through,
 echoing them out unchanged, without buffering the whole document. These
 examples break the load-a-spec / print-a-verdict mold: they pipe a
 lazily generated body through `createStreamValidator` and read the

--- a/examples/stream-basic.ts
+++ b/examples/stream-basic.ts
@@ -16,8 +16,7 @@
  * basic-validation.ts.
  *
  * Translation to the published packages: import `createStreamValidator`
- * from `@aahoughton/oav-stream-validator` (incubating, install with
- * `@experimental`). See ./README.md.
+ * from `@aahoughton/oav-stream-validator`. See ./README.md.
  *
  * Run from the repo root:
  *   pnpm dlx tsx examples/stream-basic.ts

--- a/package.json
+++ b/package.json
@@ -143,7 +143,8 @@
     "provenance": true
   },
   "scripts": {
-    "build": "tsup && pnpm --filter @aahoughton/oav build",
+    "build": "tsup && pnpm --filter @aahoughton/oav-stream-validator build && pnpm --filter @aahoughton/oav build",
+    "oav": "node packages/oav/dist/cli.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "oxlint && oxfmt --check . && pnpm check:deps",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,6 +13,7 @@
     }
   },
   "dependencies": {
+    "@aahoughton/oav-stream-validator": "workspace:*",
     "@oav/core": "workspace:*",
     "@oav/formats": "workspace:*",
     "@oav/schema": "workspace:*",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,6 +5,7 @@ import {
   compileSpecCommand,
   defaultCommandIo,
   resolveCommand,
+  streamCheckCommand,
   validateCommand,
   type CommandIo,
   type ValidateMode,
@@ -166,6 +167,63 @@ export function buildProgram(options: BuildProgramOptions = {}): Command {
       );
       exit(res.exitCode);
     });
+
+  program
+    .command("stream-check <spec>")
+    .description(
+      "Report the streaming-buffer budget per operation (which request/response bodies stream vs buffer, and where).",
+    )
+    .option("--overlay <file...>", "apply one or more overlays in order", collectOverlays, [])
+    .option(
+      "--envelope <shape>",
+      "'text' (default; per-operation table) or 'json' (the SpecBudget payload)",
+      (value: string): "text" | "json" => {
+        if (value !== "text" && value !== "json") {
+          throw new Error(`unknown envelope: ${value} (expected "text" or "json")`);
+        }
+        return value;
+      },
+      "text",
+    )
+    .option(
+      "--max-buffered-bytes <n>",
+      "buffer cap to compute the effective peak against",
+      (v: string) => Number.parseInt(v, 10),
+    )
+    .option("--fail-on-unbounded", "exit non-zero if any body has an unbounded peak buffer", false)
+    .option("--verbose", "list each unbounded buffering position with its path", false)
+    .option("-o, --output <file>", "write output to a file instead of stdout")
+    .option("--quiet", "print nothing; exit code only", false)
+    .action(
+      async (
+        spec: string,
+        opts: {
+          overlay: string[];
+          envelope: "text" | "json";
+          maxBufferedBytes?: number;
+          failOnUnbounded: boolean;
+          verbose: boolean;
+          output?: string;
+          quiet: boolean;
+        },
+      ) => {
+        const res = await streamCheckCommand(
+          {
+            spec,
+            overlays: opts.overlay ?? [],
+            envelope: opts.envelope,
+            ...(opts.maxBufferedBytes !== undefined && {
+              maxBufferedBytes: opts.maxBufferedBytes,
+            }),
+            failOnUnbounded: opts.failOnUnbounded,
+            verbose: opts.verbose,
+            options: { format: "text", output: opts.output, quiet: opts.quiet },
+          },
+          io,
+        );
+        exit(res.exitCode);
+      },
+    );
 
   program
     .command("compile-schema <schema>")

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -16,9 +16,11 @@ import {
 } from "@oav/spec";
 import { createValidator } from "@oav/validator";
 import type { OpenAPIDocument } from "@oav/core";
+import { analyzeSpec } from "@aahoughton/oav-stream-validator";
 import { emitStandalone, type StandaloneDialect } from "./emit-standalone.js";
 import { emitSpec } from "./emit-spec.js";
 import { parseHttpFile } from "./http-parser.js";
+import { hasUnbounded, renderStreamBudget } from "./stream-check.js";
 
 /**
  * Input shared by all CLI commands.
@@ -174,6 +176,56 @@ export async function resolveCommand(
   if (args.lint && args.failOn === "warning" && specHygieneIssues.length > 0) {
     return { exitCode: 1 };
   }
+  return { exitCode: 0 };
+}
+
+/**
+ * Implement the `oav stream-check <spec> ...` subcommand: roll up the
+ * streaming-buffer budget for every operation's request / response bodies
+ * and print a per-operation table (or the `SpecBudget` JSON envelope). This
+ * is the streamability analysis (`@oav/stream-validator`) surfaced over a
+ * whole resolved spec, so a deployer can see, before deploy, which bodies
+ * stream and which buffer (and where).
+ *
+ * @returns exit code 0, or 1 when `--fail-on unbounded` is set and any body
+ *          has an unbounded peak.
+ *
+ * @public
+ */
+export async function streamCheckCommand(
+  args: {
+    spec: string;
+    overlays: string[];
+    envelope: "text" | "json";
+    maxBufferedBytes?: number;
+    failOnUnbounded: boolean;
+    verbose: boolean;
+    options: CommandOptions;
+  },
+  io: CommandIo = defaultCommandIo(),
+): Promise<CommandResult> {
+  const overlayDocs = await Promise.all(
+    args.overlays.map(async (path) => (await io.reader.read(path)) as SpecOverlay),
+  );
+  const { document } = await loadSpec({
+    reader: io.reader,
+    entry: args.spec,
+    overlays: overlayDocs,
+  });
+
+  const budget = analyzeSpec(
+    document,
+    args.maxBufferedBytes === undefined ? {} : { maxBufferedBytes: args.maxBufferedBytes },
+  );
+
+  const sink = primarySink(io, args.options);
+  if (args.envelope === "json") {
+    await sink(JSON.stringify(budget, null, 2) + "\n");
+  } else {
+    await sink(renderStreamBudget(document, budget, { verbose: args.verbose }));
+  }
+
+  if (args.failOnUnbounded && hasUnbounded(budget)) return { exitCode: 1 };
   return { exitCode: 0 };
 }
 

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -187,7 +187,7 @@ export async function resolveCommand(
  * whole resolved spec, so a deployer can see, before deploy, which bodies
  * stream and which buffer (and where).
  *
- * @returns exit code 0, or 1 when `--fail-on unbounded` is set and any body
+ * @returns exit code 0, or 1 when `--fail-on-unbounded` is set and any body
  *          has an unbounded peak.
  *
  * @public

--- a/packages/cli/src/stream-check.ts
+++ b/packages/cli/src/stream-check.ts
@@ -48,7 +48,14 @@ function renderBody(body: BodyBudget, pad: number, verbose: boolean): string[] {
   const unbounded = buffers.filter((p) => p.maxBytes === "unbounded");
   const bounded = buffers.length - unbounded.length;
   const counts = buffers.length > 0 ? `  (${unbounded.length} unbounded, ${bounded} bounded)` : "";
-  const head = `  ${role} ${media} ${classLabel(report).padEnd(11)} peak ${formatBytes(report.peakBytes)}${counts}`;
+  // Surface the configured cap when it actually binds (effective < intrinsic,
+  // or a finite cap over an unbounded peak); equal means no cap is set or the
+  // cap does not bind.
+  const capped =
+    report.effectivePeakBytes === report.peakBytes
+      ? ""
+      : `  (capped to ${formatBytes(report.effectivePeakBytes)})`;
+  const head = `  ${role} ${media} ${classLabel(report).padEnd(11)} peak ${formatBytes(report.peakBytes)}${capped}${counts}`;
   if (!verbose) return [head];
 
   const lines = [head];
@@ -87,7 +94,7 @@ function tally(budget: SpecBudget): Counts {
   return c;
 }
 
-/** True when any body in the budget has an unbounded peak (the `--fail-on unbounded` trigger). */
+/** True when any body in the budget has an unbounded peak (the `--fail-on-unbounded` trigger). */
 export function hasUnbounded(budget: SpecBudget): boolean {
   return budget.operations.some((op) => op.bodies.some((b) => b.report?.peakBytes === "unbounded"));
 }

--- a/packages/cli/src/stream-check.ts
+++ b/packages/cli/src/stream-check.ts
@@ -1,0 +1,134 @@
+/**
+ * Human-readable rendering for `oav stream-check`: a per-operation
+ * streamability table over a {@link SpecBudget}, surfacing where each
+ * request / response body buffers and the unbounded positions that drive
+ * the cost. The machine-readable form is the `SpecBudget` JSON itself
+ * (`--envelope json`).
+ *
+ * @packageDocumentation
+ */
+
+import type { OpenAPIDocument } from "@oav/core";
+import type {
+  BodyBudget,
+  ByteSize,
+  SpecBudget,
+  StreamabilityReport,
+} from "@aahoughton/oav-stream-validator";
+
+/** Format a wire-byte size as a short human string. */
+export function formatBytes(size: ByteSize): string {
+  if (size === "unbounded") return "UNBOUNDED";
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// "request" / a response status, padded so the body lines align.
+function roleLabel(body: BodyBudget): string {
+  return body.role === "request" ? "request" : (body.status ?? "response");
+}
+
+function classLabel(report: StreamabilityReport): string {
+  return report.classification;
+}
+
+// A body line carrying its class + peak + buffering-island counts. Under
+// `verbose`, each unbounded island is also listed with its path and the
+// keyword that would bound it (the actionable punch list); bounded islands
+// stay a count, since they need no action.
+function renderBody(body: BodyBudget, pad: number, verbose: boolean): string[] {
+  const role = roleLabel(body).padEnd(pad);
+  const media = body.mediaType.padEnd(24);
+  if (body.error !== undefined) {
+    return [`  ${role} ${media} not-streamable: ${body.error}`];
+  }
+  const report = body.report as StreamabilityReport;
+  const buffers = report.positions.filter((p) => p.classification === "buffer");
+  const unbounded = buffers.filter((p) => p.maxBytes === "unbounded");
+  const bounded = buffers.length - unbounded.length;
+  const counts = buffers.length > 0 ? `  (${unbounded.length} unbounded, ${bounded} bounded)` : "";
+  const head = `  ${role} ${media} ${classLabel(report).padEnd(11)} peak ${formatBytes(report.peakBytes)}${counts}`;
+  if (!verbose) return [head];
+
+  const lines = [head];
+  for (const p of unbounded) {
+    const at = p.path === "" ? "(root)" : p.path;
+    lines.push(`         - ${at}  ${p.keyword}  unbounded (needs ${p.unboundedBy})`);
+  }
+  return lines;
+}
+
+interface Counts {
+  bodies: number;
+  streamable: number;
+  tee: number;
+  buffer: number;
+  unbounded: number;
+  errors: number;
+}
+
+function tally(budget: SpecBudget): Counts {
+  const c: Counts = { bodies: 0, streamable: 0, tee: 0, buffer: 0, unbounded: 0, errors: 0 };
+  for (const op of budget.operations) {
+    for (const body of op.bodies) {
+      c.bodies++;
+      if (body.error !== undefined) {
+        c.errors++;
+        continue;
+      }
+      const r = body.report as StreamabilityReport;
+      if (r.classification === "streamable") c.streamable++;
+      else if (r.classification === "tee") c.tee++;
+      else c.buffer++;
+      if (r.peakBytes === "unbounded") c.unbounded++;
+    }
+  }
+  return c;
+}
+
+/** True when any body in the budget has an unbounded peak (the `--fail-on unbounded` trigger). */
+export function hasUnbounded(budget: SpecBudget): boolean {
+  return budget.operations.some((op) => op.bodies.some((b) => b.report?.peakBytes === "unbounded"));
+}
+
+/**
+ * Render a {@link SpecBudget} as a per-operation text table. With
+ * `verbose`, each unbounded buffering position is listed under its body
+ * (path + the keyword that would bound it); otherwise bodies show only
+ * island counts.
+ *
+ * @public
+ */
+export function renderStreamBudget(
+  doc: OpenAPIDocument,
+  budget: SpecBudget,
+  options: { verbose?: boolean } = {},
+): string {
+  const verbose = options.verbose ?? false;
+  const title = doc.info?.title ?? "(untitled)";
+  const lines: string[] = [`${title}  (openapi ${doc.openapi})`, ""];
+
+  // Pad the role column to the widest label so bodies align.
+  const pad = Math.max(
+    7,
+    ...budget.operations.flatMap((op) => op.bodies.map((b) => roleLabel(b).length)),
+  );
+
+  for (const op of budget.operations) {
+    lines.push(`${op.method} ${JSON.stringify(op.path)}`);
+    for (const body of op.bodies) lines.push(...renderBody(body, pad, verbose));
+  }
+
+  const c = tally(budget);
+  const plural = (n: number, one: string, many: string): string => `${n} ${n === 1 ? one : many}`;
+  lines.push(
+    "",
+    `summary: ${plural(c.bodies, "body", "bodies")} in ` +
+      `${plural(budget.operations.length, "operation", "operations")}. ` +
+      `${c.streamable} streamable, ${c.tee} tee, ${c.buffer} buffer ` +
+      `(${c.unbounded} unbounded)` +
+      (c.errors > 0 ? `, ${c.errors} not-streamable` : ""),
+  );
+  return lines.join("\n") + "\n";
+}

--- a/packages/cli/test/stream-check.test.ts
+++ b/packages/cli/test/stream-check.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { streamCheckCommand, type CommandOptions } from "../src/commands.js";
+import { memoryIo } from "./fixtures.js";
+
+const textOpts: CommandOptions = { format: "text", quiet: false };
+
+// A spec with one streamable response and one request body that buffers
+// unboundedly (a `pattern` string with no `maxLength`).
+const SPEC = {
+  openapi: "3.1.0",
+  info: { title: "Demo", version: "1" },
+  paths: {
+    "/pets": {
+      post: {
+        requestBody: {
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                additionalProperties: false,
+                properties: { code: { type: "string", pattern: "^[A-Z]+$" } },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": { content: { "application/json": { schema: { type: "array" } } } },
+        },
+      },
+    },
+  },
+};
+
+function io() {
+  return memoryIo([["spec.json", SPEC]]);
+}
+
+const base = { spec: "spec.json", overlays: [], failOnUnbounded: false, verbose: false };
+
+describe("streamCheckCommand", () => {
+  it("prints a per-operation table with island counts (text, non-verbose)", async () => {
+    const { io: cmdIo, stdout } = io();
+    const res = await streamCheckCommand({ ...base, envelope: "text", options: textOpts }, cmdIo);
+    expect(res.exitCode).toBe(0);
+    expect(stdout.value).toContain('POST "/pets"');
+    expect(stdout.value).toContain("buffer");
+    expect(stdout.value).toContain("(1 unbounded, 0 bounded)");
+    // Non-verbose: no per-position path lines.
+    expect(stdout.value).not.toContain("code  pattern");
+    expect(stdout.value).toContain("summary: 2 bodies in 1 operation.");
+  });
+
+  it("lists each unbounded position under --verbose", async () => {
+    const { io: cmdIo, stdout } = io();
+    await streamCheckCommand(
+      { ...base, envelope: "text", verbose: true, options: textOpts },
+      cmdIo,
+    );
+    expect(stdout.value).toContain("code  pattern  unbounded (needs maxLength)");
+  });
+
+  it("emits the SpecBudget as JSON under --envelope json", async () => {
+    const { io: cmdIo, stdout } = io();
+    await streamCheckCommand({ ...base, envelope: "json", options: textOpts }, cmdIo);
+    const budget = JSON.parse(stdout.value);
+    expect(budget.operations).toHaveLength(1);
+    expect(budget.operations[0].bodies[0]).toMatchObject({
+      role: "request",
+      mediaType: "application/json",
+    });
+    expect(budget.operations[0].bodies[0].report.peakBytes).toBe("unbounded");
+  });
+
+  it("exits non-zero with --fail-on-unbounded when a body is unbounded", async () => {
+    const { io: cmdIo } = io();
+    const res = await streamCheckCommand(
+      { ...base, envelope: "text", failOnUnbounded: true, options: textOpts },
+      cmdIo,
+    );
+    expect(res.exitCode).toBe(1);
+  });
+
+  it("exits zero with --fail-on-unbounded when every body is bounded", async () => {
+    const bounded = {
+      openapi: "3.1.0",
+      info: { title: "Bounded", version: "1" },
+      paths: {
+        "/x": {
+          post: {
+            requestBody: { content: { "application/json": { schema: { type: "string" } } } },
+          },
+        },
+      },
+    };
+    const { io: cmdIo } = memoryIo([["spec.json", bounded]]);
+    const res = await streamCheckCommand(
+      { ...base, envelope: "text", failOnUnbounded: true, options: textOpts },
+      cmdIo,
+    );
+    expect(res.exitCode).toBe(0);
+  });
+});

--- a/packages/cli/test/stream-check.test.ts
+++ b/packages/cli/test/stream-check.test.ts
@@ -71,6 +71,22 @@ describe("streamCheckCommand", () => {
     expect(budget.operations[0].bodies[0].report.peakBytes).toBe("unbounded");
   });
 
+  it("shows the effective peak in the text output when --max-buffered-bytes binds", async () => {
+    const { io: cmdIo, stdout } = io();
+    await streamCheckCommand(
+      { ...base, envelope: "text", maxBufferedBytes: 1000, options: textOpts },
+      cmdIo,
+    );
+    // The unbounded request body clamps to the cap; the table must surface it.
+    expect(stdout.value).toContain("peak UNBOUNDED  (capped to 1000 B)");
+  });
+
+  it("does not show a cap suffix when no cap is set", async () => {
+    const { io: cmdIo, stdout } = io();
+    await streamCheckCommand({ ...base, envelope: "text", options: textOpts }, cmdIo);
+    expect(stdout.value).not.toContain("capped to");
+  });
+
   it("exits non-zero with --fail-on-unbounded when a body is unbounded", async () => {
     const { io: cmdIo } = io();
     const res = await streamCheckCommand(

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../formats" },
     { "path": "../schema" },
     { "path": "../spec" },
+    { "path": "../stream-validator" },
     { "path": "../validator" }
   ]
 }

--- a/packages/oav-express4/tsconfig.json
+++ b/packages/oav-express4/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "emitDeclarationOnly": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules", "src/**/*.test.ts"],

--- a/packages/oav-express5/tsconfig.json
+++ b/packages/oav-express5/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "emitDeclarationOnly": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules", "src/**/*.test.ts"],

--- a/packages/oav-fastify/tsconfig.json
+++ b/packages/oav-fastify/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "emitDeclarationOnly": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules", "src/**/*.test.ts"],

--- a/packages/oav/package.json
+++ b/packages/oav/package.json
@@ -157,6 +157,7 @@
   },
   "dependencies": {
     "@aahoughton/oav-core": "workspace:*",
+    "@aahoughton/oav-stream-validator": "workspace:*",
     "commander": "^15.0.0",
     "yaml": "^2.6.0"
   },

--- a/packages/oav/tsconfig.json
+++ b/packages/oav/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "emitDeclarationOnly": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules", "src/**/*.test.ts"],

--- a/packages/oav/tsconfig.json
+++ b/packages/oav/tsconfig.json
@@ -13,6 +13,7 @@
     { "path": "../overlay-spec" },
     { "path": "../schema" },
     { "path": "../spec" },
+    { "path": "../stream-validator" },
     { "path": "../validator" }
   ]
 }

--- a/packages/stream-validator/README.md
+++ b/packages/stream-validator/README.md
@@ -195,8 +195,9 @@ A peak is computable because the engine holds one materialized island at a
 time: sequential positions (array items, object properties) buffer one at a
 time, so the peak across siblings is a **max**, while a TEE's concurrent
 sub-spines **sum**. A BUFFER island is bounded by its subtree's structural
-keywords (`maxLength` / `maxItems` / `maxProperties` / `const` / `enum`),
-and `"unbounded"` where one is missing. Sizes are an upper-bound estimate
+keywords (`maxLength` / `maxItems` / `const` / `enum`, and a closed
+object's properties), and `"unbounded"` where one is missing (an open
+object is unbounded regardless of `maxProperties`). Sizes are an upper-bound estimate
 in the same UTF-8 wire bytes `maxBufferedBytes` caps (heavy `\uXXXX`
 escaping can exceed the per-character assumption), so treat the number as a
 capacity-planning figure, not a runtime meter. An unstreamable schema

--- a/packages/stream-validator/README.md
+++ b/packages/stream-validator/README.md
@@ -1,4 +1,4 @@
-# oav-stream-validator (incubating)
+# oav-stream-validator
 
 A streaming JSON Schema 2020-12 validator for
 [`oav-core`](https://www.npmjs.com/package/@aahoughton/oav-core). It
@@ -19,18 +19,14 @@ Thin: this package bundles nothing from `oav-core`. It declares
 `@aahoughton/oav-core` as a regular dependency, so installing the stream
 validator pulls the engine it delegates to along with it.
 
-> **Incubating, on the `experimental` dist-tag.** Published to
-> `experimental` (not `latest`) and versioned independently of the
-> `oav-core` family while the API settles (`0.x`). Install it by tag:
->
-> ```bash
-> npm install @aahoughton/oav-stream-validator@experimental
-> ```
->
-> A plain `npm install @aahoughton/oav-stream-validator` (no tag) will not
-> resolve until it graduates to `latest`. The public surface is small and
-> additive-by-design, but treat `0.x` minor bumps as potentially breaking
-> until then.
+```bash
+npm install @aahoughton/oav-stream-validator
+```
+
+> **Versioned independently of the `oav-core` family.** This package tracks
+> its own `0.x` line rather than the lockstep `oav-core` version, so a minor
+> bump may carry a breaking change while the public surface settles. The
+> surface is small and additive-by-design.
 
 ## Usage
 
@@ -68,7 +64,7 @@ it reports at the closing delimiter. The verdict is identical either way;
 eager enforcement only moves _when_ the violation surfaces (and its byte
 offset points at the cause rather than the delimiter).
 
-### Supported schemas (incubation)
+### Supported schemas
 
 The STREAM keyword set (`type`, scalar/string/number constraints,
 `properties` / `items` / `required` / bounds / `propertyNames` /
@@ -225,8 +221,8 @@ for (const op of analyzeSpec(document).operations) {
 
 ## Status
 
-Incubating: published to the `experimental` dist-tag (not `latest`) and
-versioned independently of the `oav-core` family. The classifier
+Published to the default `latest` dist-tag, on its own `0.x` line
+(versioned independently of the `oav-core` family). The classifier
 co-evolves with `oav-core`'s keyword set inside the monorepo (a CI drift
 test makes a divergence a build failure rather than silent breakage); the
 published bundle pins `@aahoughton/oav-core` so the two move together.

--- a/packages/stream-validator/README.md
+++ b/packages/stream-validator/README.md
@@ -170,6 +170,38 @@ scopes a hook sees depends on the schema's classification. Use the hooks
 for observing/editing forward-decidable structure, not as a general JSON
 visitor over an arbitrary schema.
 
+### Streamability analysis
+
+`analyzeStreamability(schema, options)` is the design-time companion to the
+runtime engine: it classifies a resolved schema and reports where it
+buffers and how much, without reading a byte. The same classification the
+engine runs on, turned into a peak-buffer budget you check before deploy.
+
+```ts
+import { analyzeStreamability } from "@aahoughton/oav-stream-validator";
+
+const report = analyzeStreamability(bodySchema, { openApiVersion: "3.1" });
+report.classification; // "streamable" | "tee" | "buffer"
+report.peakBytes; // schema-intrinsic peak in wire bytes, or "unbounded"
+report.effectivePeakBytes; // peak under maxBufferedBytes (passes clamp to the cap)
+
+// The punch list: positions with no structural bound fall back to the cap.
+for (const p of report.positions.filter((p) => p.maxBytes === "unbounded")) {
+  console.warn(`${p.path || "<root>"}: ${p.keyword} unbounded (${p.unboundedBy})`);
+}
+```
+
+A peak is computable because the engine holds one materialized island at a
+time: sequential positions (array items, object properties) buffer one at a
+time, so the peak across siblings is a **max**, while a TEE's concurrent
+sub-spines **sum**. A BUFFER island is bounded by its subtree's structural
+keywords (`maxLength` / `maxItems` / `maxProperties` / `const` / `enum`),
+and `"unbounded"` where one is missing. Sizes are an upper-bound estimate
+in the same UTF-8 wire bytes `maxBufferedBytes` caps (heavy `\uXXXX`
+escaping can exceed the per-character assumption), so treat the number as a
+capacity-planning figure, not a runtime meter. An unstreamable schema
+throws the same `ClassifierError` `createStreamValidator` raises.
+
 ## Status
 
 Incubating: published to the `experimental` dist-tag (not `latest`) and

--- a/packages/stream-validator/README.md
+++ b/packages/stream-validator/README.md
@@ -202,6 +202,26 @@ escaping can exceed the per-character assumption), so treat the number as a
 capacity-planning figure, not a runtime meter. An unstreamable schema
 throws the same `ClassifierError` `createStreamValidator` raises.
 
+`analyzeSpec(document, options)` rolls this up over a whole resolved
+OpenAPI document: one budget per operation, for the request body and each
+response body. A body whose schema cannot be classified is reported with
+an `error` field rather than throwing, so a sweep surveys the whole spec.
+The `oav` CLI surfaces it as `oav stream-check <spec>` (a per-operation
+table; `--verbose` lists each unbounded position, `--envelope json` emits
+the `SpecBudget`, `--fail-on-unbounded` exits non-zero for CI):
+
+```ts
+import { analyzeSpec } from "@aahoughton/oav-stream-validator";
+
+const { document } = await resolveSpec(source);
+for (const op of analyzeSpec(document).operations) {
+  for (const body of op.bodies) {
+    const peak = body.report?.peakBytes ?? `error: ${body.error}`;
+    console.log(`${op.method} ${op.path} ${body.role}${body.status ?? ""}: ${peak}`);
+  }
+}
+```
+
 ## Status
 
 Incubating: published to the `experimental` dist-tag (not `latest`) and

--- a/packages/stream-validator/package.json
+++ b/packages/stream-validator/package.json
@@ -54,8 +54,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
-    "tag": "experimental"
+    "provenance": true
   },
   "scripts": {
     "build": "tsup",
@@ -77,5 +76,5 @@
   "engines": {
     "node": ">=22"
   },
-  "//": "Incubating: published to the `experimental` dist-tag (publishConfig.tag), not `latest`, and versioned independently of the lockstep oav-core family. No prepublishOnly: release.yml runs `pnpm test` from root before publish."
+  "//": "Published to the default `latest` dist-tag, pre-1.0 and versioned independently of the lockstep oav-core family (so a minor bump may carry a breaking change while 0.x). No prepublishOnly: release.yml runs `pnpm test` from root before publish."
 }

--- a/packages/stream-validator/src/analyzer/analyze.ts
+++ b/packages/stream-validator/src/analyzer/analyze.ts
@@ -401,12 +401,16 @@ interface Child {
 }
 
 // Composition branches of a TEE node, which run as concurrent sub-spines.
+// A branch index uses a dotted segment (`oneOf.0`), not a bracketed one, so
+// schema navigation (composition branches) reads distinctly from instance
+// navigation (array items `[]` / tuple indices `[0]`) and the two never
+// collide visually (`oneOf.0[]`, not `oneOf[0][]`).
 function teeBranches(node: SchemaObject): Child[] {
   const out: Child[] = [];
   for (const k of ["allOf", "anyOf", "oneOf"] as const) {
     const arr = (node as Record<string, unknown>)[k];
     if (Array.isArray(arr)) {
-      (arr as SchemaOrBoolean[]).forEach((s, i) => out.push({ node: s, rel: `${k}[${i}]` }));
+      (arr as SchemaOrBoolean[]).forEach((s, i) => out.push({ node: s, rel: `${k}.${i}` }));
     }
   }
   if (node.not !== undefined) out.push({ node: node.not as SchemaOrBoolean, rel: "not" });

--- a/packages/stream-validator/src/analyzer/analyze.ts
+++ b/packages/stream-validator/src/analyzer/analyze.ts
@@ -447,6 +447,30 @@ function streamMembers(node: SchemaObject): Child[] {
   return out;
 }
 
+// The tightest `maxLength` that bounds a string: the node's own, intersected
+// with any `allOf` branch's (a sibling `allOf: [{ maxLength }]` bounds the
+// same string the node's `pattern` buffers). Undefined when none applies.
+function effectiveMaxLength(node: SchemaObject): number | undefined {
+  let m = typeof node.maxLength === "number" ? node.maxLength : undefined;
+  for (const branch of compositionArray(node, "allOf")) {
+    if (isObjectSchema(branch) && typeof branch.maxLength === "number") {
+      m = m === undefined ? branch.maxLength : Math.min(m, branch.maxLength);
+    }
+  }
+  return m;
+}
+
+// A forced-buffer scalar island for a `pattern` string (the spine buffers the
+// whole string to test the regex), bounded by the effective `maxLength`, or
+// null when the node carries no `pattern`.
+function forcedScalarIsland(node: SchemaObject, path: string): Contribution | null {
+  if (node.pattern === undefined) return null;
+  const max = effectiveMaxLength(node);
+  return max === undefined
+    ? { kind: "island", path, keyword: "pattern", intrinsic: "unbounded", unboundedBy: "maxLength" }
+    : { kind: "island", path, keyword: "pattern", intrinsic: max * BYTES_PER_CHAR + QUOTE_BYTES };
+}
+
 function walk(
   node: SchemaOrBoolean,
   path: string,
@@ -472,22 +496,6 @@ function walk(
     };
   }
 
-  // `pattern` accumulates the whole string to test the regex even on the
-  // STREAM path (the spine's `needText`), so it is a forced-buffer scalar
-  // bounded by `maxLength`. Asserting `format` is already a BUFFER island
-  // above; bounded `enum`/`const` scalars buffer a negligible amount and
-  // are not reported.
-  if (strat === "stream" && node.pattern !== undefined) {
-    const bounded = typeof node.maxLength === "number";
-    return {
-      kind: "island",
-      path,
-      keyword: "pattern",
-      intrinsic: bounded ? (node.maxLength as number) * BYTES_PER_CHAR + QUOTE_BYTES : "unbounded",
-      ...(bounded ? {} : { unboundedBy: "maxLength" }),
-    };
-  }
-
   if (seen.has(node)) return { kind: "zero" }; // recursive STREAM/TEE: counted at first visit
   const next = new Set(seen).add(node);
 
@@ -498,23 +506,31 @@ function walk(
     return walk(target, path, root, cls, next, formatAsserts);
   }
 
-  const memberParts = streamMembers(node).map((m) =>
-    walk(m.node, joinPath(path, m.rel), root, cls, next, formatAsserts),
-  );
+  // The node's own (non-composition) forward obligation: a forced-buffer
+  // scalar (`pattern`, which accumulates the whole string for the regex even
+  // on the STREAM path) plus its per-member islands, which buffer one at a
+  // time (max). Mirrors the spine's `stripComposition` sub-spine. Asserting
+  // `format` / `uniqueItems` / complex `enum`|`const` are BUFFER above;
+  // bounded scalar `enum`/`const` buffer a negligible amount and are dropped.
+  const ownParts: Contribution[] = [];
+  const scalar = forcedScalarIsland(node, path);
+  if (scalar !== null) ownParts.push(scalar);
+  for (const m of streamMembers(node)) {
+    ownParts.push(walk(m.node, joinPath(path, m.rel), root, cls, next, formatAsserts));
+  }
+  const ownPart: Contribution =
+    ownParts.length > 0 ? { kind: "max", parts: ownParts } : { kind: "zero" };
 
   if (strat === "tee") {
-    const sumNode: Contribution = {
-      kind: "sum",
-      path,
-      keyword: teeKeyword(node),
-      parts: teeBranches(node).map((b) =>
-        walk(b.node, joinPath(path, b.rel), root, cls, next, formatAsserts),
-      ),
-    };
-    return { kind: "max", parts: [sumNode, ...memberParts] };
+    // The spine fans every event to concurrent sub-spines: the node's own
+    // obligation plus one per composition branch. Concurrent islands sum.
+    const branchParts = teeBranches(node).map((b) =>
+      walk(b.node, joinPath(path, b.rel), root, cls, next, formatAsserts),
+    );
+    return { kind: "sum", path, keyword: teeKeyword(node), parts: [ownPart, ...branchParts] };
   }
 
-  return memberParts.length > 0 ? { kind: "max", parts: memberParts } : { kind: "zero" };
+  return ownPart;
 }
 
 // --- Public entry point. ---
@@ -528,14 +544,18 @@ function walk(
  * for the same configuration a validator would run under (`openApiVersion`
  * / `dialect` select the keyword set and `format` assertion;
  * `maxBufferedBytes` drives `effectivePeakBytes`; `keywords` / `parity`
- * affect classification). An unstreamable schema throws
- * {@link ClassifierError}, the same error `createStreamValidator` raises.
+ * affect classification; `enforceBounds` makes an unbounded schema throw,
+ * below). An unstreamable schema throws {@link ClassifierError}, the same
+ * error `createStreamValidator` raises.
  *
  * Wire-byte sizes are an upper-bound estimate (see the module overview),
  * not a guaranteed ceiling. An `"unbounded"` position is the headline
  * output: a buffering position with no structural bound, which falls back
- * to `maxBufferedBytes` at runtime. This is the read-only, design-time view
- * of the same bounds `enforceBounds` turns into a construction error.
+ * to `maxBufferedBytes` at runtime. Reporting these is the default; pass
+ * `enforceBounds: true` to instead throw {@link ClassifierError} on the
+ * first unbounded dimension, the design-time equivalent of refusing to
+ * construct an unsafe validator (the same bound `createStreamValidator`
+ * enforces).
  *
  * @public
  */
@@ -554,6 +574,10 @@ export function analyzeStreamability(
     dialect,
     ...(options.keywords === undefined ? {} : { customKeywords: Object.keys(options.keywords) }),
     ...(options.parity === undefined ? {} : { parity: options.parity }),
+    // Honor enforceBounds so `analyzeStreamability(schema, { enforceBounds: true })`
+    // throws on an unbounded schema, the same as `createStreamValidator` would
+    // (the design-time equivalent of refusing to construct an unsafe validator).
+    ...(options.enforceBounds === undefined ? {} : { enforceBounds: options.enforceBounds }),
   });
 
   if (!isObjectSchema(normalized)) {

--- a/packages/stream-validator/src/analyzer/analyze.ts
+++ b/packages/stream-validator/src/analyzer/analyze.ts
@@ -14,9 +14,11 @@
  *   - **A TEE fans events to one sub-spine per branch concurrently**, so
  *     within a TEE the peak is the **sum** over branches.
  *   - **A BUFFER island materializes its whole subtree**, bounded by that
- *     subtree's structural bounds (`maxLength` / `maxItems` /
- *     `maxProperties` / `const` / `enum`); **unbounded** if any required
- *     bound is missing.
+ *     subtree's structural bounds (`maxLength` / `maxItems` / `const` /
+ *     `enum`, and a closed object's properties); **unbounded** if any
+ *     required bound is missing. An open object (`additionalProperties` not
+ *     `false`) is unbounded regardless of `maxProperties`, which the byte
+ *     model does not yet read.
  *
  * Sizes are an upper bound in **UTF-8 wire bytes** (the same unit
  * `maxBufferedBytes` caps), computed from the byte model below. They are

--- a/packages/stream-validator/src/analyzer/analyze.ts
+++ b/packages/stream-validator/src/analyzer/analyze.ts
@@ -1,0 +1,575 @@
+/**
+ * Streamability analyzer: a static, design-time view of where a schema
+ * forces the streaming engine to buffer, and how much.
+ *
+ * The engine's classifier ({@link classify}) already assigns every
+ * subschema a strategy (STREAM / TEE / BUFFER); the engine itself buffers
+ * at most one materialized island at a time (the spine's single
+ * `this.island` slot). This module reads that classification and walks the
+ * schema to roll the per-position verdicts into a peak-buffer budget:
+ *
+ *   - **Sequential positions buffer one at a time** (array items, object
+ *     properties open / materialize / release before the next), so peak
+ *     across siblings is a **max**, not a sum.
+ *   - **A TEE fans events to one sub-spine per branch concurrently**, so
+ *     within a TEE the peak is the **sum** over branches.
+ *   - **A BUFFER island materializes its whole subtree**, bounded by that
+ *     subtree's structural bounds (`maxLength` / `maxItems` /
+ *     `maxProperties` / `const` / `enum`); **unbounded** if any required
+ *     bound is missing.
+ *
+ * Sizes are an upper bound in **UTF-8 wire bytes** (the same unit
+ * `maxBufferedBytes` caps), computed from the byte model below. They are
+ * an estimate, not a guaranteed ceiling: a value with heavy JSON escaping
+ * (`\uXXXX`) can exceed the per-character assumption. The number is the
+ * design-time capacity-planning figure, not a runtime meter.
+ *
+ * An unstreamable schema (a REJECT keyword such as `unevaluatedProperties`,
+ * an unknown keyword, or an unresolvable `$ref`) throws
+ * {@link ClassifierError}, the same failure `createStreamValidator` raises
+ * at construction.
+ *
+ * @packageDocumentation
+ */
+
+import type { SchemaObject, SchemaOrBoolean } from "@oav/core";
+import {
+  type Dialect,
+  FORMAT_ASSERTION_VOCAB,
+  jsonSchemaDialect,
+  openapi31Dialect,
+} from "@oav/schema";
+import { classify, type Classification } from "../classifier/index.js";
+import { normalizeOas30 } from "../openapi/index.js";
+import type { StreamValidatorOptions } from "../options.js";
+import { resolveRef as resolveRefLocal } from "../ref-resolve.js";
+
+// --- Byte model (UTF-8 wire bytes; explicit, documented assumptions) ---
+
+/**
+ * Upper-bound bytes per `maxLength` unit for a string. UTF-8 encodes a
+ * BMP code unit in at most 3 bytes; the extra headroom covers light JSON
+ * escaping. Heavy escaping (`\uXXXX` on control characters) can exceed it,
+ * so a string size is an estimate, not a hard ceiling.
+ */
+const BYTES_PER_CHAR = 4;
+/** The two `"` delimiters around a JSON string. */
+const QUOTE_BYTES = 2;
+/** Widest JSON number modeled (sign, digits, exponent). */
+const NUMBER_BYTES = 24;
+/** `"false"`, the longer of the two booleans. */
+const BOOL_BYTES = 5;
+/** `"null"`. */
+const NULL_BYTES = 4;
+/** One structural byte token: a comma, colon, or bracket. */
+const PUNCT_BYTES = 1;
+
+/** A wire-byte size: a finite upper bound, or `"unbounded"`. */
+export type ByteSize = number | "unbounded";
+
+/**
+ * Classification of an entire schema's streaming behavior.
+ *
+ *   - `streamable`: validates forward with no buffering (multi-GB safe).
+ *   - `tee`: forward composition fans events to concurrent sub-spines; no
+ *     materialization, but peak is the sum over branches.
+ *   - `buffer`: at least one position materializes a subtree (an island).
+ *
+ * @public
+ */
+export type StreamClass = "streamable" | "tee" | "buffer";
+
+/**
+ * One position that buffers or tees, the punch list a deployer tightens.
+ *
+ * @public
+ */
+export interface BufferPosition {
+  /** JSON path to the position; `""` is the root. */
+  path: string;
+  /** Whether the position materializes (`buffer`) or fans out (`tee`). */
+  classification: "buffer" | "tee";
+  /** The keyword forcing it (`contains`, `uniqueItems`, `oneOf`, `format`, ...). */
+  keyword: string;
+  /** Max wire bytes this position can hold, or `"unbounded"`. */
+  maxBytes: ByteSize;
+  /** When `maxBytes` is `"unbounded"`, the missing bound (`maxItems`, `maxLength`, ...). */
+  unboundedBy?: string;
+}
+
+/**
+ * The peak-buffer budget for a schema. See {@link analyzeStreamability}.
+ *
+ * @public
+ */
+export interface StreamabilityReport {
+  /** Overall verdict for the whole schema. */
+  classification: StreamClass;
+  /** Schema-intrinsic peak buffer, in wire bytes. `"unbounded"` if any buffering position has no structural bound. */
+  peakBytes: ByteSize;
+  /**
+   * Peak buffer a successful validation reaches under the configured caps
+   * (`maxBufferedBytes`): an island larger than the cap fails at runtime,
+   * so the most a passing stream buffers is `min(intrinsic, cap)`. Equal to
+   * {@link peakBytes} when no cap is set (and then `"unbounded"` if the
+   * intrinsic peak is).
+   */
+  effectivePeakBytes: ByteSize;
+  /** Every buffering / teeing position, in walk order. Empty iff `streamable`. */
+  positions: readonly BufferPosition[];
+}
+
+function isObjectSchema(s: unknown): s is SchemaObject {
+  return typeof s === "object" && s !== null && !Array.isArray(s);
+}
+
+function joinPath(base: string, rel: string): string {
+  if (rel === "") return base;
+  return base === "" ? rel : `${base}.${rel}`;
+}
+
+function addSize(a: ByteSize, b: ByteSize): ByteSize {
+  return a === "unbounded" || b === "unbounded" ? "unbounded" : a + b;
+}
+function maxSize(a: ByteSize, b: ByteSize): ByteSize {
+  return a === "unbounded" || b === "unbounded" ? "unbounded" : Math.max(a, b);
+}
+
+/** Wire bytes of a concrete JSON value (for `const` / `enum` candidates). */
+function literalBytes(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value) ?? "null", "utf8");
+}
+
+// --- Contribution tree: the shape of the peak computation, kept separate
+// from rollup so the intrinsic and capped peaks share one walk. ---
+
+type Contribution =
+  | { kind: "zero" }
+  | { kind: "island"; path: string; keyword: string; intrinsic: ByteSize; unboundedBy?: string }
+  | { kind: "max"; parts: Contribution[] }
+  | { kind: "sum"; path: string; keyword: string; parts: Contribution[] };
+
+/** Collapse a contribution to a size; `capIsland` maps each island's intrinsic size. */
+function rollup(c: Contribution, capIsland: (s: ByteSize) => ByteSize): ByteSize {
+  switch (c.kind) {
+    case "zero":
+      return 0;
+    case "island":
+      return capIsland(c.intrinsic);
+    case "max":
+      return c.parts.reduce<ByteSize>((acc, p) => maxSize(acc, rollup(p, capIsland)), 0);
+    case "sum":
+      return c.parts.reduce<ByteSize>((acc, p) => addSize(acc, rollup(p, capIsland)), 0);
+  }
+}
+
+/** Extract the reported positions (islands and tees) from a contribution tree. */
+function collectPositions(c: Contribution, out: BufferPosition[]): void {
+  switch (c.kind) {
+    case "zero":
+      return;
+    case "island":
+      out.push({
+        path: c.path,
+        classification: "buffer",
+        keyword: c.keyword,
+        maxBytes: c.intrinsic,
+        ...(c.unboundedBy === undefined ? {} : { unboundedBy: c.unboundedBy }),
+      });
+      return;
+    case "max":
+      for (const p of c.parts) collectPositions(p, out);
+      return;
+    case "sum": {
+      // Roll the tee's own intrinsic size from its branches.
+      const intrinsic = rollup(c, (s) => s);
+      out.push({ path: c.path, classification: "tee", keyword: c.keyword, maxBytes: intrinsic });
+      for (const p of c.parts) collectPositions(p, out);
+      return;
+    }
+  }
+}
+
+// --- Materialized-island sizing: the max wire size of a value matching a
+// subtree, bounded by its structural keywords. ---
+
+interface Sized {
+  size: ByteSize;
+  unboundedBy?: string;
+}
+
+const UNBOUNDED = (by: string): Sized => ({ size: "unbounded", unboundedBy: by });
+
+function typeList(node: SchemaObject): string[] | undefined {
+  const t = node.type;
+  if (typeof t === "string") return [t];
+  if (Array.isArray(t)) return t as string[];
+  return undefined;
+}
+
+function sizeOfType(
+  node: SchemaObject,
+  type: string,
+  root: SchemaObject,
+  seen: Set<SchemaObject>,
+): Sized {
+  switch (type) {
+    case "string": {
+      if (typeof node.maxLength !== "number") return UNBOUNDED("maxLength");
+      return { size: node.maxLength * BYTES_PER_CHAR + QUOTE_BYTES };
+    }
+    case "integer":
+    case "number":
+      return { size: NUMBER_BYTES };
+    case "boolean":
+      return { size: BOOL_BYTES };
+    case "null":
+      return { size: NULL_BYTES };
+    case "array": {
+      if (typeof node.maxItems !== "number") return UNBOUNDED("maxItems");
+      const item = arrayItemSchema(node);
+      const itemSize = materialize(item, root, seen);
+      if (itemSize.size === "unbounded") return itemSize;
+      // brackets + maxItems items + (maxItems-1) commas.
+      const size = 2 * PUNCT_BYTES + node.maxItems * (itemSize.size + PUNCT_BYTES);
+      return { size };
+    }
+    case "object":
+      return sizeOfObject(node, root, seen);
+    default:
+      return UNBOUNDED("type");
+  }
+}
+
+// Largest value an array element can take: max over prefixItems and the
+// general items/additionalItems schema.
+function arrayItemSchema(node: SchemaObject): SchemaOrBoolean {
+  const branches: SchemaOrBoolean[] = [];
+  const prefix = (node as Record<string, unknown>).prefixItems;
+  if (Array.isArray(prefix)) branches.push(...(prefix as SchemaOrBoolean[]));
+  if (node.items !== undefined) branches.push(node.items as SchemaOrBoolean);
+  const additional = (node as Record<string, unknown>).additionalItems;
+  if (additional !== undefined) branches.push(additional as SchemaOrBoolean);
+  if (branches.length === 0) return true; // no item constraint: any value
+  if (branches.length === 1) return branches[0] as SchemaOrBoolean;
+  return { anyOf: branches } as SchemaObject; // size = max over branches
+}
+
+function sizeOfObject(node: SchemaObject, root: SchemaObject, seen: Set<SchemaObject>): Sized {
+  const properties = isObjectSchema(node.properties) ? node.properties : undefined;
+  const additionalClosed =
+    node.additionalProperties === false &&
+    (node as Record<string, unknown>).patternProperties === undefined;
+  // An open object (additionalProperties not false) can hold arbitrary
+  // extra members; without a propertyNames/maxProperties bound on count and
+  // key size, its size is unbounded.
+  if (!additionalClosed) return UNBOUNDED("additionalProperties");
+  let total: ByteSize = 2 * PUNCT_BYTES; // braces
+  if (properties === undefined) return { size: total };
+  for (const [key, sub] of Object.entries(properties)) {
+    const valueSize = materialize(sub as SchemaOrBoolean, root, seen);
+    if (valueSize.size === "unbounded") return valueSize;
+    const keyBytes = Buffer.byteLength(key, "utf8") + QUOTE_BYTES + PUNCT_BYTES; // "key":
+    total = addSize(total, keyBytes + valueSize.size + PUNCT_BYTES); // member + comma
+  }
+  return { size: total };
+}
+
+/** Max wire bytes of a value matching `node`, or unbounded with the missing keyword. */
+function materialize(node: SchemaOrBoolean, root: SchemaObject, seen: Set<SchemaObject>): Sized {
+  if (node === true) return UNBOUNDED("type"); // any value
+  if (node === false || !isObjectSchema(node)) return { size: 0 }; // matches nothing
+  if (seen.has(node)) return UNBOUNDED("$ref"); // recursive: unbounded depth
+  const next = new Set(seen).add(node);
+
+  if (typeof node.$ref === "string") {
+    const target = resolveRefLocal(root, node.$ref);
+    if (target === undefined) return UNBOUNDED("$ref");
+    return materialize(target, root, next);
+  }
+
+  if (node.const !== undefined) return { size: literalBytes(node.const) };
+  if (Array.isArray(node.enum)) {
+    return { size: node.enum.reduce<number>((m, v) => Math.max(m, literalBytes(v)), 0) };
+  }
+
+  const types = typeList(node);
+  // A type union admits the largest of its members.
+  let result: Sized = UNBOUNDED("type");
+  if (types !== undefined) {
+    result = { size: 0 };
+    for (const t of types) result = maxSized(result, sizeOfType(node, t, root, next));
+  }
+
+  // Composition tightens (allOf) or widens (anyOf/oneOf) the bound.
+  for (const branch of compositionArray(node, "allOf")) {
+    const s = materialize(branch, root, next);
+    if (s.size !== "unbounded") result = minSized(result, s);
+  }
+  const widen = [...compositionArray(node, "anyOf"), ...compositionArray(node, "oneOf")];
+  if (widen.length > 0) {
+    let w: Sized = { size: 0 };
+    for (const branch of widen) w = maxSized(w, materialize(branch, root, next));
+    result = minSized(result, w);
+  }
+  return result;
+}
+
+function minSized(a: Sized, b: Sized): Sized {
+  if (a.size === "unbounded") return b;
+  if (b.size === "unbounded") return a;
+  return a.size <= b.size ? a : b;
+}
+function maxSized(a: Sized, b: Sized): Sized {
+  if (a.size === "unbounded") return a;
+  if (b.size === "unbounded") return b;
+  return a.size >= b.size ? a : b;
+}
+
+function compositionArray(node: SchemaObject, key: "allOf" | "anyOf" | "oneOf"): SchemaOrBoolean[] {
+  const arr = (node as Record<string, unknown>)[key];
+  return Array.isArray(arr) ? (arr as SchemaOrBoolean[]) : [];
+}
+
+// --- Strategy walk: build the contribution tree from the classification. ---
+
+const COMPOSITION_KEYS = ["allOf", "anyOf", "oneOf", "not", "if"] as const;
+
+function hasComplexValueEquality(node: SchemaObject): boolean {
+  const complex = (v: unknown): boolean => typeof v === "object" && v !== null;
+  if (node.const !== undefined) return complex(node.const);
+  return Array.isArray(node.enum) && node.enum.some(complex);
+}
+
+// The runtime buffer/tee/stream decision, mirroring the spine's
+// `computeKind` (spine.ts): the classifier's strategy, plus the triggers
+// the classifier marks `scalar`/forward but the spine still materializes
+// (`contains`, asserting `format`, `uniqueItems`, complex `enum`/`const`).
+// Relying on the classifier's `strategyOf` alone would miss these and
+// under-report buffering.
+function nodeKind(
+  node: SchemaObject,
+  cls: Classification,
+  formatAsserts: boolean,
+): "stream" | "tee" | "buffer" {
+  if (cls.strategyOf(node) === "buffer") return "buffer";
+  if (node.contains !== undefined) return "buffer";
+  if (
+    (node as Record<string, unknown>).dependentSchemas !== undefined ||
+    (node as Record<string, unknown>).discriminator !== undefined
+  ) {
+    return "buffer";
+  }
+  if (formatAsserts && node.format !== undefined) return "buffer";
+  if (node.uniqueItems === true) return "buffer";
+  if (hasComplexValueEquality(node)) return "buffer";
+  if (cls.strategyOf(node) === "tee") return "tee";
+  return "stream";
+}
+
+// Best-effort name of the keyword that forced a BUFFER verdict, for the report.
+function bufferKeyword(node: SchemaObject, formatAsserts: boolean): string {
+  if (node.uniqueItems === true) return "uniqueItems";
+  if ((node as Record<string, unknown>).dependentSchemas !== undefined) return "dependentSchemas";
+  if ((node as Record<string, unknown>).discriminator !== undefined) return "discriminator";
+  if (hasComplexValueEquality(node)) return node.const !== undefined ? "const" : "enum";
+  if (node.contains !== undefined) return "contains";
+  const deps = (node as Record<string, unknown>).dependencies;
+  if (isObjectSchema(deps) && Object.values(deps).some((e) => !Array.isArray(e))) {
+    return "dependencies";
+  }
+  for (const k of COMPOSITION_KEYS)
+    if ((node as Record<string, unknown>)[k] !== undefined) return k;
+  if (node.pattern !== undefined) return "pattern";
+  if (node.format !== undefined && formatAsserts) return "format";
+  return "buffer";
+}
+
+function teeKeyword(node: SchemaObject): string {
+  for (const k of COMPOSITION_KEYS)
+    if ((node as Record<string, unknown>)[k] !== undefined) return k;
+  return "composition";
+}
+
+interface Child {
+  node: SchemaOrBoolean;
+  rel: string;
+}
+
+// Composition branches of a TEE node, which run as concurrent sub-spines.
+function teeBranches(node: SchemaObject): Child[] {
+  const out: Child[] = [];
+  for (const k of ["allOf", "anyOf", "oneOf"] as const) {
+    const arr = (node as Record<string, unknown>)[k];
+    if (Array.isArray(arr)) {
+      (arr as SchemaOrBoolean[]).forEach((s, i) => out.push({ node: s, rel: `${k}[${i}]` }));
+    }
+  }
+  if (node.not !== undefined) out.push({ node: node.not as SchemaOrBoolean, rel: "not" });
+  for (const k of ["if", "then", "else"] as const) {
+    const s = (node as Record<string, unknown>)[k];
+    if (s !== undefined) out.push({ node: s as SchemaOrBoolean, rel: k });
+  }
+  return out;
+}
+
+// Per-member / per-item children of a STREAM node, which buffer one at a
+// time (peak across them is a max).
+function streamMembers(node: SchemaObject): Child[] {
+  const out: Child[] = [];
+  if (isObjectSchema(node.properties)) {
+    for (const [k, s] of Object.entries(node.properties)) out.push({ node: s, rel: k });
+  }
+  const patternProps = (node as Record<string, unknown>).patternProperties;
+  if (isObjectSchema(patternProps)) {
+    for (const [k, s] of Object.entries(patternProps)) {
+      out.push({ node: s as SchemaOrBoolean, rel: `(${k})` });
+    }
+  }
+  if (node.additionalProperties !== undefined && typeof node.additionalProperties !== "boolean") {
+    out.push({ node: node.additionalProperties as SchemaOrBoolean, rel: "*" });
+  }
+  if (node.items !== undefined) out.push({ node: node.items as SchemaOrBoolean, rel: "[]" });
+  const prefix = (node as Record<string, unknown>).prefixItems;
+  if (Array.isArray(prefix)) {
+    (prefix as SchemaOrBoolean[]).forEach((s, i) => out.push({ node: s, rel: `[${i}]` }));
+  }
+  if (node.contains !== undefined)
+    out.push({ node: node.contains as SchemaOrBoolean, rel: "contains" });
+  return out;
+}
+
+function walk(
+  node: SchemaOrBoolean,
+  path: string,
+  root: SchemaObject,
+  cls: Classification,
+  seen: Set<SchemaObject>,
+  formatAsserts: boolean,
+): Contribution {
+  if (!isObjectSchema(node)) return { kind: "zero" };
+  const strat = nodeKind(node, cls, formatAsserts);
+
+  if (strat === "buffer") {
+    if (seen.has(node)) {
+      return { kind: "island", path, keyword: "$ref", intrinsic: "unbounded", unboundedBy: "$ref" };
+    }
+    const sized = materialize(node, root, new Set());
+    return {
+      kind: "island",
+      path,
+      keyword: bufferKeyword(node, formatAsserts),
+      intrinsic: sized.size,
+      ...(sized.unboundedBy === undefined ? {} : { unboundedBy: sized.unboundedBy }),
+    };
+  }
+
+  // `pattern` accumulates the whole string to test the regex even on the
+  // STREAM path (the spine's `needText`), so it is a forced-buffer scalar
+  // bounded by `maxLength`. Asserting `format` is already a BUFFER island
+  // above; bounded `enum`/`const` scalars buffer a negligible amount and
+  // are not reported.
+  if (strat === "stream" && node.pattern !== undefined) {
+    const bounded = typeof node.maxLength === "number";
+    return {
+      kind: "island",
+      path,
+      keyword: "pattern",
+      intrinsic: bounded ? (node.maxLength as number) * BYTES_PER_CHAR + QUOTE_BYTES : "unbounded",
+      ...(bounded ? {} : { unboundedBy: "maxLength" }),
+    };
+  }
+
+  if (seen.has(node)) return { kind: "zero" }; // recursive STREAM/TEE: counted at first visit
+  const next = new Set(seen).add(node);
+
+  // Follow a bare `$ref` so the referenced subtree's member islands are sized.
+  if (typeof node.$ref === "string") {
+    const target = resolveRefLocal(root, node.$ref);
+    if (!isObjectSchema(target)) return { kind: "zero" };
+    return walk(target, path, root, cls, next, formatAsserts);
+  }
+
+  const memberParts = streamMembers(node).map((m) =>
+    walk(m.node, joinPath(path, m.rel), root, cls, next, formatAsserts),
+  );
+
+  if (strat === "tee") {
+    const sumNode: Contribution = {
+      kind: "sum",
+      path,
+      keyword: teeKeyword(node),
+      parts: teeBranches(node).map((b) =>
+        walk(b.node, joinPath(path, b.rel), root, cls, next, formatAsserts),
+      ),
+    };
+    return { kind: "max", parts: [sumNode, ...memberParts] };
+  }
+
+  return memberParts.length > 0 ? { kind: "max", parts: memberParts } : { kind: "zero" };
+}
+
+// --- Public entry point. ---
+
+/**
+ * Analyze a resolved schema's streaming behavior: classify it, locate every
+ * position that buffers or tees, and roll up a peak-buffer budget in wire
+ * bytes (schema-intrinsic and under the configured caps).
+ *
+ * The options mirror {@link StreamValidatorOptions} so a budget is computed
+ * for the same configuration a validator would run under (`openApiVersion`
+ * / `dialect` select the keyword set and `format` assertion;
+ * `maxBufferedBytes` drives `effectivePeakBytes`; `keywords` / `parity`
+ * affect classification). An unstreamable schema throws
+ * {@link ClassifierError}, the same error `createStreamValidator` raises.
+ *
+ * Wire-byte sizes are an upper-bound estimate (see the module overview),
+ * not a guaranteed ceiling. An `"unbounded"` position is the headline
+ * output: a buffering position with no structural bound, which falls back
+ * to `maxBufferedBytes` at runtime. This is the read-only, design-time view
+ * of the same bounds `enforceBounds` turns into a construction error.
+ *
+ * @public
+ */
+export function analyzeStreamability(
+  schema: SchemaOrBoolean,
+  options: StreamValidatorOptions = {},
+): StreamabilityReport {
+  const normalized = options.openApiVersion === "3.0" ? normalizeOas30(schema) : schema;
+  // Resolve the dialect exactly as the engine does, so the classifier reads
+  // the same keyword set and `formatAsserts` matches the spine's runtime
+  // `format`-buffering decision.
+  const dialect: Dialect =
+    options.dialect ??
+    (options.openApiVersion !== undefined ? openapi31Dialect : jsonSchemaDialect);
+  const cls = classify(normalized, {
+    dialect,
+    ...(options.keywords === undefined ? {} : { customKeywords: Object.keys(options.keywords) }),
+    ...(options.parity === undefined ? {} : { parity: options.parity }),
+  });
+
+  if (!isObjectSchema(normalized)) {
+    return { classification: "streamable", peakBytes: 0, effectivePeakBytes: 0, positions: [] };
+  }
+
+  const formatAsserts = dialect.vocabularies.some((v) => v.uri === FORMAT_ASSERTION_VOCAB);
+  const tree = walk(normalized, "", normalized, cls, new Set(), formatAsserts);
+
+  const positions: BufferPosition[] = [];
+  collectPositions(tree, positions);
+
+  const peakBytes = rollup(tree, (s) => s);
+  const cap = options.maxBufferedBytes;
+  const capIsland = (s: ByteSize): ByteSize =>
+    cap === undefined ? s : s === "unbounded" ? cap : Math.min(s, cap);
+  const effectivePeakBytes = rollup(tree, capIsland);
+
+  const classification: StreamClass =
+    positions.length === 0
+      ? "streamable"
+      : positions.some((p) => p.classification === "buffer")
+        ? "buffer"
+        : "tee";
+
+  return { classification, peakBytes, effectivePeakBytes, positions };
+}

--- a/packages/stream-validator/src/analyzer/analyze.ts
+++ b/packages/stream-validator/src/analyzer/analyze.ts
@@ -125,7 +125,9 @@ function isObjectSchema(s: unknown): s is SchemaObject {
 
 function joinPath(base: string, rel: string): string {
   if (rel === "") return base;
-  return base === "" ? rel : `${base}.${rel}`;
+  if (base === "") return rel;
+  // An array-index segment (`[]`, `[0]`) reads better with no separating dot.
+  return rel.startsWith("[") ? `${base}${rel}` : `${base}.${rel}`;
 }
 
 function addSize(a: ByteSize, b: ByteSize): ByteSize {

--- a/packages/stream-validator/src/analyzer/index.ts
+++ b/packages/stream-validator/src/analyzer/index.ts
@@ -5,3 +5,4 @@ export {
   type StreamabilityReport,
   type StreamClass,
 } from "./analyze.js";
+export { analyzeSpec, type BodyBudget, type OperationBudget, type SpecBudget } from "./spec.js";

--- a/packages/stream-validator/src/analyzer/index.ts
+++ b/packages/stream-validator/src/analyzer/index.ts
@@ -1,0 +1,7 @@
+export {
+  analyzeStreamability,
+  type BufferPosition,
+  type ByteSize,
+  type StreamabilityReport,
+  type StreamClass,
+} from "./analyze.js";

--- a/packages/stream-validator/src/analyzer/spec.ts
+++ b/packages/stream-validator/src/analyzer/spec.ts
@@ -1,0 +1,182 @@
+/**
+ * Per-operation streamability rollup over a resolved OpenAPI document. For
+ * every operation it analyzes the request body and each response body and
+ * returns a peak-buffer budget per body, so a deployer can see, spec-wide,
+ * which operations stream and which buffer (and where).
+ *
+ * The document must already be resolved (external `$ref`s inlined, e.g. via
+ * `resolveSpec`); this walk follows only local `#/components/...` refs. It is
+ * engine-free (it calls {@link analyzeStreamability}, never the streaming
+ * engine), so it does not pull the engine into a consumer that only wants
+ * the analysis.
+ *
+ * @packageDocumentation
+ */
+
+import type {
+  OpenAPIDocument,
+  OperationObject,
+  RequestBodyObject,
+  ResponseObject,
+} from "@oav/core";
+import {
+  carryComponents,
+  HTTP_METHODS,
+  resolveLocalRef,
+  versionFromDoc,
+} from "../openapi/body-schema.js";
+import type { StreamValidatorOptions } from "../options.js";
+import { analyzeStreamability, type StreamabilityReport } from "./analyze.js";
+
+/**
+ * The streamability budget for one request or response body of an operation.
+ * Exactly one of `report` / `error` is present: `error` holds the message
+ * when the body's schema cannot be classified (an unstreamable keyword, an
+ * unknown keyword, or an unresolvable `$ref`), the same failure
+ * `createStreamValidator` would raise.
+ *
+ * @public
+ */
+export interface BodyBudget {
+  /** Whether this is the request body or a response body. */
+  role: "request" | "response";
+  /** Response status key (`"200"`, `"default"`); absent for the request. */
+  status?: string;
+  /** The body media type (`"application/json"`, ...). */
+  mediaType: string;
+  /** The peak-buffer budget, when the schema classifies. */
+  report?: StreamabilityReport;
+  /** The classification error message, when it does not. */
+  error?: string;
+}
+
+/**
+ * The budget for one operation: every request/response body that carries a
+ * schema, in document order (request first).
+ *
+ * @public
+ */
+export interface OperationBudget {
+  /** HTTP method, upper-cased (`"POST"`). */
+  method: string;
+  /** Path-template key as declared (`"/pets/{id}"`). */
+  path: string;
+  /** Per-body budgets; empty when the operation declares no body schema. */
+  bodies: BodyBudget[];
+}
+
+/**
+ * A spec-wide streamability rollup. See {@link analyzeSpec}.
+ *
+ * @public
+ */
+export interface SpecBudget {
+  /** One entry per operation that carries at least one body schema. */
+  operations: OperationBudget[];
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+// Analyze one media-type schema, capturing a classification failure as a
+// per-body error so one bad body does not abort the whole sweep.
+function budgetForBody(
+  doc: OpenAPIDocument,
+  content: Record<string, unknown> | undefined,
+  base: { role: "request" | "response"; status?: string },
+  options: StreamValidatorOptions,
+): BodyBudget[] {
+  if (!isRecord(content)) return [];
+  const out: BodyBudget[] = [];
+  for (const [mediaType, mto] of Object.entries(content)) {
+    const schema = isRecord(mto) ? (mto.schema as unknown) : undefined;
+    if (schema === undefined) continue; // a media type with no schema is unconstrained
+    const entry: BodyBudget = { ...base, mediaType };
+    try {
+      entry.report = analyzeStreamability(carryComponents(doc, schema as never), options);
+    } catch (e) {
+      entry.error = e instanceof Error ? e.message : String(e);
+    }
+    out.push(entry);
+  }
+  return out;
+}
+
+function bodiesForOperation(
+  doc: OpenAPIDocument,
+  op: OperationObject,
+  where: string,
+  options: StreamValidatorOptions,
+): BodyBudget[] {
+  const bodies: BodyBudget[] = [];
+
+  if (op.requestBody !== undefined) {
+    try {
+      const rb = resolveLocalRef<RequestBodyObject>(doc, op.requestBody, "requestBody", where);
+      bodies.push(...budgetForBody(doc, rb.content, { role: "request" }, options));
+    } catch (e) {
+      bodies.push({
+        role: "request",
+        mediaType: "*",
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  for (const [status, responseOrRef] of Object.entries(op.responses ?? {})) {
+    try {
+      const resp = resolveLocalRef<ResponseObject>(
+        doc,
+        responseOrRef,
+        "response",
+        `${where} -> ${status}`,
+      );
+      bodies.push(...budgetForBody(doc, resp.content, { role: "response", status }, options));
+    } catch (e) {
+      bodies.push({
+        role: "response",
+        status,
+        mediaType: "*",
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  return bodies;
+}
+
+/**
+ * Roll up a streamability budget for every operation in a resolved OpenAPI
+ * document. The OpenAPI version is read off `doc.openapi` (override with
+ * `options.openApiVersion`) and applied to every body; other options
+ * (`maxBufferedBytes`, `dialect`, ...) thread through to
+ * {@link analyzeStreamability}.
+ *
+ * Operations with no body schema are omitted. A body whose schema cannot be
+ * classified is reported with `error` set rather than throwing, so a sweep
+ * over real specs surveys the whole document.
+ *
+ * @public
+ */
+export function analyzeSpec(
+  doc: OpenAPIDocument,
+  options: StreamValidatorOptions = {},
+): SpecBudget {
+  const openApiVersion = options.openApiVersion ?? versionFromDoc(doc.openapi);
+  const merged: StreamValidatorOptions =
+    openApiVersion === undefined ? options : { ...options, openApiVersion };
+
+  const operations: OperationBudget[] = [];
+  for (const [path, pathItem] of Object.entries(doc.paths ?? {})) {
+    if (!isRecord(pathItem)) continue;
+    for (const method of HTTP_METHODS) {
+      const op = pathItem[method];
+      if (!isRecord(op)) continue;
+      const where = `${method.toUpperCase()} "${path}"`;
+      const bodies = bodiesForOperation(doc, op as OperationObject, where, merged);
+      if (bodies.length > 0) operations.push({ method: method.toUpperCase(), path, bodies });
+    }
+  }
+  return { operations };
+}

--- a/packages/stream-validator/src/index.ts
+++ b/packages/stream-validator/src/index.ts
@@ -37,6 +37,13 @@ export {
   type StreamValidator,
   type ValueEvent,
 } from "./engine/index.js";
+export {
+  analyzeStreamability,
+  type BufferPosition,
+  type ByteSize,
+  type StreamabilityReport,
+  type StreamClass,
+} from "./analyzer/index.js";
 export { type OperationLocator, streamValidatorForOperation } from "./operation.js";
 export { BufferLimitError, UniqueItemsLimitError } from "./spine/index.js";
 export type { StreamVerdict, SchemaViolation } from "./spine/index.js";

--- a/packages/stream-validator/src/index.ts
+++ b/packages/stream-validator/src/index.ts
@@ -38,9 +38,13 @@ export {
   type ValueEvent,
 } from "./engine/index.js";
 export {
+  analyzeSpec,
   analyzeStreamability,
+  type BodyBudget,
   type BufferPosition,
   type ByteSize,
+  type OperationBudget,
+  type SpecBudget,
   type StreamabilityReport,
   type StreamClass,
 } from "./analyzer/index.js";

--- a/packages/stream-validator/src/index.ts
+++ b/packages/stream-validator/src/index.ts
@@ -1,10 +1,9 @@
 /**
- * `@oav/stream-validator` (incubating): a streaming JSON Schema 2020-12
- * validator. It validates a JSON document against a resolved schema as
- * the bytes stream, echoing them through unchanged while reporting
- * violations on a side channel. Memory is bounded for forward-decidable
- * schemas with structural bounds, so multi-GB bodies validate without
- * materializing in heap.
+ * `@oav/stream-validator`: a streaming JSON Schema 2020-12 validator. It
+ * validates a JSON document against a resolved schema as the bytes stream,
+ * echoing them through unchanged while reporting violations on a side
+ * channel. Memory is bounded for forward-decidable schemas with structural
+ * bounds, so multi-GB bodies validate without materializing in heap.
  *
  * This is a second engine, push-based over a token stream, distinct from
  * `@oav/schema`'s pull-based compiler. It reuses `@oav/schema`'s
@@ -12,9 +11,8 @@
  * BUFFER (so format assertion and built-in formats come from that
  * delegate), and reuses `@oav/core`'s flat error model.
  *
- * Published as `@aahoughton/oav-stream-validator` on the `experimental`
- * dist-tag during incubation, versioned independently of the `oav-core`
- * family.
+ * Published as `@aahoughton/oav-stream-validator`, versioned independently
+ * of the `oav-core` family (its own `0.x` line).
  *
  * @packageDocumentation
  */

--- a/packages/stream-validator/src/openapi/body-schema.ts
+++ b/packages/stream-validator/src/openapi/body-schema.ts
@@ -1,0 +1,119 @@
+/**
+ * Engine-free helpers for pulling a body schema out of a resolved OpenAPI
+ * document and shaping it for classification: HTTP-method recognition,
+ * version detection, local `$ref` following, and carrying the document's
+ * `components` container so internal refs resolve.
+ *
+ * Kept separate from `operation.ts` (which builds a `StreamValidator` and so
+ * imports the engine) so the analyzer can reuse the same extraction without
+ * pulling the streaming engine into its dependency subgraph. See the
+ * `./analyzer` subpath export.
+ *
+ * @packageDocumentation
+ */
+
+import type { OpenAPIDocument, SchemaObject, SchemaOrBoolean } from "@oav/core";
+import type { StreamValidatorOptions } from "../options.js";
+import { resolveRef } from "../ref-resolve.js";
+
+/** HTTP methods an OpenAPI Path Item Object may carry an operation under. */
+export const HTTP_METHODS = new Set<string>([
+  "get",
+  "put",
+  "post",
+  "delete",
+  "options",
+  "head",
+  "patch",
+  "trace",
+  "query",
+]);
+
+/**
+ * Map an OpenAPI version string (`"3.0.3"`) to the engine's normalization
+ * selector. Unknown prefixes return undefined (treated as raw JSON Schema,
+ * or overridden via `options.openApiVersion`).
+ */
+export function versionFromDoc(openapi: string): StreamValidatorOptions["openApiVersion"] {
+  if (openapi.startsWith("3.0")) return "3.0";
+  if (openapi.startsWith("3.1")) return "3.1";
+  if (openapi.startsWith("3.2")) return "3.2";
+  return undefined;
+}
+
+export function isObjectSchema(s: unknown): s is SchemaObject {
+  return typeof s === "object" && s !== null && !Array.isArray(s);
+}
+
+/**
+ * Follow a (possibly `$ref`'d) container object (a `requestBody` or a
+ * `response`) to its object form. A local `#/components/...` ref is a normal
+ * shape `resolveSpec` leaves in place, so resolve it here; an external ref
+ * should have been inlined upstream, so surface a clear error if one
+ * survived. `what` names the container in the error (`requestBody` /
+ * `response`); `where` names the operation.
+ */
+export function resolveLocalRef<T = Record<string, unknown>>(
+  doc: OpenAPIDocument,
+  node: unknown,
+  what: string,
+  where: string,
+): T {
+  let current = node;
+  for (let hops = 0; hops < 32; hops++) {
+    if (current === null || typeof current !== "object") break;
+    const ref = (current as { $ref?: unknown }).$ref;
+    if (typeof ref !== "string") return current as T;
+    if (!ref.startsWith("#")) {
+      throw new Error(
+        `external ${what} ref "${ref}" for ${where} not resolved; run resolveSpec() over the document first`,
+      );
+    }
+    const target = resolveRef(doc as unknown as SchemaObject, ref);
+    if (target === undefined) {
+      throw new Error(`${what} ref "${ref}" for ${where} does not resolve`);
+    }
+    current = target;
+  }
+  throw new Error(`${what} $ref chain for ${where} exceeded 32 hops (possible cycle)`);
+}
+
+/**
+ * Follow a top-level body `$ref` to its non-`$ref` node form. A bare-`$ref`
+ * body schema (`{ $ref }`) cannot carry a `components` sibling: 3.0
+ * `$ref`-sibling suppression (`normalizeOas30`) drops the sibling, leaving
+ * the internal ref with nothing to resolve against. Dereferencing first
+ * leaves a non-`$ref` root the container can sit beside, and internal refs
+ * inside the target still resolve through the carried `components`. Returns
+ * the schema unchanged when the top-level node is not a `$ref`, or when the
+ * ref does not resolve locally (the classifier then throws a clear
+ * `unresolvable $ref`).
+ */
+export function derefTopLevelSchemaRef(
+  doc: OpenAPIDocument,
+  schema: SchemaOrBoolean,
+): SchemaOrBoolean {
+  let current = schema;
+  for (let hops = 0; hops < 32; hops++) {
+    if (!isObjectSchema(current) || typeof current.$ref !== "string") return current;
+    const target = resolveRef(doc as unknown as SchemaObject, current.$ref);
+    if (target === undefined) return schema;
+    current = target;
+  }
+  return schema;
+}
+
+/**
+ * Shape a body schema for classification: dereference a top-level `$ref` and
+ * carry the document's `components` so internal refs resolve. A boolean
+ * schema needs nothing and is returned as-is.
+ */
+export function carryComponents(
+  doc: OpenAPIDocument,
+  bodySchema: SchemaOrBoolean,
+): SchemaOrBoolean {
+  const resolvedBody = derefTopLevelSchemaRef(doc, bodySchema);
+  return isObjectSchema(resolvedBody) && doc.components !== undefined
+    ? ({ ...resolvedBody, components: doc.components } as SchemaObject)
+    : resolvedBody;
+}

--- a/packages/stream-validator/src/operation.ts
+++ b/packages/stream-validator/src/operation.ts
@@ -21,94 +21,15 @@
  * @packageDocumentation
  */
 
-import type {
-  HttpMethod,
-  OpenAPIDocument,
-  RequestBodyObject,
-  SchemaObject,
-  SchemaOrBoolean,
-} from "@oav/core";
+import type { HttpMethod, OpenAPIDocument, RequestBodyObject } from "@oav/core";
 import { createStreamValidator, type StreamValidator } from "./engine/index.js";
+import {
+  carryComponents,
+  HTTP_METHODS,
+  resolveLocalRef,
+  versionFromDoc,
+} from "./openapi/body-schema.js";
 import type { StreamValidatorOptions } from "./options.js";
-import { resolveRef } from "./ref-resolve.js";
-
-const HTTP_METHODS = new Set<string>([
-  "get",
-  "put",
-  "post",
-  "delete",
-  "options",
-  "head",
-  "patch",
-  "trace",
-  "query",
-]);
-
-// Map an OpenAPI version string ("3.0.3") to the engine's normalization
-// selector. Unknown prefixes return undefined (treated as raw JSON Schema,
-// or overridden via options.openApiVersion).
-function versionFromDoc(openapi: string): StreamValidatorOptions["openApiVersion"] {
-  if (openapi.startsWith("3.0")) return "3.0";
-  if (openapi.startsWith("3.1")) return "3.1";
-  if (openapi.startsWith("3.2")) return "3.2";
-  return undefined;
-}
-
-function isObjectSchema(s: SchemaOrBoolean): s is SchemaObject {
-  return typeof s === "object" && s !== null && !Array.isArray(s);
-}
-
-// Follow a (possibly $ref'd) requestBody to its object form. A local
-// `#/components/requestBodies/...` ref is a normal shape resolveSpec leaves
-// in place, so resolve it here (mirroring @oav/validator's
-// resolveOperationRef) rather than rejecting it. External refs should have
-// been inlined upstream; surface a clear error if one survived.
-function resolveRequestBody(
-  doc: OpenAPIDocument,
-  requestBody: RequestBodyObject | { $ref: string },
-  where: string,
-): RequestBodyObject {
-  let current: unknown = requestBody;
-  for (let hops = 0; hops < 32; hops++) {
-    if (current === null || typeof current !== "object") break;
-    const ref = (current as { $ref?: unknown }).$ref;
-    if (typeof ref !== "string") return current as RequestBodyObject;
-    if (!ref.startsWith("#")) {
-      throw new Error(
-        `streamValidatorForOperation: external requestBody ref "${ref}" for ${where} not resolved; run resolveSpec() over the document first`,
-      );
-    }
-    const target = resolveRef(doc as unknown as SchemaObject, ref);
-    if (target === undefined) {
-      throw new Error(
-        `streamValidatorForOperation: requestBody ref "${ref}" for ${where} does not resolve`,
-      );
-    }
-    current = target;
-  }
-  throw new Error(
-    `streamValidatorForOperation: requestBody $ref chain for ${where} exceeded 32 hops (possible cycle)`,
-  );
-}
-
-// Follow a top-level body `$ref` to its non-`$ref` node form. A bare-`$ref`
-// body schema (`{ $ref }`) cannot carry a `components` sibling: 3.0
-// `$ref`-sibling suppression (normalizeOas30) drops the sibling, leaving the
-// internal ref with nothing to resolve against. Dereferencing first leaves a
-// non-`$ref` root the container can sit beside, and internal refs inside the
-// target still resolve through the carried `components`. Returns the schema
-// unchanged when the top-level node is not a `$ref`, or when the ref does not
-// resolve locally (the classifier then throws a clear `unresolvable $ref`).
-function derefTopLevelSchemaRef(doc: OpenAPIDocument, schema: SchemaOrBoolean): SchemaOrBoolean {
-  let current = schema;
-  for (let hops = 0; hops < 32; hops++) {
-    if (!isObjectSchema(current) || typeof current.$ref !== "string") return current;
-    const target = resolveRef(doc as unknown as SchemaObject, current.$ref);
-    if (target === undefined) return schema;
-    current = target;
-  }
-  return schema;
-}
 
 /**
  * Locates a request body within an {@link OpenAPIDocument}.
@@ -172,7 +93,12 @@ export function streamValidatorForOperation(
   if (operation.requestBody === undefined) {
     throw new Error(`streamValidatorForOperation: ${where} has no requestBody`);
   }
-  const requestBody = resolveRequestBody(doc, operation.requestBody, where);
+  const requestBody = resolveLocalRef<RequestBodyObject>(
+    doc,
+    operation.requestBody,
+    "requestBody",
+    where,
+  );
   const mediaType = locator.mediaType ?? "application/json";
   const mediaTypeObject = requestBody.content[mediaType];
   if (mediaTypeObject === undefined) {
@@ -184,14 +110,8 @@ export function streamValidatorForOperation(
   }
 
   // Carry the document's ref container so an internal `$ref` in the body
-  // schema resolves. Dereference a top-level body `$ref` first so the
-  // container sits beside a non-`$ref` root (see derefTopLevelSchemaRef). A
-  // boolean schema needs nothing and is passed as-is.
-  const resolvedBody = derefTopLevelSchemaRef(doc, bodySchema);
-  const schema: SchemaOrBoolean =
-    isObjectSchema(resolvedBody) && doc.components !== undefined
-      ? ({ ...resolvedBody, components: doc.components } as SchemaObject)
-      : resolvedBody;
+  // schema resolves (deref a top-level `$ref` first; see carryComponents).
+  const schema = carryComponents(doc, bodySchema);
 
   const openApiVersion = options.openApiVersion ?? versionFromDoc(doc.openapi);
   return createStreamValidator(schema, {

--- a/packages/stream-validator/test/analyze-spec.test.ts
+++ b/packages/stream-validator/test/analyze-spec.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import type { OpenAPIDocument } from "@oav/core";
+import { analyzeSpec } from "../src/index.js";
+
+function doc(partial: Record<string, unknown>): OpenAPIDocument {
+  return {
+    openapi: "3.1.0",
+    info: { title: "t", version: "1" },
+    ...partial,
+  } as OpenAPIDocument;
+}
+
+describe("analyzeSpec", () => {
+  it("analyzes request and response bodies, in document order", () => {
+    const budget = analyzeSpec(
+      doc({
+        paths: {
+          "/pets": {
+            post: {
+              requestBody: {
+                content: { "application/json": { schema: { type: "object" } } },
+              },
+              responses: {
+                "200": { content: { "application/json": { schema: { type: "array" } } } },
+                default: { content: { "application/json": { schema: { type: "string" } } } },
+              },
+            },
+          },
+        },
+      }),
+    );
+    expect(budget.operations).toHaveLength(1);
+    const op = budget.operations[0]!;
+    expect(op.method).toBe("POST");
+    expect(op.path).toBe("/pets");
+    expect(op.bodies.map((b) => [b.role, b.status])).toEqual([
+      ["request", undefined],
+      ["response", "200"],
+      ["response", "default"],
+    ]);
+    expect(op.bodies.every((b) => b.report?.classification === "streamable")).toBe(true);
+  });
+
+  it("omits operations with no body schema", () => {
+    const budget = analyzeSpec(
+      doc({ paths: { "/ping": { get: { responses: { "204": { description: "no content" } } } } } }),
+    );
+    expect(budget.operations).toEqual([]);
+  });
+
+  it("carries components so an internal $ref body resolves and surfaces unbounded positions", () => {
+    const budget = analyzeSpec(
+      doc({
+        paths: {
+          "/pets": {
+            post: {
+              requestBody: {
+                content: { "application/json": { schema: { $ref: "#/components/schemas/Pet" } } },
+              },
+            },
+          },
+        },
+        components: {
+          schemas: {
+            Pet: {
+              type: "object",
+              additionalProperties: false,
+              properties: { name: { type: "string", pattern: "^.+$" } },
+            },
+          },
+        },
+      }),
+    );
+    const report = budget.operations[0]!.bodies[0]!.report!;
+    expect(report.classification).toBe("buffer");
+    expect(report.positions).toContainEqual(
+      expect.objectContaining({ path: "name", keyword: "pattern", maxBytes: "unbounded" }),
+    );
+  });
+
+  it("follows a local response $ref", () => {
+    const budget = analyzeSpec(
+      doc({
+        paths: {
+          "/pets": {
+            get: { responses: { "200": { $ref: "#/components/responses/Pets" } } },
+          },
+        },
+        components: {
+          responses: {
+            Pets: { content: { "application/json": { schema: { type: "array" } } } },
+          },
+        },
+      }),
+    );
+    expect(budget.operations[0]!.bodies[0]).toMatchObject({ role: "response", status: "200" });
+    expect(budget.operations[0]!.bodies[0]!.report?.classification).toBe("streamable");
+  });
+
+  it("captures a classification failure per body instead of throwing", () => {
+    const budget = analyzeSpec(
+      doc({
+        paths: {
+          "/x": {
+            post: {
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: { type: "object", unevaluatedProperties: false },
+                  },
+                },
+              },
+              responses: {
+                "200": { content: { "application/json": { schema: { type: "string" } } } },
+              },
+            },
+          },
+        },
+      }),
+    );
+    const bodies = budget.operations[0]!.bodies;
+    expect(bodies[0]!.error).toMatch(/unevaluatedProperties/);
+    expect(bodies[0]!.report).toBeUndefined();
+    // The bad request body does not stop the response from being analyzed.
+    expect(bodies[1]!.report?.classification).toBe("streamable");
+  });
+
+  it("reads the OpenAPI version off doc.openapi (3.0 format is annotation, not buffered)", () => {
+    // Under 3.0 OpenAPI semantics `format` asserts, so a format string buffers;
+    // proving the version is detected. A bare 2020-12 schema would not.
+    const budget = analyzeSpec(
+      doc({
+        openapi: "3.0.3",
+        paths: {
+          "/x": {
+            post: {
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      additionalProperties: false,
+                      properties: { when: { type: "string", format: "date-time" } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+    expect(budget.operations[0]!.bodies[0]!.report?.classification).toBe("buffer");
+  });
+});

--- a/packages/stream-validator/test/analyze.test.ts
+++ b/packages/stream-validator/test/analyze.test.ts
@@ -183,6 +183,27 @@ describe("analyzeStreamability", () => {
     expect(r.positions.map((p) => p.path)).toContain("tags[]");
   });
 
+  it("renders composition-branch path segments with a dot, not brackets", () => {
+    // A oneOf whose first branch is an array and second is a scalar: the
+    // unbounded leaves are at `documents.oneOf.0[]` (array item of branch 0)
+    // and `documents.oneOf.1` (branch 1), not `oneOf[0][]` / `oneOf[1]`.
+    const r = analyze({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        documents: {
+          oneOf: [
+            { type: "array", items: { type: "string", pattern: "^.+$" } },
+            { type: "string", pattern: "^.+$" },
+          ],
+        },
+      },
+    } as unknown as SchemaObject);
+    const paths = r.positions.filter((p) => p.classification === "buffer").map((p) => p.path);
+    expect(paths).toContain("documents.oneOf.0[]");
+    expect(paths).toContain("documents.oneOf.1");
+  });
+
   it("throws ClassifierError on an unstreamable schema (same as construction)", () => {
     expect(() => analyze({ type: "object", unevaluatedProperties: false } as SchemaObject)).toThrow(
       ClassifierError,

--- a/packages/stream-validator/test/analyze.test.ts
+++ b/packages/stream-validator/test/analyze.test.ts
@@ -1,0 +1,240 @@
+import { Readable, Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { describe, expect, it } from "vitest";
+import type { SchemaObject, SchemaOrBoolean } from "@oav/core";
+import {
+  analyzeStreamability,
+  createStreamValidator,
+  ValidationFailedError,
+} from "../src/index.js";
+import { ClassifierError } from "../src/classifier/index.js";
+
+// Byte model (mirrors analyze.ts, kept here so the expectations are
+// self-documenting): string = maxLength*4 + 2 quotes; number = 24;
+// array = 2 brackets + n*(item + comma); object = 2 braces + sum of members.
+const str = (maxLength: number): number => maxLength * 4 + 2;
+const uniqueArray = (n: number, item: number): number => 2 + n * (item + 1);
+
+function analyze(schema: SchemaOrBoolean, options = {}) {
+  return analyzeStreamability(schema, options);
+}
+
+describe("analyzeStreamability", () => {
+  it("reports a fully-streamable schema with no buffering", () => {
+    const r = analyze({
+      type: "object",
+      additionalProperties: false,
+      properties: { name: { type: "string", maxLength: 10 }, age: { type: "integer" } },
+    } as SchemaObject);
+    expect(r.classification).toBe("streamable");
+    expect(r.peakBytes).toBe(0);
+    expect(r.effectivePeakBytes).toBe(0);
+    expect(r.positions).toEqual([]);
+  });
+
+  it("sizes a bounded uniqueItems array as a buffer island", () => {
+    const r = analyze({
+      type: "array",
+      uniqueItems: true,
+      maxItems: 3,
+      items: { type: "string", maxLength: 5 },
+    } as SchemaObject);
+    expect(r.classification).toBe("buffer");
+    expect(r.peakBytes).toBe(uniqueArray(3, str(5))); // 2 + 3*(22+1) = 71
+    expect(r.positions).toEqual([
+      { path: "", classification: "buffer", keyword: "uniqueItems", maxBytes: 71 },
+    ]);
+  });
+
+  it("flags an unbounded uniqueItems array (no maxItems) with the missing keyword", () => {
+    const r = analyze({
+      type: "array",
+      uniqueItems: true,
+      items: { type: "string" },
+    } as SchemaObject);
+    expect(r.peakBytes).toBe("unbounded");
+    expect(r.positions[0]).toMatchObject({
+      classification: "buffer",
+      keyword: "uniqueItems",
+      maxBytes: "unbounded",
+      unboundedBy: "maxItems",
+    });
+  });
+
+  it("sizes a complex const as a buffer island from its serialized form", () => {
+    const value = { a: 1, b: "two" };
+    const r = analyze({ const: value } as SchemaObject);
+    expect(r.classification).toBe("buffer");
+    expect(r.peakBytes).toBe(Buffer.byteLength(JSON.stringify(value), "utf8"));
+    expect(r.positions[0]).toMatchObject({ keyword: "const", classification: "buffer" });
+  });
+
+  it("treats pattern as a forced-buffer scalar bounded by maxLength", () => {
+    const bounded = analyze({ type: "string", pattern: "^x", maxLength: 10 } as SchemaObject);
+    expect(bounded.classification).toBe("buffer");
+    expect(bounded.peakBytes).toBe(str(10));
+    expect(bounded.positions[0]).toMatchObject({ keyword: "pattern", maxBytes: 42 });
+
+    const unbounded = analyze({ type: "string", pattern: "^x" } as SchemaObject);
+    expect(unbounded.peakBytes).toBe("unbounded");
+    expect(unbounded.positions[0]).toMatchObject({ keyword: "pattern", unboundedBy: "maxLength" });
+  });
+
+  it("buffers format only under an asserting (OpenAPI) dialect", () => {
+    const schema = { type: "string", format: "date-time", maxLength: 30 } as SchemaObject;
+    // Plain JSON Schema: format is an annotation, not asserted -> streams.
+    expect(analyze(schema).classification).toBe("streamable");
+    // OpenAPI dialect asserts format -> the spine buffers the string.
+    const oas = analyze(schema, { openApiVersion: "3.1" });
+    expect(oas.classification).toBe("buffer");
+    expect(oas.peakBytes).toBe(str(30));
+    expect(oas.positions[0]).toMatchObject({ keyword: "format", maxBytes: 122 });
+  });
+
+  it("takes a max (not a sum) across sequential buffering siblings", () => {
+    const island = {
+      type: "array",
+      uniqueItems: true,
+      maxItems: 2,
+      items: { type: "string", maxLength: 3 },
+    };
+    const r = analyze({
+      type: "object",
+      additionalProperties: false,
+      properties: { a: island, b: island },
+    } as unknown as SchemaObject);
+    // One island at a time: peak is the single island's size, not 2x.
+    expect(r.peakBytes).toBe(uniqueArray(2, str(3))); // 2 + 2*(14+1) = 32
+    expect(r.positions).toHaveLength(2);
+  });
+
+  it("takes a sum across concurrent tee branches", () => {
+    const island = {
+      type: "array",
+      uniqueItems: true,
+      maxItems: 2,
+      items: { type: "string", maxLength: 3 },
+    };
+    const r = analyze({ oneOf: [island, { type: "integer" }] } as unknown as SchemaObject);
+    expect(r.classification).toBe("buffer"); // a branch buffers
+    // The tee fans events to concurrent sub-spines: branch islands sum.
+    expect(r.peakBytes).toBe(uniqueArray(2, str(3))); // 32 + 0
+    const tee = r.positions.find((p) => p.classification === "tee");
+    expect(tee).toMatchObject({ keyword: "oneOf", maxBytes: 32 });
+  });
+
+  it("reports a scalar tee with zero buffer", () => {
+    const r = analyze({
+      oneOf: [{ type: "string", maxLength: 5 }, { type: "integer" }],
+    } as SchemaObject);
+    expect(r.classification).toBe("tee");
+    expect(r.peakBytes).toBe(0);
+    expect(r.positions).toEqual([
+      { path: "", classification: "tee", keyword: "oneOf", maxBytes: 0 },
+    ]);
+  });
+
+  it("clamps effectivePeakBytes by maxBufferedBytes; peakBytes stays intrinsic", () => {
+    const bounded = analyze(
+      {
+        type: "array",
+        uniqueItems: true,
+        maxItems: 3,
+        items: { type: "string", maxLength: 5 },
+      } as SchemaObject,
+      { maxBufferedBytes: 50 },
+    );
+    expect(bounded.peakBytes).toBe(71);
+    expect(bounded.effectivePeakBytes).toBe(50); // min(71, 50)
+
+    const unbounded = analyze(
+      { type: "array", uniqueItems: true, items: { type: "string" } } as SchemaObject,
+      { maxBufferedBytes: 1000 },
+    );
+    expect(unbounded.peakBytes).toBe("unbounded");
+    expect(unbounded.effectivePeakBytes).toBe(1000); // unbounded island clamps to the cap
+  });
+
+  it("reports paths for nested buffering positions", () => {
+    const r = analyze({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        tags: {
+          type: "array",
+          uniqueItems: true,
+          maxItems: 4,
+          items: { type: "string", maxLength: 8 },
+        },
+      },
+    } as unknown as SchemaObject);
+    expect(r.positions[0]).toMatchObject({ path: "tags", keyword: "uniqueItems" });
+  });
+
+  it("throws ClassifierError on an unstreamable schema (same as construction)", () => {
+    expect(() => analyze({ type: "object", unevaluatedProperties: false } as SchemaObject)).toThrow(
+      ClassifierError,
+    );
+  });
+
+  it("classifies a boolean schema as streamable", () => {
+    expect(analyze(true).classification).toBe("streamable");
+    expect(analyze(true).peakBytes).toBe(0);
+  });
+});
+
+// Soundness against the real engine: a validation never buffers more than
+// the analyzer's reported peak. Running the actual validator with
+// maxBufferedBytes set to peakBytes must succeed; a cap below what the
+// engine actually buffers must fail. This ties the static number to runtime
+// behavior, the "verified against the spine" claim in #431.
+describe("analyzeStreamability: peakBytes is a sound upper bound on real buffering", () => {
+  const enc = new TextEncoder();
+
+  async function runWithCap(
+    schema: SchemaOrBoolean,
+    value: unknown,
+    maxBufferedBytes: number,
+  ): Promise<Error | undefined> {
+    const validator = createStreamValidator(schema, { maxBufferedBytes });
+    validator.on("error", () => {});
+    void validator.result.catch(() => {}); // swallow the parallel result rejection
+    try {
+      await pipeline(
+        Readable.from(Buffer.from(enc.encode(JSON.stringify(value)))),
+        validator,
+        new Writable({ write: (_c, _e, cb) => cb() }),
+      );
+      return undefined;
+    } catch (e) {
+      // A buffer-limit breach surfaces here; a passing payload does not throw.
+      return e instanceof ValidationFailedError ? undefined : (e as Error);
+    }
+  }
+
+  it("a uniqueItems island validates at the predicted cap, fails below the real span", async () => {
+    const schema = {
+      type: "array",
+      uniqueItems: true,
+      maxItems: 3,
+      items: { type: "string", maxLength: 5 },
+    } as SchemaObject;
+    const value = ["abcde", "fghij", "klmno"]; // valid: 3 unique, each length 5
+    const peak = analyze(schema).peakBytes as number; // 71 (loose upper bound)
+
+    // At the predicted upper bound: no buffer-limit error (real span <= peak).
+    expect(await runWithCap(schema, value, peak)).toBeUndefined();
+    // The raw array spans ~25 bytes; a cap well below it must trip the limit.
+    const err = await runWithCap(schema, value, 10);
+    expect(err?.message).toMatch(/maxBufferedBytes/);
+  });
+
+  it("a pattern scalar validates at the predicted cap, fails below the real span", async () => {
+    const schema = { type: "string", pattern: "^a+$", maxLength: 10 } as SchemaObject;
+    const value = "aaaa"; // 6 raw bytes including quotes
+    const peak = analyze(schema).peakBytes as number; // 42
+
+    expect(await runWithCap(schema, value, peak)).toBeUndefined();
+    expect((await runWithCap(schema, value, 5))?.message).toMatch(/maxBufferedBytes/);
+  });
+});

--- a/packages/stream-validator/test/analyze.test.ts
+++ b/packages/stream-validator/test/analyze.test.ts
@@ -171,6 +171,18 @@ describe("analyzeStreamability", () => {
     expect(r.positions[0]).toMatchObject({ path: "tags", keyword: "uniqueItems" });
   });
 
+  it("formats an array-item position path with no dot before the bracket", () => {
+    const r = analyze({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        tags: { type: "array", items: { type: "string", pattern: "^.+$" } },
+      },
+    } as unknown as SchemaObject);
+    // The pattern string inside the array items is at `tags[]`, not `tags.[]`.
+    expect(r.positions.map((p) => p.path)).toContain("tags[]");
+  });
+
   it("throws ClassifierError on an unstreamable schema (same as construction)", () => {
     expect(() => analyze({ type: "object", unevaluatedProperties: false } as SchemaObject)).toThrow(
       ClassifierError,

--- a/packages/stream-validator/test/analyze.test.ts
+++ b/packages/stream-validator/test/analyze.test.ts
@@ -204,6 +204,49 @@ describe("analyzeStreamability", () => {
     expect(paths).toContain("documents.oneOf.1");
   });
 
+  it("counts a composition node's own forced-buffer scalar (the stripComposition sub-spine)", () => {
+    // `{ type: string, pattern, allOf: [{ maxLength }] }` tees: the runtime
+    // validates the own (non-composition) keywords as a required sub-spine, so
+    // the `pattern` string still buffers. The allOf `maxLength` bounds it.
+    const r = analyze({
+      type: "string",
+      pattern: "^a",
+      allOf: [{ maxLength: 100 }],
+    } as unknown as SchemaObject);
+    expect(r.peakBytes).toBe(str(100)); // 100*4 + 2 = 402, not 0
+    expect(r.positions).toContainEqual(
+      expect.objectContaining({ keyword: "pattern", maxBytes: str(100) }),
+    );
+  });
+
+  it("sums a tee node's own member island with its branch islands (concurrent sub-spines)", () => {
+    const island = (max: number) => ({
+      type: "array",
+      uniqueItems: true,
+      maxItems: 2,
+      items: { type: "string", maxLength: max },
+    });
+    // The object has a buffering property AND a oneOf with a buffering branch.
+    // Both run as concurrent sub-spines, so the peak is their sum, not a max.
+    const r = analyze({
+      type: "object",
+      additionalProperties: false,
+      properties: { a: island(3) },
+      oneOf: [island(4), { type: "integer" }],
+    } as unknown as SchemaObject);
+    const ownIsland = uniqueArray(2, str(3)); // property a: 2 + 2*(14+1) = 32
+    const branchIsland = uniqueArray(2, str(4)); // oneOf branch: 2 + 2*(18+1) = 40
+    expect(r.peakBytes).toBe(ownIsland + branchIsland); // summed, not max
+  });
+
+  it("throws on an unbounded schema under enforceBounds (parity with construction)", () => {
+    const schema = { type: "string", pattern: "^.+$" } as SchemaObject; // no maxLength
+    // Default: reports the unbounded position.
+    expect(analyze(schema).peakBytes).toBe("unbounded");
+    // enforceBounds: throws like createStreamValidator would.
+    expect(() => analyze(schema, { enforceBounds: true })).toThrow(ClassifierError);
+  });
+
   it("throws ClassifierError on an unstreamable schema (same as construction)", () => {
     expect(() => analyze({ type: "object", unevaluatedProperties: false } as SchemaObject)).toThrow(
       ClassifierError,
@@ -269,5 +312,23 @@ describe("analyzeStreamability: peakBytes is a sound upper bound on real bufferi
 
     expect(await runWithCap(schema, value, peak)).toBeUndefined();
     expect((await runWithCap(schema, value, 5))?.message).toMatch(/maxBufferedBytes/);
+  });
+
+  it("a composition node's own pattern buffers at runtime (own sub-spine), bounded by the predicted cap", async () => {
+    // The Codex scenario: pattern on the node, maxLength in an allOf branch.
+    // The engine buffers the string in the stripComposition sub-spine; the
+    // analyzer must predict that (peak > 0), and the real buffer stays under it.
+    const schema = {
+      type: "string",
+      pattern: "^a+$",
+      allOf: [{ maxLength: 100 }],
+    } as unknown as SchemaObject;
+    const peak = analyze(schema).peakBytes as number; // 402, not 0
+    expect(peak).toBeGreaterThan(0);
+
+    const value = "aaaa"; // valid: matches pattern, length 4 <= 100
+    expect(await runWithCap(schema, value, peak)).toBeUndefined();
+    // A cap below the real ~6-byte span trips the limit, proving it buffers.
+    expect((await runWithCap(schema, value, 4))?.message).toMatch(/maxBufferedBytes/);
   });
 });

--- a/packages/stream-validator/tsconfig.json
+++ b/packages/stream-validator/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "emitDeclarationOnly": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules", "src/**/*.test.ts"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@aahoughton/oav-stream-validator':
+        specifier: workspace:*
+        version: link:../stream-validator
       '@oav/core':
         specifier: workspace:*
         version: link:../core
@@ -69,6 +72,9 @@ importers:
       '@aahoughton/oav-core':
         specifier: workspace:*
         version: link:../..
+      '@aahoughton/oav-stream-validator':
+        specifier: workspace:*
+        version: link:../stream-validator
       commander:
         specifier: ^15.0.0
         version: 15.0.0

--- a/test/alias-parity.test.ts
+++ b/test/alias-parity.test.ts
@@ -40,10 +40,11 @@ function tsupRewriteKeys(): string[] {
 // The oav bundle re-exports oav-core's surface and bundles the CLI +
 // router; it never imports itself or the framework adapters, so those
 // keys appear in the resolution tables but not the tsup rewrite map.
-// `@oav/stream-validator` is incubating and unpublished, so it is wired
-// into the resolution tables (for typecheck / tests) but deliberately
-// not in any publish bundle. Update this list when adding or removing a
-// published package, or when stream-validator graduates.
+// `@oav/stream-validator` is published standalone and consumed by the CLI
+// as an external runtime dependency (like oav-core), so it is wired into
+// the resolution tables (for typecheck / tests) but deliberately not
+// bundled into any oav tarball. Update this list when adding or removing a
+// published package.
 const NOT_IN_OAV_BUNDLE = [
   "@oav/oav",
   "@oav/oav-express4",

--- a/workspace-aliases.ts
+++ b/workspace-aliases.ts
@@ -34,5 +34,15 @@ export function workspaceAliases(rootDir: string): Record<string, string> {
     (pkg) =>
       [`@oav/${pkg}`, resolve(rootDir, "packages", pkg, "src", "index.ts")] as [string, string],
   );
-  return Object.fromEntries([...subpathEntries, ...packageEntries]);
+  // The stream validator is published standalone as `@aahoughton/oav-stream-validator`
+  // (not folded into the oav-core bundle), so consumers inside the workspace
+  // (the CLI) import it by that published name. Alias it to source too, so
+  // tests / bundling resolve it without a prior build of its dist.
+  const publishedEntries: Array<[string, string]> = [
+    [
+      "@aahoughton/oav-stream-validator",
+      resolve(rootDir, "packages", "stream-validator", "src", "index.ts"),
+    ],
+  ];
+  return Object.fromEntries([...subpathEntries, ...packageEntries, ...publishedEntries]);
 }


### PR DESCRIPTION
Phase 1 of #431. Adds a streamability analyzer to `@oav/stream-validator` and surfaces it as a CLI command, so you can see ahead of time which request/response bodies stream vs. buffer (and where).

## What's here
- `analyzeStreamability(schema)` → a peak-buffer budget: `streamable | tee | buffer`, `peakBytes` (wire bytes, or `"unbounded"`), and a `positions[]` punch list of every buffering spot with the keyword that would bound it.
- `analyzeSpec(doc)` → the same, rolled up per operation over a whole resolved spec.
- `oav stream-check <spec>` → a per-operation table. `--verbose` lists the unbounded positions with their paths, `--envelope json` emits the `SpecBudget`, `--fail-on-unbounded` exits non-zero for CI, `--max-buffered-bytes` sets the cap.

```
POST "/data/documents/v1"
  request multipart/form-data      buffer      peak UNBOUNDED  (2 unbounded, 0 bounded)
         - documents.oneOf.0[]  format  unbounded (needs maxLength)
         - documents.oneOf.1    format  unbounded (needs maxLength)
```

## Notes
- The analyzer mirrors the spine's `computeKind` (not just the classifier), so `contains` / asserting `format` / `uniqueItems` and a composition node's own `pattern` are all counted; concurrent tee sub-spines sum, sequential islands max. Byte sizes are a documented upper-bound estimate. A differential test runs the real engine at the predicted cap to keep the numbers sound.
- No new deploy dependencies: the validator packages are untouched, and `analyzeSpec` takes an already-resolved doc, so spec-loading stays in the CLI.
- Also folds in the dev-run fixups: `pnpm oav <args>`, and `emitDeclarationOnly` on the standalone-tsup packages so `tsc -b` stops clobbering the tsup bundle (this was breaking every built command, not just stream-check).

#431 stays open for Phase 2.