### PR TITLE
refactor(stream-validator): exclusive BodyBudget union and readonly cleanups

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -25,7 +25,7 @@ for `@aahoughton/oav` in import specifiers that don't touch
 The streaming examples import from `packages/stream-validator/src`, which
 translates to `@aahoughton/oav-stream-validator`. That is a separate
 package (not part of the `oav` / `oav-core` re-export), versioned
-independently on its own `0.x` line:
+independently on its own version line:
 
 ```bash
 npm install @aahoughton/oav-stream-validator

--- a/packages/cli/src/stream-check.ts
+++ b/packages/cli/src/stream-check.ts
@@ -40,10 +40,10 @@ function classLabel(report: StreamabilityReport): string {
 function renderBody(body: BodyBudget, pad: number, verbose: boolean): string[] {
   const role = roleLabel(body).padEnd(pad);
   const media = body.mediaType.padEnd(24);
-  if (body.error !== undefined) {
+  if (body.report === undefined) {
     return [`  ${role} ${media} not-streamable: ${body.error}`];
   }
-  const report = body.report as StreamabilityReport;
+  const report = body.report;
   const buffers = report.positions.filter((p) => p.classification === "buffer");
   const unbounded = buffers.filter((p) => p.maxBytes === "unbounded");
   const bounded = buffers.length - unbounded.length;
@@ -80,11 +80,11 @@ function tally(budget: SpecBudget): Counts {
   for (const op of budget.operations) {
     for (const body of op.bodies) {
       c.bodies++;
-      if (body.error !== undefined) {
+      if (body.report === undefined) {
         c.errors++;
         continue;
       }
-      const r = body.report as StreamabilityReport;
+      const r = body.report;
       if (r.classification === "streamable") c.streamable++;
       else if (r.classification === "tee") c.tee++;
       else c.buffer++;

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -320,18 +320,21 @@ export type ErrorParamsFor<Code extends keyof BuiltInErrorParams> = BuiltInError
 export interface ValidationError {
   /** Stable identifier of the keyword or validation layer that produced this error. */
   code: string;
-  /** Path segments pointing at the offending data location. */
-  path: PathSegment[];
+  /**
+   * Path segments pointing at the offending data location. Read-only: the
+   * validator snapshots/freezes these at construction and never mutates them.
+   */
+  readonly path: readonly PathSegment[];
   /** Human-readable description of the failure. */
   message: string;
   /**
    * Keyword-specific machine-readable details. The shape per `code` is
    * documented in {@link BuiltInErrorParams}; consumers can use
-   * {@link ErrorParamsFor} to narrow.
+   * {@link ErrorParamsFor} to narrow. Read-only after construction.
    */
-  params: Record<string, unknown>;
-  /** Child errors; always an array, empty for leaf errors. */
-  children: ValidationError[];
+  readonly params: Readonly<Record<string, unknown>>;
+  /** Child errors; always an array, empty for leaf errors. Read-only after construction. */
+  readonly children: readonly ValidationError[];
 }
 
 /**
@@ -343,13 +346,13 @@ export interface CreateErrorParams {
   /** Stable identifier of the keyword/layer. */
   code: string;
   /** Path segments of the offending data. */
-  path: PathSegment[];
+  path: readonly PathSegment[];
   /** Human-readable message. */
   message: string;
   /** Machine-readable details. Defaults to `{}`. */
-  params?: Record<string, unknown>;
+  params?: Readonly<Record<string, unknown>>;
   /** Child errors. Defaults to `[]`. */
-  children?: ValidationError[];
+  children?: readonly ValidationError[];
 }
 
 /**
@@ -437,21 +440,18 @@ export function createLeafError(
 }
 
 // Shared frozen empty array so leaf errors reuse one `children` value
-// instead of allocating a fresh `[]` per failure. `Object.freeze([])`
-// is typed `readonly never[]` which TS refuses to narrow to
-// `ValidationError[]` directly; the double cast expresses intent:
-// readers treat a leaf's `children` as read-only already, and the
-// freeze is a runtime safety net against accidental mutation.
-const EMPTY_CHILDREN = Object.freeze([]) as unknown as ValidationError[];
+// instead of allocating a fresh `[]` per failure. `children` is
+// `readonly ValidationError[]`, so the frozen empty array assigns
+// directly; the freeze is a runtime safety net against accidental mutation.
+const EMPTY_CHILDREN: readonly ValidationError[] = Object.freeze([]);
 
 // Shared frozen empty params for the common no-details case (branch
 // wrappers like the "schema" node, leaves whose `code` carries no
 // params). Mirrors EMPTY_CHILDREN: one value instead of a fresh `{}`
-// per error. Safe because `params` is read-only by contract (consumers
-// narrow and read it; nothing in the validator mutates it after
-// construction) and the freeze is the runtime safety net. Call sites
+// per error. `params` is `readonly` by type, so the frozen object
+// assigns directly; the freeze is the runtime safety net. Call sites
 // that do carry details pass their own object and never see this.
-const EMPTY_PARAMS = Object.freeze({}) as Record<string, unknown>;
+const EMPTY_PARAMS: Readonly<Record<string, unknown>> = Object.freeze({});
 
 /**
  * Construct a branch error that wraps a list of child errors (e.g. the
@@ -568,7 +568,7 @@ export function collectLeaves(error: ValidationError): ValidationError[] {
  *
  * @public
  */
-export function joinPath(path: PathSegment[]): string {
+export function joinPath(path: readonly PathSegment[]): string {
   let out = "";
   for (const segment of path) {
     if (typeof segment === "number") {

--- a/packages/schema/src/keywords/types.ts
+++ b/packages/schema/src/keywords/types.ts
@@ -495,8 +495,12 @@ export interface KeywordDefinition {
 export interface Vocabulary {
   /** Vocabulary URI (per JSON Schema spec). */
   uri: string;
-  /** Ordered list of keyword definitions. */
-  keywords: KeywordDefinition[];
+  /**
+   * Ordered list of keyword definitions. Read-only: the compiler and the
+   * introspection cache rely on a stable vocabulary keyword order, and an
+   * `as const` keyword array satisfies this directly.
+   */
+  keywords: readonly KeywordDefinition[];
 }
 
 /**

--- a/packages/schema/src/keywords/vocabulary.ts
+++ b/packages/schema/src/keywords/vocabulary.ts
@@ -269,7 +269,7 @@ export const contentVocabulary: Vocabulary = {
  *
  * @public
  */
-export const defaultVocabularies: Vocabulary[] = [
+export const defaultVocabularies: readonly Vocabulary[] = [
   coreVocabulary,
   validationVocabulary,
   applicatorVocabulary,

--- a/packages/spec/src/load.ts
+++ b/packages/spec/src/load.ts
@@ -17,7 +17,7 @@ export interface LoadSpecOptions {
   /** Base directory/URI for resolving relative refs. Defaults to the entry's directory. */
   baseUri?: string;
   /** Overlays to apply in order after resolution. */
-  overlays?: SpecOverlay[];
+  overlays?: readonly SpecOverlay[];
   /**
    * Run spec-hygiene lint passes against the post-overlay document.
    * Findings land in {@link ResolvedSpec.specHygieneIssues}. Defaults
@@ -89,7 +89,7 @@ export interface LoadSpecSyncOptions {
   /** Base directory/URI for resolving relative refs. Defaults to the entry's directory. */
   baseUri?: string;
   /** Overlays to apply in order after resolution. */
-  overlays?: SpecOverlay[];
+  overlays?: readonly SpecOverlay[];
   /**
    * Run spec-hygiene lint passes against the post-overlay document.
    * Findings land in {@link ResolvedSpec.specHygieneIssues}. Defaults

--- a/packages/spec/src/overlay.ts
+++ b/packages/spec/src/overlay.ts
@@ -398,7 +398,10 @@ const METHODS: HttpMethod[] = [
  *
  * @public
  */
-export function applyOverlays(base: OpenAPIDocument, overlays: SpecOverlay[]): OpenAPIDocument {
+export function applyOverlays(
+  base: OpenAPIDocument,
+  overlays: readonly SpecOverlay[],
+): OpenAPIDocument {
   let doc: OpenAPIDocument = structuredClone(base);
   for (const overlay of overlays) doc = applyOverlay(doc, overlay);
   return doc;

--- a/packages/stream-validator/src/analyzer/index.ts
+++ b/packages/stream-validator/src/analyzer/index.ts
@@ -5,4 +5,10 @@ export {
   type StreamabilityReport,
   type StreamClass,
 } from "./analyze.js";
-export { analyzeSpec, type BodyBudget, type OperationBudget, type SpecBudget } from "./spec.js";
+export {
+  analyzeSpec,
+  type BodyBudget,
+  type BodyBudgetBase,
+  type OperationBudget,
+  type SpecBudget,
+} from "./spec.js";

--- a/packages/stream-validator/src/analyzer/spec.ts
+++ b/packages/stream-validator/src/analyzer/spec.ts
@@ -14,6 +14,7 @@
  */
 
 import type {
+  MediaTypeObject,
   OpenAPIDocument,
   OperationObject,
   RequestBodyObject,
@@ -29,26 +30,33 @@ import type { StreamValidatorOptions } from "../options.js";
 import { analyzeStreamability, type StreamabilityReport } from "./analyze.js";
 
 /**
- * The streamability budget for one request or response body of an operation.
- * Exactly one of `report` / `error` is present: `error` holds the message
- * when the body's schema cannot be classified (an unstreamable keyword, an
- * unknown keyword, or an unresolvable `$ref`), the same failure
- * `createStreamValidator` would raise.
+ * Fields common to every {@link BodyBudget} variant.
  *
  * @public
  */
-export interface BodyBudget {
+export interface BodyBudgetBase {
   /** Whether this is the request body or a response body. */
   role: "request" | "response";
   /** Response status key (`"200"`, `"default"`); absent for the request. */
   status?: string;
   /** The body media type (`"application/json"`, ...). */
   mediaType: string;
-  /** The peak-buffer budget, when the schema classifies. */
-  report?: StreamabilityReport;
-  /** The classification error message, when it does not. */
-  error?: string;
 }
+
+/**
+ * The streamability budget for one request or response body of an operation.
+ * Exactly one of `report` / `error` is present (an exclusive union, so a
+ * consumer that narrows on `error` reads `report` without a cast): `error`
+ * holds the message when the body's schema cannot be classified (an
+ * unstreamable keyword, an unknown keyword, or an unresolvable `$ref`), the
+ * same failure `createStreamValidator` would raise; otherwise `report` holds
+ * the peak-buffer budget.
+ *
+ * @public
+ */
+export type BodyBudget =
+  | (BodyBudgetBase & { report: StreamabilityReport; error?: never })
+  | (BodyBudgetBase & { error: string; report?: never });
 
 /**
  * The budget for one operation: every request/response body that carries a
@@ -83,22 +91,21 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 // per-body error so one bad body does not abort the whole sweep.
 function budgetForBody(
   doc: OpenAPIDocument,
-  content: Record<string, unknown> | undefined,
-  base: { role: "request" | "response"; status?: string },
+  content: Record<string, MediaTypeObject> | undefined,
+  base: Omit<BodyBudgetBase, "mediaType">,
   options: StreamValidatorOptions,
 ): BodyBudget[] {
-  if (!isRecord(content)) return [];
+  if (content === undefined) return [];
   const out: BodyBudget[] = [];
   for (const [mediaType, mto] of Object.entries(content)) {
-    const schema = isRecord(mto) ? (mto.schema as unknown) : undefined;
+    const schema = mto.schema;
     if (schema === undefined) continue; // a media type with no schema is unconstrained
-    const entry: BodyBudget = { ...base, mediaType };
     try {
-      entry.report = analyzeStreamability(carryComponents(doc, schema as never), options);
+      const report = analyzeStreamability(carryComponents(doc, schema), options);
+      out.push({ ...base, mediaType, report });
     } catch (e) {
-      entry.error = e instanceof Error ? e.message : String(e);
+      out.push({ ...base, mediaType, error: e instanceof Error ? e.message : String(e) });
     }
-    out.push(entry);
   }
   return out;
 }

--- a/packages/stream-validator/src/engine/stream-validator.ts
+++ b/packages/stream-validator/src/engine/stream-validator.ts
@@ -145,7 +145,8 @@ type CompiledValidator = (
 function violationFromError(e: ValidationError, byteOffset: number): SchemaViolation {
   return {
     code: e.code,
-    path: e.path,
+    // Copy the read-only error path into the violation's mutable path.
+    path: [...e.path],
     byteOffset,
     message: e.message,
     params: e.params,

--- a/packages/stream-validator/src/index.ts
+++ b/packages/stream-validator/src/index.ts
@@ -12,7 +12,7 @@
  * delegate), and reuses `@oav/core`'s flat error model.
  *
  * Published as `@aahoughton/oav-stream-validator`, versioned independently
- * of the `oav-core` family (its own `0.x` line).
+ * of the `oav-core` family (its own version line).
  *
  * @packageDocumentation
  */
@@ -39,6 +39,7 @@ export {
   analyzeSpec,
   analyzeStreamability,
   type BodyBudget,
+  type BodyBudgetBase,
   type BufferPosition,
   type ByteSize,
   type OperationBudget,


### PR DESCRIPTION
Type-soundness cleanups from a code review.

- **BodyBudget exclusive union** — `BodyBudget` carries either `report` or `error`, never both, but encoded both as optional, forcing `body.report as StreamabilityReport` casts in the CLI. Now an exclusive union (`BodyBudgetBase & ({ report; error?: never } | { error; report?: never })`); narrowing on `report` drops both casts.
- **analyzeSpec typing** — `budgetForBody` takes the already-typed `Record<string, MediaTypeObject>` content and reads `mto.schema` directly, removing a `schema as never` and redundant runtime guards.
- **readonly overlay inputs** — `applyOverlays` / `LoadSpecOptions.overlays` only iterate, so they're widened to `readonly SpecOverlay[]` (a parameter widening: accepts more caller shapes, fully backward-compatible).
- **readonly ValidationError fields** — `path` / `params` / `children` are immutable by contract (the validator snapshots the path and shares frozen empty singletons, with casts that admitted as much). Tighten them to `readonly`, removing the casts. Ripple was 3 sites (`joinPath` reads only; the stream validator copies at its violation boundary).
- **readonly vocabulary stacks** — `Vocabulary.keywords` and `defaultVocabularies` are now `readonly`, matching the already-`readonly` `Dialect.vocabularies` and the compiler's stable-order assumption; custom dialects can pass `as const` keyword arrays.

The two field-tightenings (`ValidationError`, `Vocabulary`) touch the stable oav-core/schema public types; folded in here per confirmation there are no consumers that mutate them. Full suite green; typecheck/lint clean.