### PR TITLE
chore: drop source maps from published tarballs

### DIFF
--- a/packages/oav-express4/tsup.config.ts
+++ b/packages/oav-express4/tsup.config.ts
@@ -38,7 +38,8 @@ export default defineConfig({
   format: ["esm", "cjs"],
   dts: true,
   clean: true,
-  sourcemap: true,
+  // No published source maps; see root tsup.config.ts for the rationale.
+  sourcemap: false,
   target: "es2022",
   tsconfig: resolve(__dirname, "../../tsconfig.build.json"),
   external: ["express", "@aahoughton/oav-core"],

--- a/packages/oav-express5/tsup.config.ts
+++ b/packages/oav-express5/tsup.config.ts
@@ -30,7 +30,8 @@ export default defineConfig({
   format: ["esm", "cjs"],
   dts: true,
   clean: true,
-  sourcemap: true,
+  // No published source maps; see root tsup.config.ts for the rationale.
+  sourcemap: false,
   target: "es2022",
   tsconfig: resolve(__dirname, "../../tsconfig.build.json"),
   external: ["express", "@aahoughton/oav-core"],

--- a/packages/oav-fastify/tsup.config.ts
+++ b/packages/oav-fastify/tsup.config.ts
@@ -30,7 +30,8 @@ export default defineConfig({
   format: ["esm", "cjs"],
   dts: true,
   clean: true,
-  sourcemap: true,
+  // No published source maps; see root tsup.config.ts for the rationale.
+  sourcemap: false,
   target: "es2022",
   tsconfig: resolve(__dirname, "../../tsconfig.build.json"),
   external: ["fastify", "@aahoughton/oav-core"],

--- a/packages/oav/tsup.config.ts
+++ b/packages/oav/tsup.config.ts
@@ -87,7 +87,8 @@ export default defineConfig([
     format: ["esm", "cjs"],
     dts: true,
     clean: true,
-    sourcemap: true,
+    // No published source maps; see root tsup.config.ts for the rationale.
+    sourcemap: false,
     target: "es2022",
     tsconfig: "../../tsconfig.build.json",
     external,
@@ -98,7 +99,8 @@ export default defineConfig([
     format: ["esm"],
     dts: false,
     clean: false,
-    sourcemap: true,
+    // No published source maps; see root tsup.config.ts for the rationale.
+    sourcemap: false,
     target: "es2022",
     tsconfig: "../../tsconfig.build.json",
     external,

--- a/packages/stream-validator/tsup.config.ts
+++ b/packages/stream-validator/tsup.config.ts
@@ -44,7 +44,8 @@ export default defineConfig({
   format: ["esm", "cjs"],
   dts: true,
   clean: true,
-  sourcemap: true,
+  // No published source maps; see root tsup.config.ts for the rationale.
+  sourcemap: false,
   target: "es2022",
   tsconfig: resolve(__dirname, "../../tsconfig.build.json"),
   external: ["@aahoughton/oav-core"],

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -41,7 +41,13 @@ export default defineConfig({
   format: ["esm", "cjs"],
   dts: true,
   clean: true,
-  sourcemap: true,
+  // No source maps in published tarballs: they were ~55% of oav-core's
+  // unpacked size (each map embeds the full original TS via sourcesContent),
+  // and bundlers never pull .map into application output, so the cost was all
+  // install-disk and npm sticker size for zero runtime benefit. The build is
+  // unminified, so a consumer debugging into oav still lands in readable JS
+  // with original identifier names and // src/*.ts markers.
+  sourcemap: false,
   splitting: true,
   target: "es2022",
   tsconfig: "tsconfig.build.json",


### PR DESCRIPTION
Sets `sourcemap: false` across every published tsup config (root oav-core + oav, the three adapters, stream-validator).

Source maps were dead weight in the tarballs: ~55% of oav-core's unpacked size (each map embeds the full TS source via `sourcesContent`), and bundlers never pull `.map` into app output. So they only cost install-disk and npm sticker size for zero runtime benefit. The build is unminified, so anyone debugging into oav still lands in readable JS with original names and `// src/*.ts` markers, just without per-line mapping to the `.ts`.

Measured: oav-core `dist` 2812 KB -> 1244 KB (the maps were exactly 55%). Verified the packed tarballs ship zero `.map` files and oav-core still installs + loads from a clean `npm install`.

Reversible: flip the flag back if we ever want a size-constrained-vs-debuggable split. The `.d.cts` mirror is a separate size axis left alone here (dropping it risks breaking `require()` type resolution for nodenext consumers).

Closes #208.