### PR TITLE
feat(stream-validator): member-level key edit (rename/drop) on the stream path

### DIFF
--- a/packages/stream-validator/README.md
+++ b/packages/stream-validator/README.md
@@ -12,8 +12,9 @@ This is a second engine, not a mode of the in-memory validator.
 `oav-core`'s compiler is pull-based over a fully-parsed value; this engine
 is push-based over a token stream. It reuses `oav-core`'s in-memory
 validator for the subtrees a compile-time classifier marks BUFFER (so
-format assertion and built-in formats come from that delegate), and reuses
-its flat error model.
+`format` assertion runs in that delegate, against the formats you register
+through the `formats` option; no format library is bundled by default),
+and reuses its flat error model.
 
 Thin: this package bundles nothing from `oav-core`. It declares
 `@aahoughton/oav-core` as a regular dependency, so installing the stream

--- a/packages/stream-validator/README.md
+++ b/packages/stream-validator/README.md
@@ -117,6 +117,35 @@ bytes before a scope's closing delimiter (append-only; appended bytes are
 not validated). A `ScopeContext` carries the scope path, verdict, member
 count, and a `field(name, value)` helper.
 
+Reshaping the envelope: `editMember(at, cb)` renames or drops an object
+member as it streams, the in-place edit `editClose` cannot do. The hook
+fires at the member's value start (so it knows the value type) and returns
+`{ action: "rename", key }`, `{ action: "drop" }`, or `{ action: "keep" }`
+(or `null`). A `rename` rewrites the key token only and streams the value
+verbatim, so renaming a key in front of a multi-GB array never buffers the
+array. A `drop` suppresses the member and absorbs one delimiter, leaving
+valid JSON.
+
+```ts
+const validator = createStreamValidator(bodySchema);
+validator.editMember(["message_ids"], () => ({ action: "rename", key: "records" }));
+validator.editMember(["legacy_field"], () => ({ action: "drop" }));
+// {"message_ids":[...big...],"legacy_field":1,"keep":2}
+//   -> {"records":[...big...],"keep":2}
+```
+
+`at` matches the member's **full path** (the enclosing scope plus the key),
+the same coordinate `valueEvents.at` uses. Validation is pre-edit: the
+input shape is validated as received (a dropped member is still validated;
+the edit only changes the output). A rename whose target collides with a
+key in the same object, and two hooks returning conflicting edits for one
+member, are fatal. Two caps bound the buffering the edit introduces and
+default finite (unlike the resource limits above): `maxMemberPrefixBytes`
+(the held key-to-value span, default 4 KiB) and `maxMemberDropBytes` (a
+dropped member's span, default 64 KiB); over-cap is fatal. Dropping a
+container-valued member is not supported on the stream path; rename works
+for any value type.
+
 Recovering scalar fields: `valueEvents` emits a `value` event when a
 scalar object-member value completes, carrying the member's absolute
 input-byte span (`valueStart` / `valueEnd`). Code that needs a few small
@@ -158,11 +187,14 @@ not fire. `capture` retains a matched member's decoded bytes bounded by
 already buffered for its own check, so there `maxCaptureBytes` only gates
 delivery (the memory bound is `maxBufferedBytes`).
 
-`onScopeClose` / `editClose` fire for STREAM scopes only. A scope the
-classifier routes to a BUFFER island (`uniqueItems`, `contains`, an
-object-valued `const`) or a TEE composition branch
-(`oneOf`/`anyOf`/`allOf`) does not emit a scope-close hook, so which
-scopes a hook sees depends on the schema's classification. Use the hooks
+`onScopeClose` / `editClose` / `editMember` fire for STREAM structure
+only. A member whose enclosing object the classifier routes to a BUFFER
+island (`uniqueItems`, `contains`, an object-valued `const`) or a TEE
+composition branch (`oneOf`/`anyOf`/`allOf`) does not emit a hook, so which
+scopes and members a hook sees depends on the schema's classification.
+(A streamed-object member whose own value is a scalar BUFFER island, e.g.
+a `format`-bearing scalar, is still editable: the enclosing object streams
+and the edit is decided at the value start.) Use the hooks
 for observing/editing forward-decidable structure, not as a general JSON
 visitor over an arbitrary schema.
 

--- a/packages/stream-validator/src/engine/hooks.ts
+++ b/packages/stream-validator/src/engine/hooks.ts
@@ -94,6 +94,74 @@ export type ScopeObserver = (ctx: ScopeContext) => void;
 /** An edit hook: returns bytes to append before the delimiter, or null for no-op. */
 export type ScopeEditor = (ctx: ScopeContext) => Bytes | null;
 
+/**
+ * Default cap on the held key-to-value span (key bytes + colon +
+ * whitespace) for a `editMember` hook, applied when `maxMemberPrefixBytes`
+ * is unset. JSON allows unbounded whitespace between the colon and the
+ * value, so this span needs its own bound: a legitimate key plus even
+ * deep pretty-print indentation is well under this, while a whitespace-
+ * padding attack trips it. Unlike the schema-bound resource limits
+ * (`maxBufferedBytes`, ...), the edit caps default finite, because they
+ * bound buffers the edit itself introduces. Over-cap is fatal.
+ */
+export const DEFAULT_MAX_MEMBER_PREFIX_BYTES = 4096;
+
+/**
+ * Context passed to a member-edit hook. Fires at the member's value start
+ * (after its key, before the value streams), so {@link valueType} is
+ * known.
+ *
+ * @public
+ */
+export interface MemberContext {
+  /**
+   * Full path to the member: the enclosing object's path plus the member
+   * key. The same coordinate `editMember`'s `at` filter matches (a
+   * top-level member `{version}` is `["version"]`), so the filter and the
+   * context speak one path. The last segment equals {@link key}.
+   */
+  readonly path: PathSegment[];
+  /** The member's current (pre-edit) key. */
+  readonly key: string;
+  /** JSON type of the member's value. */
+  readonly valueType: "object" | "array" | "string" | "number" | "boolean" | "null";
+}
+
+/**
+ * The edit a member-edit hook returns.
+ *
+ *   - `keep`: pass the member through unchanged (also the `null` no-op).
+ *   - `rename`: substitute the key token (`JSON.stringify(key)`); the
+ *     value streams verbatim, so a rename never buffers the value.
+ *   - `drop`: suppress the member (key + value + one delimiter).
+ *
+ * A rename whose target collides with another key in the same object, and
+ * two hooks returning conflicting edits for one member, are both fatal.
+ *
+ * @public
+ */
+export type MemberEdit =
+  | { action: "keep" }
+  | { action: "rename"; key: string }
+  | { action: "drop" };
+
+/**
+ * A member-edit hook: decides whether to keep, rename, or drop a matched
+ * object member. Returns `null` for a no-op (equivalent to `keep`).
+ *
+ * @public
+ */
+export type MemberEditor = (member: MemberContext) => MemberEdit | null;
+
+/** Build the {@link MemberContext} for a member at its value start. */
+export function makeMemberContext(
+  path: PathSegment[],
+  key: string,
+  valueType: MemberContext["valueType"],
+): MemberContext {
+  return { path, key, valueType };
+}
+
 /** Coerce hook output to a Buffer (a string is UTF-8 encoded). */
 export function toBuffer(bytes: Bytes): Buffer {
   if (typeof bytes === "string") return Buffer.from(bytes, "utf8");

--- a/packages/stream-validator/src/engine/hooks.ts
+++ b/packages/stream-validator/src/engine/hooks.ts
@@ -82,8 +82,11 @@ export interface ScopeContext {
   readonly memberCount: number;
   /**
    * Build an object member to append, handling the leading comma: returns
-   * `"name":value` when the scope is empty, `,"name":value` otherwise.
-   * For object scopes; arrays append their own element bytes.
+   * `"name":value` when no member survives to the output (an empty scope, or
+   * one whose every member was dropped by `editMember`), `,"name":value`
+   * otherwise. The comma tracks surviving output members, not the input
+   * {@link memberCount}. For object scopes; arrays append their own element
+   * bytes.
    */
   field(name: string, value: JsonValue): string;
 }
@@ -168,12 +171,20 @@ export function toBuffer(bytes: Bytes): Buffer {
   return Buffer.from(bytes);
 }
 
-/** Build the {@link ScopeContext} for a closing scope. */
+/**
+ * Build the {@link ScopeContext} for a closing scope. `memberCount` is the
+ * input-observed count surfaced on the context; `outputMemberCount` is the
+ * post-edit surviving count (kept + renamed) that drives `field()`'s leading
+ * comma, so an appended field after all members were dropped does not emit a
+ * stray comma. The two differ only under member edits; otherwise pass the
+ * same value.
+ */
 export function makeScopeContext(
   path: PathSegment[],
   kind: "object" | "array",
   valid: boolean,
   memberCount: number,
+  outputMemberCount: number,
 ): ScopeContext {
   return {
     path,
@@ -181,7 +192,7 @@ export function makeScopeContext(
     verdict: valid ? "valid" : "invalid",
     memberCount,
     field(name: string, value: JsonValue): string {
-      const lead = memberCount > 0 ? "," : "";
+      const lead = outputMemberCount > 0 ? "," : "";
       return `${lead}${JSON.stringify(name)}:${JSON.stringify(value)}`;
     },
   };

--- a/packages/stream-validator/src/engine/index.ts
+++ b/packages/stream-validator/src/engine/index.ts
@@ -4,5 +4,14 @@ export {
   StreamValidator,
   ValidationFailedError,
 } from "./stream-validator.js";
-export { DEFAULT_MAX_CAPTURE_BYTES } from "./hooks.js";
-export type { Bytes, ScopeContext, ScopeEditor, ScopeObserver, ValueEvent } from "./hooks.js";
+export { DEFAULT_MAX_CAPTURE_BYTES, DEFAULT_MAX_MEMBER_PREFIX_BYTES } from "./hooks.js";
+export type {
+  Bytes,
+  MemberContext,
+  MemberEdit,
+  MemberEditor,
+  ScopeContext,
+  ScopeEditor,
+  ScopeObserver,
+  ValueEvent,
+} from "./hooks.js";

--- a/packages/stream-validator/src/engine/stream-validator.ts
+++ b/packages/stream-validator/src/engine/stream-validator.ts
@@ -44,6 +44,8 @@ import { classify } from "../classifier/index.js";
 import {
   BudgetReached,
   type IslandDelegate,
+  type MemberDecision,
+  MemberEditError,
   type ScopeClose,
   SpineValidator,
   type StreamVerdict,
@@ -53,7 +55,10 @@ import { JsonTokenizer } from "../tokenizer/index.js";
 import type { JsonPath, PathFilter, StreamValidatorOptions } from "../options.js";
 import {
   DEFAULT_MAX_CAPTURE_BYTES,
+  DEFAULT_MAX_MEMBER_PREFIX_BYTES,
+  makeMemberContext,
   makeScopeContext,
+  type MemberEditor,
   type ScopeEditor,
   type ScopeObserver,
   toBuffer,
@@ -85,6 +90,14 @@ function matchValueFilter(
     filter.length === scopePath.length + 1 &&
     filter.every((seg, i) => (i < scopePath.length ? seg === scopePath[i] : seg === key))
   );
+}
+
+// Two member decisions agree (so multiple matching hooks are not a
+// conflict): both drop, or both rename to the same key.
+function sameDecision(a: MemberDecision, b: MemberDecision): boolean {
+  if (a.kind !== b.kind) return false;
+  if (a.kind === "rename" && b.kind === "rename") return a.key === b.key;
+  return true;
 }
 
 /**
@@ -261,7 +274,25 @@ export class StreamValidator extends Transform {
   private readonly scopeHooks: Array<
     { at: PathFilter; observe: ScopeObserver } | { at: PathFilter; edit: ScopeEditor }
   > = [];
-  private pendingInjections: Array<{ offset: number; bytes: Buffer }> = [];
+
+  // Member-edit hooks (rename/drop a matched object member), in
+  // registration order. Their presence routes a chunk through the
+  // collect-then-echo path, the same as scope hooks.
+  private readonly memberHooks: Array<{ at: PathFilter; edit: MemberEditor }> = [];
+  private readonly maxMemberPrefixBytes: number;
+  private readonly maxMemberDropBytes: number;
+
+  // The editing echo: input bytes are held from `heldBase` until the spine
+  // resolves any edit that could touch them, then flushed (verbatim or with
+  // the resolved edits spliced in). `pendingEdits` are span edits in
+  // absolute input offsets: `bytes === null` is a deletion (drop), a
+  // non-null `bytes` with `start < end` is a replacement (rename), and
+  // `start === end` is an insertion (an `editClose` append). Held bytes are
+  // bounded by the pending key / drop span, so the bounded-heap property
+  // holds.
+  private pendingEdits: Array<{ start: number; end: number; bytes: Buffer | null }> = [];
+  private heldBytes: Buffer = Buffer.alloc(0);
+  private heldBase = 0;
 
   /** Resolves with the final verdict (rejects on a fatal parse / I/O error). */
   readonly result: Promise<StreamVerdict>;
@@ -297,6 +328,18 @@ export class StreamValidator extends Transform {
         "Omit it to use the default capture cap.",
       );
     }
+    assertPositiveIntOption(
+      "maxMemberPrefixBytes",
+      options.maxMemberPrefixBytes,
+      "Omit it to use the default member-prefix cap.",
+    );
+    assertPositiveIntOption(
+      "maxMemberDropBytes",
+      options.maxMemberDropBytes,
+      "Omit it to use the default member-drop cap.",
+    );
+    this.maxMemberPrefixBytes = options.maxMemberPrefixBytes ?? DEFAULT_MAX_MEMBER_PREFIX_BYTES;
+    this.maxMemberDropBytes = options.maxMemberDropBytes ?? DEFAULT_MAX_CAPTURE_BYTES;
     this.maxErrors = options.maxErrors ?? 1;
     this.policy = options.policy ?? "terminate";
     this.maxTotalBytes = options.maxTotalBytes;
@@ -388,6 +431,15 @@ export class StreamValidator extends Transform {
           }
         : {}),
       onScopeClose: (close: ScopeClose) => this.handleScopeClose(close),
+      // Member edits: wired unconditionally (cheap closures), but the spine
+      // ignores them until `editMember` flips it on, so a stream with no
+      // member hooks pays nothing.
+      memberEdit: (scopePath, key, valueType) => this.resolveMemberEdit(scopePath, key, valueType),
+      emitReplace: (start, end, bytes) =>
+        this.pendingEdits.push({ start, end, bytes: Buffer.from(bytes, "utf8") }),
+      emitDelete: (start, end) => this.pendingEdits.push({ start, end, bytes: null }),
+      maxMemberPrefixBytes: this.maxMemberPrefixBytes,
+      maxMemberDropBytes: this.maxMemberDropBytes,
     });
     this.tokenizer = new JsonTokenizer(this.spine);
     this.result = new Promise<StreamVerdict>((resolve, reject) => {
@@ -460,6 +512,53 @@ export class StreamValidator extends Transform {
     this.scopeHooks.push({ at, edit });
   }
 
+  /**
+   * Rename or drop a matched object member as it streams. The hook fires
+   * at the member's value start (after its key, before the value), so it
+   * can decide `keep` / `rename` / `drop` with the value type known.
+   * `rename` rewrites the key token only and streams the value verbatim
+   * (no value buffering, any value size); `drop` suppresses the member
+   * and one delimiter. Register before piping. The matched member's
+   * value is still validated against the input schema (a `drop` removes
+   * it from the output, not from the verdict). Return `null` for a no-op.
+   *
+   * A rename whose target collides with another key in the same object,
+   * and two hooks returning conflicting edits for one member, are both
+   * fatal.
+   */
+  editMember(at: PathFilter, edit: MemberEditor): void {
+    this.memberHooks.push({ at, edit });
+    if (this.memberHooks.length === 1) this.spine.enableMemberEdits();
+  }
+
+  // Resolve the registered member hooks for one member into a single
+  // decision. Multiple matching hooks must agree (a rename to the same key,
+  // or all keep); a genuine conflict (rename-vs-drop, or two different
+  // rename targets) is fatal, since the order would otherwise silently pick
+  // a winner.
+  private resolveMemberEdit(
+    scopePath: readonly PathSegment[],
+    key: string,
+    valueType: "object" | "array" | "string" | "number" | "boolean" | "null",
+  ): MemberDecision | null {
+    let decision: MemberDecision | null = null;
+    for (const h of this.memberHooks) {
+      if (!matchValueFilter(h.at, scopePath, key)) continue;
+      const r = h.edit(makeMemberContext([...scopePath, key], key, valueType));
+      if (r === null || r.action === "keep") continue;
+      const d: MemberDecision =
+        r.action === "rename" ? { kind: "rename", key: r.key } : { kind: "drop" };
+      if (decision !== null && !sameDecision(decision, d)) {
+        throw new MemberEditError(
+          `conflicting member edits for ${JSON.stringify([...scopePath, key])}`,
+          0,
+        );
+      }
+      decision = d;
+    }
+    return decision;
+  }
+
   private handleScopeClose(close: ScopeClose): void {
     if (this.scopeHooks.length === 0) return;
     const ctx = makeScopeContext(close.path, close.kind, close.valid, close.memberCount);
@@ -473,24 +572,67 @@ export class StreamValidator extends Transform {
       }
     }
     if (parts.length > 0) {
-      this.pendingInjections.push({ offset: close.delimiterOffset, bytes: Buffer.concat(parts) });
+      // An append before the closing delimiter is an insertion (start === end).
+      const at = close.delimiterOffset;
+      this.pendingEdits.push({ start: at, end: at, bytes: Buffer.concat(parts) });
     }
   }
 
-  // Echo a chunk, splicing each scope-close injection in before its
-  // delimiter byte. Injections arrive in ascending offset order (scopes
-  // close child-before-parent).
-  private emitWithInjections(chunk: Buffer, base: number): void {
-    let local = 0;
-    for (const inj of this.pendingInjections) {
-      const cut = inj.offset - base;
-      if (cut < local || cut > chunk.length) continue;
-      if (cut > local) this.push(chunk.subarray(local, cut));
-      this.push(inj.bytes);
-      local = cut;
+  // Whether any editing hook is registered; routes a chunk through the
+  // collect-then-flush echo instead of the verbatim fast path.
+  private get editsActive(): boolean {
+    return this.scopeHooks.length > 0 || this.memberHooks.length > 0;
+  }
+
+  // Emit held bytes up to `limit` (absolute), splicing in any pending edit
+  // fully resolved within that range. Edits past `limit` and bytes at or
+  // past `limit` stay held for a later flush. Edits are applied in offset
+  // order; overlapping deletions (a trailing drop that re-covers an earlier
+  // following-comma delete) merge via the running cursor.
+  private flushEdits(limit: number): void {
+    if (limit <= this.heldBase) return;
+    const ready: Array<{ start: number; end: number; bytes: Buffer | null }> = [];
+    const rest: Array<{ start: number; end: number; bytes: Buffer | null }> = [];
+    for (const e of this.pendingEdits) (e.end <= limit ? ready : rest).push(e);
+    this.pendingEdits = rest;
+    ready.sort((a, b) => a.start - b.start || b.end - a.end);
+    const base = this.heldBase;
+    const buf = this.heldBytes;
+    let cur = base;
+    for (const e of ready) {
+      if (e.start < cur) {
+        // Overlapped by an earlier (wider) edit: extend the cursor for a
+        // delete/replace, drop an insertion that fell inside a deleted span.
+        if (e.end > cur) cur = e.end;
+        continue;
+      }
+      if (e.start > cur) this.push(buf.subarray(cur - base, e.start - base));
+      if (e.bytes !== null) this.push(e.bytes);
+      cur = Math.max(cur, e.end);
     }
-    if (local < chunk.length) this.push(chunk.subarray(local));
-    this.pendingInjections = [];
+    if (cur < limit) this.push(buf.subarray(cur - base, limit - base));
+    this.heldBytes = buf.subarray(limit - base);
+    this.heldBase = limit;
+  }
+
+  // The highest offset safe to emit now: nothing held past here is subject
+  // to a still-pending edit decision (a key onKey'd but undecided, a mid-key
+  // token, or a dropped member awaiting delimiter resolution).
+  private editSafeLimit(): number {
+    return Math.min(this.spine.editSafeOffset, this.tokenizer.editHoldOffset(), this.totalBytes);
+  }
+
+  // Flush resolved edits, then dump any still-held tail verbatim and discard
+  // unresolved edits. Used when sealing (detach budget) or finishing: no
+  // further edit decisions will arrive, so the remainder echoes as-is.
+  private flushHeldVerbatim(): void {
+    this.flushEdits(this.editSafeLimit());
+    if (this.heldBytes.length > 0) {
+      this.push(this.heldBytes);
+      this.heldBase += this.heldBytes.length;
+      this.heldBytes = Buffer.alloc(0);
+    }
+    this.pendingEdits = [];
   }
 
   override _transform(chunk: Buffer, _enc: BufferEncoding, cb: TransformCallback): void {
@@ -511,21 +653,24 @@ export class StreamValidator extends Transform {
       return;
     }
 
-    // With edit hooks, tokenize first (collecting injections), then echo
-    // with the injections spliced in. Without hooks, echo verbatim up
-    // front (the fast path).
-    if (this.scopeHooks.length > 0) {
-      this.pendingInjections = [];
+    // With edit hooks, hold the chunk, tokenize (the spine collects edits),
+    // then flush the bytes the spine has cleared, with edits spliced in.
+    // Without hooks, echo verbatim up front (the fast path).
+    if (this.editsActive) {
+      this.heldBytes = this.heldBytes.length === 0 ? chunk : Buffer.concat([this.heldBytes, chunk]);
+      if (this.heldBytes.length === chunk.length) this.heldBase = base;
       let err: unknown;
       try {
         this.tokenizer.write(chunk);
       } catch (e) {
         err = e;
       }
-      this.emitWithInjections(chunk, base);
       if (err === undefined) {
+        this.flushEdits(this.editSafeLimit());
         cb();
       } else if (err instanceof BudgetReached) {
+        // Detach echoes the tail verbatim; flush whatever is held first.
+        this.flushHeldVerbatim();
         this.applyBudget(cb);
       } else {
         this.finished = true;
@@ -563,6 +708,9 @@ export class StreamValidator extends Transform {
     if (!this.sealed) {
       try {
         this.tokenizer.end();
+        // End of input: all scopes closed, so every edit is resolved. Flush
+        // the held tail with edits spliced in.
+        if (this.editsActive) this.flushEdits(this.totalBytes);
       } catch (err) {
         // BudgetReached at close just finalizes (below); other throws are fatal.
         if (!(err instanceof BudgetReached)) {

--- a/packages/stream-validator/src/engine/stream-validator.ts
+++ b/packages/stream-validator/src/engine/stream-validator.ts
@@ -561,7 +561,13 @@ export class StreamValidator extends Transform {
 
   private handleScopeClose(close: ScopeClose): void {
     if (this.scopeHooks.length === 0) return;
-    const ctx = makeScopeContext(close.path, close.kind, close.valid, close.memberCount);
+    const ctx = makeScopeContext(
+      close.path,
+      close.kind,
+      close.valid,
+      close.memberCount,
+      close.outputMemberCount,
+    );
     const parts: Buffer[] = [];
     for (const h of this.scopeHooks) {
       if (!matchPathFilter(h.at, close.path, close.kind)) continue;
@@ -618,8 +624,16 @@ export class StreamValidator extends Transform {
   // The highest offset safe to emit now: nothing held past here is subject
   // to a still-pending edit decision (a key onKey'd but undecided, a mid-key
   // token, or a dropped member awaiting delimiter resolution).
+  //
+  // The tokenizer's mid-key hold only matters when a rename can rewrite the
+  // key, so it is folded in only when member hooks are registered. With
+  // scope-only `editClose` there is no key rewrite, so a chunk-straddling
+  // key must not be held (it would buffer to its closing quote with no
+  // member-prefix cap, regressing the append-only path's memory behavior).
   private editSafeLimit(): number {
-    return Math.min(this.spine.editSafeOffset, this.tokenizer.editHoldOffset(), this.totalBytes);
+    const keyHold =
+      this.memberHooks.length > 0 ? this.tokenizer.editHoldOffset() : Number.POSITIVE_INFINITY;
+    return Math.min(this.spine.editSafeOffset, keyHold, this.totalBytes);
   }
 
   // Flush resolved edits, then dump any still-held tail verbatim and discard

--- a/packages/stream-validator/src/index.ts
+++ b/packages/stream-validator/src/index.ts
@@ -21,9 +21,13 @@ export type { JsonPath, PathFilter, StreamValidatorOptions } from "./options.js"
 export {
   createStreamValidator,
   DEFAULT_MAX_CAPTURE_BYTES,
+  DEFAULT_MAX_MEMBER_PREFIX_BYTES,
   MaxTotalBytesError,
   ValidationFailedError,
   type Bytes,
+  type MemberContext,
+  type MemberEdit,
+  type MemberEditor,
   type ScopeContext,
   type ScopeEditor,
   type ScopeObserver,
@@ -48,6 +52,6 @@ export {
   type StreamClass,
 } from "./analyzer/index.js";
 export { type OperationLocator, streamValidatorForOperation } from "./operation.js";
-export { BufferLimitError, UniqueItemsLimitError } from "./spine/index.js";
+export { BufferLimitError, MemberEditError, UniqueItemsLimitError } from "./spine/index.js";
 export type { StreamVerdict, SchemaViolation } from "./spine/index.js";
 export { toValidationError } from "./violation.js";

--- a/packages/stream-validator/src/options.ts
+++ b/packages/stream-validator/src/options.ts
@@ -218,7 +218,9 @@ export interface StreamValidatorOptions {
    * buffering unbounded. Defaults *finite* ({@link
    * DEFAULT_MAX_CAPTURE_BYTES}, 64 KB), the same "small member" size as
    * scalar capture but an independent knob: raise it to drop a larger
-   * (still bounded) member, e.g. a small array.
+   * (still bounded) scalar member. Dropping a container-valued member is
+   * not supported on the stream path (it throws `MemberEditError`), so
+   * this cap only ever bounds a scalar span.
    */
   maxMemberDropBytes?: number;
 

--- a/packages/stream-validator/src/options.ts
+++ b/packages/stream-validator/src/options.ts
@@ -200,6 +200,29 @@ export interface StreamValidatorOptions {
   maxUniqueItems?: number;
 
   /**
+   * Cap on the held key-to-value span (key bytes + colon + whitespace)
+   * for an `editMember` hook. JSON permits unbounded whitespace between
+   * the colon and the value, so this span is bounded separately from the
+   * value itself; over-cap is fatal. Unlike the schema-bound resource
+   * limits above, this defaults *finite*
+   * ({@link DEFAULT_MAX_MEMBER_PREFIX_BYTES}, 4 KB), because it bounds a
+   * buffer the edit itself introduces. Raise it only for unusually
+   * whitespace-heavy input.
+   */
+  maxMemberPrefixBytes?: number;
+
+  /**
+   * Cap on the withheld span of a dropped member (key + value +
+   * delimiter), for an `editMember` hook that returns `drop`. A member
+   * whose span exceeds the cap fails the stream fatally rather than
+   * buffering unbounded. Defaults *finite* ({@link
+   * DEFAULT_MAX_CAPTURE_BYTES}, 64 KB), the same "small member" size as
+   * scalar capture but an independent knob: raise it to drop a larger
+   * (still bounded) member, e.g. a small array.
+   */
+  maxMemberDropBytes?: number;
+
+  /**
    * Turn the classifier's unbounded-* warnings into compile errors: an
    * unbounded `pattern` / `format` string, an unbounded BUFFER island,
    * unbounded depth, or `uniqueItems` with no `maxItems`. The recommended

--- a/packages/stream-validator/src/spine/index.ts
+++ b/packages/stream-validator/src/spine/index.ts
@@ -1,10 +1,12 @@
 export {
   BudgetReached,
   BufferLimitError,
+  MemberEditError,
   SpineUnsupportedError,
   SpineValidator,
   UniqueItemsLimitError,
   type IslandDelegate,
+  type MemberDecision,
   type ScopeClose,
   type SpineOptions,
   type StreamVerdict,

--- a/packages/stream-validator/src/spine/spine.ts
+++ b/packages/stream-validator/src/spine/spine.ts
@@ -101,6 +101,28 @@ export class UniqueItemsLimitError extends Error {
   }
 }
 
+/**
+ * A member edit could not be applied. Fatal (the `error` channel), distinct
+ * from a {@link SchemaViolation}: the input may be valid, but the requested
+ * rename/drop cannot be carried out safely or unambiguously.
+ *
+ * Covers the member-edit failure modes:
+ *   - the held key-to-value span exceeded `maxMemberPrefixBytes`;
+ *   - a dropped member's span exceeded `maxMemberDropBytes`;
+ *   - a rename produced a duplicate key in the same object;
+ *   - a `drop` targeted a container value (not supported on the stream
+ *     path yet).
+ */
+export class MemberEditError extends Error {
+  /** Stream-absolute byte offset at which the failure was detected. */
+  readonly byteOffset: number;
+  constructor(message: string, byteOffset: number) {
+    super(message);
+    this.name = "MemberEditError";
+    this.byteOffset = byteOffset;
+  }
+}
+
 /** Validates a materialized island value against schemas; returns flat violations. */
 export type IslandDelegate = (
   schemas: SchemaObject[],
@@ -230,7 +252,35 @@ export interface SpineOptions {
    * verdict is not final at the streaming close.
    */
   onScopeClose?: (close: ScopeClose) => void;
+  /**
+   * Resolve a member-edit decision for a STREAM object member, called at
+   * the member's value start (so the value type is known). Returns the
+   * effective edit, or `null`/`{kind:"keep"}` for a pass-through. Set only
+   * when member-edit hooks are registered; the engine owns hook matching
+   * and conflict resolution, the spine owns offsets, the prefix cap, and
+   * same-scope output-key collision.
+   */
+  memberEdit?: (
+    scopePath: readonly PathSegment[],
+    key: string,
+    valueType: "object" | "array" | "string" | "number" | "boolean" | "null",
+  ) => MemberDecision | null;
+  /** Emit a key-token replacement (rename): replace input `[start, end)` with `bytes`. */
+  emitReplace?: (start: number, end: number, bytes: string) => void;
+  /** Emit a member deletion (drop): delete input `[start, end)` (delimiter ownership resolved by the spine). */
+  emitDelete?: (start: number, end: number) => void;
+  /** Cap on the held key-to-value span for a member edit; over-cap is fatal. */
+  maxMemberPrefixBytes?: number;
+  /** Cap on a dropped member's withheld span; over-cap is fatal. */
+  maxMemberDropBytes?: number;
 }
+
+/**
+ * A resolved member-edit decision (engine-resolved from the registered
+ * hooks). `keep` passes through; `rename` rewrites the key token and
+ * streams the value; `drop` suppresses the member.
+ */
+export type MemberDecision = { kind: "keep" } | { kind: "rename"; key: string } | { kind: "drop" };
 
 /** The verdict of a streaming validation. */
 export interface StreamVerdict {
@@ -252,6 +302,21 @@ interface ObjectFrame {
   count: number;
   pendingKey: string | null;
   violationsAtOpen: number;
+  // Member-edit bookkeeping (set only when member edits are active).
+  // Byte span of the pending key's token, for a rename replacement.
+  pendingKeyStart: number;
+  pendingKeyEnd: number;
+  // Effective output names seen in this object, each flagged whether it
+  // came from a rename, to make a rename-induced duplicate key fatal while
+  // leaving a pre-existing input duplicate alone.
+  outputKeys: Map<string, boolean> | null;
+  // Offset just past the last kept/renamed member's value (the left bound
+  // when deleting a trailing dropped member, to absorb its leading comma).
+  // Initialized to the offset just after the opening `{`.
+  lastKeptValueEnd: number;
+  // A dropped member awaiting delimiter resolution (at the next member key
+  // or the object close).
+  pendingDrop: { keyStart: number; valueEnd: number } | null;
 }
 
 interface ArrayFrame {
@@ -354,6 +419,22 @@ export class SpineValidator implements JsonEventHandler {
     | undefined;
   private readonly maxCaptureBytes: number | undefined;
   private readonly onScopeClose: ((close: ScopeClose) => void) | undefined;
+  private readonly memberEdit: SpineOptions["memberEdit"];
+  private readonly emitReplace: SpineOptions["emitReplace"];
+  private readonly emitDelete: SpineOptions["emitDelete"];
+  // Off until `enableMemberEdits()`; gates all member-edit work so a stream
+  // with no hooks pays nothing.
+  private memberEditActive = false;
+  private readonly maxMemberPrefixBytes: number;
+  private readonly maxMemberDropBytes: number;
+  // A key seen (onKey) whose member-edit decision is pending until its
+  // value starts; the editing echo holds bytes from here so a rename can
+  // rewrite the key. `+Infinity` when no decision is pending.
+  private pendingDecisionKeyStart = Number.POSITIVE_INFINITY;
+  // A string value member's resolved decision, carried from its start
+  // (`onStringStart`) to its end (`onStringEnd`, where the value end
+  // finalizes a drop span); null when no decision is pending.
+  private pendingStringDecision: MemberDecision | null = null;
   // Verdict-only mode (TEE branch sub-spines): track a single invalid flag
   // instead of retaining a violation per failure, so a branch over a huge
   // array stays O(1) memory. The parent only reads `verdict().valid`.
@@ -409,6 +490,9 @@ export class SpineValidator implements JsonEventHandler {
     depth: number;
     inString: boolean;
     started: boolean;
+    // The tee'd value opened a container (so it is a container member): used
+    // to record its value-end for a later trailing-drop delete.
+    sawContainer: boolean;
   } | null = null;
 
   constructor(root: SchemaOrBoolean, options: SpineOptions = {}) {
@@ -430,6 +514,131 @@ export class SpineValidator implements JsonEventHandler {
     this.shouldCapture = options.shouldCapture;
     this.maxCaptureBytes = options.maxCaptureBytes;
     this.onScopeClose = options.onScopeClose;
+    this.memberEdit = options.memberEdit;
+    this.emitReplace = options.emitReplace;
+    this.emitDelete = options.emitDelete;
+    this.maxMemberPrefixBytes = options.maxMemberPrefixBytes ?? Number.POSITIVE_INFINITY;
+    this.maxMemberDropBytes = options.maxMemberDropBytes ?? Number.POSITIVE_INFINITY;
+  }
+
+  /**
+   * Turn on member-edit processing. Off by default so a stream with no
+   * `editMember` hooks pays nothing (the per-value decision, key-offset
+   * tracking, and output-key sets are all gated on this). Called by the
+   * engine when the first member hook registers.
+   */
+  enableMemberEdits(): void {
+    this.memberEditActive = true;
+  }
+
+  /**
+   * The lowest input-byte offset whose emission must wait for a member-edit
+   * decision: a key onKey'd but not yet decided, or a dropped member awaiting
+   * delimiter resolution. `+Infinity` when nothing is pending. Combined with
+   * the tokenizer's mid-key hold offset by the editing echo.
+   */
+  get editSafeOffset(): number {
+    let s = this.pendingDecisionKeyStart;
+    const top = this.frames[this.frames.length - 1];
+    if (top !== undefined && top.kind === "object" && top.pendingDrop !== null) {
+      s = Math.min(s, top.pendingDrop.keyStart);
+    }
+    return s;
+  }
+
+  // Record a member's effective output name, making a rename-induced
+  // duplicate within the same object fatal. A pre-existing input duplicate
+  // (two kept members with the same key) is left alone; we only police
+  // collisions an edit introduced.
+  private recordOutputKey(top: ObjectFrame, name: string, fromRename: boolean): void {
+    const keys = top.outputKeys as Map<string, boolean>;
+    const existing = keys.get(name);
+    if (existing !== undefined && (fromRename || existing)) {
+      throw new MemberEditError(
+        `member rename produced a duplicate key ${JSON.stringify(name)} in the same object`,
+        this.curOffset,
+      );
+    }
+    keys.set(name, fromRename || (existing ?? false));
+  }
+
+  // Resolve a member-edit decision at the member's value start: enforce the
+  // prefix cap, consult the engine, apply collision rules, and emit a rename
+  // replacement. Returns the decision so the caller can finalize the member
+  // (a drop's span, or advancing `lastKeptValueEnd`) once its value end is
+  // known. A no-op `keep` decision when member edits are off or this is not
+  // an object member.
+  private decideMember(
+    valueType: "object" | "array" | "string" | "number" | "boolean" | "null",
+    valueStart: number,
+  ): MemberDecision {
+    this.pendingDecisionKeyStart = Number.POSITIVE_INFINITY;
+    const top = this.frames[this.frames.length - 1];
+    if (!this.memberEditActive || top === undefined || top.kind !== "object") {
+      return { kind: "keep" };
+    }
+    const key = top.pendingKey as string;
+    if (valueStart - top.pendingKeyEnd > this.maxMemberPrefixBytes) {
+      throw new MemberEditError(
+        `member ${JSON.stringify(key)} key-to-value span exceeded maxMemberPrefixBytes=${this.maxMemberPrefixBytes}`,
+        valueStart,
+      );
+    }
+    const decision = this.memberEdit!(this.path, key, valueType) ?? { kind: "keep" };
+    switch (decision.kind) {
+      case "keep":
+        this.recordOutputKey(top, key, false);
+        break;
+      case "rename":
+        this.recordOutputKey(top, decision.key, true);
+        this.emitReplace!(top.pendingKeyStart, top.pendingKeyEnd, JSON.stringify(decision.key));
+        break;
+      case "drop":
+        if (valueType === "object" || valueType === "array") {
+          throw new MemberEditError(
+            `dropping a container-valued member (${JSON.stringify(key)}) is not supported on the stream path`,
+            valueStart,
+          );
+        }
+        // Hold from the key right away (value end filled in at finalize), so
+        // the dropped value's bytes are not flushed before the delete is
+        // resolved at the next sibling key or the object close.
+        top.pendingDrop = { keyStart: top.pendingKeyStart, valueEnd: -1 };
+        break;
+    }
+    return decision;
+  }
+
+  // After a container value (object/array) member closes, advance the
+  // enclosing object's `lastKeptValueEnd` to just past it. Container members
+  // are always kept (a container drop is unsupported), so this records the
+  // value-end that a later trailing-drop delete needs as its left bound.
+  private noteContainerMemberEnd(closeOffset: number): void {
+    if (!this.memberEditActive) return;
+    const parent = this.frames[this.frames.length - 1];
+    if (parent !== undefined && parent.kind === "object") parent.lastKeptValueEnd = closeOffset + 1;
+  }
+
+  // Finalize a scalar member once its value end is known: record a dropped
+  // member's span (bounded by `maxMemberDropBytes`) for delimiter resolution,
+  // or advance `lastKeptValueEnd` for a kept/renamed member.
+  private finalizeScalarMember(decision: MemberDecision, valueEnd: number): void {
+    if (!this.memberEditActive) return;
+    const top = this.frames[this.frames.length - 1];
+    if (top === undefined || top.kind !== "object") return;
+    if (decision.kind === "drop") {
+      // `pendingDrop` was opened at the decision (value start) to hold the
+      // value's bytes; fill in its end and enforce the span cap.
+      if (valueEnd - top.pendingKeyStart > this.maxMemberDropBytes) {
+        throw new MemberEditError(
+          `dropped member ${JSON.stringify(top.pendingKey)} span exceeded maxMemberDropBytes=${this.maxMemberDropBytes}`,
+          valueEnd,
+        );
+      }
+      if (top.pendingDrop !== null) top.pendingDrop.valueEnd = valueEnd;
+    } else {
+      top.lastKeptValueEnd = valueEnd;
+    }
   }
 
   // The enclosing object member's key, when the value about to / just
@@ -741,6 +950,9 @@ export class SpineValidator implements JsonEventHandler {
     }
     this.popSegment();
     this.advance();
+    // A container island is always a kept member (container drop is
+    // unsupported); record its value-end for a later trailing-drop delete.
+    this.noteContainerMemberEnd(this.curOffset);
   }
 
   // A sub-spine validating the same value against one composition branch.
@@ -799,7 +1011,14 @@ export class SpineValidator implements JsonEventHandler {
       ),
     ];
     this.pushSegment();
-    this.tee = { obligations, subs, depth: 0, inString: false, started: false };
+    this.tee = {
+      obligations,
+      subs,
+      depth: 0,
+      inString: false,
+      started: false,
+      sawContainer: false,
+    };
   }
 
   private teeFeed(feed: (s: SpineValidator) => void): void {
@@ -812,11 +1031,17 @@ export class SpineValidator implements JsonEventHandler {
   }
 
   private finalizeTee(): void {
-    const o = (this.tee as NonNullable<typeof this.tee>).obligations;
+    const t = this.tee as NonNullable<typeof this.tee>;
+    const o = t.obligations;
+    const sawContainer = t.sawContainer;
     this.tee = null;
     if (!combineTee(o)) this.fail("composition");
     this.popSegment();
     this.advance();
+    // A container-valued tee'd member is kept; record its value-end. A
+    // scalar/string tee'd member already had its end recorded at the scalar
+    // finalize, so skip it here to avoid overshooting.
+    if (sawContainer) this.noteContainerMemberEnd(this.curOffset);
   }
 
   // A scalar value at a TEE position: feed the single event to every sub
@@ -928,12 +1153,17 @@ export class SpineValidator implements JsonEventHandler {
       this.teeFeed((s) => s.onStartObject(offset));
       this.tee.depth += 1;
       this.tee.started = true;
+      this.tee.sawContainer = true;
       return;
     }
     if (this.island !== null) {
       this.forwardIsland((b) => b.onStartObject());
       return;
     }
+    // A rename of this object-valued member rewrites only its key (the value
+    // streams); a drop of a container value is not supported on the stream
+    // path. Decided before the value's own classification.
+    if (this.memberEditActive) this.decideMember("object", offset);
     const app = this.schemasForValue();
     if (this.needsIsland(app)) {
       this.beginContainerIsland(app);
@@ -945,6 +1175,7 @@ export class SpineValidator implements JsonEventHandler {
       this.teeFeed((s) => s.onStartObject(offset));
       this.tee!.depth = 1;
       this.tee!.started = true;
+      this.tee!.sawContainer = true;
       return;
     }
     this.checkDepth();
@@ -959,6 +1190,11 @@ export class SpineValidator implements JsonEventHandler {
       count: 0,
       pendingKey: null,
       violationsAtOpen: this.violations.length,
+      pendingKeyStart: 0,
+      pendingKeyEnd: 0,
+      outputKeys: this.memberEditActive ? new Map() : null,
+      lastKeptValueEnd: offset + 1,
+      pendingDrop: null,
     });
   }
 
@@ -975,6 +1211,13 @@ export class SpineValidator implements JsonEventHandler {
       return;
     }
     const frame = this.frames.pop() as ObjectFrame;
+    if (this.memberEditActive && frame.pendingDrop !== null) {
+      // A trailing dropped member (last in the object): delete from the last
+      // kept value's end through the dropped member, absorbing the preceding
+      // comma and leaving valid JSON.
+      this.emitDelete!(frame.lastKeptValueEnd, frame.pendingDrop.valueEnd);
+      frame.pendingDrop = null;
+    }
     for (const s of frame.schemas) {
       if (Array.isArray(s.required)) {
         for (const r of s.required) if (!frame.seen.has(r)) this.fail("required");
@@ -1015,6 +1258,7 @@ export class SpineValidator implements JsonEventHandler {
     });
     this.popSegment();
     this.advance();
+    this.noteContainerMemberEnd(offset);
   }
 
   onStartArray(offset: number): void {
@@ -1023,12 +1267,16 @@ export class SpineValidator implements JsonEventHandler {
       this.teeFeed((s) => s.onStartArray(offset));
       this.tee.depth += 1;
       this.tee.started = true;
+      this.tee.sawContainer = true;
       return;
     }
     if (this.island !== null) {
       this.forwardIsland((b) => b.onStartArray());
       return;
     }
+    // Renaming an array-valued member rewrites only its key; the array
+    // streams unbuffered (the headline case). A container drop is unsupported.
+    if (this.memberEditActive) this.decideMember("array", offset);
     const app = this.schemasForValue();
     if (this.needsIsland(app)) {
       this.beginContainerIsland(app);
@@ -1040,6 +1288,7 @@ export class SpineValidator implements JsonEventHandler {
       this.teeFeed((s) => s.onStartArray(offset));
       this.tee!.depth = 1;
       this.tee!.started = true;
+      this.tee!.sawContainer = true;
       return;
     }
     this.checkDepth();
@@ -1082,9 +1331,10 @@ export class SpineValidator implements JsonEventHandler {
     });
     this.popSegment();
     this.advance();
+    this.noteContainerMemberEnd(offset);
   }
 
-  onKey(value: string, codePoints: number, startOffset: number): void {
+  onKey(value: string, codePoints: number, startOffset: number, endOffset = startOffset): void {
     this.curOffset = startOffset;
     if (this.tee !== null) {
       this.teeFeed((s) => s.onKey(value, codePoints, startOffset));
@@ -1096,6 +1346,17 @@ export class SpineValidator implements JsonEventHandler {
     }
     this.keyEvent?.(this.path, value, startOffset);
     const top = this.frames[this.frames.length - 1] as ObjectFrame;
+    if (this.memberEditActive) {
+      // A preceding dropped member ends at this sibling's key: delete it
+      // through to here, absorbing the following comma + whitespace.
+      if (top.pendingDrop !== null) {
+        this.emitDelete!(top.pendingDrop.keyStart, startOffset);
+        top.pendingDrop = null;
+      }
+      top.pendingKeyStart = startOffset;
+      top.pendingKeyEnd = endOffset;
+      this.pendingDecisionKeyStart = startOffset;
+    }
     for (const s of top.schemas) {
       if (s.propertyNames !== undefined) this.checkPropertyName(s.propertyNames, value, codePoints);
       // Over-limit is decided at the (max+1)th key, before its value
@@ -1147,6 +1408,11 @@ export class SpineValidator implements JsonEventHandler {
       this.forwardIsland((b) => b.onStringStart());
       return;
     }
+    // Decide the member edit at value start (key known, value type known),
+    // before the value's own classification (a tee'd or island string value
+    // is still an editable member of a streamed object). Carry the decision
+    // to onStringEnd, where the value end finalizes a drop span.
+    this.pendingStringDecision = this.memberEditActive ? this.decideMember("string", offset) : null;
     const app = this.schemasForValue();
     if (this.needsTee(app)) {
       this.beginTee(app);
@@ -1252,6 +1518,14 @@ export class SpineValidator implements JsonEventHandler {
 
   onStringEnd(codePoints: number, startOffset: number, endOffset: number): void {
     this.curOffset = endOffset;
+    // Finalize a string member's edit at its value end, which is known here
+    // regardless of how the value itself classifies (a tee'd or island value
+    // still completes via this handler). Runs before the value's own
+    // tee/island handling below.
+    if (this.pendingStringDecision !== null) {
+      this.finalizeScalarMember(this.pendingStringDecision, endOffset);
+      this.pendingStringDecision = null;
+    }
     if (this.tee !== null) {
       this.teeFeed((s) => s.onStringEnd(codePoints, startOffset, endOffset));
       this.tee.inString = false;
@@ -1323,6 +1597,8 @@ export class SpineValidator implements JsonEventHandler {
       this.forwardIsland((b) => b.onNumber(value));
       return;
     }
+    if (this.memberEditActive)
+      this.finalizeScalarMember(this.decideMember("number", startOffset), endOffset);
     const app = this.schemasForValue();
     const type = Number.isInteger(value) ? "integer" : "number";
     if (this.needsTee(app)) {
@@ -1346,6 +1622,8 @@ export class SpineValidator implements JsonEventHandler {
       this.forwardIsland((b) => b.onBoolean(value));
       return;
     }
+    if (this.memberEditActive)
+      this.finalizeScalarMember(this.decideMember("boolean", startOffset), endOffset);
     const app = this.schemasForValue();
     if (this.needsTee(app)) {
       this.teeScalar(app, (s) => s.onBoolean(value, startOffset, endOffset));
@@ -1368,6 +1646,8 @@ export class SpineValidator implements JsonEventHandler {
       this.forwardIsland((b) => b.onNull());
       return;
     }
+    if (this.memberEditActive)
+      this.finalizeScalarMember(this.decideMember("null", startOffset), endOffset);
     const app = this.schemasForValue();
     if (this.needsTee(app)) {
       this.teeScalar(app, (s) => s.onNull(startOffset, endOffset));

--- a/packages/stream-validator/src/spine/spine.ts
+++ b/packages/stream-validator/src/spine/spine.ts
@@ -346,7 +346,18 @@ export interface ScopeClose {
   path: PathSegment[];
   kind: "object" | "array";
   valid: boolean;
+  /**
+   * Members (object) or elements (array) seen in the *input*. The observe
+   * count, surfaced verbatim as `ScopeContext.memberCount`.
+   */
   memberCount: number;
+  /**
+   * Members that survive to the *output* after member edits: kept + renamed,
+   * excluding dropped. Equals {@link memberCount} when no member edits apply.
+   * Drives the leading-comma decision in `ScopeContext.field()`, so an
+   * appended field after an all-members drop does not emit a stray comma.
+   */
+  outputMemberCount: number;
   /** Byte offset of the closing delimiter (`}` / `]`). */
   delimiterOffset: number;
 }
@@ -1254,6 +1265,9 @@ export class SpineValidator implements JsonEventHandler {
       kind: "object",
       valid: this.violations.length === frame.violationsAtOpen,
       memberCount: frame.count,
+      // Surviving output members: kept + renamed (a drop never enters
+      // `outputKeys`). Null when member edits are off, where output == input.
+      outputMemberCount: frame.outputKeys !== null ? frame.outputKeys.size : frame.count,
       delimiterOffset: offset,
     });
     this.popSegment();
@@ -1327,6 +1341,8 @@ export class SpineValidator implements JsonEventHandler {
       kind: "array",
       valid: this.violations.length === frame.violationsAtOpen,
       memberCount: frame.count,
+      // Array elements are never member-dropped, so output == input.
+      outputMemberCount: frame.count,
       delimiterOffset: offset,
     });
     this.popSegment();

--- a/packages/stream-validator/src/tokenizer/tokenizer.ts
+++ b/packages/stream-validator/src/tokenizer/tokenizer.ts
@@ -125,6 +125,26 @@ export class JsonTokenizer {
   }
 
   /**
+   * The lowest input-byte offset whose emission must wait for a member-edit
+   * decision: the start of an object key currently mid-parse (so a key that
+   * straddles a chunk boundary is not echoed before a rename can rewrite it),
+   * else `+Infinity`. The editing echo holds bytes at or past this offset.
+   * Values are never held here (only keys are edit targets), so a large value
+   * streams regardless. Cheap to call after {@link write}.
+   */
+  editHoldOffset(): number {
+    if (
+      this.stringIsKey &&
+      (this.state === ST_IN_STRING ||
+        this.state === ST_IN_STRING_ESCAPE ||
+        this.state === ST_IN_STRING_UNICODE)
+    ) {
+      return this.stringStart;
+    }
+    return Number.POSITIVE_INFINITY;
+  }
+
+  /**
    * Feed the next chunk of input bytes. The per-byte state dispatch is
    * inlined here (rather than a per-byte method call) because it is the
    * hot loop; the string body, numbers, and escapes batch in their own

--- a/packages/stream-validator/test/member-edit.test.ts
+++ b/packages/stream-validator/test/member-edit.test.ts
@@ -327,3 +327,113 @@ describe("editMember nested objects", () => {
     ]);
   });
 });
+
+describe("editMember on a scalar routed through a BUFFER island", () => {
+  // Under an asserting OpenAPI dialect a `format`-bearing scalar is delegated
+  // to the in-memory engine (a scalar BUFFER island), not stream-checked. The
+  // edit is decided at the value start (pre-classification) and finalized at
+  // the value end; the delegate validates the materialized value but never
+  // emits output, so the echo remains the single output path. These pin that
+  // boundary: edit applies, verdict comes from the delegate. A custom format
+  // (deterministic, definitely asserting) forces the island.
+  const schema = {
+    type: "object",
+    properties: { when: { type: "string", format: "even-len" } },
+  };
+  const opts = {
+    openApiVersion: "3.1",
+    formats: { "even-len": (s: string) => s.length % 2 === 0 },
+  };
+
+  it("renames a delegated format scalar, value verbatim, verdict from the delegate", async () => {
+    const r = await run(
+      schema,
+      '{"when":"abcd","keep":1}',
+      (v) => v.editMember(["when"], rename("ts")),
+      opts,
+    );
+    expect(r.output).toBe('{"ts":"abcd","keep":1}');
+    expect(r.valid).toBe(true);
+  });
+
+  it("drops a delegated format scalar (still validated, then suppressed)", async () => {
+    const r = await run(
+      schema,
+      '{"when":"abcd","keep":1}',
+      (v) => v.editMember(["when"], drop),
+      opts,
+    );
+    expect(r.output).toBe('{"keep":1}');
+    expect(r.valid).toBe(true);
+  });
+
+  it("applies the rename even when the delegated value fails its format", async () => {
+    // decide-before-classification: the key is rewritten at value start, so an
+    // invalid format still renames; the delegate's verdict flows independently.
+    const r = await run(schema, '{"when":"abc"}', (v) => v.editMember(["when"], rename("ts")), {
+      ...opts,
+      maxErrors: Number.POSITIVE_INFINITY,
+      policy: "detach",
+    });
+    expect(r.output).toBe('{"ts":"abc"}');
+    expect(r.valid).toBe(false);
+  });
+});
+
+describe("editMember rename of a container routed through BUFFER/TEE, then trailing drop", () => {
+  // Rename is decided at the key token, independent of how the value
+  // classifies, so a key in front of a non-streamed container renames the same
+  // as in front of a plain array. The load-bearing assertion is that
+  // `noteContainerMemberEnd` records the right `lastKeptValueEnd` on the
+  // finalizeIsland / finalizeTee paths, so a following trailing scalar drop
+  // absorbs the correct comma.
+  it("renames a BUFFER container (uniqueItems) then drops a trailing scalar", async () => {
+    const schema = {
+      type: "object",
+      properties: { tags: { type: "array", uniqueItems: true } },
+    };
+    const r = await run(schema, '{"tags":[1,2,3],"drop_me":1}', (v) => {
+      v.editMember(["tags"], rename("labels"));
+      v.editMember(["drop_me"], drop);
+    });
+    expect(r.output).toBe('{"labels":[1,2,3]}');
+    expect(r.valid).toBe(true);
+  });
+
+  it("renames a TEE container (oneOf) then drops a trailing scalar", async () => {
+    const schema = {
+      type: "object",
+      properties: { val: { oneOf: [{ type: "array" }, { type: "number" }] } },
+    };
+    const r = await run(schema, '{"val":[1,2],"drop_me":1}', (v) => {
+      v.editMember(["val"], rename("value"));
+      v.editMember(["drop_me"], drop);
+    });
+    expect(r.output).toBe('{"value":[1,2]}');
+    expect(r.valid).toBe(true);
+  });
+});
+
+describe("editMember collision rule keys on surviving output names", () => {
+  // The duplicate-key guard polices effective *surviving* output names, not
+  // raw input keys: a rename onto a name whose original is itself dropped is
+  // legal (the original never reaches the output). The symmetric case (rename
+  // onto a surviving key) stays fatal, covered above.
+  it("allows a->b when the original b is dropped", async () => {
+    const r = await run({ type: "object" }, '{"a":1,"b":2}', (v) => {
+      v.editMember(["a"], rename("b"));
+      v.editMember(["b"], drop);
+    });
+    expect(r.err).toBeUndefined();
+    expect(r.output).toBe('{"b":1}');
+  });
+
+  it("allows b->a when the original a is dropped", async () => {
+    const r = await run({ type: "object" }, '{"a":1,"b":2}', (v) => {
+      v.editMember(["a"], drop);
+      v.editMember(["b"], rename("a"));
+    });
+    expect(r.err).toBeUndefined();
+    expect(r.output).toBe('{"a":2}');
+  });
+});

--- a/packages/stream-validator/test/member-edit.test.ts
+++ b/packages/stream-validator/test/member-edit.test.ts
@@ -1,0 +1,329 @@
+import { Readable, Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { describe, expect, it } from "vitest";
+import type { SchemaOrBoolean } from "@oav/core";
+import {
+  createStreamValidator,
+  type MemberContext,
+  type MemberEdit,
+  type StreamValidator,
+} from "../src/index.js";
+
+const enc = new TextEncoder();
+
+interface RunResult {
+  output: string;
+  err: Error | undefined;
+  valid: boolean | undefined;
+}
+
+async function run(
+  schema: SchemaOrBoolean,
+  json: string,
+  setup: (v: StreamValidator) => void,
+  opts: Record<string, unknown> = {},
+  chunkSize = 0,
+): Promise<RunResult> {
+  const v = createStreamValidator(schema, opts as never);
+  setup(v);
+  v.on("error", () => {});
+  const out: Buffer[] = [];
+  const sink = new Writable({
+    write(c: Buffer, _e, cb) {
+      out.push(Buffer.from(c));
+      cb();
+    },
+  });
+  const bytes = enc.encode(json);
+  const chunks =
+    chunkSize > 0
+      ? Array.from({ length: Math.ceil(bytes.length / chunkSize) }, (_, i) =>
+          Buffer.from(bytes.subarray(i * chunkSize, (i + 1) * chunkSize)),
+        )
+      : [Buffer.from(bytes)];
+  let err: Error | undefined;
+  try {
+    await pipeline(Readable.from(chunks), v, sink);
+  } catch (e) {
+    err = e as Error;
+  }
+  const verdict = await v.result.then(
+    (r) => r.valid,
+    () => undefined,
+  );
+  return { output: Buffer.concat(out).toString("utf8"), err, valid: verdict };
+}
+
+const rename = (key: string) => (): MemberEdit => ({ action: "rename", key });
+const drop = (): MemberEdit => ({ action: "drop" });
+
+describe("editMember rename", () => {
+  it("renames a scalar key, value verbatim", async () => {
+    const r = await run({ type: "object" }, '{"a":1,"b":2}', (v) =>
+      v.editMember(["a"], rename("z")),
+    );
+    expect(r.output).toBe('{"z":1,"b":2}');
+    expect(r.valid).toBe(true);
+  });
+
+  it("renames a key whose value is an array, streaming the array verbatim", async () => {
+    const schema = { type: "object", properties: { ids: { type: "array" } } };
+    const r = await run(schema, '{"ids":[1,2,3,4,5]}', (v) =>
+      v.editMember(["ids"], rename("records")),
+    );
+    expect(r.output).toBe('{"records":[1,2,3,4,5]}');
+    expect(r.valid).toBe(true);
+  });
+
+  it("renames a key whose value is an object", async () => {
+    const r = await run({ type: "object" }, '{"meta":{"x":1}}', (v) =>
+      v.editMember(["meta"], rename("m")),
+    );
+    expect(r.output).toBe('{"m":{"x":1}}');
+  });
+
+  it("only renames the targeted (full-path) member", async () => {
+    const r = await run({ type: "object" }, '{"a":{"a":1}}', (v) =>
+      v.editMember(["a"], rename("z")),
+    );
+    // The nested "a" is at path ["a","a"], not matched by ["a"].
+    expect(r.output).toBe('{"z":{"a":1}}');
+  });
+
+  it("renames correctly across tiny chunk boundaries", async () => {
+    const schema = { type: "object", properties: { message_ids: { type: "array" } } };
+    const json = '{"message_ids":["x","y","z"],"batch":7}';
+    for (const cs of [1, 2, 3, 5, 8]) {
+      const r = await run(
+        schema,
+        json,
+        (v) => v.editMember(["message_ids"], rename("records")),
+        {},
+        cs,
+      );
+      expect(r.output, `chunk size ${cs}`).toBe('{"records":["x","y","z"],"batch":7}');
+      expect(r.valid).toBe(true);
+    }
+  });
+
+  it("preserves whitespace/formatting around the renamed key", async () => {
+    const r = await run({ type: "object" }, '{\n  "a" : 1\n}', (v) =>
+      v.editMember(["a"], rename("zz")),
+    );
+    expect(r.output).toBe('{\n  "zz" : 1\n}');
+  });
+});
+
+describe("editMember rename does not buffer the value", () => {
+  it("renames a key over a large array under a tiny maxBufferedBytes", async () => {
+    // A value far larger than the cap: if rename buffered it, the cap would trip.
+    const schema = {
+      type: "object",
+      properties: { ids: { type: "array", items: { type: "number" } } },
+    };
+    const big = Array.from({ length: 20000 }, (_, i) => i).join(",");
+    const json = `{"ids":[${big}]}`;
+    const r = await run(
+      schema,
+      json,
+      (v) => v.editMember(["ids"], rename("records")),
+      { maxBufferedBytes: 64 },
+      256,
+    );
+    expect(r.valid).toBe(true);
+    expect(r.err).toBeUndefined();
+    expect(r.output).toBe(`{"records":[${big}]}`);
+  });
+});
+
+describe("editMember drop", () => {
+  it("drops a middle member (absorbs the following comma)", async () => {
+    const r = await run({ type: "object" }, '{"a":1,"b":2,"c":3}', (v) =>
+      v.editMember(["b"], drop),
+    );
+    expect(r.output).toBe('{"a":1,"c":3}');
+    expect(r.valid).toBe(true);
+  });
+
+  it("drops the first member", async () => {
+    const r = await run({ type: "object" }, '{"a":1,"b":2}', (v) => v.editMember(["a"], drop));
+    expect(r.output).toBe('{"b":2}');
+  });
+
+  it("drops the last member (absorbs the preceding comma)", async () => {
+    const r = await run({ type: "object" }, '{"a":1,"b":2}', (v) => v.editMember(["b"], drop));
+    expect(r.output).toBe('{"a":1}');
+  });
+
+  it("drops the only member", async () => {
+    const r = await run({ type: "object" }, '{"a":1}', (v) => v.editMember(["a"], drop));
+    expect(JSON.parse(r.output)).toEqual({});
+  });
+
+  it("drops two consecutive members", async () => {
+    const r = await run({ type: "object" }, '{"a":1,"b":2,"c":3,"d":4}', (v) => {
+      v.editMember(["b"], drop);
+      v.editMember(["c"], drop);
+    });
+    expect(r.output).toBe('{"a":1,"d":4}');
+  });
+
+  it("drops trailing members after a kept array sibling", async () => {
+    const schema = { type: "object", properties: { ids: { type: "array" } } };
+    const r = await run(schema, '{"ids":[1,2,3],"x":1,"y":2}', (v) => {
+      v.editMember(["x"], drop);
+      v.editMember(["y"], drop);
+    });
+    expect(r.output).toBe('{"ids":[1,2,3]}');
+    expect(r.valid).toBe(true);
+  });
+
+  it("drops a deprecated scalar across chunk boundaries", async () => {
+    const json = '{"keep":"v","old":"deprecated","tail":3}';
+    for (const cs of [1, 2, 4, 7]) {
+      const r = await run({ type: "object" }, json, (v) => v.editMember(["old"], drop), {}, cs);
+      expect(r.output, `chunk size ${cs}`).toBe('{"keep":"v","tail":3}');
+    }
+  });
+
+  it("still validates a dropped member (validate-by-default)", async () => {
+    const schema = {
+      type: "object",
+      properties: { gone: { type: "number" } },
+    };
+    // "gone" is a string but the schema says number: invalid even though dropped.
+    const r = await run(schema, '{"gone":"x","keep":1}', (v) => v.editMember(["gone"], drop), {
+      maxErrors: Number.POSITIVE_INFINITY,
+      policy: "detach",
+    });
+    expect(r.valid).toBe(false);
+    expect(r.output).toBe('{"keep":1}');
+  });
+});
+
+describe("editMember rename + drop together", () => {
+  it("renames one member and drops another", async () => {
+    const schema = { type: "object", properties: { ids: { type: "array" } } };
+    const r = await run(schema, '{"ids":[1,2],"old":true,"keep":9}', (v) => {
+      v.editMember(["ids"], rename("records"));
+      v.editMember(["old"], drop);
+    });
+    expect(r.output).toBe('{"records":[1,2],"keep":9}');
+    expect(JSON.parse(r.output)).toEqual({ records: [1, 2], keep: 9 });
+  });
+});
+
+describe("editMember collisions and conflicts are fatal", () => {
+  it("fails when a rename target duplicates an existing later key", async () => {
+    const r = await run({ type: "object" }, '{"a":1,"b":2}', (v) =>
+      v.editMember(["a"], rename("b")),
+    );
+    expect(r.err).toBeDefined();
+    expect(r.err?.name).toBe("MemberEditError");
+  });
+
+  it("fails when a rename target duplicates an existing earlier key", async () => {
+    const r = await run({ type: "object" }, '{"b":2,"a":1}', (v) =>
+      v.editMember(["a"], rename("b")),
+    );
+    expect(r.err?.name).toBe("MemberEditError");
+  });
+
+  it("allows a key swap (rename a->b while b->c)", async () => {
+    const r = await run({ type: "object" }, '{"a":1,"b":2}', (v) => {
+      v.editMember(["a"], rename("b"));
+      v.editMember(["b"], rename("c"));
+    });
+    expect(r.err).toBeUndefined();
+    expect(r.output).toBe('{"b":1,"c":2}');
+  });
+
+  it("fails on conflicting hooks for one member", async () => {
+    const r = await run({ type: "object" }, '{"a":1}', (v) => {
+      v.editMember(["a"], rename("x"));
+      v.editMember(["a"], rename("y"));
+    });
+    expect(r.err?.name).toBe("MemberEditError");
+  });
+
+  it("tolerates two hooks that agree (same rename)", async () => {
+    const r = await run({ type: "object" }, '{"a":1}', (v) => {
+      v.editMember(["a"], rename("x"));
+      v.editMember(["a"], rename("x"));
+    });
+    expect(r.err).toBeUndefined();
+    expect(r.output).toBe('{"x":1}');
+  });
+});
+
+describe("editMember caps", () => {
+  it("fails when colon-to-value whitespace exceeds maxMemberPrefixBytes", async () => {
+    const pad = " ".repeat(64);
+    const r = await run(
+      { type: "object" },
+      `{"a":${pad}1}`,
+      (v) => v.editMember(["a"], rename("z")),
+      {
+        maxMemberPrefixBytes: 16,
+      },
+    );
+    expect(r.err?.name).toBe("MemberEditError");
+  });
+
+  it("fails when a dropped member's span exceeds maxMemberDropBytes", async () => {
+    const big = "x".repeat(200);
+    const r = await run(
+      { type: "object" },
+      `{"a":"${big}","b":2}`,
+      (v) => v.editMember(["a"], drop),
+      {
+        maxMemberDropBytes: 32,
+      },
+    );
+    expect(r.err?.name).toBe("MemberEditError");
+  });
+
+  it("rejects a container drop as unsupported", async () => {
+    const schema = { type: "object", properties: { obj: { type: "object" } } };
+    const r = await run(schema, '{"obj":{"x":1}}', (v) => v.editMember(["obj"], drop));
+    expect(r.err?.name).toBe("MemberEditError");
+  });
+});
+
+describe("editMember nested objects", () => {
+  it("renames and drops members in a nested object selected by full path", async () => {
+    const schema = { type: "object", properties: { inner: { type: "object" } } };
+    const r = await run(schema, '{"inner":{"a":1,"b":2,"c":3}}', (v) => {
+      v.editMember(["inner", "a"], rename("z"));
+      v.editMember(["inner", "b"], drop);
+    });
+    expect(r.output).toBe('{"inner":{"z":1,"c":3}}');
+    expect(JSON.parse(r.output)).toEqual({ inner: { z: 1, c: 3 } });
+  });
+
+  it("keep is a no-op (returning null too)", async () => {
+    const r = await run({ type: "object" }, '{"a":1,"b":2}', (v) => {
+      v.editMember(["a"], () => ({ action: "keep" }));
+      v.editMember(["b"], () => null);
+    });
+    expect(r.output).toBe('{"a":1,"b":2}');
+  });
+
+  it("exposes the member context (path, key, valueType)", async () => {
+    const seen: MemberContext[] = [];
+    await run({ type: "object" }, '{"s":"x","n":1,"arr":[]}', (v) =>
+      v.editMember(
+        () => true,
+        (m) => {
+          seen.push(m);
+          return { action: "keep" };
+        },
+      ),
+    );
+    expect(seen.map((m) => [m.key, m.valueType])).toEqual([
+      ["s", "string"],
+      ["n", "number"],
+      ["arr", "array"],
+    ]);
+  });
+});

--- a/packages/stream-validator/test/member-edit.test.ts
+++ b/packages/stream-validator/test/member-edit.test.ts
@@ -437,3 +437,94 @@ describe("editMember collision rule keys on surviving output names", () => {
     expect(r.output).toBe('{"a":2}');
   });
 });
+
+describe("editMember + editClose interaction (cross-hook output-member count)", () => {
+  // `editClose`'s field() leading comma must track *surviving output* members,
+  // not the pre-edit input count: after a member drop the appended field has to
+  // know whether anything is left to comma-separate from. A drop never enters
+  // the output-key set, so an all-members drop leaves a zero output count and
+  // field() omits the comma.
+  it("drop-all + editClose field omits the stray comma (root)", async () => {
+    const r = await run({ type: "object" }, '{"a":1}', (v) => {
+      v.editMember(["a"], drop);
+      v.editClose([], (ctx) => ctx.field("x", 1));
+    });
+    expect(r.err).toBeUndefined();
+    expect(r.output).toBe('{"x":1}');
+  });
+
+  it("drop-all + editClose field omits the comma in a nested object (per-frame count)", async () => {
+    const r = await run({ type: "object" }, '{"outer":{"a":1}}', (v) => {
+      v.editMember(["outer", "a"], drop);
+      v.editClose(["outer"], (ctx) => ctx.field("x", 1));
+    });
+    expect(r.err).toBeUndefined();
+    expect(r.output).toBe('{"outer":{"x":1}}');
+  });
+
+  it("partial drop + editClose field keeps the comma (a survivor remains)", async () => {
+    const r = await run({ type: "object" }, '{"a":1,"b":2}', (v) => {
+      v.editMember(["b"], drop);
+      v.editClose([], (ctx) => ctx.field("x", 1));
+    });
+    expect(r.err).toBeUndefined();
+    expect(r.output).toBe('{"a":1,"x":1}');
+  });
+
+  it("rename-only + editClose field keeps the comma (a renamed member is a survivor)", async () => {
+    const r = await run({ type: "object" }, '{"a":1}', (v) => {
+      v.editMember(["a"], rename("z"));
+      v.editClose([], (ctx) => ctx.field("x", 1));
+    });
+    expect(r.err).toBeUndefined();
+    expect(r.output).toBe('{"z":1,"x":1}');
+  });
+
+  it("observer memberCount stays the pre-edit input count under drop-all", async () => {
+    let observed: number | undefined;
+    const r = await run({ type: "object" }, '{"a":1}', (v) => {
+      v.editMember(["a"], drop);
+      v.onScopeClose([], (ctx) => {
+        observed = ctx.memberCount;
+      });
+    });
+    expect(r.err).toBeUndefined();
+    expect(r.output).toBe("{}");
+    // memberCount is the input observation, not the surviving output count.
+    expect(observed).toBe(1);
+  });
+});
+
+describe("scope-only editClose does not hold a chunk-split key", () => {
+  // The tokenizer mid-key hold exists for rename safety. With only `editClose`
+  // registered (no member hooks), there is no key rewrite, so a key straddling
+  // a chunk boundary must not be held: it would buffer to its closing quote
+  // with no member-prefix cap, regressing the append-only path. Observed
+  // directly: after a chunk that ends mid-key, the bytes preceding the key are
+  // already flushed downstream rather than withheld.
+  it("flushes the pre-key bytes before the split key closes", async () => {
+    const v = createStreamValidator({ type: "object" }, {});
+    v.editClose([], (ctx) => ctx.field("x", 1));
+    v.on("error", () => {});
+    const out: Buffer[] = [];
+    v.on("data", (c: Buffer) => out.push(Buffer.from(c)));
+
+    const longKey = "k".repeat(50000);
+    const json = `{"${longKey}":1}`;
+    const cut = 2 + 25000; // mid-key: past the leading `{"`, inside the key body
+    v.write(Buffer.from(json.slice(0, cut)));
+    await new Promise((resolve) => setImmediate(resolve));
+    // Held (pre-fix) would leave only the opening `{` flushed (~1 byte). With
+    // the hold gated off, everything up to the cut streams through.
+    const flushed = Buffer.concat(out).length;
+    expect(flushed).toBeGreaterThan(20000);
+
+    v.end(Buffer.from(json.slice(cut)));
+    const valid = await v.result.then(
+      (res) => res.valid,
+      () => undefined,
+    );
+    expect(Buffer.concat(out).toString("utf8")).toBe(`{"${longKey}":1,"x":1}`);
+    expect(valid).toBe(true);
+  });
+});


### PR DESCRIPTION
Implements #440: `editMember(at, fn)` to rename or drop an object member as it streams. This is the in-place edit `editClose` (append-only) could not do, and it retires the duplicate-key-shadow workaround a downstream consumer was relying on.

## What it does

- **rename** rewrites the key token only; the value streams verbatim, so renaming a key in front of a multi-GB array never buffers the array (the headline case: `message_ids` -> `records`).
- **drop** suppresses a member and absorbs one delimiter (the following comma for a middle member, the preceding comma for the last), leaving valid JSON.
- The hook fires at the member value start, so it sees the value type and returns keep / rename / drop.

## How

- The echo became an ordered span-edit layer (replace / delete / insert) with bounded cross-chunk retention, replacing the append-only injection splice. Held bytes are bounded by the pending key / drop span, so the bounded-heap property holds (verified: a rename over a 20k-element array under `maxBufferedBytes: 64` passes).
- Validation is pre-edit: the input shape is validated, edits are an output-only transform. A dropped member is still validated by default.
- A rename colliding with a same-scope key, and conflicting hooks on one member, are fatal. A key swap (`a`->`b` while `b`->`c`) is allowed via the effective-output-name set.
- Two caps default finite (they bound buffers the edit introduces): `maxMemberPrefixBytes` (held key-to-value span) and `maxMemberDropBytes` (dropped span).
- Member-edit work is gated behind a flag the engine flips on first `editMember`, so a stream with no member hooks pays nothing.
- Container drop is deferred to a later phase; rename works for any value type.

All design questions from #440 are settled (separate `editMember`, finite caps, fatal collision/conflict, validate-dropped-by-default).

## Review (agent forum, Codex)

A pre-merge review caught two defects at the seam between the new hook and the existing `editClose`, both fixed in the final commit:

- **Drop-all-members + `editClose(ctx.field())` emitted invalid JSON** (`{,"x":1}`): `field()`'s leading comma keyed on the pre-edit input count. Fixed by adding a surviving output-member count to `ScopeClose` (`outputKeys.size` for objects, since a drop never enters that map) and keying the comma on it; observer `memberCount` keeps its input-count meaning.
- **Scope-only `editClose` held a chunk-straddling key uncapped**: the tokenizer mid-key hold (added for rename safety) applied even with no member hooks, regressing the append-only path's memory behavior. Fixed by folding the hold into `editSafeLimit()` only when member hooks are registered.

Both have reproducer-checked regression tests (reverting either fix fails exactly the bug-exercising cases, while the guard tests pass either way).

## Tests

`test/member-edit.test.ts`: rename (scalar/array/object, cross-chunk, large-array-unbuffered, formatting preserved), drop (first/middle/last/only, consecutive, trailing-after-array, cross-chunk, validate-by-default), rename+drop together, collision/conflict/swap, the two caps, container-drop-unsupported, nested objects, member-context exposure, and the cross-hook edges from review (drop-all + field at root and nested, partial-drop-stays-commaful, rename-only survivor, observer memberCount unchanged, scope-only no-hold flush). Full suite green; typecheck and lint (oxlint/oxfmt/check-deps) clean.

Note: the `pnpm build && pnpm typecheck` ordering quirk in CI (tsup `clean` wiping tsc's per-file `.d.ts`) is pre-existing and reproduces on `main`; `tsc -b --force` is clean.

## Follow-up (not in this PR)

#439 (report peak buffered bytes) is the sibling runtime-telemetry feature and stays a separate PR. When it lands, its peak accounting must include the member-prefix, drop-retention, and cross-chunk edit-retention spans this PR introduces, otherwise the meter under-reports under edit hooks. At that point the rename-over-large-array no-buffering test can tighten from a `maxBufferedBytes` ceiling to an exact-peak assertion.

Closes #440.