### PR TITLE
feat(stream-validator): report peak buffered bytes on the verdict

### DIFF
--- a/packages/stream-validator/README.md
+++ b/packages/stream-validator/README.md
@@ -47,7 +47,7 @@ try {
 
 // Or observe the side channel directly:
 validator.on("violation", (v) => console.warn(v.code, v.path, v.byteOffset));
-const verdict = await validator.result; // { valid, violations }
+const verdict = await validator.result; // { valid, violations, peakBufferedBytes }
 ```
 
 Output bytes are the input verbatim (provisional until a clean finish).
@@ -231,6 +231,13 @@ in the same UTF-8 wire bytes `maxBufferedBytes` caps (heavy `\uXXXX`
 escaping can exceed the per-character assumption), so treat the number as a
 capacity-planning figure, not a runtime meter. An unstreamable schema
 throws the same `ClassifierError` `createStreamValidator` raises.
+
+The runtime meter is `verdict.peakBufferedBytes` on `validator.result`: the
+high-water buffered wire bytes an actual stream reached, in the same model
+(`0` when nothing buffered, a single island exact, sibling buffers maxed, a
+TEE's branches summed, plus any edit-hook retention). Compare it to this
+report's `peakBytes` to see how close real traffic came to the predicted
+peak. The analyzer bounds the schema; `peakBufferedBytes` reports the input.
 
 `analyzeSpec(document, options)` rolls this up over a whole resolved
 OpenAPI document: one budget per operation, for the request body and each

--- a/packages/stream-validator/src/engine/stream-validator.ts
+++ b/packages/stream-validator/src/engine/stream-validator.ts
@@ -293,6 +293,10 @@ export class StreamValidator extends Transform {
   private pendingEdits: Array<{ start: number; end: number; bytes: Buffer | null }> = [];
   private heldBytes: Buffer = Buffer.alloc(0);
   private heldBase = 0;
+  // High-water mark of the edit-retention echo: the residual held across
+  // `_transform` calls (a member-prefix / drop / cross-chunk span awaiting an
+  // edit decision). Folded into the spine's buffered-byte peak on the verdict.
+  private peakHeldBytes = 0;
 
   /** Resolves with the final verdict (rejects on a fatal parse / I/O error). */
   readonly result: Promise<StreamVerdict>;
@@ -450,6 +454,29 @@ export class StreamValidator extends Transform {
     // rejecting instead). Mark it handled so a rejection here is not an
     // unhandled-rejection warning; explicit awaiters still observe it.
     this.result.catch(() => {});
+  }
+
+  // The post-flush residual is the bytes that could not be emitted yet (held
+  // for a pending edit decision); its high-water across `_transform` calls is
+  // the edit-retention cost.
+  private noteHeldPeak(): void {
+    if (this.heldBytes.length > this.peakHeldBytes) this.peakHeldBytes = this.heldBytes.length;
+  }
+
+  // The spine's verdict with the engine's edit-retention high-water folded
+  // into `peakBufferedBytes`. The spine's analyzer-model peak and the
+  // edit-retention residual peak are *summed*, not maxed: they are distinct
+  // retention sites, so a conservative total is the honest number for a
+  // budget meter (matching how a TEE sums its concurrent branch peaks). A
+  // `max` would under-report, the wrong failure mode here. The cost is one
+  // add. Note the edit side is the held residual high-water, not exact
+  // concurrent live bytes.
+  private sealedVerdict(): StreamVerdict {
+    const v = this.spine.verdict();
+    return {
+      ...v,
+      peakBufferedBytes: v.peakBufferedBytes + this.peakHeldBytes,
+    };
   }
 
   private handleViolation(violation: SchemaViolation): void {
@@ -681,9 +708,13 @@ export class StreamValidator extends Transform {
       }
       if (err === undefined) {
         this.flushEdits(this.editSafeLimit());
+        this.noteHeldPeak();
         cb();
       } else if (err instanceof BudgetReached) {
-        // Detach echoes the tail verbatim; flush whatever is held first.
+        // The budget tripped on this chunk: record the held residual before
+        // `flushHeldVerbatim` dumps it, so the edit-retention peak this chunk
+        // reached still reaches `sealedVerdict` (applyBudget resolves there).
+        this.noteHeldPeak();
         this.flushHeldVerbatim();
         this.applyBudget(cb);
       } else {
@@ -735,7 +766,7 @@ export class StreamValidator extends Transform {
         }
       }
     }
-    const verdict = this.spine.verdict();
+    const verdict = this.sealedVerdict();
     this.finished = true;
     this.emit("verdict", verdict);
     this.resolveResult(verdict);
@@ -751,7 +782,7 @@ export class StreamValidator extends Transform {
   // The validation budget was reached mid-write: under `terminate`, fail
   // the stream now; under `detach`, seal the verdict and echo the tail.
   private applyBudget(cb: TransformCallback): void {
-    const verdict = this.spine.verdict();
+    const verdict = this.sealedVerdict();
     if (this.policy === "terminate") {
       this.finished = true;
       this.emit("verdict", verdict);

--- a/packages/stream-validator/src/spine/spine.ts
+++ b/packages/stream-validator/src/spine/spine.ts
@@ -286,6 +286,25 @@ export type MemberDecision = { kind: "keep" } | { kind: "rename"; key: string } 
 export interface StreamVerdict {
   valid: boolean;
   violations: SchemaViolation[];
+  /**
+   * High-water buffered wire bytes (UTF-8 source span), the runtime companion
+   * to `analyzeStreamability().peakBytes`. This is an upper-bound *estimate*
+   * in the analyzer's concurrency model, not an exact live-heap gauge: a
+   * single BUFFER island is exact, sibling buffers take the max, and a TEE
+   * sums its branch peaks (conservative, since branches overlap but the sum
+   * assumes full concurrency). The engine adds its edit-retention echo on top.
+   * Interpret it as the analyzer-model peak, comparable to the predicted
+   * `peakBytes`:
+   *
+   *   - `0` means no buffering happened (a fully-streamable validation with no
+   *     edit hooks).
+   *   - A non-zero value is how close real traffic came to the buffer budget
+   *     (`maxBufferedBytes`), in the same unit.
+   *
+   * A proportional proxy for heap, not a heap figure (the materialized value
+   * is larger than its source span).
+   */
+  peakBufferedBytes: number;
 }
 
 type JsonType = "object" | "array" | "string" | "number" | "integer" | "boolean" | "null";
@@ -407,6 +426,10 @@ export class SpineValidator implements JsonEventHandler {
   private readonly delegate: IslandDelegate | undefined;
   private readonly maxErrors: number;
   private readonly maxBufferedBytes: number | undefined;
+  // High-water mark of buffered wire bytes (see {@link StreamVerdict.peakBufferedBytes}).
+  // Bumped where a buffer's span is known: the island cap check, the
+  // forced-buffer scalar close, and a TEE close (sum of branch peaks).
+  private peakBufferedBytes = 0;
   private readonly maxUniqueItems: number | undefined;
   private readonly maxDepth: number | undefined;
   private readonly regexCompiler: RegexCompiler | undefined;
@@ -713,8 +736,23 @@ export class SpineValidator implements JsonEventHandler {
 
   /** The verdict so far (final once `end` has been called on the tokenizer). */
   verdict(): StreamVerdict {
-    if (this.verdictOnly) return { valid: !this.invalid, violations: this.violations };
-    return { valid: this.violations.length === 0, violations: this.violations };
+    const peakBufferedBytes = this.peakBufferedBytes;
+    if (this.verdictOnly)
+      return { valid: !this.invalid, violations: this.violations, peakBufferedBytes };
+    return { valid: this.violations.length === 0, violations: this.violations, peakBufferedBytes };
+  }
+
+  /** The buffered-bytes high-water reached so far. Read by an enclosing TEE
+   * to sum its branch sub-spines' peaks. */
+  peakBuffered(): number {
+    return this.peakBufferedBytes;
+  }
+
+  // Raise the buffered-bytes high-water to `bytes` if it exceeds the current
+  // mark. Called where a buffer's span is known (island cap check, scalar
+  // close, TEE close).
+  private notePeakBuffered(bytes: number): void {
+    if (bytes > this.peakBufferedBytes) this.peakBufferedBytes = bytes;
   }
 
   private fail(code: string, path: PathSegment[] = this.path): void {
@@ -935,10 +973,14 @@ export class SpineValidator implements JsonEventHandler {
   private forwardIsland(feed: (b: ValueBuilder) => void): void {
     const island = this.island as NonNullable<typeof this.island>;
     feed(island.builder);
-    if (
-      this.maxBufferedBytes !== undefined &&
-      this.curOffset - island.byteStart > this.maxBufferedBytes
-    ) {
+    // The island's source span grows monotonically as it buffers; the last
+    // event before close carries its full span, so noting it per event lands
+    // the peak without a separate close hook. On the completing event
+    // `curOffset` is the closing `}` / `]`, whose own byte is part of the
+    // buffered span, so add it (the cap check keeps the pre-close convention).
+    const span = this.curOffset - island.byteStart;
+    this.notePeakBuffered(island.builder.complete ? span + 1 : span);
+    if (this.maxBufferedBytes !== undefined && span > this.maxBufferedBytes) {
       throw new BufferLimitError(this.maxBufferedBytes, this.curOffset);
     }
     // The island's root array grows one entry per top-level element; refuse
@@ -1045,6 +1087,13 @@ export class SpineValidator implements JsonEventHandler {
     const t = this.tee as NonNullable<typeof this.tee>;
     const o = t.obligations;
     const sawContainer = t.sawContainer;
+    // The branches buffered concurrently, so their peak is the sum of the
+    // per-branch peaks: a safe upper bound that does not chase exact overlap
+    // under nested tees. Each sub-spine ran its own buffering (islands,
+    // scalars, nested tees), so this rolls those up recursively.
+    let branchSum = 0;
+    for (const sub of t.subs) branchSum += sub.peakBuffered();
+    this.notePeakBuffered(branchSum);
     this.tee = null;
     if (!combineTee(o)) this.fail("composition");
     this.popSegment();
@@ -1556,6 +1605,11 @@ export class SpineValidator implements JsonEventHandler {
     }
     const s = this.str as NonNullable<typeof this.str>;
     this.str = null;
+    // A forced-buffer scalar held its full text (`s.text`); its source span
+    // is the buffered-byte cost, known in full only now. (Capture-only
+    // retention is bounded by `maxCaptureBytes`, a separate budget, and is
+    // not counted here.)
+    if (s.needText) this.notePeakBuffered(endOffset - s.offset);
     // Close the single-chunk bypass: cap the forced-buffer scalar on its
     // full source-byte span, known only now.
     if (

--- a/packages/stream-validator/test/member-edit.test.ts
+++ b/packages/stream-validator/test/member-edit.test.ts
@@ -15,6 +15,7 @@ interface RunResult {
   output: string;
   err: Error | undefined;
   valid: boolean | undefined;
+  peakBufferedBytes: number | undefined;
 }
 
 async function run(
@@ -48,10 +49,15 @@ async function run(
     err = e as Error;
   }
   const verdict = await v.result.then(
-    (r) => r.valid,
+    (r) => r,
     () => undefined,
   );
-  return { output: Buffer.concat(out).toString("utf8"), err, valid: verdict };
+  return {
+    output: Buffer.concat(out).toString("utf8"),
+    err,
+    valid: verdict?.valid,
+    peakBufferedBytes: verdict?.peakBufferedBytes,
+  };
 }
 
 const rename = (key: string) => (): MemberEdit => ({ action: "rename", key });
@@ -115,14 +121,15 @@ describe("editMember rename", () => {
 });
 
 describe("editMember rename does not buffer the value", () => {
-  it("renames a key over a large array under a tiny maxBufferedBytes", async () => {
+  const schema = {
+    type: "object",
+    properties: { ids: { type: "array", items: { type: "number" } } },
+  };
+  const big = Array.from({ length: 20000 }, (_, i) => i).join(",");
+  const json = `{"ids":[${big}]}`; // ~109 KB, dominated by the array
+
+  it("renames a key over a large array buffering nothing at realistic chunking", async () => {
     // A value far larger than the cap: if rename buffered it, the cap would trip.
-    const schema = {
-      type: "object",
-      properties: { ids: { type: "array", items: { type: "number" } } },
-    };
-    const big = Array.from({ length: 20000 }, (_, i) => i).join(",");
-    const json = `{"ids":[${big}]}`;
     const r = await run(
       schema,
       json,
@@ -133,6 +140,22 @@ describe("editMember rename does not buffer the value", () => {
     expect(r.valid).toBe(true);
     expect(r.err).toBeUndefined();
     expect(r.output).toBe(`{"records":[${big}]}`);
+    // The exact meter (#439): the `"ids":` key resolves within one chunk, so
+    // nothing is held across a boundary. The array streams; peak is zero.
+    expect(r.peakBufferedBytes).toBe(0);
+  });
+
+  it("holds only the key span, never the array, even byte-at-a-time", async () => {
+    // Pathological 1-byte chunks force the key token to straddle boundaries;
+    // the held high-water is the `"ids":` span (~6 bytes), orders of magnitude
+    // below the ~109 KB array. This is the #441 no-array-buffering promise,
+    // now asserted exactly rather than via a `maxBufferedBytes` ceiling.
+    const r = await run(schema, json, (v) => v.editMember(["ids"], rename("records")), {}, 1);
+    expect(r.valid).toBe(true);
+    expect(r.output).toBe(`{"records":[${big}]}`);
+    expect(r.peakBufferedBytes).toBeGreaterThan(0);
+    expect(r.peakBufferedBytes).toBeLessThanOrEqual('"ids":'.length);
+    expect(r.peakBufferedBytes).toBeLessThan(json.length / 1000);
   });
 });
 

--- a/packages/stream-validator/test/peak-buffered-bytes.test.ts
+++ b/packages/stream-validator/test/peak-buffered-bytes.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+import type { SchemaOrBoolean } from "@oav/core";
+import {
+  analyzeStreamability,
+  createStreamValidator,
+  type MemberEdit,
+  type StreamValidator,
+} from "../src/index.js";
+
+const enc = new TextEncoder();
+
+/**
+ * Stream `json` through the engine and return the verdict's
+ * `peakBufferedBytes`. `chunkSize > 0` feeds the input in fixed-size chunks
+ * (needed to observe edit-retention, which only persists across `_transform`
+ * calls); `0` writes it in one shot.
+ */
+async function streamPeak(
+  schema: SchemaOrBoolean,
+  json: string,
+  setup: (v: StreamValidator) => void = () => {},
+  opts: Record<string, unknown> = {},
+  chunkSize = 0,
+): Promise<number> {
+  const v = createStreamValidator(schema, {
+    policy: "detach",
+    maxErrors: Number.POSITIVE_INFINITY,
+    ...opts,
+  } as never);
+  setup(v);
+  v.on("error", () => {});
+  v.resume(); // drain (and discard) the echoed bytes
+  const result = v.result;
+  const bytes = Buffer.from(enc.encode(json));
+  if (chunkSize > 0) {
+    for (let i = 0; i < bytes.length; i += chunkSize) {
+      v.write(bytes.subarray(i, i + chunkSize));
+    }
+    v.end();
+  } else {
+    v.end(bytes);
+  }
+  return (await result).peakBufferedBytes;
+}
+
+const rename = (key: string) => (): MemberEdit => ({ action: "rename", key });
+const drop = (): MemberEdit => ({ action: "drop" });
+
+describe("peakBufferedBytes: fully-streamable paths report 0", () => {
+  it("a streamable object buffers nothing", async () => {
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      properties: { name: { type: "string", maxLength: 10 }, age: { type: "integer" } },
+    };
+    expect(await streamPeak(schema, '{"name":"ada","age":36}')).toBe(0);
+  });
+
+  it("a streamed array of scalars buffers nothing", async () => {
+    const schema = { type: "object", properties: { ids: { type: "array" } } };
+    expect(await streamPeak(schema, '{"ids":[1,2,3,4,5,6,7,8,9,10]}')).toBe(0);
+  });
+});
+
+describe("peakBufferedBytes: a BUFFER island reports its span", () => {
+  it("a uniqueItems array reports a non-zero peak within the analyzer's bound", async () => {
+    const schema = { type: "array", uniqueItems: true, maxItems: 3, items: { type: "integer" } };
+    const json = "[1,2,3]";
+    const peak = await streamPeak(schema, json);
+    // Exact for a single island: the full wire span, both brackets included.
+    expect(peak).toBe(Buffer.byteLength(json));
+    // Runtime peak is the actual input's span, never above the static
+    // worst-case the analyzer predicts for the schema.
+    expect(peak).toBeLessThanOrEqual(analyzeStreamability(schema).peakBytes);
+  });
+
+  it("a forced-buffer scalar (pattern) reports the string's span", async () => {
+    const schema = { type: "string", pattern: "^a+$" };
+    const peak = await streamPeak(schema, '"aaaaaaaa"');
+    // The whole string is held for the pattern test; its span is ~10 bytes.
+    expect(peak).toBeGreaterThan(0);
+    expect(peak).toBeLessThanOrEqual('"aaaaaaaa"'.length);
+  });
+});
+
+describe("peakBufferedBytes: a TEE sums its branch peaks", () => {
+  it("oneOf of two forced-buffer branches reports the sum, not the max", async () => {
+    const json = '"aaaa"';
+    const single = await streamPeak({ type: "string", pattern: "^a+$" }, json);
+    const tee = await streamPeak(
+      {
+        oneOf: [
+          { type: "string", pattern: "^a" },
+          { type: "string", pattern: "a$" },
+        ],
+      },
+      json,
+    );
+    expect(single).toBeGreaterThan(0);
+    // Both branches buffer the same string concurrently; the conservative
+    // upper bound is the sum of the per-branch peaks, not a single span.
+    expect(tee).toBe(2 * single);
+  });
+});
+
+describe("peakBufferedBytes: edit-retention is bounded and folded in", () => {
+  it("rename over a large array stays bounded to the key/prefix, not the array", async () => {
+    const schema = { type: "object", properties: { message_ids: { type: "array" } } };
+    const big = Array.from({ length: 2000 }, (_, i) => i).join(",");
+    const json = `{"message_ids":[${big}],"batch":7}`;
+    const peak = await streamPeak(
+      schema,
+      json,
+      (v) => v.editMember(["message_ids"], rename("records")),
+      {},
+      4, // tiny chunks: the array streams, only the key span is held across a boundary
+    );
+    expect(peak).toBeGreaterThan(0); // the key span is held across chunk boundaries
+    expect(peak).toBeLessThan(200); // ... and is tiny next to the ~7 KB array
+    expect(peak).toBeLessThan(json.length / 10);
+  });
+
+  it("a fully-streamable schema with no edit hooks still reports 0 under chunking", async () => {
+    const schema = { type: "object", properties: { ids: { type: "array" } } };
+    expect(await streamPeak(schema, '{"ids":[1,2,3,4,5]}', () => {}, {}, 3)).toBe(0);
+  });
+
+  it("dropping a scalar counts the withheld drop span", async () => {
+    const schema = { type: "object" };
+    const peak = await streamPeak(
+      schema,
+      '{"keep":1,"deprecated":"some-value-here","tail":2}',
+      (v) => v.editMember(["deprecated"], drop),
+      {},
+      4,
+    );
+    // The dropped member's span is held until the delete resolves at the next
+    // sibling key; it is non-zero and bounded by the member's own size.
+    expect(peak).toBeGreaterThan(0);
+    expect(peak).toBeLessThan(100);
+  });
+
+  it("sums a concurrent spine island and edit-retention, not maxes them", async () => {
+    // A schema buffer (uniqueItems island) on one member and an edit-hook
+    // drop on another are distinct retention sites; the verdict reports their
+    // sum (conservative), not the dominant one.
+    const islandSchema = {
+      type: "object",
+      properties: {
+        tags: { type: "array", uniqueItems: true, maxItems: 5, items: { type: "integer" } },
+      },
+    };
+    const plainSchema = { type: "object" };
+    const json = '{"tags":[1,2,3],"deprecated":"a-removed-value","tail":2}';
+    const dropDeprecated = (v: StreamValidator) => v.editMember(["deprecated"], drop);
+
+    const islandAlone = await streamPeak(islandSchema, json, () => {}, {}, 4);
+    const dropAlone = await streamPeak(plainSchema, json, dropDeprecated, {}, 4);
+    const combined = await streamPeak(islandSchema, json, dropDeprecated, {}, 4);
+
+    expect(islandAlone).toBeGreaterThan(0); // the uniqueItems array islands
+    expect(dropAlone).toBeGreaterThan(0); // the dropped member is held
+    // Sum, not max: the combined peak is strictly larger than either site
+    // alone, and equals their sum.
+    expect(combined).toBe(islandAlone + dropAlone);
+    expect(combined).toBeGreaterThan(Math.max(islandAlone, dropAlone));
+  });
+
+  it("records edit-retention even when the validation budget trips while held", async () => {
+    // The budget trips at object close (a `required` miss) while the sole
+    // dropped member is still held pending its delete. The retention peak for
+    // that final chunk must reach the verdict, not be discarded by the
+    // budget-path flush before it is recorded.
+    const peak = await streamPeak(
+      { type: "object", required: ["missing"] },
+      '{"drop_me":"some value"}',
+      (v) => v.editMember(["drop_me"], drop),
+      { policy: "detach", maxErrors: 1 },
+    );
+    // The whole held member span is counted; without the fix this is 0.
+    expect(peak).toBeGreaterThan(10);
+  });
+});


### PR DESCRIPTION
Closes #439.

## What

Adds `peakBufferedBytes` to `StreamVerdict` (resolved on `validator.result`): the high-water buffered wire bytes (UTF-8 source span) an actual stream reached. The runtime companion to `analyzeStreamability`, which predicts the peak statically; this reports what really happened, so a deployer sees how close real traffic came to the buffer budget (`maxBufferedBytes`) without watching memory.

`0` for a fully-streamable validation with no edit hooks. The no-edit fast path is unchanged except for carrying one number on the verdict (scalar counters, no new per-frame allocation).

## Model

An upper-bound estimate in the analyzer's concurrency model, not an exact live-heap gauge (heap-exact is out of scope; the materialized value is larger than its source span). What counts:

- **BUFFER islands** — the source span, including the closing bracket (the completing event's offset is the bracket itself), so a single island reads exact.
- **Forced-buffer scalars** — a `pattern` / `enum` / `const` string's accumulated span (capture-only retention is on the separate `maxCaptureBytes` budget, not counted).
- **TEE branches** — the sum of the per-branch sub-spine peaks (concurrent, a safe upper bound; doesn't chase exact overlap).
- **Edit-retention echo** — the engine's held residual across `_transform` calls (the member-prefix / drop / cross-chunk span held pending an edit decision, from #441).

Sibling buffers take the max; the spine peak and the edit-retention residual are **summed**, not maxed: they're distinct retention sites, so a conservative total is the honest number for a budget meter (a max would under-report, the wrong failure mode here). This matches how a TEE sums its concurrent branches.

## Review

Designed and reviewed via an agent forum session (Codex). Two design forks were settled there: per-site-max + tee-sum over an exact running gauge (cheaper, comparable to the analyzer), and sum over max for combining the edit-retention residual with the spine peak. Codex's review of the implementation then caught two defects, both fixed and reproducer-checked:

- A container island undercounted by one byte (its closing bracket was excluded from the span). A single island now reads the exact wire-byte length.
- The validation-budget path (`BudgetReached`) flushed held edit bytes before recording the retention high-water, so a budget tripping while bytes were held under-reported. The residual is now recorded before the flush.

## Tests

`packages/stream-validator/test/peak-buffered-bytes.test.ts` (11 cases): fully-streamable (0, and under chunking); a uniqueItems island (exact `Buffer.byteLength`, within the analyzer's static bound); a forced-buffer pattern scalar; a oneOf of two pattern branches asserting `tee === 2 * single` (sum, not max); rename over a ~7 KB array staying under 200 bytes (the #441 no-buffering promise); drop retention; the concurrent island + edit-drop summing (`combined === islandAlone + dropAlone`); and the budget-tripped-while-held regression. Full suite 1412 passing, typecheck and lint clean.

## Member-edit test tightening (add-on commit)

Now that the meter exists, the rename-over-large-array no-buffering test from the member-edit suite (#441) is tightened here from a `maxBufferedBytes` ceiling to an exact `peakBufferedBytes` assertion: at realistic 256-byte chunking the peak is exactly `0` (the `"ids":` key resolves within one chunk; the ~109 KB array streams), and byte-at-a-time chunking holds only the ~6-byte key span, never the array. The no-array-buffering promise is now stated directly rather than inferred from the cap not tripping.
