### PR TITLE
docs: reframe README around streaming validation and buffer budgets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,7 +227,7 @@ string) => boolean>` shaped for `compileSchema`'s `formats` option. A
   so error paths are unambiguous. Also exports the Fetch-API adapter
   (`httpRequestFromFetch`, …) for Next.js / Hono / Bun / Deno.
 - **`@aahoughton/oav-stream-validator`** (published standalone on its own
-  `0.x` line, not folded into the `oav-core` bundle): a second, push-based
+  independent `1.x` line, not folded into the `oav-core` bundle): a second, push-based
   streaming engine. Beyond
   `createStreamValidator`, it exports the **streamability analyzer**:
   `analyzeStreamability(schema)` returns a peak-buffer budget (where a
@@ -296,8 +296,8 @@ as a real runtime dependency (the same shape the framework adapters use for
 `@aahoughton/oav-core`). The `pack-smoke` job installs the locally-packed
 stream-validator tarball alongside oav so this dep resolves to the workspace
 build, not the registry. `stream-validator` is unlinked from the `oav-core`
-release group (its own `0.x` line), so a `stream-validator` bump can ripple
-into a CLI release that picks it up.
+release group (its own independent line, currently `1.x`), so a
+`stream-validator` bump can ripple into a CLI release that picks it up.
 
 ## Extending the compiler
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 
 Validate HTTP requests and responses against your OpenAPI spec.
 OpenAPI 3.0, 3.1, and 3.2, for JavaScript and TypeScript services.
+Large JSON bodies stream through a separate validator that checks
+them as they arrive, and a design-time analyzer reports which bodies
+stream and which must buffer before you ship.
 
 ```ts
 import { createValidator } from "@aahoughton/oav";
@@ -34,6 +37,14 @@ thrown exception, and `oav` never mutates your `req` / `res`.
 
 **Reach for oav when you want**
 
+- A pre-deploy answer to "which request and response bodies can stream,
+  which must buffer, and how large can a buffer get?" `analyzeSpec`
+  reports a per-operation peak-buffer budget from the spec alone;
+  `oav stream-check openapi.yaml` prints it as a table.
+- To validate large JSON bodies as they arrive, without holding a
+  multi-GB payload in heap. A separate streaming engine
+  (`@aahoughton/oav-stream-validator`) checks the body against its
+  operation schema while echoing the bytes through.
 - Structured errors with stable codes and paths, ready for
   `application/problem+json`, logs, or your own client messages.
 - A spec compiled to a single zero-dependency module that runs where
@@ -49,6 +60,8 @@ thrown exception, and `oav` never mutates your `req` / `res`.
 | Generic JSON Schema validation across many drafts   | Ajv                       |
 | Turnkey Express middleware with uploads + auth      | express-openapi-validator |
 | Framework-neutral OpenAPI request/response checking | oav                       |
+| Streaming validation of large JSON bodies           | oav                       |
+| A pre-deploy report of which bodies can stream      | oav                       |
 | Per-tenant or per-deployment spec overlays          | oav                       |
 | A standalone validator for edge / serverless        | oav                       |
 
@@ -65,14 +78,15 @@ Express 4 / 5 + Fastify integration. See
 Pick the package that matches what you need. (`oav` is the shorthand
 used elsewhere in the docs for `@aahoughton/oav`.)
 
-| You need                                         | Install                                        |
-| ------------------------------------------------ | ---------------------------------------------- |
-| YAML specs, HTTP/YAML readers, and the `oav` CLI | `@aahoughton/oav`                              |
-| JSON or pre-parsed specs with zero runtime deps  | `@aahoughton/oav-core`                         |
-| Express 4 request middleware                     | `@aahoughton/oav` + `@aahoughton/oav-express4` |
-| Express 5 request middleware                     | `@aahoughton/oav` + `@aahoughton/oav-express5` |
-| Fastify `preValidation` hook                     | `@aahoughton/oav` + `@aahoughton/oav-fastify`  |
-| Edge/serverless validator emitted at build time  | `@aahoughton/oav` as a dev/build dependency    |
+| You need                                         | Install                                                                                             |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| YAML specs, HTTP/YAML readers, and the `oav` CLI | `@aahoughton/oav`                                                                                   |
+| JSON or pre-parsed specs with zero runtime deps  | `@aahoughton/oav-core`                                                                              |
+| Express 4 request middleware                     | `@aahoughton/oav` + `@aahoughton/oav-express4`                                                      |
+| Express 5 request middleware                     | `@aahoughton/oav` + `@aahoughton/oav-express5`                                                      |
+| Fastify `preValidation` hook                     | `@aahoughton/oav` + `@aahoughton/oav-fastify`                                                       |
+| Streaming large bodies + buffer-budget analysis  | `@aahoughton/oav-stream-validator` (+ `@aahoughton/oav` or `@aahoughton/oav-core` to load the spec) |
+| Edge/serverless validator emitted at build time  | `@aahoughton/oav` as a dev/build dependency                                                         |
 
 `oav` is a superset of `oav-core`: same programmatic surface plus YAML
 readers and the `oav` CLI. The CLI's `commander` and `esbuild` deps
@@ -85,6 +99,7 @@ npm install @aahoughton/oav-core       # JSON only, zero runtime deps
 npm install @aahoughton/oav-express4   # Express 4 adapter (transitively pulls oav-core)
 npm install @aahoughton/oav-express5   # Express 5 adapter
 npm install @aahoughton/oav-fastify    # Fastify adapter
+npm install @aahoughton/oav-stream-validator   # streaming body validation + analyzeSpec
 ```
 
 Want to try it against your own spec before wiring anything in? The CLI
@@ -159,21 +174,61 @@ For a multi-file spec or a spec hosted over HTTP, compose readers:
 `composeReaders([createYamlFileReader(), createSmartHttpReader(), createFileReader()])`
 handles local YAML, remote JSON / YAML, and local JSON transparently.
 
-`validateRequest` / `validateResponse` return `{ valid: true }` on
-success, or `{ valid: false, errors, truncated }` on failure. The
-zero-config default is a flat `errors` list that stops at the first
-problem (`maxErrors: 1`); raise `maxErrors` to collect more, or pass
-`output: "tree"` for a nested error tree under
-`error` (or `output: "predicate"` for a bare boolean). Every error
-carries a stable `code` (e.g. `"type"`, `"required"`, `"content-type"`,
-`"oneOf"`), a `path` rooted at the HTTP frame (e.g. `["body", "pets", 3,
-"name"]`), a human-readable `message`, and a machine-readable `params`
-object whose shape per code is documented in `BuiltInErrorParams`.
+`validateRequest` / `validateResponse` return `{ valid: true }`, or
+`{ valid: false, errors, truncated }` on failure. The default is a flat
+`errors` list that stops at the first problem (`maxErrors: 1`);
+`maxErrors` and `output: "tree" | "predicate"` tune count and shape.
+Each leaf carries a stable `code`, an HTTP-rooted `path` (e.g.
+`["body", "pets", 3, "name"]`), a `message`, and a `params` object; see
+[docs/configuration.md](https://github.com/aahoughton/oav/blob/main/docs/configuration.md)
+and the `ValidatorOptions` TSDoc for the full contract.
 
 Runnable end-to-end demos in [`examples/`](https://github.com/aahoughton/oav/blob/main/examples/README.md):
 custom formats, custom keywords, cross-field constraints, error
 budgets, version differences, overlays, and spec-derived middleware
 config.
+
+### Streaming large bodies
+
+`createValidator` validates a fully-parsed value. For a body too large
+to hold in memory, the separate `@aahoughton/oav-stream-validator`
+package validates it as it streams, echoing the bytes through to a sink
+while reporting violations on a side channel. It is a second engine,
+not a mode of `createValidator`: your router still picks the operation,
+and the validator checks one resolved schema.
+
+```ts
+import { pipeline } from "node:stream/promises";
+import { streamValidatorForOperation } from "@aahoughton/oav-stream-validator";
+
+// `document` is the parsed spec from loadSpec, as above.
+const validator = streamValidatorForOperation(document, { method: "post", path: "/pets" });
+validator.on("violation", (v) => console.warn(v.code, v.path, v.byteOffset));
+
+await pipeline(request, validator, sink);
+const { valid, peakBufferedBytes } = await validator.result;
+```
+
+Not every schema can stream: `uniqueItems`, `contains`, an
+object-level `const`, or an asserting `format` force a subtree to
+buffer. `analyzeSpec` answers which bodies stream and which buffer (and
+how large a buffer can get) from the spec alone, before any traffic:
+
+```ts
+import { analyzeSpec } from "@aahoughton/oav-stream-validator";
+
+for (const op of analyzeSpec(document).operations) {
+  for (const body of op.bodies) {
+    console.log(`${op.method} ${op.path} ${body.role}: ${body.report?.peakBytes ?? body.error}`);
+  }
+}
+```
+
+`oav stream-check openapi.yaml` prints the same per-operation budget as
+a table (`--fail-on-unbounded` makes it a CI gate). The stream validator
+versions independently of the `oav-core` family on its own `1.x` line;
+see [`packages/stream-validator/README.md`](https://github.com/aahoughton/oav/blob/main/packages/stream-validator/README.md)
+for the engine, the buffer model, and the edit hooks.
 
 ### Overlay quickstart
 
@@ -226,14 +281,15 @@ shapes live in [`docs/integration.md`](https://github.com/aahoughton/oav/blob/ma
 
 ## Where to go next
 
-| Task                                      | Read                                                                                                             |
-| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| Wire into Express, Fastify, Next.js, Hono | [docs/integration.md](https://github.com/aahoughton/oav/blob/main/docs/integration.md)                           |
-| Patch a spec you do not own               | [docs/overlays.md](https://github.com/aahoughton/oav/blob/main/docs/overlays.md)                                 |
-| Emit standalone validators                | [packages/cli/README.md](https://github.com/aahoughton/oav/blob/main/packages/cli/README.md#compile-spec-output) |
-| Compare against Ajv and other tools       | [docs/comparison.md](https://github.com/aahoughton/oav/blob/main/docs/comparison.md)                             |
-| Migrate from express-openapi-validator    | [docs/migration-from-eov.md](https://github.com/aahoughton/oav/blob/main/docs/migration-from-eov.md)             |
-| Use custom formats, keywords, or limits   | [docs/configuration.md](https://github.com/aahoughton/oav/blob/main/docs/configuration.md)                       |
+| Task                                       | Read                                                                                                                   |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| Wire into Express, Fastify, Next.js, Hono  | [docs/integration.md](https://github.com/aahoughton/oav/blob/main/docs/integration.md)                                 |
+| Stream large bodies / check buffer budgets | [packages/stream-validator/README.md](https://github.com/aahoughton/oav/blob/main/packages/stream-validator/README.md) |
+| Patch a spec you do not own                | [docs/overlays.md](https://github.com/aahoughton/oav/blob/main/docs/overlays.md)                                       |
+| Emit standalone validators                 | [packages/cli/README.md](https://github.com/aahoughton/oav/blob/main/packages/cli/README.md#compile-spec-output)       |
+| Compare against Ajv and other tools        | [docs/comparison.md](https://github.com/aahoughton/oav/blob/main/docs/comparison.md)                                   |
+| Migrate from express-openapi-validator     | [docs/migration-from-eov.md](https://github.com/aahoughton/oav/blob/main/docs/migration-from-eov.md)                   |
+| Use custom formats, keywords, or limits    | [docs/configuration.md](https://github.com/aahoughton/oav/blob/main/docs/configuration.md)                             |
 
 ## How it compares
 
@@ -241,20 +297,17 @@ The JavaScript ecosystem already has solid OpenAPI validation tools:
 Ajv for JSON Schema, `express-openapi-validator` for Express,
 `openapi-backend` for operationId routing plus validation, and smaller
 request/response validators for custom stacks. oav is aimed at
-HTTP-aware validation with structured errors, overlays, and standalone
+HTTP-aware validation with structured errors, streaming validation of
+large bodies plus design-time buffer budgets, overlays, and standalone
 OpenAPI validator output. See [docs/comparison.md](https://github.com/aahoughton/oav/blob/main/docs/comparison.md)
 for the feature map, and [docs/migration-from-eov.md](https://github.com/aahoughton/oav/blob/main/docs/migration-from-eov.md)
 if you are migrating from `express-openapi-validator`.
 
-On raw speed, oav wins some and loses some against Ajv. oav compiles
-schemas far faster (tens of microseconds against milliseconds),
-validates competitively on typical request bodies, and carries a
-slightly smaller steady-state memory footprint than
-`express-openapi-validator`. Ajv is faster on fast-fail validation of
-some ordinary object shapes. At normal request volumes these gaps are
-nanoseconds per call; they only start to matter at extreme volume or
-against pathological shapes (very large `uniqueItems` arrays, very long
-length-bounded strings).
+On raw speed, oav and Ajv trade wins: oav compiles schemas one to two
+orders of magnitude faster, validates competitively on typical bodies,
+and runs a touch lighter on memory than `express-openapi-validator`;
+Ajv leads on fast-fail rejection of some plain object shapes. At normal
+request volumes these gaps are nanoseconds per call.
 
 For the host-stamped per-shape numbers, the memory comparison, and the
 methodology, see [docs/comparison.md](https://github.com/aahoughton/oav/blob/main/docs/comparison.md).
@@ -293,12 +346,14 @@ oav validate openapi.yaml --path "POST /pets" --body payload.json
 oav validate openapi.yaml --path "GET /pets" --response --status 200 --body resp.json
 oav compile-schema schema.json -o validator.mjs             # JSON Schema -> standalone validator
 oav compile-spec openapi.yaml  -o validator.mjs             # OpenAPI   -> standalone HTTP validator (edge / Lambda)
+oav stream-check openapi.yaml                               # per-operation streamability + peak-buffer budget
 ```
 
 Flags: `--format text|json|summary`, `--depth n`, `--overlay file`
 (repeatable), `-o file`, `--quiet`, `--dialect` (compile-schema /
 compile-spec), `--requests-only` (compile-spec), `--only METHOD PATH`
-(compile-spec, repeatable). See
+(compile-spec, repeatable), `--verbose` / `--fail-on-unbounded` /
+`--envelope json` (stream-check). See
 [packages/cli/README.md](https://github.com/aahoughton/oav/blob/main/packages/cli/README.md) for the full
 surface, the `.http` file format, and both compile commands' output
 contracts.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -23,15 +23,15 @@ comes down to the shape of integration you want.
 
 ## Ecosystem map
 
-| Tool family                                    | Best fit                                                                                      |
-| ---------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| Ajv                                            | JSON Schema validation, many drafts, maximum ecosystem maturity                               |
-| `express-openapi-validator`                    | Existing Express apps that want one middleware to validate requests/responses                 |
-| `openapi-backend`                              | OperationId routing, auth handlers, validation, and mocking together                          |
-| `openapi-enforcer` / middleware                | OpenAPI 2.0 / 3.0 services that want validation plus serialization/mocking                    |
-| `openapi-request-validator` / response sibling | Lower-level request or response checks around your own routing                                |
-| Spec validators/parsers                        | Validating the OpenAPI document, resolving refs, linting, or tooling                          |
-| oav                                            | HTTP-aware validation with structured errors, overlays, and standalone OpenAPI validator emit |
+| Tool family                                    | Best fit                                                                              |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Ajv                                            | JSON Schema validation, many drafts, maximum ecosystem maturity                       |
+| `express-openapi-validator`                    | Existing Express apps that want one middleware to validate requests/responses         |
+| `openapi-backend`                              | OperationId routing, auth handlers, validation, and mocking together                  |
+| `openapi-enforcer` / middleware                | OpenAPI 2.0 / 3.0 services that want validation plus serialization/mocking            |
+| `openapi-request-validator` / response sibling | Lower-level request or response checks around your own routing                        |
+| Spec validators/parsers                        | Validating the OpenAPI document, resolving refs, linting, or tooling                  |
+| oav                                            | HTTP-aware validation, streamability budgets, overlays, and standalone validator emit |
 
 This document is about behavior and capabilities. For raw numbers
 and methodology see [`performance/README.md`](../performance/README.md);
@@ -202,6 +202,26 @@ Capabilities that the Ajv stack covers and oav does not.
 Capabilities oav has that Ajv (alone or with
 `express-openapi-validator`) doesn't.
 
+- **Streaming body validation.** The separate
+  `@aahoughton/oav-stream-validator` package validates a JSON body
+  against its operation schema as it streams, echoing the input bytes
+  through to a sink and reporting violations on a side channel. Memory
+  stays bounded for schemas with structural bounds (or configured
+  caps), so a multi-GB body validates without materializing in heap. A
+  second, push-based engine that reuses oav's keyword set and flat error
+  model. Ajv and `express-openapi-validator` validate a fully-parsed
+  value; there is no streaming path.
+- **Design-time buffer budgets.** `analyzeSpec(document)` reports, per
+  operation, which request and response bodies can stream, which must
+  buffer, and how large a buffer can get (in wire bytes, or
+  `"unbounded"` where the schema has no structural cap), without reading
+  a byte of traffic. It runs the same classifier the streaming engine
+  uses, so the budget matches runtime behavior. The CLI surfaces it as
+  `oav stream-check <spec>`, with `--fail-on-unbounded` as a CI gate.
+  An Ajv + middleware stack can validate the parsed body, but a buffer
+  budget needs the resolved (and overlaid) operation schema and the
+  streaming classifier in one place; in a split stack no one layer
+  normally holds that whole view.
 - **HTTP-aware validation.** Route matching, content-type negotiation,
   parameter `style` / `explode` deserialisation, response status
   matching (exact, then NXX class, then default) are part of one
@@ -310,13 +330,14 @@ operation handlers should be driven by the spec. Pick
 `openapi-enforcer` when its OpenAPI 2.0 / 3.0 validation,
 serialization, and mocking model fits your service.
 
-Pick oav when you want a structured error tree, overlays over specs you
-don't own, an OpenAPI 3.0 dialect built into the validator, explicit
-control over where validation runs in your HTTP stack, or standalone
-OpenAPI HTTP validator output for edge/serverless deployments. It also
-fits compile-heavy workloads: the benchmarks show one to two orders
-of magnitude faster schema compile than Ajv; see the Performance
-section above.
+Pick oav when you want a structured error tree, streaming validation of
+large bodies with a design-time buffer budget you can check before
+deploy, overlays over specs you don't own, an OpenAPI 3.0 dialect built
+into the validator, explicit control over where validation runs in your
+HTTP stack, or standalone OpenAPI HTTP validator output for
+edge/serverless deployments. It also fits compile-heavy workloads: the
+benchmarks show one to two orders of magnitude faster schema compile
+than Ajv; see the Performance section above.
 
 For benchmark numbers rather than feature comparisons, see
 [`performance/README.md`](../performance/README.md).

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -41,6 +41,10 @@ oav compile-schema <schema.json> --dialect openapi-3.0
 oav compile-spec <openapi.yaml> -o v.mjs                 # OpenAPI spec -> standalone HTTP validator
 oav compile-spec <openapi.yaml> --requests-only -o v.mjs
 oav compile-spec <openapi.yaml> --only "POST /pets" -o v.mjs
+
+oav stream-check <openapi.yaml>                          # per-operation streaming-buffer budget
+oav stream-check <openapi.yaml> --verbose                # list each unbounded buffering position
+oav stream-check <openapi.yaml> --fail-on-unbounded      # CI gate: exit 1 if any body is unbounded
 ```
 
 Pass `-` as the file path to read from stdin (e.g. `--body -`).
@@ -54,21 +58,24 @@ below for the expected shape.
 
 ## Flags
 
-| Flag                                          | Command                           | Meaning                                                                                              |
-| --------------------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `--format text\|json\|summary`                | validate                          | Error rendering. Default `text`. `summary` is one line per leaf; `flat` is its deprecated alias.     |
-| `--depth <n>`                                 | validate                          | Truncate error tree depth (text format).                                                             |
-| `--overlay <file>`                            | resolve / validate / compile-spec | Repeatable; applies overlays in order.                                                               |
-| `--lint`                                      | resolve                           | Run spec-hygiene checks; findings to stderr (or JSON envelope with `--envelope json`).               |
-| `--fail-on <level>`                           | resolve                           | Non-zero exit on any finding at or above `<level>`. Requires `--lint`. Currently only `warning`.     |
-| `--envelope text\|json`                       | resolve                           | `text` (default; document on stdout, findings on stderr) or `json` (single payload).                 |
-| `--dialect 2020-12\|openapi-3.1\|openapi-3.0` | compile-schema / compile-spec     | Schema dialect. Defaults: 2020-12 (compile-schema), auto-detect from `openapi` field (compile-spec). |
-| `--requests-only`                             | compile-spec                      | Skip response-validator emit. Smaller output.                                                        |
-| `--only <method-path...>`                     | compile-spec                      | Repeatable; restrict emit to given ops, e.g. `--only "POST /pets"`.                                  |
-| `--output-mode flat\|tree\|predicate`         | compile-spec                      | Result shape of the emitted validators. Default `flat`. Mirrors `output`.                            |
-| `--max-errors <n>`                            | compile-spec                      | Leaf-error cap baked in: a positive integer or `all`. Default `1`. Mirrors `maxErrors`.              |
-| `-o <file>`                                   | all                               | Write output to a file instead of stdout.                                                            |
-| `--quiet`                                     | resolve / validate                | Exit code only, no stdout.                                                                           |
+| Flag                                          | Command                                          | Meaning                                                                                                                                                       |
+| --------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--format text\|json\|summary`                | validate                                         | Error rendering. Default `text`. `summary` is one line per leaf; `flat` is its deprecated alias.                                                              |
+| `--depth <n>`                                 | validate                                         | Truncate error tree depth (text format).                                                                                                                      |
+| `--overlay <file>`                            | resolve / validate / compile-spec / stream-check | Repeatable; applies overlays in order.                                                                                                                        |
+| `--lint`                                      | resolve                                          | Run spec-hygiene checks; findings to stderr (or JSON envelope with `--envelope json`).                                                                        |
+| `--fail-on <level>`                           | resolve                                          | Non-zero exit on any finding at or above `<level>`. Requires `--lint`. Currently only `warning`.                                                              |
+| `--envelope text\|json`                       | resolve / stream-check                           | resolve: `text` (document on stdout, findings on stderr) or `json` (single payload). stream-check: `text` (per-operation table) or `json` (the `SpecBudget`). |
+| `--dialect 2020-12\|openapi-3.1\|openapi-3.0` | compile-schema / compile-spec                    | Schema dialect. Defaults: 2020-12 (compile-schema), auto-detect from `openapi` field (compile-spec).                                                          |
+| `--requests-only`                             | compile-spec                                     | Skip response-validator emit. Smaller output.                                                                                                                 |
+| `--only <method-path...>`                     | compile-spec                                     | Repeatable; restrict emit to given ops, e.g. `--only "POST /pets"`.                                                                                           |
+| `--output-mode flat\|tree\|predicate`         | compile-spec                                     | Result shape of the emitted validators. Default `flat`. Mirrors `output`.                                                                                     |
+| `--max-errors <n>`                            | compile-spec                                     | Leaf-error cap baked in: a positive integer or `all`. Default `1`. Mirrors `maxErrors`.                                                                       |
+| `--fail-on-unbounded`                         | stream-check                                     | Exit non-zero if any request/response body has an unbounded peak buffer. CI gate.                                                                             |
+| `--verbose`                                   | stream-check                                     | List each unbounded buffering position with its path under its body.                                                                                          |
+| `--max-buffered-bytes <n>`                    | stream-check                                     | Buffer cap the effective peak is computed against (clamps over-cap positions to the cap).                                                                     |
+| `-o <file>`                                   | all                                              | Write output to a file instead of stdout.                                                                                                                     |
+| `--quiet`                                     | resolve / validate / stream-check                | Exit code only, no stdout.                                                                                                                                    |
 
 ## `compile-schema` output
 
@@ -188,14 +195,36 @@ parameter deserialisation (style / explode), response status
 matching, and shape-only security checks, emitted directly rather
 than hand-built over a standalone schema validator.
 
+## `stream-check` output
+
+`oav stream-check <openapi.yaml>` reports the streaming-buffer budget
+for every operation: for the request body and each response body, which
+bodies stream, which must buffer, and how large a buffer can get. It is
+the streamability analysis (`@aahoughton/oav-stream-validator`'s
+`analyzeSpec`) surfaced over a whole resolved spec, so a deployer can
+see before deploy where a body would be materialized in heap.
+
+The default `text` envelope is a per-operation table. `--verbose` lists
+each unbounded buffering position with its path and the keyword that
+left it unbounded. `--envelope json` emits the `SpecBudget` payload for
+machine consumers. `--fail-on-unbounded` exits `1` when any body has an
+unbounded peak, so CI can reject a spec that can't stream within a
+fixed memory bound; `--max-buffered-bytes <n>` computes the effective
+peak against a chosen cap. Overlays apply first (`--overlay`, same
+semantics as `oav resolve`).
+
+A body whose schema can't be classified is reported with an error
+rather than aborting the sweep, so one unclassifiable body doesn't hide
+the budget for the rest of the spec.
+
 ## Exit codes
 
-| Code | Meaning               |
-| ---- | --------------------- |
-| 0    | valid                 |
-| 1    | validation errors     |
-| 2    | spec resolution error |
-| 3    | input / usage error   |
+| Code | Meaning                                                               |
+| ---- | --------------------------------------------------------------------- |
+| 0    | valid                                                                 |
+| 1    | validation errors, or `stream-check --fail-on-unbounded` gate failure |
+| 2    | spec resolution error                                                 |
+| 3    | input / usage error                                                   |
 
 ## `.http` file format
 


### PR DESCRIPTION
## What

Reframes the top README and `docs/comparison.md` to lead with the two capabilities the Ajv ecosystem cannot assemble from parts: streaming body validation and design-time per-operation buffer budgets (`analyzeSpec` / `oav stream-check`). Overlays and standalone-validator emit stay visible but move to supporting infrastructure rather than the headline.

## Why

The previous first screen read like a generic OpenAPI validator (structured errors, AOT, overlays), and streaming plus `analyzeSpec` were absent from the top-level story, surfacing only in `packages/stream-validator/README.md`. Overlays are getting commoditized as standalone doc-transform tools, so positioning oav as "the overlay-aware validator" is a weakening angle; streaming + buffer-budget analysis is the durable, hard-to-assemble differentiator (it needs the resolved/overlaid operation schema and the streaming classifier in one place).

## Changes

- **README**: streaming sentence in the intro; reordered "reach for oav" bullets and the at-a-glance / install rows to lead with budgets + streaming; a `streamValidatorForOperation` + `analyzeSpec` snippet before the overlay quickstart; `stream-check` in the CLI section. The stream validator is described throughout as a separate engine, not a mode of `createValidator`.
- **docs/comparison.md**: streaming + buffer-budget entries under "Where oav does more", the ecosystem-map row, and the summary. The buffer-budget claim is framed as an information-boundary point, not an absolute.
- **packages/cli/README.md**: document the `stream-check` command, flags, output, and exit-code behavior (closing the gap where the top README pointed at a command the CLI docs did not teach).
- **CLAUDE.md**: correct the stream-validator version line (`0.x` -> its own independent `1.x` line).
- Trim two top-level passages that duplicated linked docs: the full error-leaf enumeration (now a sketch + pointer to `docs/configuration.md` / `ValidatorOptions` TSDoc) and the perf prose (now one paragraph; `docs/comparison.md` owns the tables).

## Out of scope (noted for follow-up)

- The CLI `--overlay` flag accepts only the typed `SpecOverlay` and silently mishandles standard OpenAPI Overlay 1.0 documents: tracked in #448.

Docs-only; `pnpm lint` (oxlint + oxfmt + check:deps) green.