### PR TITLE
feat(schema): return at the maxErrors cap in flat mode (fast-fail)

### DIFF
--- a/packages/schema/src/compiler/compiler.ts
+++ b/packages/schema/src/compiler/compiler.ts
@@ -236,10 +236,12 @@ export type ValidationResult =
       /** The flat list of leaf errors. Always non-empty when `!valid`. */
       errors: ValidationError[];
       /**
-       * `true` when at least one error was dropped because the configured
-       * `maxErrors` cap was hit. The v3 default is `maxErrors: 1`, so a
-       * payload with more than one problem reports `truncated: true`;
-       * `false` when the list is complete.
+       * `true` when the configured `maxErrors` cap was reached, meaning
+       * the list may be incomplete: validation returns as soon as the
+       * budget drains, without checking the remaining keywords. Under
+       * the v3 default (`maxErrors: 1`) every failing result therefore
+       * reports `truncated: true`. `false` means the cap was never hit
+       * and the list is complete.
        */
       truncated: boolean;
     };
@@ -511,11 +513,13 @@ export interface CompileOptions {
    * `Number.POSITIVE_INFINITY` to collect everything.
    *
    * When set to a finite value:
-   * - Once the cap is reached, further errors are dropped and
-   *   `truncated: true` is set on the returned result.
-   * - Hot loops (array items, object properties, `allOf`/`anyOf`
-   *   branches) short-circuit as soon as the budget is exhausted, so
-   *   the CPU and memory cost of validating a huge payload is bounded.
+   * - Once the cap is reached, `truncated: true` is set on the returned
+   *   result and no further errors are reported.
+   * - In flat mode (the default output), reaching the cap returns from
+   *   the validator immediately, skipping the remaining keyword checks
+   *   entirely; `maxErrors: 1` behaves like ajv's `allErrors: false`
+   *   fast-fail. Tree mode keeps walking (to preserve the tree shape)
+   *   but stops collecting.
    *
    * `maxErrors: 1` is the default (classic fast-fail). To collect every
    * error, pass `Number.POSITIVE_INFINITY`.
@@ -1185,7 +1189,7 @@ function buildFunctionBody(
       gen.line("return false;");
     } else {
       const falseErr = `${NAMES.DEPS}.createLeafError("false", ${NAMES.PATH}, "schema is false, nothing is valid")`;
-      gen.line(emitPushStatement(NAMES.ERRORS, falseErr, state.gated));
+      gen.line(emitPushStatement(NAMES.ERRORS, falseErr, state.gated, flat));
     }
   } else {
     const trackProps = needsPropTracking(schema, state);

--- a/packages/schema/src/keywords/context.ts
+++ b/packages/schema/src/keywords/context.ts
@@ -258,13 +258,33 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
       void errExpr;
       return "return false;";
     }
-    if (kind === "leaf") return emitPushStatement(inputs.errors, errExpr, gated);
+    if (kind === "leaf") return emitPushStatement(inputs.errors, errExpr, gated, flat);
     // kind === "lift": already-counted sub-validator result being
     // propagated. Never interacts with the budget. In flat mode the
     // callee returns a `ValidationError[]` (its leaves), so the lift
     // appends that list onto the accumulator; in tree mode it returns a
     // single node, pushed as one child.
-    if (flat) return appendErrorsStatement(inputs.errors, errExpr);
+    if (flat) {
+      const append = appendErrorsStatement(inputs.errors, errExpr);
+      if (!gated) return append;
+      // Gated flat mode: a callee that drained the budget already
+      // returned early from its own frame; bail from this frame too so
+      // the unwind reaches the top instead of running the remaining
+      // keywords one frame up. Braced so the compound stays a single
+      // block statement at unbraced `if (e !== null) ...` call sites.
+      //
+      // The bail can fire between a validateSubschema push/pop pair,
+      // leaving the shared path array one segment long. Unobservable
+      // today: every frame on the unwind bails before touching the
+      // path again, error paths were copied at creation, and the
+      // top-level validate() hands each call a fresh array. Keep that
+      // invariant in mind before adding code that reads the mutable
+      // path after a lifted fast-return.
+      return (
+        `{ ${append} if (${NAMES.DEPS}.errorsRemaining <= 0) { ` +
+        `${NAMES.DEPS}.truncated = true; return ${inputs.errors}; } }`
+      );
+    }
     return `(${inputs.errors} ??= []).push(${errExpr});`;
   };
   // Append a flat `ValidationError[]` expression onto an accumulator
@@ -279,8 +299,12 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
   const budgetBreakStatement = (): string =>
     // Predicate mode never fills an error budget; its loops short-
     // circuit with `return false;` directly. Returning `""` keeps
-    // existing `emitBudgetBreak()` callers a no-op.
-    predicate || !gated
+    // existing `emitBudgetBreak()` callers a no-op. Gated flat mode
+    // needs no loop breaks either: every push and lift site returns
+    // from the function the moment the budget drains, so a loop head
+    // can never observe an exhausted budget; skipping the check saves
+    // a deps load + compare per iteration on the valid path.
+    predicate || !gated || flat
       ? ""
       : `if (${NAMES.DEPS}.errorsRemaining <= 0) { ${NAMES.DEPS}.truncated = true; break; }`;
   const emitBudgetBreak = (): void => {
@@ -637,12 +661,34 @@ export function createKeywordContext(inputs: KeywordContextInputs): KeywordCompi
  * `maxErrors` budget when `gated` is `true`. Callers of this helper
  * pass it to {@link CodeGen.line} or embed it into a generated block.
  *
+ * With `flatReturn` (gated flat mode), draining the budget returns the
+ * accumulator from the enclosing function immediately: `truncated`
+ * means "the cap was reached; the list may be incomplete", so there is
+ * nothing left to do once the cap is hit, and skipping the remaining
+ * keyword checks is what makes `maxErrors: 1` a true fast-fail
+ * (matching ajv's `allErrors: false`). Tree mode keeps the
+ * keep-walking form: its early return would have to route through
+ * `wrapErrors` and would change the tree shape of pending inline
+ * wraps, so it stays drop-and-continue.
+ *
  * @internal
  */
-export function emitPushStatement(errorsVar: string, errExpr: string, gated: boolean): string {
+export function emitPushStatement(
+  errorsVar: string,
+  errExpr: string,
+  gated: boolean,
+  flatReturn = false,
+): string {
   if (!gated) return `(${errorsVar} ??= []).push(${errExpr});`;
+  if (!flatReturn) {
+    return (
+      `if (${NAMES.DEPS}.errorsRemaining > 0) { (${errorsVar} ??= []).push(${errExpr}); ${NAMES.DEPS}.errorsRemaining -= 1; }` +
+      ` else { ${NAMES.DEPS}.truncated = true; }`
+    );
+  }
   return (
-    `if (${NAMES.DEPS}.errorsRemaining > 0) { (${errorsVar} ??= []).push(${errExpr}); ${NAMES.DEPS}.errorsRemaining -= 1; }` +
-    ` else { ${NAMES.DEPS}.truncated = true; }`
+    `if (${NAMES.DEPS}.errorsRemaining > 0) { (${errorsVar} ??= []).push(${errExpr}); ` +
+    `if ((${NAMES.DEPS}.errorsRemaining -= 1) === 0) { ${NAMES.DEPS}.truncated = true; return ${errorsVar}; } }` +
+    ` else { ${NAMES.DEPS}.truncated = true; return ${errorsVar}; }`
   );
 }

--- a/packages/schema/test/flat-mode.test.ts
+++ b/packages/schema/test/flat-mode.test.ts
@@ -129,12 +129,18 @@ describe("flat mode: leaf-set parity with the tree (non-composition schemas)", (
 });
 
 describe("flat mode: finite-maxErrors leaf-set parity with the tree (non-composition)", () => {
-  // The budget short-circuit drops errors mid-evaluation. Flat codegen and
+  // The budget short-circuit stops collection mid-evaluation. Flat codegen and
   // tree codegen run the identical keyword dispatch under the identical gated
-  // counter, so a finite cap must drop the SAME leaves in both modes: the flat
-  // list and collectLeaves(tree) stay equal, and truncated agrees. Nothing else
-  // forces these two flat-list producers equal under a budget (the Infinity
-  // block above only exercises the un-gated path).
+  // counter, so a finite cap must keep the SAME leading leaves in both modes:
+  // the flat list and collectLeaves(tree) stay equal. Nothing else forces
+  // these two flat-list producers equal under a budget (the Infinity block
+  // above only exercises the un-gated path).
+  //
+  // `truncated` semantics differ by mode: flat returns the moment the cap is
+  // reached (truncated means "cap reached; list may be incomplete", so it is
+  // exactly `errors.length === maxErrors`), while tree keeps walking and
+  // reports truncated only when it observably dropped or skipped something.
+  // Tree truncation therefore implies flat truncation, never the reverse.
   for (const { name, schema, data } of LEAF_CASES) {
     for (const maxErrors of [1, 2, 3]) {
       it(`${name} @ maxErrors=${maxErrors}`, () => {
@@ -144,7 +150,8 @@ describe("flat mode: finite-maxErrors leaf-set parity with the tree (non-composi
         expect(f.valid).toBe(false);
         expect(bag(f.errors!)).toEqual(bag(collectLeaves(t.error!)));
         expect(f.errors!.length).toBeLessThanOrEqual(maxErrors);
-        expect(f.truncated).toBe(t.truncated);
+        expect(f.truncated).toBe(f.errors!.length === maxErrors);
+        if (t.truncated) expect(f.truncated).toBe(true);
         for (const e of f.errors!) expect(e.children).toEqual([]);
       });
     }

--- a/packages/schema/test/max-errors.test.ts
+++ b/packages/schema/test/max-errors.test.ts
@@ -116,3 +116,96 @@ describe("maxErrors option", () => {
     expect(() => compile({ type: "number" }, 1.5)).toThrow(/must be a positive integer/);
   });
 });
+
+describe("flat-mode fast-fail (budget exhaustion returns immediately)", () => {
+  // Flat is the mode where `truncated` means "the cap was reached; the
+  // list may be incomplete": the validator returns the moment the
+  // budget drains instead of walking the remaining keywords. Matches
+  // the migration guide ("under the default maxErrors: 1, every
+  // rejection reports truncated: true") and ajv's allErrors: false.
+  function flatCompile(schema: unknown, options?: Record<string, unknown>) {
+    return compileSchema(schema as never, { dialect: jsonSchemaDialect, ...options });
+  }
+
+  it("default maxErrors: 1 reports truncated: true on every rejection", () => {
+    const v = flatCompile({ type: "integer" });
+    const r = v.validate("nope");
+    expect(r.valid).toBe(false);
+    if (r.valid) return;
+    expect(r.errors).toHaveLength(1);
+    expect(r.truncated).toBe(true);
+  });
+
+  it("stops evaluating keywords once the budget is exhausted", () => {
+    // The custom keyword runs after the built-ins on the same schema
+    // object. With the budget already drained by the `const` failure,
+    // fast-fail must return before ever invoking it.
+    let calls = 0;
+    const v = flatCompile(
+      { const: "expected", tracer: true },
+      {
+        keywords: {
+          tracer: () => {
+            calls += 1;
+            return true;
+          },
+        },
+      },
+    );
+    const r = v.validate("something-else");
+    expect(r.valid).toBe(false);
+    if (r.valid) return;
+    expect(r.errors.map((e) => e.code)).toEqual(["const"]);
+    expect(r.truncated).toBe(true);
+    expect(calls).toBe(0);
+
+    // Valid data still reaches the custom keyword.
+    expect(v.validate("expected").valid).toBe(true);
+    expect(calls).toBe(1);
+  });
+
+  it("stops descending into later subschemas once the budget is exhausted", () => {
+    let calls = 0;
+    const v = flatCompile(
+      {
+        type: "object",
+        properties: {
+          a: { type: "integer" },
+          b: { tracer: true },
+        },
+      },
+      {
+        keywords: {
+          tracer: () => {
+            calls += 1;
+            return true;
+          },
+        },
+      },
+    );
+    const r = v.validate({ a: "bad", b: 1 });
+    expect(r.valid).toBe(false);
+    if (r.valid) return;
+    expect(r.errors.map((e) => e.code)).toEqual(["type"]);
+    expect(r.truncated).toBe(true);
+    expect(calls).toBe(0);
+  });
+
+  it("a cap larger than the error count completes with truncated: false", () => {
+    const v = flatCompile({ required: ["a", "b"] }, { maxErrors: 5 });
+    const r = v.validate({});
+    expect(r.valid).toBe(false);
+    if (r.valid) return;
+    expect(r.errors).toHaveLength(2);
+    expect(r.truncated).toBe(false);
+  });
+
+  it("landing exactly on the cap reports truncated: true", () => {
+    const v = flatCompile({ required: ["a", "b"] }, { maxErrors: 2 });
+    const r = v.validate({});
+    expect(r.valid).toBe(false);
+    if (r.valid) return;
+    expect(r.errors).toHaveLength(2);
+    expect(r.truncated).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

With a finite `maxErrors`, flat-mode codegen stopped *pushing* errors once the budget drained but kept executing every remaining keyword check. ajv's `allErrors: false` returns at the first error, so oav's default `maxErrors: 1` paid for work whose results were always discarded. Gated flat mode now returns from the generated function the moment the budget reaches zero:

- push sites return right after the cap-hitting push (and immediately when entered with a drained budget)
- lift sites bail when a callee drained the budget, so the unwind reaches the top instead of running remaining keywords one frame up
- per-iteration loop budget checks are dropped in this mode (unreachable once every push/lift returns), which also removes a deps load + compare per item on the **valid** path

Tree mode is unchanged (an early return there would route through `wrapErrors` and change pending inline-wrap shapes). Predicate mode never had budget machinery.

## Semantics

`truncated` in flat mode now means **the cap was reached; the list may be incomplete**. This is what [docs/migration-v3.md](../blob/main/docs/migration-v3.md) and configuration.md already documented ("under the default maxErrors: 1, every rejection reports truncated: true"); the previous implementation reported `truncated: false` on single-error rejections, violating its own migration guide. Tree mode keeps the observed-drop meaning; per-mode TSDoc on `ValidationResult` / `TreeValidationResult` spells out the difference. Signed off by Andrew in the perf-review session (option: redefine as cap-reached).

## Benchmarks

performance/run.ts, oav flat relative to ajv = 1.00, before -> after:

| case | before | after |
|---|---|---|
| petstore invalid mid (minLength) | 0.66 | 1.08 |
| petstore invalid deep (minimum) | 0.78 | 1.34 |
| petstore invalid late (addProps) | 0.80 | 0.93 |
| petstore invalid many | 1.36 | 2.64 |
| petstore valid | 0.97 | 1.28 |
| composition invalid no-match | 2.91 | 4.28 |

Tree, predicate, and uncapped (`maxErrors: Infinity`) numbers unchanged (within noise). Micro-bench upper-bound measurement that motivated this: 79->50ns on early-failure petstore payloads.

## Tests

- 6 flat-vs-tree `truncated`-parity assertions updated to the new per-mode relationship (leaf-set parity unchanged and still asserted)
- 5 new tests pin the fast-fail behavior, including custom-keyword tracers proving evaluation stops at the cap (same-schema keyword and later-subschema descent)
- Full suite 2846/2846, typecheck, lint, check:deps green