### PR TITLE
perf(validator): cache media type matching

### DIFF
--- a/packages/cli/src/emit-spec.ts
+++ b/packages/cli/src/emit-spec.ts
@@ -22,6 +22,7 @@
  */
 
 import { builtInFormats } from "@oav/formats";
+import { compileMediaTypePatterns } from "@oav/validator/internals";
 import {
   compileSchema,
   createRefResolver,
@@ -235,7 +236,7 @@ export function emitSpec(document: OpenAPIDocument, options: EmitSpecOptions = {
     `import { createLeafError, createBranchError, createError } from "${importPrefix}/core";`,
     `import { createDeps, deepEqual, typeOf, wrapErrors } from "${importPrefix}/schema/internals";`,
     `import { builtInFormats } from "${importPrefix}/formats";`,
-    `import { deserialize, matchMediaType, matchResponseKey, httpRequestFromFetch, httpResponseFromFetch, checkSecurity, compileOperationSecurity, resolveOperationRef, createRouter, reshapeResult, toFetchResult } from "${importPrefix}/validator/internals";`,
+    `import { deserialize, matchParsedMediaType, matchResponseKey, httpRequestFromFetch, httpResponseFromFetch, checkSecurity, compileOperationSecurity, resolveOperationRef, createRouter, reshapeResult, toFetchResult } from "${importPrefix}/validator/internals";`,
     "",
     "void createBranchError; void createError; void deepEqual; void typeOf; void wrapErrors;",
     "void resolveOperationRef;",
@@ -419,6 +420,7 @@ function buildEmittedOp(args: BuildEmittedOpArgs): EmittedOp {
         requestBodyRequired,
         hasRequestBody: requestBody !== undefined,
         bodyValidators: toPlaceholderMap(bodyValidators),
+        bodyMediaTypes: compileMediaTypePatterns(Object.keys(bodyValidators)),
         responses: mapResponsesToPlaceholders(responses),
         __security: security,
       },
@@ -483,7 +485,11 @@ function mapResponsesToPlaceholders(
         __validator: h.validator === null ? "__NULL__" : `__REF:${h.validator}__`,
       };
     }
-    out[status] = { bodyValidators: toPlaceholderMap(r.bodyValidators), headers: headerOut };
+    out[status] = {
+      bodyValidators: toPlaceholderMap(r.bodyValidators),
+      bodyMediaTypes: compileMediaTypePatterns(Object.keys(r.bodyValidators)),
+      headers: headerOut,
+    };
   }
   return out;
 }
@@ -624,17 +630,18 @@ function renderValidateRequestTree(): string {
 
   // Content-type gate (only if there's a request body).
   const hasBody = req.body !== undefined && req.body !== null;
-  const bodyMediaTypes = Object.keys(op.bodyValidators);
+  const bodyMediaTypes = op.bodyMediaTypes;
+  let requestBodyMediaType;
   if (op.hasRequestBody && hasBody && bodyMediaTypes.length > 0) {
-    const mt = matchMediaType(req.contentType, bodyMediaTypes);
-    if (mt === undefined) {
+    requestBodyMediaType = matchParsedMediaType(req.contentType, bodyMediaTypes);
+    if (requestBodyMediaType === undefined) {
       return createBranchError(
         "request", [],
         \`\${method} \${match.pathPattern}: request validation failed\`,
         [createLeafError(
           "content-type", ["body"],
           \`request Content-Type "\${req.contentType ?? "<missing>"}" is not accepted\`,
-          { contentType: req.contentType, accepted: bodyMediaTypes },
+          { contentType: req.contentType, accepted: bodyMediaTypes.map((mt) => mt.pattern) },
         )],
         { method, pathPattern: match.pathPattern },
       );
@@ -656,7 +663,7 @@ function renderValidateRequestTree(): string {
         children.push(createLeafError("body", ["body"], "missing required request body", {}));
       }
     } else {
-      const mt = matchMediaType(req.contentType, bodyMediaTypes);
+      const mt = requestBodyMediaType ?? matchParsedMediaType(req.contentType, bodyMediaTypes);
       if (mt !== undefined) {
         const v = op.bodyValidators[mt];
         const r = v.validate(req.body, ["body"]);
@@ -738,8 +745,7 @@ function renderValidateResponseTree(): string {
     return createLeafError("route", [], \`no route matches \${method} \${req.path}\`, { method, path: req.path });
   }
   const children = [];
-  const statusKeys = Object.keys(op.responses);
-  const statusKey = matchResponseKey(res.status, Object.fromEntries(statusKeys.map((k) => [k, null])));
+  const statusKey = matchResponseKey(res.status, op.responses);
   if (statusKey === undefined) {
     children.push(createLeafError("status", [], \`no response defined for status \${res.status}\`, { status: res.status }));
   } else {
@@ -762,11 +768,11 @@ function renderValidateResponseTree(): string {
         }
       }
       // Body validation.
-      const bodyMediaTypes = Object.keys(resp.bodyValidators);
+      const bodyMediaTypes = resp.bodyMediaTypes;
       if (bodyMediaTypes.length > 0 && res.body !== undefined) {
-        const mt = matchMediaType(res.contentType, bodyMediaTypes);
+        const mt = matchParsedMediaType(res.contentType, bodyMediaTypes);
         if (mt === undefined) {
-          children.push(createLeafError("content-type", ["body"], \`response Content-Type "\${res.contentType ?? "<missing>"}" is not accepted\`, { contentType: res.contentType, accepted: bodyMediaTypes }));
+          children.push(createLeafError("content-type", ["body"], \`response Content-Type "\${res.contentType ?? "<missing>"}" is not accepted\`, { contentType: res.contentType, accepted: bodyMediaTypes.map((m) => m.pattern) }));
         } else {
           const v = resp.bodyValidators[mt];
           const r = v.validate(res.body, ["body"]);

--- a/packages/validator/src/deserialize.ts
+++ b/packages/validator/src/deserialize.ts
@@ -131,30 +131,77 @@ export function matchMediaType(
   contentType: string | undefined,
   patterns: Iterable<string>,
 ): string | undefined {
-  if (contentType === undefined) return undefined;
-  const concrete = parseMediaType(contentType);
-  if (concrete === undefined) return undefined;
-  let best: { pattern: string; specificity: number } | undefined;
+  return matchParsedMediaType(contentType, compileMediaTypePatterns(patterns));
+}
+
+/**
+ * Parsed, spec-derived media-type pattern. Callers that match the same
+ * OpenAPI `content` keys repeatedly can precompute these once and avoid
+ * reparsing declarations on every request.
+ *
+ * @internal
+ */
+export interface ParsedMediaTypePattern {
+  pattern: string;
+  type: string;
+  subtype: string;
+  params: Record<string, string>;
+  paramEntries: Array<[string, string]>;
+  specificity: number;
+}
+
+/**
+ * Parse OpenAPI media-type patterns once for repeated matching.
+ *
+ * @internal
+ */
+export function compileMediaTypePatterns(patterns: Iterable<string>): ParsedMediaTypePattern[] {
+  const out: ParsedMediaTypePattern[] = [];
   for (const pattern of patterns) {
     const parsed = parseMediaType(pattern);
     if (parsed === undefined) continue;
+    const paramEntries = Object.entries(parsed.params);
+    out.push({
+      pattern,
+      type: parsed.type,
+      subtype: parsed.subtype,
+      params: parsed.params,
+      paramEntries,
+      specificity:
+        (parsed.type === "*" ? 0 : 2) + (parsed.subtype === "*" ? 0 : 1) + paramEntries.length,
+    });
+  }
+  return out;
+}
+
+/**
+ * Match a concrete Content-Type against pre-parsed OpenAPI media-type
+ * patterns. Ties preserve declaration order, matching {@link matchMediaType}.
+ *
+ * @internal
+ */
+export function matchParsedMediaType(
+  contentType: string | undefined,
+  patterns: readonly ParsedMediaTypePattern[],
+): string | undefined {
+  if (contentType === undefined) return undefined;
+  const concrete = parseMediaType(contentType);
+  if (concrete === undefined) return undefined;
+  let best: ParsedMediaTypePattern | undefined;
+  for (const parsed of patterns) {
     const typeMatch = parsed.type === "*" || parsed.type === concrete.type;
     const subtypeMatch = parsed.subtype === "*" || parsed.subtype === concrete.subtype;
     if (!typeMatch || !subtypeMatch) continue;
     let paramsMatch = true;
-    for (const [k, v] of Object.entries(parsed.params)) {
+    for (const [k, v] of parsed.paramEntries) {
       if (concrete.params[k] !== v) {
         paramsMatch = false;
         break;
       }
     }
     if (!paramsMatch) continue;
-    const spec =
-      (parsed.type === "*" ? 0 : 2) +
-      (parsed.subtype === "*" ? 0 : 1) +
-      Object.keys(parsed.params).length;
-    if (!best || spec > best.specificity) {
-      best = { pattern, specificity: spec };
+    if (!best || parsed.specificity > best.specificity) {
+      best = parsed;
     }
   }
   return best?.pattern;

--- a/packages/validator/src/internals.ts
+++ b/packages/validator/src/internals.ts
@@ -18,7 +18,14 @@
 // Parameter deserialisation primitives: `style` + `explode`
 // interpretation, Content-Type negotiation, response-status key
 // matching (exact → NXX class → default).
-export { deserialize, matchMediaType, matchResponseKey } from "./deserialize.js";
+export {
+  compileMediaTypePatterns,
+  deserialize,
+  matchMediaType,
+  matchParsedMediaType,
+  matchResponseKey,
+  type ParsedMediaTypePattern,
+} from "./deserialize.js";
 
 // Query-object assembly helpers. Handle the two OAS query shapes that
 // spread an object across multiple top-level keys: `style: form +

--- a/packages/validator/src/operation-cache.ts
+++ b/packages/validator/src/operation-cache.ts
@@ -10,6 +10,7 @@ import { resolveJsonPointer } from "@oav/core";
 import type { RouteMatch } from "@oav/router";
 import type { CompiledTreeSchema } from "@oav/schema";
 import type { BodyDirection } from "./body-schema-transform.js";
+import { compileMediaTypePatterns, type ParsedMediaTypePattern } from "./deserialize.js";
 import type { CompiledSecurity } from "./security.js";
 
 /**
@@ -33,6 +34,7 @@ export interface OperationCache {
   knownQueryParameters: Set<string>;
   requestBody: RequestBodyObject | undefined;
   bodyValidators: Map<string, CompiledTreeSchema>;
+  bodyMediaTypes: ParsedMediaTypePattern[];
   responses: Map<string, ResponseCompiled>;
   /**
    * Pre-compiled shape-only security check, or `undefined` when the
@@ -60,6 +62,7 @@ export interface ResponseCompiled {
    * are only ever asked about a single status/media-type pairing.
    */
   bodySchemas: Map<string, SchemaOrBoolean>;
+  bodyMediaTypes: ParsedMediaTypePattern[];
   /** Header schemas keyed by lowercased name; compiled lazily. */
   headerSchemas: Map<string, SchemaOrBoolean>;
   /** Memoization caches for the lazy compiles. */
@@ -179,6 +182,7 @@ export function buildOperationCache(
       object: response,
       headers: headersResolved,
       bodySchemas,
+      bodyMediaTypes: compileMediaTypePatterns(bodySchemas.keys()),
       headerSchemas,
       bodyValidators: new Map(),
       headerValidators: new Map(),
@@ -194,6 +198,7 @@ export function buildOperationCache(
     cookieParamValidators,
     requestBody,
     bodyValidators,
+    bodyMediaTypes: compileMediaTypePatterns(bodyValidators.keys()),
     responses,
     // Security is populated by `createValidator` after this call
     // returns; `buildOperationCache` deliberately doesn't see the full

--- a/packages/validator/src/validate-step.ts
+++ b/packages/validator/src/validate-step.ts
@@ -6,7 +6,7 @@ import {
 } from "@oav/core";
 import type { RouteMatch } from "@oav/router";
 import type { CompiledTreeSchema } from "@oav/schema";
-import { deserialize, matchMediaType } from "./deserialize.js";
+import { deserialize, matchParsedMediaType } from "./deserialize.js";
 import type { OperationCache } from "./operation-cache.js";
 import { assembleObjectQueryParam } from "./query-assembly.js";
 
@@ -179,6 +179,20 @@ export function checkBodyContentType(
   req: HttpRequest,
   cache: OperationCache,
 ): ValidationError | null {
+  const match = matchRequestBodyMediaType(req, cache);
+  return typeof match === "string" ? null : match;
+}
+
+/**
+ * Return the matched request-body media type, a content-type error, or
+ * `null` when no body media-type gate applies.
+ *
+ * @internal
+ */
+export function matchRequestBodyMediaType(
+  req: HttpRequest,
+  cache: OperationCache,
+): string | ValidationError | null {
   if (cache.requestBody === undefined) return null;
   if (cache.bodyValidators.size === 0) return null;
   const hasBody = req.body !== undefined && req.body !== null;
@@ -186,8 +200,8 @@ export function checkBodyContentType(
   // payload, so the actionable signal is the missing body, not a 415
   // for an unsent header. Defer to validateBody.
   if (!hasBody && req.contentType === undefined) return null;
-  const mt = matchMediaType(req.contentType, cache.bodyValidators.keys());
-  if (mt !== undefined) return null;
+  const mt = matchParsedMediaType(req.contentType, cache.bodyMediaTypes);
+  if (mt !== undefined) return mt;
   return createLeafError(
     "content-type",
     ["body"],
@@ -206,7 +220,11 @@ export function checkBodyContentType(
  *
  * @internal
  */
-export function validateBody(req: HttpRequest, cache: OperationCache): ValidationError | null {
+export function validateBody(
+  req: HttpRequest,
+  cache: OperationCache,
+  matchedMediaType?: string,
+): ValidationError | null {
   const body = cache.requestBody;
   if (body === undefined) return null;
   const hasBody = req.body !== undefined && req.body !== null;
@@ -217,7 +235,7 @@ export function validateBody(req: HttpRequest, cache: OperationCache): Validatio
     return null;
   }
   if (cache.bodyValidators.size === 0) return null;
-  const mt = matchMediaType(req.contentType, cache.bodyValidators.keys());
+  const mt = matchedMediaType ?? matchParsedMediaType(req.contentType, cache.bodyMediaTypes);
   if (mt === undefined) return null; // content-type gate ran upstream; defensive no-op.
   const validator = cache.bodyValidators.get(mt);
   if (validator === undefined) return null;

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -31,7 +31,7 @@ import {
   type TreeValidationResult,
   type ValidationResult,
 } from "@oav/schema";
-import { deserialize, matchMediaType, matchResponseKey } from "./deserialize.js";
+import { deserialize, matchParsedMediaType, matchResponseKey } from "./deserialize.js";
 import { reshapeResult, toFetchResult } from "./reshape.js";
 import {
   createDirectionResolver,
@@ -49,7 +49,7 @@ import {
   type OperationCache,
 } from "./operation-cache.js";
 import { checkSecurity, compileOperationSecurity, type SecurityMode } from "./security.js";
-import { checkBodyContentType, validateBody, validateParameter } from "./validate-step.js";
+import { matchRequestBodyMediaType, validateBody, validateParameter } from "./validate-step.js";
 
 /**
  * Coerce {@link ValidatorOptions.validateSecurity} (enum string |
@@ -1001,13 +1001,13 @@ export function createValidator(
     // Content-Type doesn't match any declared media type, short-circuit
     // with a single leaf. Parameter / body schema diagnostics against a
     // request the server can't parse in the first place are noise.
-    const ctErr = checkBodyContentType(req, cache);
-    if (ctErr !== null) {
+    const bodyMediaTypeOrErr = matchRequestBodyMediaType(req, cache);
+    if (bodyMediaTypeOrErr !== null && typeof bodyMediaTypeOrErr !== "string") {
       return createBranchError(
         "request",
         [],
         `${req.method.toUpperCase()} ${match.pathPattern}: request validation failed`,
-        [ctErr],
+        [bodyMediaTypeOrErr],
         { method: req.method, pathPattern: match.pathPattern },
       );
     }
@@ -1018,7 +1018,11 @@ export function createValidator(
     }
 
     if (cache.requestBody !== undefined) {
-      const err = validateBody(req, cache);
+      const err = validateBody(
+        req,
+        cache,
+        typeof bodyMediaTypeOrErr === "string" ? bodyMediaTypeOrErr : undefined,
+      );
       if (err !== null) children.push(err);
     }
 
@@ -1144,7 +1148,7 @@ export function createValidator(
         }
 
         if (responseCompiled.bodySchemas.size > 0 && res.body !== undefined) {
-          const mt = matchMediaType(res.contentType, responseCompiled.bodySchemas.keys());
+          const mt = matchParsedMediaType(res.contentType, responseCompiled.bodyMediaTypes);
           if (mt === undefined) {
             children.push(
               createLeafError(

--- a/performance/README.md
+++ b/performance/README.md
@@ -89,6 +89,19 @@ more specs and reports:
 Use it to sanity-check a new spec loads end-to-end through oav, or to
 regression-check when you touch `@oav/spec` / `@oav/validator`.
 
+### `bench-http-validator.ts`: HTTP request/response hot paths
+
+```bash
+pnpm bench:http                         # default 500ms per task
+pnpm bench:http -- --time=1500          # longer per-task budget
+```
+
+Runs `createValidator` once for a small OpenAPI document with multiple
+declared request and response body media types, then times the hot
+`validateRequest` and `validateResponse` calls. It includes valid body
+matches and wrong-Content-Type failures, so changes to HTTP
+orchestration and media-type negotiation have a direct benchmark.
+
 ### `mem.ts`: steady-state memory under HTTP load
 
 ```bash
@@ -122,6 +135,7 @@ retention.
 | How does library choice scale across a real spec's schemas?            | `run.ts --spec=<path>`                                                    |
 | Does this real spec load cleanly through oav's pipeline?               | `bench-real-world.mjs`                                                    |
 | How long does oav take from spec-on-disk to "first validated request"? | `bench-real-world.mjs`                                                    |
+| Did HTTP validator request/response orchestration get faster?          | `bench-http-validator.ts`                                                 |
 | What's the steady-state memory cost of each library in an HTTP server? | `mem.ts`                                                                  |
 
 ## Reading the results

--- a/performance/bench-http-validator.ts
+++ b/performance/bench-http-validator.ts
@@ -1,0 +1,202 @@
+/**
+ * Hot-path benchmark for @oav/validator request/response orchestration.
+ *
+ * This complements run.ts, which measures the JSON Schema compiler
+ * directly. The validator benchmark constructs one OpenAPI validator,
+ * then times repeated validateRequest / validateResponse calls through
+ * routing, content negotiation, and body-schema validation.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { arch, cpus, platform } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Bench } from "tinybench";
+import { createValidator } from "../packages/validator/src/index.ts";
+import type { HttpRequest, HttpResponse, OpenAPIDocument } from "../packages/core/src/index.ts";
+
+const args = process.argv.slice(2);
+const numArg = (name: string, dflt: number): number => {
+  const a = args.find((x) => x.startsWith(`--${name}=`));
+  return a ? Number.parseInt(a.slice(name.length + 3), 10) : dflt;
+};
+const time = numArg("time", 500);
+
+type Result = {
+  task: string;
+  hz: number;
+  mean: number;
+};
+
+function fmtHz(hz: number): string {
+  if (hz >= 1e6) return (hz / 1e6).toFixed(2) + "M";
+  if (hz >= 1e3) return (hz / 1e3).toFixed(1) + "K";
+  return hz.toFixed(0);
+}
+
+function fmtUs(us: number): string {
+  if (us < 1) return (us * 1000).toFixed(2) + "ns";
+  if (us < 1000) return us.toFixed(2) + "us";
+  return (us / 1000).toFixed(2) + "ms";
+}
+
+function taskStats(t: { result?: unknown }): { hz: number; mean: number } | null {
+  const r = t.result as { throughput?: { mean?: number }; latency?: { mean?: number } } | undefined;
+  const hz = r?.throughput?.mean;
+  const latency = r?.latency?.mean;
+  if (typeof hz !== "number" || typeof latency !== "number") return null;
+  return { hz, mean: latency * 1e3 };
+}
+
+const widgetSchema = {
+  type: "object",
+  required: ["id", "name", "price", "tags"],
+  additionalProperties: false,
+  properties: {
+    id: { type: "string", minLength: 1 },
+    name: { type: "string", minLength: 3, maxLength: 80 },
+    price: { type: "number", minimum: 0 },
+    tags: {
+      type: "array",
+      minItems: 1,
+      maxItems: 8,
+      items: { type: "string", minLength: 1 },
+    },
+  },
+} as const;
+
+const content = {
+  "application/json": { schema: widgetSchema },
+  "application/vnd.oav.widget+json; version=1": { schema: widgetSchema },
+  "application/*": { schema: widgetSchema },
+} as const;
+
+const spec: OpenAPIDocument = {
+  openapi: "3.1.0",
+  info: { title: "HTTP validator benchmark", version: "1.0.0" },
+  paths: {
+    "/widgets/{id}": {
+      post: {
+        parameters: [
+          {
+            name: "id",
+            in: "path",
+            required: true,
+            schema: { type: "string", minLength: 1 },
+          },
+        ],
+        requestBody: {
+          required: true,
+          content,
+        },
+        responses: {
+          "200": {
+            description: "ok",
+            content,
+          },
+        },
+      },
+    },
+  },
+};
+
+const validator = createValidator(spec);
+
+const body = {
+  id: "w-123",
+  name: "desk lamp",
+  price: 42,
+  tags: ["lighting", "office"],
+};
+
+const reqValid: HttpRequest = {
+  method: "POST",
+  path: "/widgets/w-123",
+  contentType: "application/vnd.oav.widget+json; version=1; charset=utf-8",
+  pathParams: {},
+  body,
+};
+
+const reqWrongContentType: HttpRequest = {
+  ...reqValid,
+  contentType: "text/csv",
+};
+
+const resValid: HttpResponse = {
+  status: 200,
+  contentType: "application/vnd.oav.widget+json; version=1; charset=utf-8",
+  body,
+};
+
+const resWrongContentType: HttpResponse = {
+  ...resValid,
+  contentType: "text/csv",
+};
+
+if (!validator.validateRequest(reqValid).valid) throw new Error("valid request preflight failed");
+if (validator.validateRequest(reqWrongContentType).valid) {
+  throw new Error("wrong-content-type request preflight failed");
+}
+if (!validator.validateResponse(reqValid, resValid).valid) {
+  throw new Error("valid response preflight failed");
+}
+if (validator.validateResponse(reqValid, resWrongContentType).valid) {
+  throw new Error("wrong-content-type response preflight failed");
+}
+
+const bench = new Bench({ time });
+bench
+  .add("validateRequest valid media type", () => {
+    validator.validateRequest(reqValid);
+  })
+  .add("validateRequest wrong content-type", () => {
+    validator.validateRequest(reqWrongContentType);
+  })
+  .add("validateResponse valid media type", () => {
+    validator.validateResponse(reqValid, resValid);
+  })
+  .add("validateResponse wrong content-type", () => {
+    validator.validateResponse(reqValid, resWrongContentType);
+  });
+
+await bench.run();
+
+const results: Result[] = [];
+console.log(`\n=== HTTP validator hot path (${time}ms/task) ===`);
+for (const t of bench.tasks) {
+  const stats = taskStats(t);
+  if (stats === null) {
+    console.log(`  ${t.name.padEnd(42)} ERRORED`);
+    continue;
+  }
+  console.log(
+    `  ${t.name.padEnd(42)} ${fmtHz(stats.hz).padStart(8)} ops/s  ${fmtUs(stats.mean).padStart(10)} / op`,
+  );
+  results.push({ task: t.name, hz: stats.hz, mean: stats.mean });
+}
+
+const perfDir = dirname(fileURLToPath(import.meta.url));
+const timestamp = new Date().toISOString();
+const cpuList = cpus();
+const payload = JSON.stringify(
+  {
+    meta: {
+      timestamp,
+      nodeVersion: process.version,
+      platform: platform(),
+      arch: arch(),
+      cpu: cpuList[0]?.model ?? "unknown",
+      cpuCount: cpuList.length,
+      timePerTaskMs: time,
+    },
+    results,
+  },
+  null,
+  2,
+);
+
+const historyDir = resolve(perfDir, "results");
+mkdirSync(historyDir, { recursive: true });
+const outPath = join(historyDir, `http-validator-${timestamp.replace(/:/g, "-")}.json`);
+writeFileSync(outPath, payload);
+console.log(`\nRaw numbers written to ${outPath}`);

--- a/performance/package.json
+++ b/performance/package.json
@@ -14,6 +14,7 @@
     "bench:stream": "tsx bench-stream.ts",
     "bench:stream-profile": "tsx profile-stream.ts",
     "bench:endpoint": "tsx bench-endpoint.ts",
+    "bench:http": "tsx bench-http-validator.ts",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- precompile OpenAPI request/response media type patterns in the operation cache
- reuse the matched request body media type across content-type gating and body validation
- keep AOT emitted validators in parity and avoid rebuilding response status maps on each response validation
- add a focused HTTP validator hot-path benchmark

## Benchmark
Fixed fixture with application/json, application/vnd.oav.widget+json; version=1, and application/* media types; wrong content-type uses text/csv.

main:
- request valid: 451.4K ops/s, 2.23us/op
- request wrong content-type: 859.7K ops/s, 1.17us/op
- response valid: 732.4K ops/s, 1.38us/op
- response wrong content-type: 838.5K ops/s, 1.20us/op

patched:
- request valid: 1.05M ops/s, 967.52ns/op
- request wrong content-type: 1.85M ops/s, 544.26ns/op
- response valid: 1.09M ops/s, 928.72ns/op
- response wrong content-type: 1.78M ops/s, 569.70ns/op

## Verification
- npm test
- npm run typecheck
- npm run lint