### PR TITLE
perf(router): defer match() allocations until structurally needed

### DIFF
--- a/packages/router/src/matcher.ts
+++ b/packages/router/src/matcher.ts
@@ -11,6 +11,9 @@ import type { HttpMethod, OperationObject, PathItem } from "@oav/core";
  * (yielding the normal 404) instead of crashing.
  */
 function decodePathToken(token: string): string {
+  // No "%" means nothing to decode; skip the decodeURIComponent call
+  // (and its per-token try frame) on the overwhelmingly common case.
+  if (!token.includes("%")) return token;
   try {
     return decodeURIComponent(token);
   } catch {
@@ -359,7 +362,12 @@ export function createRouter(paths: Record<string, PathItem>): Router {
       const normMethod = method.toLowerCase() as HttpMethod;
       const stripped = path.split("?")[0] ?? path;
       const trimmed = stripped.replace(/^\/+/, "").replace(/\/+$/, "");
-      const tokens = trimmed === "" ? [] : trimmed.split("/").map(decodePathToken);
+      // Decode in place instead of mapping: split already allocated the
+      // array, and most tokens carry no escapes to decode.
+      const tokens = trimmed === "" ? [] : trimmed.split("/");
+      for (let i = 0; i < tokens.length; i += 1) {
+        tokens[i] = decodePathToken(tokens[i]!);
+      }
 
       // If we scan every matching path without finding the method, we
       // still want to report a 405 (not 404) and carry the union of
@@ -367,11 +375,16 @@ export function createRouter(paths: Record<string, PathItem>): Router {
       // `/items/42` and `/items/{id}` can both match `POST /items/42`
       // even though neither declares POST.
       let firstMatchedPattern: string | undefined;
-      const allowed = new Set<string>();
+      // Allocated on the first structural match without the method; the
+      // common outcomes (match or plain 404) never build the Set.
+      let allowed: Set<string> | undefined;
 
       for (const route of routes) {
         if (route.segments.length !== tokens.length) continue;
-        const params: Record<string, string> = {};
+        // Allocated at the first template/compound segment, after the
+        // preceding literals matched; a candidate rejected on a literal
+        // (the common miss) costs no allocation.
+        let params: Record<string, string> | undefined;
         let matched = true;
         for (let i = 0; i < tokens.length; i += 1) {
           const seg = route.segments[i];
@@ -386,13 +399,14 @@ export function createRouter(paths: Record<string, PathItem>): Router {
               break;
             }
           } else if (seg.kind === "template") {
-            params[seg.name] = tok;
+            (params ??= {})[seg.name] = tok;
           } else {
             const m = seg.regex.exec(tok);
             if (m === null) {
               matched = false;
               break;
             }
+            params ??= {};
             for (let j = 0; j < seg.names.length; j += 1) {
               params[seg.names[j]!] = m[j + 1]!;
             }
@@ -412,7 +426,7 @@ export function createRouter(paths: Record<string, PathItem>): Router {
             operation,
             pathItem: route.pathItem,
             pathPattern: route.pathPattern,
-            pathParams: params,
+            pathParams: params ?? {},
           };
         }
 
@@ -420,6 +434,7 @@ export function createRouter(paths: Record<string, PathItem>): Router {
         // request's verb. Remember the first (most-specific) matched
         // pattern, union the declared methods, and keep scanning.
         if (firstMatchedPattern === undefined) firstMatchedPattern = route.pathPattern;
+        allowed ??= new Set<string>();
         for (const m of ALL_METHODS) {
           if (route.pathItem[m] !== undefined) allowed.add(m.toUpperCase());
         }
@@ -431,7 +446,7 @@ export function createRouter(paths: Record<string, PathItem>): Router {
         return {
           kind: "method-not-allowed",
           pathPattern: firstMatchedPattern,
-          allowed: [...allowed].sort(),
+          allowed: allowed === undefined ? [] : [...allowed].sort(),
         };
       }
       return undefined;


### PR DESCRIPTION
Backlog item 3 from the 2026-07-04 perf review (channel ledger; follows #451/#452).

## What

`match()` paid three allocation costs on every call regardless of outcome:

- `params = {}` per candidate route with the right segment count, allocated **before** the literal comparison could reject the candidate. Specs with many same-arity templates (`/users/{id}`, `/items/{id}`, ...) allocated one dead object per candidate per miss.
- `allowed = new Set()` up front, though only the rare 405 path reads it.
- a second tokens array from `.map(decodePathToken)`, plus a `decodeURIComponent` call (with its try frame) per token even when the token has no `%`.

Now: `params` allocates at the first template/compound segment (a match with only literal segments allocates one `{}` at return), `allowed` at the first structural-match-without-method, tokens decode in place on the array `split` already produced, and `decodePathToken` returns escape-free tokens untouched.

No behavioral change: same match results, same 405 `allowed` union, same malformed-escape tolerance. `RouteMatch.pathParams` still gets a fresh mutable object per match.

## Numbers

`performance/bench-http-validator.ts` (added in #452), same session, main vs branch:

| task | main | branch |
|---|---|---|
| validateRequest, valid | 1.38M ops/s | 1.74M ops/s |
| validateRequest, wrong content-type | 1.97M ops/s | 2.84M ops/s |
| validateResponse, valid | 1.38M ops/s | 1.80M ops/s |
| validateResponse, wrong content-type | 1.90M ops/s | 2.61M ops/s |

## Tests

router + validator suites (315 tests), typecheck, lint, check:deps green.