### PR TITLE
perf(schema): hoist format-assertion lookups to module scope

### DIFF
--- a/packages/schema/src/keywords/string.ts
+++ b/packages/schema/src/keywords/string.ts
@@ -115,8 +115,13 @@ export const formatAssertionKeyword: KeywordDefinition = {
   compile(ctx: KeywordCompileContext): void {
     const formatName = ctx.schema as string;
     const formatLit = quoteString(formatName);
-    const fnVar = ctx.gen.scope.name("fmt");
-    ctx.gen.const(fnVar, `${NAMES.DEPS}.formats.get(${formatLit})`);
+    // Hoisted to module scope: the Map lookup runs once when the
+    // factory binds deps, not per validate() call (or per element when
+    // inlined in an items loop). Consequence: formats must be
+    // registered before compileSchema returns, which the `formats`
+    // option guarantees; mutating deps.formats afterwards is not
+    // observed. Same lifecycle as the hoisted deps.compilePattern.
+    const fnVar = ctx.hoistConstant(`${NAMES.DEPS}.formats.get(${formatLit})`, "fmt");
     ctx.gen.if(
       `typeof ${ctx.data} === "string" && ${fnVar} !== undefined && !${fnVar}(${ctx.data})`,
       () => {


### PR DESCRIPTION
Backlog item from the 2026-07-04 perf review (follows #451/#452/#457).

## What

The format-assertion keyword emitted `deps.formats.get("uuid")` into the validator function body, so the Map lookup ran on every validate() call per format site, and per element when the format sits inside an items loop. `pattern` already hoists its compiled regex via `ctx.hoistConstant`; `format` now does the same: one module-scope `const fmt_N = deps.formats.get(...)` resolved when the factory binds deps.

## Behavior note

Formats must be registered before `compileSchema` returns. The `formats` option and the AOT emitter's prelude both already guarantee this; what changes is that mutating `deps.formats` *after* compilation is no longer observed. That was never a supported path (deps is not exposed by the public API), but it is a real difference for anyone poking at internals, so it is called out here and in a comment at the hoist site.

## Numbers

Measured ~2% on a six-format object (967 -> 951ns/op): the format validators themselves (uuid/date-time/email regexes) dominate, and V8's monomorphic Map.get fast path is cheap. Shipped as a riskless cleanup, not a headline; the review thread has the full measurement.

## Tests

Full suite 2846/2846, typecheck, lint, check:deps green. Generated-source check: exactly one `formats.get` per format name, at module scope.