### PR TITLE
chore: refresh perf reference tables and fix mem-bench fresh installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,8 +306,8 @@ if you are migrating from `express-openapi-validator`.
 On raw speed, oav and Ajv trade wins: oav compiles schemas one to two
 orders of magnitude faster, validates competitively on typical bodies,
 and runs a touch lighter on memory than `express-openapi-validator`;
-Ajv leads on fast-fail rejection of some plain object shapes. At normal
-request volumes these gaps are nanoseconds per call.
+Ajv leads narrowly on fast-fail rejection of some plain object shapes.
+At normal request volumes these gaps are nanoseconds per call.
 
 For the host-stamped per-shape numbers, the memory comparison, and the
 methodology, see [docs/comparison.md](https://github.com/aahoughton/oav/blob/main/docs/comparison.md).

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -41,9 +41,9 @@ the host-stamped per-shape numbers are below.
 
 - **Host:** AWS c7i.large, Intel Xeon Platinum 8488C (Sapphire Rapids),
   x86_64, 2 vCPU, Linux
-- **Runtime:** Node v22.22.3, Ajv 8.20.0
+- **Runtime:** Node v22.23.1, Ajv 8.20.0
 - **Method:** synthetic shape suite, 1000 ms/task, 500 ms cooldown,
-  median of 3 runs; commit `2754996`, 2026-06-09
+  median of 3 runs; commit `6270795`, 2026-07-05
 
 The harness measures five configurations: Ajv fast-fail
 (`allErrors: false`), Ajv full-collect (`allErrors: true`), oav fast-fail
@@ -63,13 +63,13 @@ AOT module emit).
 
 | shape               | Ajv     | oav      | speedup |
 | ------------------- | ------- | -------- | ------- |
-| `tiny`              | 9.38 ms | 32.7 µs  | 287×    |
-| `petstore`          | 7.96 ms | 160.2 µs | 50×     |
-| `tree`              | 8.00 ms | 81.2 µs  | 99×     |
-| `composition`       | 8.13 ms | 358.2 µs | 23×     |
-| `array-heavy`       | 7.66 ms | 117.6 µs | 65×     |
-| `unique-primitives` | 7.01 ms | 46.7 µs  | 150×    |
-| `long-string`       | 7.12 ms | 85.3 µs  | 83×     |
+| `tiny`              | 7.82 ms | 27.4 µs  | 285×    |
+| `petstore`          | 6.69 ms | 132.1 µs | 51×     |
+| `tree`              | 7.05 ms | 70.0 µs  | 101×    |
+| `composition`       | 7.04 ms | 297.9 µs | 24×     |
+| `array-heavy`       | 6.68 ms | 97.7 µs  | 68×     |
+| `unique-primitives` | 6.10 ms | 41.1 µs  | 149×    |
+| `long-string`       | 6.29 ms | 73.5 µs  | 86×     |
 
 ### Validate
 
@@ -78,43 +78,50 @@ Each cell is oav's throughput as a percent of the matched Ajv mode:
 request bodies the absolute per-call gaps are tens of nanoseconds, so
 these percentages move real numbers only at extreme validation volume.
 
+Because each column is normalized to a different Ajv baseline, cells
+compare down a column, not across. A fast-fail cell below a
+full-collect cell does not mean full-collect outruns fast-fail; on
+single-error rejects the two modes do near-identical absolute work,
+and fast-fail pulls ahead as the error count grows.
+
 Valid input:
 
 | shape               | oav fast-fail | oav full-collect | oav predicate |
 | ------------------- | ------------- | ---------------- | ------------- |
-| `tiny`              | 144%          | 149%             | 149%          |
-| `petstore`          | 74%           | 101%             | 107%          |
-| `tree`              | 99%           | 103%             | 121%          |
-| `composition`       | 139%          | 170%             | 183%          |
-| `array-heavy`       | 111%          | 115%             | 211%          |
-| `unique-primitives` | 159%          | 162%             | 161%          |
+| `tiny`              | 138%          | 153%             | 136%          |
+| `petstore`          | 95%           | 97%              | 110%          |
+| `tree`              | 112%          | 110%             | 131%          |
+| `composition`       | 181%          | 178%             | 216%          |
+| `array-heavy`       | 117%          | 114%             | 209%          |
+| `unique-primitives` | 174%          | 167%             | 173%          |
 | `long-string`       | >1000×†       | >1000×†          | >1000×†       |
 
 Invalid input (averaged across failure-position fixtures):
 
 | shape               | oav fast-fail | oav full-collect | oav predicate |
 | ------------------- | ------------- | ---------------- | ------------- |
-| `tiny`              | 81%           | 104%             | 123%          |
-| `petstore`          | 61%           | 93%              | 147%          |
-| `tree`              | 87%           | 115%             | 189%          |
-| `composition`       | 97%           | 75%              | 228%          |
-| `array-heavy`       | 106%          | 78%              | 208%          |
-| `unique-primitives` | 313%          | 295%             | 316%          |
-| `long-string`       | 42%           | 89%              | >1000×†       |
+| `tiny`              | 84%           | 105%             | 121%          |
+| `petstore`          | 85%           | 97%              | 160%          |
+| `tree`              | 87%           | 108%             | 180%          |
+| `composition`       | 109%          | 74%              | 219%          |
+| `array-heavy`       | 112%          | 77%              | 210%          |
+| `unique-primitives` | 323%          | 309%             | 319%          |
+| `long-string`       | 43%           | 87%              | >1000×†       |
 
-The trade-off: oav fast-fail trails Ajv fast-fail on plain object
-rejection (`petstore` 61–74%), trades places on the other shapes, and
-leads clearly on `uniqueItems`. oav full-collect stays close to Ajv
-full-collect: ahead on most accept-path shapes, mixed on rejection
-(trailing on `composition` and `array-heavy`, where collecting every
-error costs more). oav predicate mode, which skips error
-materialisation, is at or above parity everywhere.
+The trade-off: oav fast-fail trails Ajv fast-fail modestly on plain
+object rejection (`tiny`/`petstore`/`tree` at 84–87%), leads on
+`composition` and `array-heavy`, and leads clearly on `uniqueItems`.
+oav full-collect stays close to Ajv full-collect: ahead on most
+accept-path shapes, mixed on rejection (trailing on `composition` and
+`array-heavy`, where collecting every error costs more). oav predicate
+mode, which skips error materialisation, is at or above parity
+everywhere.
 
 † `long-string` is a pathological shape. On the accept path oav is
 roughly three to four thousand times faster than Ajv (capped here to
 `>1000×`), because Ajv's handling of very long length-bounded strings is
 expensive on this input while oav short-circuits. The reject path is
-noisier and swings the other way for fast-fail (oav at 42%). Read this
+noisier and swings the other way for fast-fail (oav at 43%). Read this
 row as a shape-specific signal, not a typical result.
 
 ### Memory
@@ -125,15 +132,17 @@ same 40-schema spec and identical traffic:
 
 | metric                          | oav      | eov + Ajv |
 | ------------------------------- | -------- | --------- |
-| Baseline RSS                    | 75.6 MB  | 72.4 MB   |
-| Steady-state RSS (avg)          | 102.5 MB | 106.6 MB  |
-| Steady-state heap used (avg)    | 12.8 MB  | 14.7 MB   |
-| Post-idle RSS                   | 102.3 MB | 106.8 MB  |
-| Throughput (ms / 500-req batch) | 525 ms   | 578 ms    |
+| Baseline RSS                    | 77.1 MB  | 85.8 MB   |
+| Steady-state RSS (avg)          | 102.3 MB | 102.7 MB  |
+| Steady-state heap used (avg)    | 12.6 MB  | 14.5 MB   |
+| Post-idle RSS                   | 102.2 MB | 102.6 MB  |
+| Throughput (ms / 500-req batch) | 894 ms   | 920 ms    |
 
-oav settles a few percent lighter on RSS, carries less heap, and turns
-the same workload over a little faster. Neither footprint is large; the
-gap is unlikely to decide a deployment.
+The steady-state footprints track each other closely; oav carries a
+little less heap and turns the same workload over a few percent faster.
+Neither footprint is large; the gap is unlikely to decide a deployment.
+(Batch times are not comparable across runs of this table: the driver
+is bound by Node's fetch client, which shifts between Node versions.)
 
 Full methodology, the synthetic shape definitions, the `--spec` mode for
 real-world OpenAPI documents, and the raw host-stamped JSON live in

--- a/performance/mem-bench/package.json
+++ b/performance/mem-bench/package.json
@@ -5,8 +5,8 @@
   "description": "Isolated HTTP-server fixtures for the steady-state memory benchmark. Both servers validate the same OpenAPI spec against identical traffic; the memory probe endpoint (/__memory) lets the runner compare RSS/heap across runs.",
   "type": "module",
   "devDependencies": {
-    "@aahoughton/oav": "file:../../packages/oav",
-    "@aahoughton/oav-core": "file:../..",
+    "@aahoughton/oav": "link:../../packages/oav",
+    "@aahoughton/oav-core": "link:../..",
     "express": "^4.21.2",
     "express-openapi-validator": "^5.5.9"
   },
@@ -15,7 +15,7 @@
   },
   "pnpm": {
     "overrides": {
-      "@aahoughton/oav-core": "file:../..",
+      "@aahoughton/oav-core": "link:../..",
       "esbuild": ">=0.28.1"
     }
   }

--- a/performance/mem-bench/pnpm-lock.yaml
+++ b/performance/mem-bench/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@aahoughton/oav-core': file:../..
+  '@aahoughton/oav-core': link:../..
   esbuild: '>=0.28.1'
 
 importers:
@@ -13,11 +13,11 @@ importers:
   .:
     devDependencies:
       '@aahoughton/oav':
-        specifier: file:../../packages/oav
-        version: file:../../packages/oav
+        specifier: link:../../packages/oav
+        version: link:../../packages/oav
       '@aahoughton/oav-core':
-        specifier: file:../..
-        version: file:../..
+        specifier: link:../..
+        version: link:../..
       express:
         specifier: ^4.21.2
         version: 4.22.2
@@ -26,20 +26,6 @@ importers:
         version: 5.6.2(@types/json-schema@7.0.15)(express@4.22.2)
 
 packages:
-
-  '@aahoughton/oav-core@file:../..':
-    resolution: {directory: ../.., type: directory}
-    engines: {node: '>=22'}
-
-  '@aahoughton/oav@file:../../packages/oav':
-    resolution: {directory: ../../packages/oav, type: directory}
-    engines: {node: '>=22'}
-    hasBin: true
-    peerDependencies:
-      esbuild: '>=0.28.1'
-    peerDependenciesMeta:
-      esbuild:
-        optional: true
 
   '@apidevtools/json-schema-ref-parser@14.2.1':
     resolution: {integrity: sha512-HmdFw9CDYqM6B25pqGBpNeLCKvGPlIx1EbLrVL0zPvj50CJQUHyBNBw45Muk0kEIkogo1VZvOKHajdMuAzSxRg==}
@@ -68,11 +54,11 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/multer@2.1.0':
-    resolution: {integrity: sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==}
+  '@types/multer@2.2.0':
+    resolution: {integrity: sha512-3U1troeqGV8Ntp7Q3klwf4zr23VEoqYVocYXaswm9+8z3O9UHDYAqLxjJ/h550iRADTjKdOdhhasXw6gD6kYtg==}
 
-  '@types/node@25.9.3':
-    resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
+  '@types/node@26.1.0':
+    resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
 
   '@types/qs@6.15.1':
     resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
@@ -140,10 +126,6 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
-
-  commander@15.0.0:
-    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
-    engines: {node: '>=22.12.0'}
 
   concat-stream@2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
@@ -222,8 +204,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
   finalhandler@1.3.2:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
@@ -275,8 +257,8 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   json-schema-traverse@1.0.0:
@@ -360,8 +342,8 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
 
   range-parser@1.2.1:
@@ -435,8 +417,8 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  undici-types@7.24.6:
-    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -453,40 +435,27 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  yaml@2.9.0:
-    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
-
 snapshots:
-
-  '@aahoughton/oav-core@file:../..': {}
-
-  '@aahoughton/oav@file:../../packages/oav':
-    dependencies:
-      '@aahoughton/oav-core': file:../..
-      commander: 15.0.0
-      yaml: 2.9.0
 
   '@apidevtools/json-schema-ref-parser@14.2.1(@types/json-schema@7.0.15)':
     dependencies:
       '@types/json-schema': 7.0.15
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
 
   '@jsdevtools/ono@7.1.3': {}
 
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 25.9.3
+      '@types/node': 26.1.0
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.0
 
   '@types/express-serve-static-core@5.1.1':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.0
       '@types/qs': 6.15.1
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -501,13 +470,13 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/multer@2.1.0':
+  '@types/multer@2.2.0':
     dependencies:
       '@types/express': 5.0.6
 
-  '@types/node@25.9.3':
+  '@types/node@26.1.0':
     dependencies:
-      undici-types: 7.24.6
+      undici-types: 8.3.0
 
   '@types/qs@6.15.1': {}
 
@@ -515,12 +484,12 @@ snapshots:
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 26.1.0
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 25.9.3
+      '@types/node': 26.1.0
 
   accepts@1.3.8:
     dependencies:
@@ -538,7 +507,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -558,7 +527,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.15.2
+      qs: 6.15.3
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -582,8 +551,6 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
-
-  commander@15.0.0: {}
 
   concat-stream@2.0.0:
     dependencies:
@@ -635,7 +602,7 @@ snapshots:
   express-openapi-validator@5.6.2(@types/json-schema@7.0.15)(express@4.22.2):
     dependencies:
       '@apidevtools/json-schema-ref-parser': 14.2.1(@types/json-schema@7.0.15)
-      '@types/multer': 2.1.0
+      '@types/multer': 2.2.0
       ajv: 8.20.0
       ajv-draft-04: 1.0.0(ajv@8.20.0)
       ajv-formats: 3.0.1(ajv@8.20.0)
@@ -648,7 +615,7 @@ snapshots:
       multer: 2.2.0
       ono: 7.1.3
       path-to-regexp: 8.4.2
-      qs: 6.15.2
+      qs: 6.15.3
     transitivePeerDependencies:
       - '@types/json-schema'
 
@@ -675,7 +642,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.15.2
+      qs: 6.15.3
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2
@@ -690,7 +657,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.3: {}
 
   finalhandler@1.3.2:
     dependencies:
@@ -752,7 +719,7 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -814,8 +781,9 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  qs@6.15.2:
+  qs@6.15.3:
     dependencies:
+      es-define-property: 1.0.1
       side-channel: 1.1.1
 
   range-parser@1.2.1: {}
@@ -913,7 +881,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  undici-types@7.24.6: {}
+  undici-types@8.3.0: {}
 
   unpipe@1.0.0: {}
 
@@ -922,5 +890,3 @@ snapshots:
   utils-merge@1.0.1: {}
 
   vary@1.1.2: {}
-
-  yaml@2.9.0: {}


### PR DESCRIPTION
Two cleanups from the 2026-07-05 reference benchmark run (fresh c7i.large, same Xeon 8488C as the June reference host; pre `f2eded7` vs post `6270795` interleaved, median of 3 at 1000ms/task, 500ms cooldown).

## Docs refresh

`docs/comparison.md` tables and provenance move from commit `2754996` (2026-06-09) to `6270795` (2026-07-05), picking up #451/#452/#457/#458:

- petstore fast-fail rejection: 61% -> 85% of Ajv (per-fixture 59–155%, one fixture now ahead)
- petstore fast-fail accept: 74% -> 95%
- composition rejection: 97% -> 109% (now ahead); composition accept 139% -> 181%
- compile ratios and the oav-all full-collect gaps are unchanged, as expected
- the trade-off paragraph and README's fast-fail sentence updated to match

Memory table: footprints match June within a megabyte, but absolute batch times moved ~70% for BOTH oav and eov (the driver is bound by Node's fetch client, v22.22.3 -> v22.23.1), so the table now carries a caveat against cross-run throughput comparison. The oav-vs-eov ratio holds (~3% faster, less heap).

## mem-bench fresh-install fix

Since #435 gave `packages/oav` a `workspace:*` dep on the stream validator, a fresh `pnpm install` in `performance/mem-bench` fails with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`: pnpm copies `file:` deps and tries to resolve their dependencies inside mem-bench's empty workspace. Existing checkouts with a pre-#435 node_modules still work, which is why this went unnoticed; the reference run hit it on a clean host.

Fix: `file:` -> `link:` for the two `@aahoughton` deps. `link:` symlinks the real package directory without re-resolving its deps, so imports resolve through the main workspace's install, which is how the servers already resolve at runtime. The bootstrap steps in `performance/README.md` (build, then install) are unchanged. Verified with a fresh install and a 2-batch `bench:mem` run. Lockfile regenerated; express-openapi-validator moved 5.5.9 -> 5.6.2 within its declared range.

Raw artifacts, logs, and the full writeup from the run are in `~/Desktop/oav-refbench-2026-07-05/` (results stay out of the repo; `performance/results/` is gitignored).